### PR TITLE
Support empty digests in stores

### DIFF
--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
     name = "nativelink-store",
     srcs = [
         "src/ac_utils.rs",
+        "src/cas_utils.rs",
         "src/completeness_checking_store.rs",
         "src/compression_store.rs",
         "src/dedup_store.rs",
@@ -106,6 +107,7 @@ rust_test_suite(
         "@crate_index//:once_cell",
         "@crate_index//:pretty_assertions",
         "@crate_index//:rand",
+        "@crate_index//:sha2",
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
     ],

--- a/nativelink-store/src/cas_utils.rs
+++ b/nativelink-store/src/cas_utils.rs
@@ -1,0 +1,39 @@
+// Copyright 2023 The Native Link Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nativelink_util::common::DigestInfo;
+
+const ZERO_BYTE_DIGESTS: [DigestInfo; 2] = [
+    // Sha256 hash of zero bytes.
+    DigestInfo::new(
+        [
+            0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae,
+            0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+        ],
+        0,
+    ),
+    // Blake3 hash of zero bytes.
+    DigestInfo::new(
+        [
+            0xaf, 0x13, 0x49, 0xb9, 0xf5, 0xf9, 0xa1, 0xa6, 0xa0, 0x40, 0x4d, 0xea, 0x36, 0xdc, 0xc9, 0x49, 0x9b, 0xcb,
+            0x25, 0xc9, 0xad, 0xc1, 0x12, 0xb7, 0xcc, 0x9a, 0x93, 0xca, 0xe4, 0x1f, 0x32, 0x62,
+        ],
+        0,
+    ),
+];
+
+#[inline]
+pub fn is_zero_digest(digest: &DigestInfo) -> bool {
+    digest.size_bytes == 0 && ZERO_BYTE_DIGESTS.contains(digest)
+}

--- a/nativelink-store/src/lib.rs
+++ b/nativelink-store/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod ac_utils;
+pub mod cas_utils;
 pub mod completeness_checking_store;
 pub mod compression_store;
 pub mod dedup_store;

--- a/nativelink-store/tests/cas_utils_test.rs
+++ b/nativelink-store/tests/cas_utils_test.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 The Native Link Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod cas_utils_tests {
+    use blake3::Hasher as Blake3;
+    use nativelink_store::cas_utils::is_zero_digest;
+    use nativelink_util::common::DigestInfo;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn sha256_is_zero_digest() {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+        assert_eq!(is_zero_digest(&digest), true);
+    }
+
+    #[test]
+    fn sha256_is_non_zero_digest() {
+        let mut hasher = Sha256::new();
+        hasher.update(b"a");
+        let digest = DigestInfo {
+            packed_hash: hasher.finalize().into(),
+            size_bytes: 1,
+        };
+        assert_eq!(is_zero_digest(&digest), false);
+    }
+
+    #[test]
+    fn blake_is_zero_digest() {
+        let digest = DigestInfo {
+            packed_hash: Blake3::new().finalize().into(),
+            size_bytes: 0,
+        };
+        assert_eq!(is_zero_digest(&digest), true);
+    }
+
+    #[test]
+    fn blake_is_non_zero_digest() {
+        let mut hasher = Blake3::new();
+        hasher.update(b"a");
+        let digest = DigestInfo {
+            packed_hash: hasher.finalize().into(),
+            size_bytes: 1,
+        };
+        assert_eq!(is_zero_digest(&digest), false);
+    }
+}

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, SystemTime};
 
 use async_lock::RwLock;
 use async_trait::async_trait;
+use bytes::Bytes;
 use filetime::{set_file_atime, FileTime};
 use futures::executor::block_on;
 use futures::task::Poll;
@@ -41,6 +42,7 @@ use nativelink_util::evicting_map::LenEntry;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
 use once_cell::sync::Lazy;
 use rand::{thread_rng, Rng};
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Barrier;
 use tokio::time::sleep;
