### PR TITLE
[Breaking] listen_address renamed/remapped in config

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json
+++ b/deployment-examples/docker-compose/local-storage-cas.json
@@ -40,7 +40,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051"
+      }
+    },
     "services": {
       "cas": {
         "main": {
@@ -63,7 +67,11 @@
     }
   }, {
     // Only publish metrics on a private port.
-    "listen_address": "0.0.0.0:50061",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061"
+      }
+    },
     "services": {
       "prometheus": {
         "path": "/metrics"
@@ -71,10 +79,14 @@
     }
   },
   {
-    "listen_address": "0.0.0.0:50071",
-    "tls": {
-      "cert_file": "/root/example-do-not-use-in-prod-rootca.crt",
-      "key_file": "/root/example-do-not-use-in-prod-key.pem"
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50071",
+        "tls": {
+          "cert_file": "/root/example-do-not-use-in-prod-rootca.crt",
+          "key_file": "/root/example-do-not-use-in-prod-key.pem"
+        }
+      }
     },
     "services": {
       "cas": {

--- a/deployment-examples/docker-compose/scheduler.json
+++ b/deployment-examples/docker-compose/scheduler.json
@@ -27,7 +27,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50052",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+      }
+    },
     "services": {
       "ac": {
         "main": {
@@ -49,7 +53,11 @@
       }
     }
   }, {
-    "listen_address": "0.0.0.0:50061",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061",
+      }
+    },
     "services": {
       // Note: This should be served on a different port, because it has
       // a different permission set than the other services.

--- a/deployment-examples/terraform/AWS/scripts/cas.json
+++ b/deployment-examples/terraform/AWS/scripts/cas.json
@@ -110,7 +110,7 @@
         "verify_size": true,
         "verify_hash": true
       }
