### PR TITLE
[Breaking] Standardize configurations so they are all lower case

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json
+++ b/deployment-examples/docker-compose/local-storage-cas.json
@@ -10,7 +10,7 @@
         "backend": {
           "compression": {
             "compression_algorithm": {
-              "LZ4": {}
+              "lz4": {}
             },
             "backend": {
               "filesystem": {

--- a/deployment-examples/docker-compose/scheduler.json
+++ b/deployment-examples/docker-compose/scheduler.json
@@ -5,7 +5,7 @@
       "grpc": {
         "instance_name": "main",
         "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
-        "store_type": "CAS"
+        "store_type": "cas"
       }
     },
     "GRPC_LOCAL_AC_STORE": {
@@ -13,7 +13,7 @@
       "grpc": {
         "instance_name": "main",
         "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
-        "store_type": "AC"
+        "store_type": "ac"
       }
     }
   },
@@ -21,7 +21,7 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum"
+          "cpu_count": "minimum"
         }
       }
     }

--- a/deployment-examples/docker-compose/worker.json
+++ b/deployment-examples/docker-compose/worker.json
@@ -5,7 +5,7 @@
       "grpc": {
         "instance_name": "main",
         "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
-        "store_type": "CAS"
+        "store_type": "cas"
       }
     },
     "GRPC_LOCAL_AC_STORE": {
@@ -13,7 +13,7 @@
       "grpc": {
         "instance_name": "main",
         "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
-        "store_type": "AC"
+        "store_type": "ac"
       }
     },
     "WORKER_FAST_SLOW_STORE": {

--- a/deployment-examples/terraform/AWS/scripts/cas.json
+++ b/deployment-examples/terraform/AWS/scripts/cas.json
@@ -3,7 +3,7 @@
     "AC_S3_STORE": {
       "compression": {
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         },
         "backend": {
           "fast_slow": {
@@ -70,7 +70,7 @@
             "content_store": {
               "compression": {
                 "compression_algorithm": {
-                  "LZ4": {}
+                  "lz4": {}
                 },
                 "backend": {
                   "fast_slow": {
@@ -116,7 +116,7 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum"
+          "cpu_count": "minimum"
         }
       }
     }

--- a/deployment-examples/terraform/AWS/scripts/scheduler.json
+++ b/deployment-examples/terraform/AWS/scripts/scheduler.json
@@ -3,7 +3,7 @@
     "AC_S3_STORE": {
       "compression": {
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         },
         "backend": {
           "fast_slow": {
@@ -68,7 +68,7 @@
         "content_store": {
           "compression": {
             "compression_algorithm": {
-              "LZ4": {}
+              "lz4": {}
             },
             "backend": {
               "fast_slow": {
@@ -110,10 +110,10 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum",
-          "cpu_arch": "Exact",
-          "memory_kb": "Minimum",
-          "kernel_version": "Exact",
+          "cpu_count": "minimum",
+          "cpu_arch": "exact",
+          "memory_kb": "minimum",
+          "kernel_version": "exact",
         }
       }
     }

--- a/deployment-examples/terraform/AWS/scripts/worker.json
+++ b/deployment-examples/terraform/AWS/scripts/worker.json
@@ -3,7 +3,7 @@
     "AC_S3_STORE": {
       "compression": {
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         },
         "backend": {
           // TODO(allada) This needs to be some kind of sharding store, because s3 has
@@ -57,7 +57,7 @@
             "content_store": {
               "compression": {
                 "compression_algorithm": {
-                  "LZ4": {}
+                  "lz4": {}
                 },
                 "backend": {
                   // TODO(allada) This needs to be some kind of sharding store, because s3 has

--- a/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
+++ b/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
@@ -14,7 +14,7 @@
           }
         },
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         }
       }
     },
@@ -32,7 +32,7 @@
           }
         },
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         }
       }
     }

--- a/deployment-examples/terraform/GCP/module/scripts/cas.json
+++ b/deployment-examples/terraform/GCP/module/scripts/cas.json
@@ -25,7 +25,7 @@
           }
         },
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         }
       }
     },
@@ -65,7 +65,7 @@
               }
             },
             "compression_algorithm": {
-              "LZ4": {}
+              "lz4": {}
             }
           }
         },