@@ -906,6 +908,111 @@ mod filesystem_store_tests {
             .err_tip(|| "Error reading bytes")?;
 
         assert_eq!(&file_data, large_value.as_bytes(), "Expected file content to match");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_part_is_zero_digest() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+        let content_path = make_temp_path("content_path");
+        let temp_path = make_temp_path("temp_path");
+
+        let store = Arc::new(
+            FilesystemStore::<FileEntryImpl>::new_with_timeout(
+                &nativelink_config::stores::FilesystemStore {
+                    content_path: content_path.clone(),
+                    temp_path: temp_path.clone(),
+                    read_buffer_size: 1,
+                    ..Default::default()
+                },
+                |_| sleep(Duration::ZERO),
+            )
+            .await?,
+        );
+
+        let store_clone = store.clone();
+        let (mut writer, mut reader) = make_buf_channel_pair();
+
+        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+            let _ = Pin::new(store_clone.as_ref())
+                .get_part_ref(digest, &mut writer, 0, None)
+                .await
+                .err_tip(|| "Failed to get_part_ref");
+        }));
+
+        let file_data = DropCloserReadHalf::take(&mut reader, 1024)
+            .await
+            .err_tip(|| "Error reading bytes")?;
+
+        let empty_bytes = Bytes::new();
+        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+        let content_path = make_temp_path("content_path");
+        let temp_path = make_temp_path("temp_path");
+
+        let store = Arc::new(
+            FilesystemStore::<FileEntryImpl>::new_with_timeout(
+                &nativelink_config::stores::FilesystemStore {
+                    content_path: content_path.clone(),
+                    temp_path: temp_path.clone(),
+                    read_buffer_size: 1,
+                    ..Default::default()
+                },
+                |_| sleep(Duration::ZERO),
+            )
+            .await?,
+        );
+
+        let digests = vec![digest];
+        let mut results = vec![None];
+        let _ = Pin::new(store.as_ref())
+            .has_with_results(&digests, &mut results)
+            .await
+            .err_tip(|| "Failed to get_part_ref");
+        assert_eq!(results, vec!(Some(0)));
+
+        async fn wait_for_empty_content_file<Fut: Future<Output = Result<(), Error>>, F: Fn() -> Fut>(
+            content_path: &str,
+            digest: DigestInfo,
+            yield_fn: F,
+        ) -> Result<(), Error> {
+            loop {
+                yield_fn().await?;
+
+                let empty_digest_file_name =
+                    OsString::from(format!("{}/{}-{}", content_path, digest.hash_str(), digest.size_bytes));
+
+                let file_metadata = fs::metadata(empty_digest_file_name)
+                    .await
+                    .err_tip(|| "Failed to open content file")?;
+
+                // Test that the empty digest file is created and contains an empty length.
+                if file_metadata.is_file() && file_metadata.len() == 0 {
+                    println!("{}", file_metadata.is_file());
+                    return Ok(());
+                }
+            }
+            // Unreachable.
+        }
+
+        wait_for_empty_content_file(&content_path, digest, || async move {
+            tokio::task::yield_now().await;
+            Ok(())
+        })
+        .await?;
 
         Ok(())
     }

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 use std::pin::Pin;
+use std::sync::Arc;
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use memory_stats::memory_stats;
 use nativelink_error::{Error, ResultExt};
 use nativelink_store::memory_store::MemoryStore;
-use nativelink_util::common::DigestInfo;
+use nativelink_util::buf_channel::{make_buf_channel_pair, DropCloserReadHalf};
+use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
 use nativelink_util::store_trait::Store;
+use sha2::{Digest, Sha256};
 
 const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 const VALID_HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
