### PR TITLE
S3 Store Credential Provider

### DIFF
--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use std::{cmp, env};
 
 use async_trait::async_trait;
+use aws_config::default_provider::credentials;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
 use aws_sdk_s3::operation::get_object::GetObjectError;
@@ -152,7 +153,9 @@ impl S3Store {
         });
         let s3_client = {
             let http_client = HyperClientBuilder::new().build(TlsConnector::new(config, jitter_fn.clone()));
+            let credential_provider = credentials::default_provider().await;
             let mut config_builder = aws_config::from_env()
+                .credentials_provider(credential_provider)
                 .region(Region::new(Cow::Owned(config.region.clone())))
                 .http_client(http_client);
             // TODO(allada) When aws-sdk supports this env variable we should be able


### PR DESCRIPTION
# Description

Credential provider is not supplied when creating [`aws_config::from_env()`](https://docs.rs/aws-config/0.57.1/aws_config/fn.from_env.html), that leads to failure responses seen in https://github.com/TraceMachina/nativelink/issues/428.

Pass the [`aws_config::default_provider::credentials.default_provider`](https://docs.rs/aws-config/0.57.1/aws_config/default_provider/credentials/fn.default_provider.html) into the `aws_config::from_env()` builder which should pick up the proper credentials for the environment based on the following [resolution order](https://docs.rs/aws-config/0.57.1/src/aws_config/default_provider/credentials.rs.html#27). 

Fixes # (issue)

https://github.com/TraceMachina/nativelink/issues/428 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested credentials provider with https://gist.github.com/adam-singer/8123e54aa990816ef400200d3de32591, since test depends on live buckets/environments an integration test was not provided (yet?). 

Without the credential provider the expected response object would contain

```
Err(
    DispatchFailure(
        DispatchFailure {
            source: ConnectorError {
                kind: Other(
                    None,
                ),
                source: CredentialsNotLoaded(
                    CredentialsNotLoaded {
                        source: "no providers in chain provided credentials",
                    },
                ),
                connection: Unknown,
            },
        },
    ),
)
``` 

With the credential provider the expected response object should contain

```
[...]
Ok(
    ListObjectsOutput {
        is_truncated: false,
        marker: Some(
            "",
        ),
        next_marker: None,
        contents: Some(
            [
                Object {
                    key: Some(
                        "test1.txt",
                    ),
[...]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/494)
<!-- Reviewable:end -->