-    },
+    }
   },
   "schedulers": {
     "MAIN_SCHEDULER": {
@@ -122,7 +122,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051",
+      }
+    },
     "services": {
       "cas": {
         "main": {

--- a/deployment-examples/terraform/AWS/scripts/scheduler.json
+++ b/deployment-examples/terraform/AWS/scripts/scheduler.json
@@ -119,7 +119,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50052",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+      }
+    },
     "services": {
       "ac": {
         "main": {
@@ -141,7 +145,11 @@
       }
     }
   }, {
-    "listen_address": "0.0.0.0:50061",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061",
+      }
+    },
     "services": {
       "prometheus": {
         "path": "/metrics"

--- a/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
+++ b/deployment-examples/terraform/GCP/module/scripts/browser_proxy.json
@@ -40,7 +40,11 @@
   "servers": [{
     // Non-public apis. We re-export the CAS services so we don't need to go through
     // an external load balancer.
-    "listen_address": "0.0.0.0:50052",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+      }
+    },
     "services": {
       "prometheus": {
         "path": "/metrics"

--- a/deployment-examples/terraform/GCP/module/scripts/cas.json
+++ b/deployment-examples/terraform/GCP/module/scripts/cas.json
@@ -77,18 +77,22 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
-    "tls": {
-      "cert_file": "${NATIVELINK_CERT_FILE:-}",
-      "key_file": "${NATIVELINK_KEY_FILE:-}"
-    },
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
-    },
-    // External apis support compression.
-    "compression": {
-      "send_compression_algorithm": "gzip",
-      "accepted_compression_algorithms": ["gzip"]
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051",
+        "tls": {
+          "cert_file": "${NATIVELINK_CERT_FILE:-}",
+          "key_file": "${NATIVELINK_KEY_FILE:-}"
+        },
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        },
+        // External apis support compression.
+        "compression": {
+          "send_compression_algorithm": "gzip",
+          "accepted_compression_algorithms": ["gzip"]
+        }
+      }
     },
     "services": {
       "cas": {
@@ -115,9 +119,13 @@
   }, {
     // Non-public apis. We re-export the CAS services so we don't need to go through
     // an external load balancer.
-    "listen_address": "0.0.0.0:50052",
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     "services": {
       "prometheus": {

--- a/deployment-examples/terraform/GCP/module/scripts/scheduler.json
+++ b/deployment-examples/terraform/GCP/module/scripts/scheduler.json
@@ -86,13 +86,17 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
-    "tls": {
-      "cert_file": "${nativelink_CERT_FILE:-}",
-      "key_file": "${nativelink_KEY_FILE:-}"
-    },
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051",
+        "tls": {
+          "cert_file": "${nativelink_CERT_FILE:-}",
+          "key_file": "${nativelink_KEY_FILE:-}"
+        },
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     "services": {
       "ac": {
@@ -117,9 +121,13 @@
   }, {
     // Non-public apis. We re-export the Scheduler services on a non-tls connection
     // for local services that don't need a load balancer.
-    "listen_address": "0.0.0.0:50052",
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     "services": {
       "prometheus": {
@@ -146,9 +154,13 @@
     }
   }, {
     // Internal Worker endpoint.
-    "listen_address": "0.0.0.0:50061",
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     "services": {
       // Note: This should be served on a different port, because it has

--- a/deployment-examples/terraform/GCP/module/scripts/worker.json
+++ b/deployment-examples/terraform/GCP/module/scripts/worker.json
@@ -84,16 +84,24 @@
     }
   }],
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     // Only /status will be served.
     "services": {}
   }, {
-    "listen_address": "0.0.0.0:50052",
-    "advanced_http": {
-      "http2_keep_alive_interval": 10
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50052",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
     },
     "services": {
       "prometheus": {

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -35,7 +35,14 @@ A very basic configuration that is a pure in-memory store is:
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051",
+        "advanced_http": {
+          "http2_keep_alive_interval": 10
+        }
+      }
+    },
     "services": {
       "cas": {
         "main": {

--- a/nativelink-config/examples/basic_cas.json
+++ b/nativelink-config/examples/basic_cas.json
@@ -91,7 +91,11 @@
   }],
   "servers": [{
     "name": "public",
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051"
+      }
+    },
     "services": {
       "cas": {
         "main": {
@@ -126,7 +130,11 @@
     }
   }, {
     "name": "private_workers_servers",
-    "listen_address": "0.0.0.0:50061",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061"
+      }
+    },
     "services": {
       "prometheus": {
         "path": "/metrics"

--- a/nativelink-config/examples/filesystem_cas.json
+++ b/nativelink-config/examples/filesystem_cas.json
@@ -114,7 +114,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051"
+      }
+    },
     "services": {
       "cas": {
         "main": {
@@ -148,7 +152,11 @@
       }
     }
   }, {
-    "listen_address": "0.0.0.0:50061",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50061"
+      }
+    },
     "services": {
       // Note: This should be served on a different port, because it has
       // a different permission set than the other services.

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json
@@ -129,7 +129,11 @@
     }
   },
   "servers": [{
-    "listen_address": "0.0.0.0:50051",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051"
+      }
+    },
     "services": {
       "cas": {
         "main": {

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -35,6 +35,7 @@ pub enum CompressionAlgorithm {
     /// No compression.
     #[default]
     none,
+
     /// Zlib compression.
     gzip,
 }
@@ -226,30 +227,71 @@ pub struct TlsConfig {
 /// specified.
 #[derive(Deserialize, Debug, Default)]
 pub struct HttpServerConfig {
-    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_max_pending_accept_reset_streams: Option<u32>,
-    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_initial_stream_window_size: Option<u32>,
-    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_initial_connection_window_size: Option<u32>,
-    #[serde(default)]
-    pub http2_adaptive_window: Option<bool>,
-    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_max_frame_size: Option<u32>,
-    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_max_concurrent_streams: Option<u32>,
+    /// Interval to send keep-alive pings via HTTP2.
     /// Note: This is in seconds.
     #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
     pub http2_keep_alive_interval: Option<u32>,
+
+    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
+    pub experimental_http2_max_pending_accept_reset_streams: Option<u32>,
+
+    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
+    pub experimental_http2_initial_stream_window_size: Option<u32>,
+
+    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
+    pub experimental_http2_initial_connection_window_size: Option<u32>,
+
+    #[serde(default)]
+    pub experimental_http2_adaptive_window: Option<bool>,
+
+    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
+    pub experimental_http2_max_frame_size: Option<u32>,
+
+    #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
+    pub experimental_http2_max_concurrent_streams: Option<u32>,
+
     /// Note: This is in seconds.
     #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_keep_alive_timeout: Option<u32>,
+    pub experimental_http2_keep_alive_timeout: Option<u32>,
+
     #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_max_send_buf_size: Option<u32>,
+    pub experimental_http2_max_send_buf_size: Option<u32>,
+
     #[serde(default)]
-    pub http2_enable_connect_protocol: Option<bool>,
+    pub experimental_http2_enable_connect_protocol: Option<bool>,
+
     #[serde(default, deserialize_with = "convert_optinoal_numeric_with_shellexpand")]
-    pub http2_max_header_list_size: Option<u32>,
+    pub experimental_http2_max_header_list_size: Option<u32>,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Deserialize, Debug)]
+pub enum ListenerConfig {
+    /// Listener for HTTP/HTTPS/HTTP2 sockets.
+    http(HttpListener),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct HttpListener {
+    /// Address to listen on. Example: `127.0.0.1:8080` or `:8080` to listen
+    /// to all IPs.
+    #[serde(deserialize_with = "convert_string_with_shellexpand")]
+    pub socket_address: String,
+
+    /// Data transport compression configuration to use for this service.
+    #[serde(default)]
+    pub compression: CompressionConfig,
+
+    /// Advanced Http server configuration.
+    #[serde(default)]
+    pub advanced_http: HttpServerConfig,
+
+    /// Tls Configuration for this server.
+    /// If not set, the server will not use TLS.
+    ///
+    /// Default: None
+    #[serde(default)]
+    pub tls: Option<TlsConfig>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -261,28 +303,11 @@ pub struct ServerConfig {
     #[serde(default, deserialize_with = "convert_string_with_shellexpand")]
     pub name: String,
 
-    /// Address to listen on. Example: `127.0.0.1:8080` or `:8080` to listen
-    /// to all IPs.
-    #[serde(deserialize_with = "convert_string_with_shellexpand")]
-    pub listen_address: String,
-
-    /// Data transport compression configuration to use for this service.
-    #[serde(default)]
-    pub compression: CompressionConfig,
-
-    /// Advanced Http server configuration.
-    #[serde(default)]
-    pub advanced_http: HttpServerConfig,
+    /// Configuration
+    pub listener: ListenerConfig,
 
     /// Services to attach to server.
     pub services: Option<ServicesConfig>,
-
-    /// Tls Configuration for this server.
-    /// If not set, the server will not use TLS.
-    ///
-    /// Default: None
-    #[serde(default)]
-    pub tls: Option<TlsConfig>,
 }
 
 #[allow(non_camel_case_types)]
@@ -330,7 +355,7 @@ pub enum UploadCacheResultsStrategy {
 #[allow(non_camel_case_types)]
 #[derive(Clone, Deserialize, Debug)]
 pub enum EnvironmentSource {
-    /// The name of the property in the action to get the value from.
+    /// The name of the platform property in the action to get the value from.
     property(String),
 
     /// The raw value to set.
@@ -517,7 +542,12 @@ pub enum WorkerConfig {
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Clone, Copy)]
 pub enum ConfigDigestHashFunction {
+    /// Use the sha256 hash function.
+    /// <https://en.wikipedia.org/wiki/SHA-2>
     sha256,
+
+    /// Use the blake3 hash function.
+    /// <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
     blake3,
 }
 
@@ -567,7 +597,7 @@ pub struct GlobalConfig {
     /// Default hash function to use while uploading blobs to the CAS when not set
     /// by client.
     ///
-    /// Default: ConfigDigestHashFunction::Sha256
+    /// Default: ConfigDigestHashFunction::sha256
     pub default_digest_hash_function: Option<ConfigDigestHashFunction>,
 }
 


### PR DESCRIPTION
Moved `listen_address` to `listener.http.socket_address` mapping.

This future proofs our config a bit more so we can add other kinds of listeners that are not http based (like unix sockets).

In doing this we also moved the http(s)/http2 related fields into the same struct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/476)
<!-- Reviewable:end -->
