### PR TITLE
Fix kill_all_waits_for_all_tasks_to_finish test stuck on windows

### DIFF
--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -2508,7 +2508,7 @@ exit 1
         tokio::pin!(execute_results_fut);
         {
             // Advance the action as far as possible and ensure we are not waiting on cleanup.
-            for _ in 0..1000 {
+            for _ in 0..100 {
                 assert!(futures::poll!(&mut execute_results_fut).is_pending());
                 tokio::task::yield_now().await;
             }


### PR DESCRIPTION
# Description

While I was testing on Windows x64 machine, I found out that running_actions_manager_tests::kill_all_waits_for_all_tasks_to_finish test never ends when I test with cargo test --all command.
Decreasing this number from 1000 to 100 seems to fix the problem on my machine.
I think being stuck or not depends on the operating system and the device's performance.
My Windows x64 machine was VPS with 8GB RAM. So maybe 1000 iteration got stuck I think.
In my opinion, 100 would be a reasonable number for this.

Fixes #492 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/525)
<!-- Reviewable:end -->