@@ -87,8 +87,8 @@
     },
     // External apis support compression.
     "compression": {
-      "send_compression_algorithm": "Gzip",
-      "accepted_compression_algorithms": ["Gzip"]
+      "send_compression_algorithm": "gzip",
+      "accepted_compression_algorithms": ["gzip"]
     },
     "services": {
       "cas": {

--- a/deployment-examples/terraform/GCP/module/scripts/scheduler.json
+++ b/deployment-examples/terraform/GCP/module/scripts/scheduler.json
@@ -23,7 +23,7 @@
               }
             },
             "compression_algorithm": {
-              "LZ4": {}
+              "lz4": {}
             }
           }
         }
@@ -63,7 +63,7 @@
                   }
                 },
                 "compression_algorithm": {
-                  "LZ4": {}
+                  "lz4": {}
                 }
               }
             }
@@ -80,7 +80,7 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum"
+          "cpu_count": "minimum"
         }
       }
     }

--- a/deployment-examples/terraform/GCP/module/scripts/worker.json
+++ b/deployment-examples/terraform/GCP/module/scripts/worker.json
@@ -14,7 +14,7 @@
           }
         },
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         }
       }
     },
@@ -32,7 +32,7 @@
           }
         },
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         }
       }
     },

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -67,7 +67,7 @@ A very basic configuration that is a pure in-memory store is:
 
 The following configuration will cause the underlying data to be backed by the
 filesystem, and when the number of bytes reaches over 100mb for AC objects and
-10gb for CAS objects evict them, but apply LZ4 compression on the data before
+10gb for CAS objects evict them, but apply lz4 compression on the data before
 sending it to to be stored. This will also automatically decompress the data
 when the data is retrieved.
 
