### PR TITLE
Migrate L2 announcements and LB-IPAM to cilium

### DIFF
--- a/deployment-examples/kubernetes/01_operations.sh
+++ b/deployment-examples/kubernetes/01_operations.sh
@@ -3,7 +3,11 @@
 # TODO(aaronmondal): Add Grafana, OpenTelemetry and the various other standard
 #                    deployments one would expect in a cluster.
 
-kubectl apply -f gateway.yaml
+set -xeuo pipefail
+
+SRC_ROOT=$(git rev-parse --show-toplevel)
+
+kubectl apply -f ${SRC_ROOT}/deployment-examples/kubernetes/gateway.yaml
 
 IMAGE_TAG=$(nix eval .#image.imageTag --raw)
 

--- a/deployment-examples/kubernetes/README.md
+++ b/deployment-examples/kubernetes/README.md
@@ -3,8 +3,8 @@
 This deployment sets up a 3-container deployment with separate CAS, scheduler
 and worker. Don't use this example deployment in production. It's insecure.
 
-In this example we're using `kind` to set up the cluster and `cilium` with
-`metallb` to provide a `LoadBalancer` and `GatewayController`.
+In this example we're using `kind` to set up the cluster `cilium` to provide a
+`LoadBalancer` and `GatewayController`.
 
 First set up a local development cluster:
 
@@ -41,8 +41,8 @@ echo "Scheduler IP: $SCHEDULER"
 
 # Prints something like:
 #
-# Cache IP: 172.20.255.200
-# Scheduler IP: 172.20.255.201
+# Cache IP: 172.20.255.4
+# Scheduler IP: 172.20.255.5
 ```
 
 You can now pass these IPs to your bazel invocation to use the remote cache and
@@ -65,8 +65,8 @@ bazel test \
 > # .bazelrc.user
 > build --config=lre
 > build --remote_instance_name=main
-> build --remote_cache=grpc://172.20.255.200:50051
-> build --remote_executor=grpc://172.20.255.201:50052
+> build --remote_cache=grpc://172.20.255.4:50051
+> build --remote_executor=grpc://172.20.255.5:50052
 > ```
 
 When you're done testing, delete the cluster:


### PR DESCRIPTION
No need to use MetalLB since Cilium can do this as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/505)
<!-- Reviewable:end -->
