### PR TITLE
Make max_bytes_per_stream optional in config

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json
+++ b/deployment-examples/docker-compose/local-storage-cas.json
@@ -56,9 +56,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }, {
@@ -91,9 +89,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }]

--- a/deployment-examples/terraform/AWS/scripts/cas.json
+++ b/deployment-examples/terraform/AWS/scripts/cas.json
@@ -140,9 +140,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_S3_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }]

--- a/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
+++ b/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
@@ -61,9 +61,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_STORE"
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000 // 64kb.
+        }
       }
     }
   }]

--- a/deployment-examples/terraform/GCP/module/scripts/cas.json
+++ b/deployment-examples/terraform/GCP/module/scripts/cas.json
@@ -107,9 +107,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_STORE"
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000 // 64kb.
+        }
       }
     }
   }, {
@@ -139,9 +137,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_STORE"
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000 // 64kb.
+        }
       }
     }
   }]

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -53,10 +53,7 @@ A very basic configuration that is a pure in-memory store is:
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371
-        // 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }]

--- a/nativelink-config/examples/basic_cas.json
+++ b/nativelink-config/examples/basic_cas.json
@@ -119,9 +119,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }, {

--- a/nativelink-config/examples/filesystem_cas.json
+++ b/nativelink-config/examples/filesystem_cas.json
@@ -142,9 +142,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }, {

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json
@@ -157,9 +157,7 @@
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",
-        },
-        // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
-        "max_bytes_per_stream": 64000, // 64kb.
+        }
       }
     }
   }]

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -120,7 +120,11 @@ pub struct ByteStreamConfig {
     pub cas_stores: HashMap<InstanceName, StoreRefName>,
 
     /// Max number of bytes to send on each grpc stream chunk.
-    #[serde(deserialize_with = "convert_numeric_with_shellexpand")]
+    /// According to <https://github.com/grpc/grpc.github.io/issues/371>
+    /// 16KiB - 64KiB is optimal.
+    ///
+    /// Defaults: 64KiB
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_bytes_per_stream: usize,
 
     /// In the event a client disconnects while uploading a blob, we will hold


### PR DESCRIPTION
Defaults "max_bytes_per_stream" to 64Kib in config file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/474)
<!-- Reviewable:end -->