@@ -77,7 +77,7 @@ when the data is retrieved.
     "CAS_MAIN_STORE": {
       "compression": {
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         },
         "backend": {
           "filesystem": {
@@ -145,7 +145,7 @@ only transfer the the bytes around where the changes occurred.
           // Then apply a compression configuration to the individual file chunks.
           "compression": {
             "compression_algorithm": {
-              "LZ4": {}
+              "lz4": {}
             },
             "backend": {
               // Then take those compressed chunks and store them to the filesystem.

--- a/nativelink-config/examples/basic_cas.json
+++ b/nativelink-config/examples/basic_cas.json
@@ -37,23 +37,23 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum",
-          "memory_kb": "Minimum",
-          "network_kbps": "Minimum",
-          "disk_read_iops": "Minimum",
-          "disk_read_bps": "Minimum",
-          "disk_write_iops": "Minimum",
-          "disk_write_bps": "Minimum",
-          "shm_size": "Minimum",
-          "gpu_count": "Minimum",
-          "gpu_model": "Exact",
-          "cpu_vendor": "Exact",
-          "cpu_arch": "Exact",
-          "cpu_model": "Exact",
-          "kernel_version": "Exact",
+          "cpu_count": "minimum",
+          "memory_kb": "minimum",
+          "network_kbps": "minimum",
+          "disk_read_iops": "minimum",
+          "disk_read_bps": "minimum",
+          "disk_write_iops": "minimum",
+          "disk_write_bps": "minimum",
+          "shm_size": "minimum",
+          "gpu_count": "minimum",
+          "gpu_model": "exact",
+          "cpu_vendor": "exact",
+          "cpu_arch": "exact",
+          "cpu_model": "exact",
+          "kernel_version": "exact",
           // Example of how to set which docker images are available and set
           // them in the platform properties.
-          // "docker_image": "Priority",
+          // "docker_image": "priority",
         }
       }
     }

--- a/nativelink-config/examples/filesystem_cas.json
+++ b/nativelink-config/examples/filesystem_cas.json
@@ -8,7 +8,7 @@
     "FS_CONTENT_STORE": {
       "compression": {
         "compression_algorithm": {
-          "LZ4": {}
+          "lz4": {}
         },
         "backend": {
           "filesystem": {
@@ -94,21 +94,21 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum",
-          "memory_kb": "Minimum",
-          "network_kbps": "Minimum",
-          "disk_read_iops": "Minimum",
-          "disk_read_bps": "Minimum",
-          "disk_write_iops": "Minimum",
-          "disk_write_bps": "Minimum",
-          "shm_size": "Minimum",
-          "gpu_count": "Minimum",
-          "gpu_model": "Exact",
-          "cpu_vendor": "Exact",
-          "cpu_arch": "Exact",
-          "cpu_model": "Exact",
-          "kernel_version": "Exact",
-          "docker_image": "Priority",
+          "cpu_count": "minimum",
+          "memory_kb": "minimum",
+          "network_kbps": "minimum",
+          "disk_read_iops": "minimum",
+          "disk_read_bps": "minimum",
+          "disk_write_iops": "minimum",
+          "disk_write_bps": "minimum",
+          "shm_size": "minimum",
+          "gpu_count": "minimum",
+          "gpu_model": "exact",
+          "cpu_vendor": "exact",
+          "cpu_arch": "exact",
+          "cpu_model": "exact",
+          "kernel_version": "exact",
+          "docker_image": "priority",
         }
       }
     }

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json
@@ -34,7 +34,7 @@
             "content_store": {
               "compression": {
                 "compression_algorithm": {
-                  "LZ4": {}
+                  "lz4": {}
                 },
                 "backend": {
                   "fast_slow": {
@@ -109,21 +109,21 @@
     "MAIN_SCHEDULER": {
       "simple": {
         "supported_platform_properties": {
-          "cpu_count": "Minimum",
-          "memory_kb": "Minimum",
-          "network_kbps": "Minimum",
-          "disk_read_iops": "Minimum",
-          "disk_read_bps": "Minimum",
-          "disk_write_iops": "Minimum",
-          "disk_write_bps": "Minimum",
-          "shm_size": "Minimum",
-          "gpu_count": "Minimum",
-          "gpu_model": "Exact",
-          "cpu_vendor": "Exact",
-          "cpu_arch": "Exact",
-          "cpu_model": "Exact",
-          "kernel_version": "Exact",
-          "docker_image": "Priority",
+          "cpu_count": "minimum",
+          "memory_kb": "minimum",
+          "network_kbps": "minimum",
+          "disk_read_iops": "minimum",
+          "disk_read_bps": "minimum",
+          "disk_write_iops": "minimum",
+          "disk_write_bps": "minimum",
+          "shm_size": "minimum",
+          "gpu_count": "minimum",
+          "gpu_model": "exact",
+          "cpu_vendor": "exact",
+          "cpu_arch": "exact",
+          "cpu_model": "exact",
+          "kernel_version": "exact",
+          "docker_image": "priority",
         }
       }
     }

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -29,13 +29,14 @@ pub type SchedulerRefName = String;
 /// Used when the config references `instance_name` in the protocol.
 pub type InstanceName = String;
 
+#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Default, Clone, Copy)]
 pub enum CompressionAlgorithm {
     /// No compression.
     #[default]
-    None,
+    none,
     /// Zlib compression.
-    Gzip,
+    gzip,
 }
 
 /// Note: Compressing data in the cloud rarely has a benefit, since most
@@ -309,33 +310,35 @@ pub struct EndpointConfig {
     pub timeout: Option<f32>,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Deserialize, Debug, Default)]
 pub enum UploadCacheResultsStrategy {
     /// Only upload action results with an exit code of 0.
     #[default]
-    SuccessOnly,
+    success_only,
 
     /// Don't upload any action results.
-    Never,
+    never,
 
     /// Upload all action results that complete.
-    Everything,
+    everything,
 
     /// Only upload action results that fail.
-    FailuresOnly,
+    failures_only,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Clone, Deserialize, Debug)]
 pub enum EnvironmentSource {
     /// The name of the property in the action to get the value from.
-    Property(String),
+    property(String),
 
     /// The raw value to set.
-    Value(#[serde(deserialize_with = "convert_string_with_shellexpand")] String),
+    value(#[serde(deserialize_with = "convert_string_with_shellexpand")] String),
 
     /// The max amount of time in milliseconds the command is allowed to run
     /// (requested by the client).
-    TimeoutMillis,
+    timeout_millis,
 
     /// A special file path will be provided that can be used to comminicate
     /// with the parent process about out-of-band information. This file
@@ -353,7 +356,7 @@ pub enum EnvironmentSource {
     ///
     /// All fields are optional, file does not need to be created and may be
     /// empty.
-    SideChannelFile,
+    side_channel_file,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -30,25 +30,26 @@ pub enum SchedulerConfig {
 
 /// When the scheduler matches tasks to workers that are capable of running
 /// the task, this value will be used to determine how the property is treated.
+#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum PropertyType {
     /// Requires the platform property to be a u64 and when the scheduler looks
     /// for appropriate worker nodes that are capable of executing the task,
     /// the task will not run on a node that has less than this value.
-    Minimum,
+    minimum,
 
     /// Requires the platform property to be a string and when the scheduler
     /// looks for appropriate worker nodes that are capable of executing the
     /// task, the task will not run on a node that does not have this property
     /// set to the value with exact string match.
-    Exact,
+    exact,
 
     /// Does not restrict on this value and instead will be passed to the worker
     /// as an informational piece.
     /// TODO(allada) In the future this will be used by the scheduler and worker
     /// to cause the scheduler to prefer certain workers over others, but not
     /// restrict them based on these values.
-    Priority,
+    priority,
 }
 
 /// When a worker is being searched for to run a job, this will be used
@@ -59,9 +60,9 @@ pub enum PropertyType {
 pub enum WorkerAllocationStrategy {
     /// Prefer workers that have been least recently used to run a job.
     #[default]
-    LeastRecentlyUsed,
+    least_recently_used,
     /// Prefer workers that have been most recently used to run a job.
-    MostRecentlyUsed,
+    most_recently_used,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -72,7 +73,7 @@ pub struct SimpleScheduler {
     ///
     /// For example, a value of:
     /// ```json
-    /// { "cpu_count": "Minimum", "cpu_arch": "Exact" }
+    /// { "cpu_count": "minimum", "cpu_arch": "exact" }
     /// ```
     /// With a job that contains:
     /// ```json
@@ -156,12 +157,13 @@ pub struct PlatformPropertyAddition {
     pub value: String,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Clone)]
 pub enum PropertyModification {
     /// Add a property to the action properties.
-    Add(PlatformPropertyAddition),
+    add(PlatformPropertyAddition),
     /// Remove a named property from the action.
-    Remove(String),
+    remove(String),
 }
 
 #[derive(Deserialize, Debug)]

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -369,6 +369,7 @@ pub struct Lz4Config {
     pub max_decode_block_size: u32,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum CompressionAlgorithm {
     /// LZ4 compression algorithm is extremely fast for compression and
@@ -378,7 +379,7 @@ pub enum CompressionAlgorithm {
     /// compressible.
     ///
     /// see: <https://lz4.github.io/lz4/>
-    LZ4(Lz4Config),
+    lz4(Lz4Config),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -453,12 +454,13 @@ pub struct S3Store {
     pub insecure_allow_http: bool,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum StoreType {
     /// The store is content addressable storage.
-    CAS,
+    cas,
     /// The store is an action cache.
-    AC,
+    ac,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -173,7 +173,7 @@ impl ActionScheduler for GrpcScheduler {
                     .err_tip(|| "Unable to get execution properties in GrpcScheduler")?
                     .supported_node_properties
                     .iter()
-                    .map(|property| (property.clone(), nativelink_config::schedulers::PropertyType::Exact))
+                    .map(|property| (property.clone(), nativelink_config::schedulers::PropertyType::exact))
                     .collect(),
             ));
 

--- a/nativelink-scheduler/src/platform_property_manager.rs
+++ b/nativelink-scheduler/src/platform_property_manager.rs
@@ -41,7 +41,7 @@ impl PlatformPropertyManager {
     pub fn make_prop_value(&self, key: &str, value: &str) -> Result<PlatformPropertyValue, Error> {
         if let Some(prop_type) = self.known_properties.get(key) {
             return match prop_type {
-                PropertyType::Minimum => Ok(PlatformPropertyValue::Minimum(value.parse::<u64>().err_tip_with_code(
+                PropertyType::minimum => Ok(PlatformPropertyValue::Minimum(value.parse::<u64>().err_tip_with_code(
                     |e| {
                         (
                             Code::InvalidArgument,
@@ -49,8 +49,8 @@ impl PlatformPropertyManager {
                         )
                     },
                 )?)),
-                PropertyType::Exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
-                PropertyType::Priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
+                PropertyType::exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
+                PropertyType::priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
             };
         }
         Err(make_input_err!("Unknown platform property '{}'", key))

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -58,10 +58,10 @@ impl ActionScheduler for PropertyModifierScheduler {
         let mut known_properties = property_manager.get_known_properties().clone();
         for modification in &self.modifications {
             match modification {
-                PropertyModification::Remove(name) => {
-                    known_properties.entry(name.into()).or_insert(PropertyType::Priority);
+                PropertyModification::remove(name) => {
+                    known_properties.entry(name.into()).or_insert(PropertyType::priority);
                 }
-                PropertyModification::Add(_) => (),
+                PropertyModification::add(_) => (),
             }
         }
         let property_manager = {
@@ -86,13 +86,13 @@ impl ActionScheduler for PropertyModifierScheduler {
             .err_tip(|| "In PropertyModifierScheduler::add_action")?;
         for modification in &self.modifications {
             match modification {
-                PropertyModification::Add(addition) => action_info.platform_properties.properties.insert(
+                PropertyModification::add(addition) => action_info.platform_properties.properties.insert(
                     addition.name.clone(),
                     platform_property_manager
                         .make_prop_value(&addition.name, &addition.value)
                         .err_tip(|| "In PropertyModifierScheduler::add_action")?,
                 ),
-                PropertyModification::Remove(name) => action_info.platform_properties.properties.remove(name),
+                PropertyModification::remove(name) => action_info.platform_properties.properties.remove(name),
             };
         }
         self.scheduler.add_action(action_info).await

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -144,10 +144,10 @@ impl Workers {
         let mut workers_iter = self.workers.iter_mut();
         let workers_iter = match self.allocation_strategy {
             // Use rfind to get the least recently used that satisfies the properties.
-            WorkerAllocationStrategy::LeastRecentlyUsed => workers_iter
+            WorkerAllocationStrategy::least_recently_used => workers_iter
                 .rfind(|(_, w)| w.can_accept_work() && action_properties.is_satisfied_by(&w.platform_properties)),
             // Use find to get the most recently used that satisfies the properties.
-            WorkerAllocationStrategy::MostRecentlyUsed => workers_iter
+            WorkerAllocationStrategy::most_recently_used => workers_iter
                 .find(|(_, w)| w.can_accept_work() && action_properties.is_satisfied_by(&w.platform_properties)),
         };
         let worker_id = workers_iter.map(|(_, w)| &w.id);

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -65,7 +65,7 @@ mod property_modifier_scheduler_tests {
     async fn add_action_adds_property() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::Add(PlatformPropertyAddition {
+        let context = make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
             name: name.clone(),
             value: value.clone(),
         })]);
@@ -76,7 +76,7 @@ mod property_modifier_scheduler_tests {
         }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
             name.clone(),
-            PropertyType::Exact,
+            PropertyType::exact,
         )])));
         let (_, _, action_info) = join!(
             context.modifier_scheduler.add_action(action_info),
@@ -97,7 +97,7 @@ mod property_modifier_scheduler_tests {
         let name = "name".to_string();
         let original_value = "value".to_string();
         let replaced_value = "replaced".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::Add(PlatformPropertyAddition {
+        let context = make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
             name: name.clone(),
             value: replaced_value.clone(),
         })]);
@@ -112,7 +112,7 @@ mod property_modifier_scheduler_tests {
         }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
             name.clone(),
-            PropertyType::Exact,
+            PropertyType::exact,
         )])));
         let (_, _, action_info) = join!(
             context.modifier_scheduler.add_action(action_info),
@@ -133,8 +133,8 @@ mod property_modifier_scheduler_tests {
         let name = "name".to_string();
         let value = "value".to_string();
         let context = make_modifier_scheduler(vec![
-            PropertyModification::Remove(name.clone()),
-            PropertyModification::Add(PlatformPropertyAddition {
+            PropertyModification::remove(name.clone()),
+            PropertyModification::add(PlatformPropertyAddition {
                 name: name.clone(),
                 value: value.clone(),
             }),
@@ -146,7 +146,7 @@ mod property_modifier_scheduler_tests {
         }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
             name.clone(),
-            PropertyType::Exact,
+            PropertyType::exact,
         )])));
         let (_, _, action_info) = join!(
             context.modifier_scheduler.add_action(action_info),
@@ -167,11 +167,11 @@ mod property_modifier_scheduler_tests {
         let name = "name".to_string();
         let value = "value".to_string();
         let context = make_modifier_scheduler(vec![
-            PropertyModification::Add(PlatformPropertyAddition {
+            PropertyModification::add(PlatformPropertyAddition {
                 name: name.clone(),
                 value: value.clone(),
             }),
-            PropertyModification::Remove(name.clone()),
+            PropertyModification::remove(name.clone()),
         ]);
         let action_info = make_base_action_info(UNIX_EPOCH);
         let (_forward_watch_channel_tx, forward_watch_channel_rx) = watch::channel(Arc::new(ActionState {
@@ -180,7 +180,7 @@ mod property_modifier_scheduler_tests {
         }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
             name,
-            PropertyType::Exact,
+            PropertyType::exact,
         )])));
         let (_, _, action_info) = join!(
             context.modifier_scheduler.add_action(action_info),
@@ -197,7 +197,7 @@ mod property_modifier_scheduler_tests {
     async fn add_action_property_remove() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
+        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
         let mut action_info = make_base_action_info(UNIX_EPOCH);
         action_info
             .platform_properties
@@ -239,7 +239,7 @@ mod property_modifier_scheduler_tests {
     #[tokio::test]
     async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
         let name = "name".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
+        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
         let scheduler_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
         let get_property_manager_fut = context
             .mock_scheduler
@@ -247,7 +247,7 @@ mod property_modifier_scheduler_tests {
         let property_manager_fut = context.modifier_scheduler.get_platform_property_manager(INSTANCE_NAME);
         let (actual_instance_name, property_manager) = join!(get_property_manager_fut, property_manager_fut);
         assert_eq!(
-            HashMap::<_, _>::from_iter([(name, PropertyType::Priority)]),
+            HashMap::<_, _>::from_iter([(name, PropertyType::priority)]),
             *property_manager?.get_known_properties()
         );
         assert_eq!(actual_instance_name, INSTANCE_NAME);
@@ -257,10 +257,10 @@ mod property_modifier_scheduler_tests {
     #[tokio::test]
     async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
         let name = "name".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
+        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
         let scheduler_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::<_, _>::from_iter([(
             name.clone(),
-            PropertyType::Exact,
+            PropertyType::exact,
         )])));
         let get_property_manager_fut = context
             .mock_scheduler
@@ -268,7 +268,7 @@ mod property_modifier_scheduler_tests {
         let property_manager_fut = context.modifier_scheduler.get_platform_property_manager(INSTANCE_NAME);
         let (_, property_manager) = join!(get_property_manager_fut, property_manager_fut);
         assert_eq!(
-            HashMap::<_, _>::from_iter([(name, PropertyType::Exact)]),
+            HashMap::<_, _>::from_iter([(name, PropertyType::exact)]),
             *property_manager?.get_known_properties()
         );
         Ok(())

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -209,7 +209,7 @@ impl CompressionStore {
         inner_store: Arc<dyn Store>,
     ) -> Result<Self, Error> {
         let lz4_config = match compression_config.compression_algorithm {
-            nativelink_config::stores::CompressionAlgorithm::LZ4(mut lz4_config) => {
+            nativelink_config::stores::CompressionAlgorithm::lz4(mut lz4_config) => {
                 if lz4_config.block_size == 0 {
                     lz4_config.block_size = DEFAULT_BLOCK_SIZE;
                 }

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -149,7 +149,7 @@ impl GrpcStore {
         grpc_request: Request<FindMissingBlobsRequest>,
     ) -> Result<Response<FindMissingBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -170,7 +170,7 @@ impl GrpcStore {
         grpc_request: Request<BatchUpdateBlobsRequest>,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -191,7 +191,7 @@ impl GrpcStore {
         grpc_request: Request<BatchReadBlobsRequest>,
     ) -> Result<Response<BatchReadBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -212,7 +212,7 @@ impl GrpcStore {
         grpc_request: Request<GetTreeRequest>,
     ) -> Result<Response<Streaming<GetTreeResponse>>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -233,7 +233,7 @@ impl GrpcStore {
         grpc_request: impl IntoRequest<ReadRequest>,
     ) -> Result<Response<Streaming<ReadResponse>>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -266,7 +266,7 @@ impl GrpcStore {
         E: Into<Error> + 'static,
     {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -358,7 +358,7 @@ impl GrpcStore {
         grpc_request: Request<QueryWriteStatusRequest>,
     ) -> Result<Response<QueryWriteStatusResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::AC),
+            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
             "CAS operation on AC store"
         );
 
@@ -492,7 +492,7 @@ impl Store for GrpcStore {
         digests: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error> {
-        if matches!(self.store_type, nativelink_config::stores::StoreType::AC) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
             digests
                 .iter()
                 .zip(results.iter_mut())
@@ -546,7 +546,7 @@ impl Store for GrpcStore {
         reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
-        if matches!(self.store_type, nativelink_config::stores::StoreType::AC) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
             return self.update_action_result_from_bytes(digest, reader).await;
         }
 
@@ -617,7 +617,7 @@ impl Store for GrpcStore {
         offset: usize,
         length: Option<usize>,
     ) -> Result<(), Error> {
-        if matches!(self.store_type, nativelink_config::stores::StoreType::AC) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
             return self.get_action_result_as_part(digest, writer, offset, length).await;
         }
 

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -68,7 +68,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config { ..Default::default() },
                 ),
             },
@@ -97,7 +97,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config {
                         block_size: 10,
                         ..Default::default()
@@ -150,7 +150,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config { ..Default::default() },
                 ),
             },
@@ -183,7 +183,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config { ..Default::default() },
                 ),
             },
@@ -232,7 +232,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config {
                         block_size: BLOCK_SIZE,
                         ..Default::default()
@@ -311,7 +311,7 @@ mod compression_store_tests {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
                 ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::LZ4(
+                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                     nativelink_config::stores::Lz4Config {
                         block_size: BLOCK_SIZE,
                         ..Default::default()

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -428,7 +428,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -528,7 +528,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -635,7 +635,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -794,7 +794,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -954,7 +954,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -1131,7 +1131,7 @@ mod running_actions_manager_tests {
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -1248,7 +1248,7 @@ mod running_actions_manager_tests {
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1384,7 +1384,7 @@ exit 0
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1510,17 +1510,17 @@ exit 0
                 additional_environment: Some(HashMap::from([
                     (
                         "PROPERTY".to_string(),
-                        EnvironmentSource::Property("property_name".to_string()),
+                        EnvironmentSource::property("property_name".to_string()),
                     ),
-                    ("VALUE".to_string(), EnvironmentSource::Value("raw_value".to_string())),
-                    ("INNER_TIMEOUT".to_string(), EnvironmentSource::TimeoutMillis),
+                    ("VALUE".to_string(), EnvironmentSource::value("raw_value".to_string())),
+                    ("INNER_TIMEOUT".to_string(), EnvironmentSource::timeout_millis),
                 ])),
             },
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1650,14 +1650,14 @@ exit 1
                 entrypoint_cmd: Some(test_wrapper_script.into_string().unwrap()),
                 additional_environment: Some(HashMap::from([(
                     "SIDE_CHANNEL_FILE".to_string(),
-                    EnvironmentSource::SideChannelFile,
+                    EnvironmentSource::side_channel_file,
                 )])),
             },
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1720,7 +1720,7 @@ exit 1
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1779,7 +1779,7 @@ exit 1
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Everything,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::everything,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1839,7 +1839,7 @@ exit 1
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
                 ),
                 success_message_template: "{historical_results_hash}-{historical_results_size}".to_string(),
                 ..Default::default()
@@ -1921,7 +1921,7 @@ exit 1
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
                 ),
                 success_message_template: "{historical_results_hash}-{historical_results_size}".to_string(),
                 ..Default::default()
@@ -1955,7 +1955,7 @@ exit 1
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::FailuresOnly,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::failures_only,
                 ),
                 failure_message_template: "{historical_results_hash}-{historical_results_size}".to_string(),
                 ..Default::default()
@@ -2013,7 +2013,7 @@ exit 1
             ac_store: Some(Pin::into_inner(ac_store.clone())),
             historical_store: Pin::into_inner(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
+                upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
                 success_message_template: "{action_digest_hash}-{action_digest_size}".to_string(),
                 ..Default::default()
             },
@@ -2109,7 +2109,7 @@ exit 1
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
                     historical_store: Pin::into_inner(cas_store.clone()),
                     upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                         ..Default::default()
                     },
                     max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2177,7 +2177,7 @@ exit 1
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
                     historical_store: Pin::into_inner(cas_store.clone()),
                     upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                         ..Default::default()
                     },
                     max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2248,7 +2248,7 @@ exit 1
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
                     historical_store: Pin::into_inner(cas_store.clone()),
                     upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                        upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                         ..Default::default()
                     },
                     max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2320,7 +2320,7 @@ exit 1
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,
@@ -2428,7 +2428,7 @@ exit 1
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
                 historical_store: Pin::into_inner(cas_store.clone()),
                 upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
+                    upload_ac_results_strategy: nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                     ..Default::default()
                 },
                 max_action_timeout: Duration::MAX,

--- a/src/bin/cas.rs
+++ b/src/bin/cas.rs
@@ -119,8 +119,8 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
 
     fn into_encoding(from: &CompressionAlgorithm) -> Option<CompressionEncoding> {
         match from {
-            CompressionAlgorithm::Gzip => Some(CompressionEncoding::Gzip),
-            CompressionAlgorithm::None => None,
+            CompressionAlgorithm::gzip => Some(CompressionEncoding::Gzip),
+            CompressionAlgorithm::none => None,
         }
     }
 
@@ -197,7 +197,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                         AcServer::new(&cfg, &store_manager).map(|v| {
                             let mut service = v.into_service();
                             let send_algo = &server_cfg.compression.send_compression_algorithm;
-                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                                 service = service.send_compressed(encoding);
                             }
                             for encoding in server_cfg
@@ -221,7 +221,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                         CasServer::new(&cfg, &store_manager).map(|v| {
                             let mut service = v.into_service();
                             let send_algo = &server_cfg.compression.send_compression_algorithm;
-                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                                 service = service.send_compressed(encoding);
                             }
                             for encoding in server_cfg
@@ -245,7 +245,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                         ExecutionServer::new(&cfg, &action_schedulers, &store_manager).map(|v| {
                             let mut service = v.into_service();
                             let send_algo = &server_cfg.compression.send_compression_algorithm;
-                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                                 service = service.send_compressed(encoding);
                             }
                             for encoding in server_cfg
@@ -269,7 +269,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                         ByteStreamServer::new(&cfg, &store_manager).map(|v| {
                             let mut service = v.into_service();
                             let send_algo = &server_cfg.compression.send_compression_algorithm;
-                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                                 service = service.send_compressed(encoding);
                             }
                             for encoding in server_cfg
@@ -302,7 +302,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                 .map(|v| {
                     let mut service = v.into_service();
                     let send_algo = &server_cfg.compression.send_compression_algorithm;
-                    if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                    if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                         service = service.send_compressed(encoding);
                     }
                     for encoding in server_cfg
@@ -324,7 +324,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                         WorkerApiServer::new(&cfg, &worker_schedulers).map(|v| {
                             let mut service = v.into_service();
                             let send_algo = &server_cfg.compression.send_compression_algorithm;
-                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::None)) {
+                            if let Some(encoding) = into_encoding(&send_algo.unwrap_or(CompressionAlgorithm::none)) {
                                 service = service.send_compressed(encoding);
                             }
                             for encoding in server_cfg


### PR DESCRIPTION
To make the configuration more standardized we have moved all config properties that might be set in the json to be lower case.

Before we had a mix of sometimes lower case and sometimes upper. By making this a hard rule, we simplify a lot of this thought.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/461)
<!-- Reviewable:end -->
