### PR TITLE
Shard store weight scale distribution

### DIFF
--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -62,6 +62,12 @@ impl MemoryStore {
         }
     }
 
+    /// Returns the number of key-value pairs that are currently in the the cache.
+    /// Function is not for production code paths.
+    pub async fn len_for_test(&self) -> usize {
+        self.evicting_map.len_for_test().await
+    }
+
     pub async fn remove_entry(&self, digest: &DigestInfo) -> bool {
         self.evicting_map.remove(digest).await
     }

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -19,19 +19,27 @@ use nativelink_error::Error;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_store::shard_store::ShardStore;
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::store_trait::Store;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
 const MEGABYTE_SZ: usize = 1024 * 1024;
 
-fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<dyn Store>>) {
+fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<MemoryStore>>) {
     let memory_store_config = nativelink_config::stores::MemoryStore::default();
     let store_config = nativelink_config::stores::StoreConfig::memory(memory_store_config.clone());
     let stores: Vec<_> = weights
         .iter()
-        .map(|_| -> Arc<dyn Store> { Arc::new(MemoryStore::new(&memory_store_config)) })
+        .map(|_| Arc::new(MemoryStore::new(&memory_store_config)))
         .collect();
+    let stores_dyn: Vec<_> = stores
+        .clone()
+        .iter()
+        .cloned()
+        .map(|x| -> Arc<dyn Store> { x })
+        .collect();
+
     let shard_store = Arc::new(
         ShardStore::new(
             &nativelink_config::stores::ShardStore {
@@ -43,7 +51,7 @@ fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<dyn Store>>) {
                     })
                     .collect(),
             },
-            stores.clone(),
+            stores_dyn.clone(),
         )
         .unwrap(),
     );
@@ -57,8 +65,43 @@ fn make_random_data(sz: usize) -> Vec<u8> {
     value
 }
 
+async fn verify_weights(
+    weights: &[u32],
+    expected_hits: &[usize],
+    rounds: u64,
+    print_results: bool,
+) -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(weights);
+    let shard_store = Pin::new(shard_store.as_ref());
+    let stores: Vec<_> = stores.iter().map(|store| Pin::new(store.as_ref())).collect();
+    let data = make_random_data(MEGABYTE_SZ);
+
+    for counter in 0..rounds {
+        let hasher = &mut DigestHasher::from(DigestHasherFunc::Blake3);
+        hasher.update(&counter.to_le_bytes());
+        let digest = hasher.finalize_digest(counter as i64);
+        shard_store.update_oneshot(digest, data.clone().into()).await?;
+    }
+
+    let stores_and_hits: Vec<(&Pin<&MemoryStore>, &usize)> = stores.iter().zip(expected_hits.iter()).collect();
+
+    for (index, (&store, &expected_hit)) in stores_and_hits.iter().enumerate() {
+        let total_hits = store.len_for_test().await;
+        if print_results {
+            println!("expected_hit: {expected_hit} - total_hits: {total_hits}");
+        } else {
+            assert_eq!(
+                expected_hit, total_hits,
+                "Index {index} failed with expected_hit: {expected_hit} != total_hits: {total_hits}"
+            )
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod shard_store_tests {
+
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -241,5 +284,30 @@ mod shard_store_tests {
         assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ)));
         assert_eq!(stores[1].has(digest1).await, Ok(None));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn verify_weights_even_weights() -> Result<(), Error> {
+        verify_weights(&[1, 1, 1, 1, 1, 1], &[188, 168, 158, 175, 147, 164], 1000, false).await
+    }
+
+    #[tokio::test]
+    async fn verify_weights_mid_right_bias() -> Result<(), Error> {
+        verify_weights(&[1, 1, 1, 100, 1, 1], &[5, 13, 12, 956, 4, 10], 1000, false).await
+    }
+
+    #[tokio::test]
+    async fn verify_weights_mid_left_bias() -> Result<(), Error> {
+        verify_weights(&[1, 1, 100, 1, 1, 1], &[5, 13, 962, 6, 4, 10], 1000, false).await
+    }
+
+    #[tokio::test]
+    async fn verify_weights_left_bias() -> Result<(), Error> {
+        verify_weights(&[100, 1, 1, 1, 1, 1], &[961, 11, 8, 6, 4, 10], 1000, false).await
+    }
+
+    #[tokio::test]
+    async fn verify_weights_right_bias() -> Result<(), Error> {
+        verify_weights(&[1, 1, 1, 1, 1, 100], &[5, 13, 12, 5, 11, 954], 1000, false).await
     }
 }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -165,6 +165,12 @@ where
         }
     }
 
+    /// Returns the number of key-value pairs that are currently in the the cache.
+    /// Function is not for production code paths.
+    pub async fn len_for_test(&self) -> usize {
+        self.state.lock().await.lru.len()
+    }
+
     pub async fn build_lru_index(&self) -> SerializedLRU {
         let state = self.state.lock().await;
         let mut serialized_lru = SerializedLRU {


### PR DESCRIPTION
# Description

* Fixes a bug where weights are not scaled to distribution space by summing weights after being scaled.
* Extend key data with size in bytes of digest object.
* Added test methods for getting internal length state, methods not needed for general use and marked as `_test`
* Added tests for verifying distributions with rounds of tests, spot checked the distributions look correct without statistical testing.  

Fixes # (issue)

https://github.com/TraceMachina/nativelink/issues/497

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/574)
<!-- Reviewable:end -->
