### PR TITLE
Add small sleep in some tests to reduce flakes in CI

### DIFF
--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -496,6 +496,8 @@ mod local_worker_tests {
             drop(file);
             precondition_script
         };
+        // TODO(#527) Sleep to reduce flakey chances.
+        tokio::time::sleep(Duration::from_millis(250)).await;
         let local_worker_config = LocalWorkerConfig {
             experimental_precondition_script: Some(precondition_script),
             ..Default::default()

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -1376,6 +1376,9 @@ exit 0
             test_wrapper_script
         };
 
+        // TODO(#527) Sleep to reduce flakey chances.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
             root_work_directory: root_work_directory.clone(),
             execution_configuration: ExecutionConfiguration {
@@ -1504,6 +1507,9 @@ exit 0
 
             test_wrapper_script
         };
+
+        // TODO(#527) Sleep to reduce flakey chances.
+        tokio::time::sleep(Duration::from_millis(250)).await;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
             root_work_directory: root_work_directory.clone(),
@@ -1645,6 +1651,9 @@ exit 1
 
             test_wrapper_script
         };
+
+        // TODO(#527) Sleep to reduce flakey chances.
+        tokio::time::sleep(Duration::from_millis(250)).await;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
             root_work_directory: root_work_directory.clone(),


### PR DESCRIPTION
This is to get around a docker-in-ci bug with how the host machine
is not able to sync files to disk properly.
    
see: #527

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/526)
<!-- Reviewable:end -->
