### PR TITLE
MacOS enable flake nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,10 +30,10 @@
 
           maybeDarwinDeps = pkgs.lib.optionals isDarwin [
               pkgs.darwin.apple_sdk.frameworks.Security
-              pkgs.libiconv
+              pkgs.darwin.libiconv
           ];
 
-          customStdenv = import ./tools/llvmStdenv.nix { inherit pkgs; };
+          customStdenv = import ./tools/llvmStdenv.nix { inherit pkgs isDarwin; };
 
           # TODO(aaronmondal): This doesn't work with rules_rust yet.
           # Tracked in https://github.com/TraceMachina/nativelink/issues/477.
@@ -54,11 +54,10 @@
           commonArgs = {
             inherit src;
             strictDeps = true;
-            buildInputs = [ ];
+            buildInputs = maybeDarwinDeps;
             nativeBuildInputs = [
-              pkgs.autoPatchelfHook
               pkgs.cacert
-            ] ++ maybeDarwinDeps;
+            ] ++ maybeDarwinDeps ++ pkgs.lib.optionals (!isDarwin) [ pkgs.autoPatchelfHook ];
             stdenv = customStdenv;
           };
 

--- a/tools/llvmStdenv.nix
+++ b/tools/llvmStdenv.nix
@@ -1,7 +1,24 @@
-{ pkgs, ... }:
+{ pkgs, isDarwin ? false, ... }:
 
 let
 llvmPackages = pkgs.llvmPackages_16;
+
+toolchain = if isDarwin then (
+  pkgs.overrideCC (
+    llvmPackages.libcxxStdenv.override {
+      targetPlatform.useLLVM = true;
+    }
+  )
+  llvmPackages.clangUseLLVM
+) else (pkgs.useMoldLinker (
+  pkgs.overrideCC (
+    llvmPackages.libcxxStdenv.override {
+      targetPlatform.useLLVM = true;
+    }
+  )
+  llvmPackages.clangUseLLVM
+));
+
 in
 
 # This toolchain uses Clang as compiler, Mold as linker, libc++ as C++ standard
@@ -31,11 +48,4 @@ in
 # compatibility, reduced closure size, and static-linking-friendly licensing.
 # This requires building the llvm project with the correct multistage
 # bootstrapping process.
-pkgs.useMoldLinker (
-  pkgs.overrideCC (
-    llvmPackages.libcxxStdenv.override {
-      targetPlatform.useLLVM = true;
-    }
-  )
-  llvmPackages.clangUseLLVM
-)
+toolchain


### PR DESCRIPTION
# Description

* Use built in darwin iconv library
* Make auto elf optional and not included on darwin
* On darwin use llvm linker and non-llvm use mold linker

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually tests on MacOS

```
nix build
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/529)
<!-- Reviewable:end -->