@@ -31,6 +34,7 @@ const INVALID_HASH: &str = "g111111111111111111111111111111111111111111111111111
 
 #[cfg(test)]
 mod memory_store_tests {
+
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -207,6 +211,56 @@ mod memory_store_tests {
             // With an empty store .get() should fail too.
             get_should_fail(store, VALID_HASH1, 1).await;
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_part_is_zero_digest() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+
+        let store = Arc::new(MemoryStore::new(&nativelink_config::stores::MemoryStore::default()));
+        let store_clone = store.clone();
+        let (mut writer, mut reader) = make_buf_channel_pair();
+
+        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+            let _ = Pin::new(store_clone.as_ref())
+                .get_part_ref(digest, &mut writer, 0, None)
+                .await
+                .err_tip(|| "Failed to get_part_ref");
+        }));
+
+        let file_data = DropCloserReadHalf::take(&mut reader, 1024)
+            .await
+            .err_tip(|| "Error reading bytes")?;
+
+        let empty_bytes = Bytes::new();
+        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+        let digests = vec![digest];
+        let mut results = vec![None];
+
+        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+        let store = Pin::new(&store_owned);
+
+        let _ = store
+            .as_ref()
+            .has_with_results(&digests, &mut results)
+            .await
+            .err_tip(|| "Failed to get_part_ref");
+        assert_eq!(results, vec!(Some(0)));
+
         Ok(())
     }
 }

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -26,8 +26,10 @@ use http::status::StatusCode;
 use hyper::Body;
 use nativelink_error::{Error, ResultExt};
 use nativelink_store::s3_store::S3Store;
-use nativelink_util::common::DigestInfo;
+use nativelink_util::buf_channel::{make_buf_channel_pair, DropCloserReadHalf};
+use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
 use nativelink_util::store_trait::Store;
+use sha2::{Digest, Sha256};
 
 // TODO(aaronmondal): Figure out how to test the connector retry mechanism.
 
@@ -520,6 +522,81 @@ mod s3_store_tests {
         );
 
         mock_client.assert_requests_match(&[]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_part_is_zero_digest() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+
+        let mock_client = StaticReplayClient::new(vec![]);
+        let test_config = Builder::new()
+            .region(Region::from_static(REGION))
+            .http_client(mock_client)
+            .build();
+        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+        let store = Arc::new(S3Store::new_with_client_and_jitter(
+            &nativelink_config::stores::S3Store {
+                bucket: BUCKET_NAME.to_string(),
+                ..Default::default()
+            },
+            s3_client,
+            Arc::new(move |_delay| Duration::from_secs(0)),
+        )?);
+        let store_clone = store.clone();
+        let (mut writer, mut reader) = make_buf_channel_pair();
+
+        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+            let _ = Pin::new(store_clone.as_ref())
+                .get_part_ref(digest, &mut writer, 0, None)
+                .await
+                .err_tip(|| "Failed to get_part_ref");
+        }));
+
+        let file_data = DropCloserReadHalf::take(&mut reader, 1024)
+            .await
+            .err_tip(|| "Error reading bytes")?;
+
+        let empty_bytes = Bytes::new();
+        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+        let digest = DigestInfo {
+            packed_hash: Sha256::new().finalize().into(),
+            size_bytes: 0,
+        };
+        let digests = vec![digest];
+        let mut results = vec![None];
+
+        let mock_client = StaticReplayClient::new(vec![]);
+        let test_config = Builder::new()
+            .region(Region::from_static(REGION))
+            .http_client(mock_client)
+            .build();
+        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+        let store_owned = S3Store::new_with_client_and_jitter(
+            &nativelink_config::stores::S3Store {
+                bucket: BUCKET_NAME.to_string(),
+                ..Default::default()
+            },
+            s3_client,
+            Arc::new(move |_delay| Duration::from_secs(0)),
+        )?;
+        let store = Pin::new(&store_owned);
+
+        let _ = store
+            .as_ref()
+            .has_with_results(&digests, &mut results)
+            .await
+            .err_tip(|| "Failed to get_part_ref");
+        assert_eq!(results, vec!(Some(0)));
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

[remote_execution.proto](https://github.com/TraceMachina/nativelink/blob/e1c495fa68b5d85872c98f9231689da4581161b1/nativelink-proto/build/bazel/remote/execution/v2/remote_execution.proto#L333) specification allows for uploading and fetching of empty digests regardless if they have been uploaded before a fetch. Expectation is the requests should always respond successfully. This can be an optimized path in cases but violates expectations in native link underlying storage consistencies.

Fixes # 

https://github.com/TraceMachina/nativelink/issues/498

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests

## Checklist

- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/507)
<!-- Reviewable:end -->
