### PR TITLE
Include the long command example for Windows Powershell in documentat…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,14 @@ various Cloud CLIs for you:
     @rules_rust//:rustfmt
   ```
 
+  For Windows Powershell;
+
+  ```powershell
+  bazel run `
+    --@rules_rust//:rustfmt.toml=//:.rustfmt.toml `
+    @rules_rust//:rustfmt
+  ```
+
 ## Updating Rust dependencies
 
 After modifying the corresponding `Cargo.toml` file in either the top level or

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ bazel test //... \
   --remote_default_exec_properties=cpu_count=1
 ```
 
+For Windows Powershell;
+
+```powershell
+bazel test //... `
+  --remote_instance_name=main `
+  --remote_cache=grpc://127.0.0.1:50051 `
+  --remote_executor=grpc://127.0.0.1:50051 `
+  --remote_default_exec_properties=cpu_count=1
+```
+
 This causes bazel to run the commands through an all-in-one `CAS`, `scheduler`
 and `worker`.
 


### PR DESCRIPTION
# Description

On Ubuntu and MacOS, they use "\" character for line truncations of a long command.
But the problem is that on Windows, we use "^" character for line truncations on Command Prompt Tool and "`" character on Powershell Tool. Most users like to copy the whole lines of command without editing when they first approach this project.
More detailed description can be found in the issue below.

Fixes #500 

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/501)
<!-- Reviewable:end -->
