### PR TITLE
Add Blake3 support for Verify Store

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json
+++ b/deployment-examples/docker-compose/local-storage-cas.json
@@ -25,7 +25,7 @@
           }
         },
         "verify_size": true,
-        "verify_hash": true
+        "hash_verification_function": "sha256"
       }
     },
     "AC_MAIN_STORE": {

--- a/deployment-examples/terraform/experimental_AWS/scripts/cas.json
+++ b/deployment-examples/terraform/experimental_AWS/scripts/cas.json
@@ -108,7 +108,7 @@
           }
         },
         "verify_size": true,
-        "verify_hash": true
+        "hash_verification_function": "sha256"
       }
     }
   },

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -291,9 +291,10 @@ the rest will be stored in AWS's S3:
 
 This store is special. It's only job is to verify the content as it is fetched
 and uploaded to ensure it meets some criteria or errors. This store should only
-be added to the CAS. If `verify_hash` is set to true, it will apply a sha256
-algorithm on the data as it is sent/received and at the end if it does not match
-the name of the digest it will cancel the upload/download and return an error.
+be added to the CAS. If `hash_verification_function` is set, it will apply the
+hashing algorithm on the data as it is sent/received and at the end if it does
+not match the name of the digest it will cancel the upload/download and return
+an error. If it's not set, the hashing verification will be disabled.
 If `verify_size` is set, a similar item will happen, but count the bytes sent
 and check it against the digest instead.
 
@@ -311,7 +312,8 @@ and check it against the digest instead.
           }
         },
         "verify_size": true,
-        "verify_hash": true,
+        // sha256 or blake3
+        "hash_verification_function": "sha256",
       }
     },
     "AC_MAIN_STORE": {

--- a/nativelink-config/examples/filesystem_cas.json
+++ b/nativelink-config/examples/filesystem_cas.json
@@ -76,7 +76,7 @@
           }
         },
         "verify_size": true,
-        "verify_hash": true
+        "hash_verification_function": "sha256"
       }
     },
     "AC_MAIN_STORE": {

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json
@@ -68,7 +68,7 @@
           }
         },
         "verify_size": true,
-        "verify_hash": true
+        "hash_verification_function": "sha256"
       }
     },
     "AC_MAIN_STORE": {

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -20,7 +20,7 @@ use crate::schedulers::SchedulerConfig;
 use crate::serde_utils::{
     convert_numeric_with_shellexpand, convert_optinoal_numeric_with_shellexpand, convert_string_with_shellexpand,
 };
-use crate::stores::{StoreConfig, StoreRefName};
+use crate::stores::{ConfigDigestHashFunction, StoreConfig, StoreRefName};
 
 /// Name of the scheduler. This type will be used when referencing a
 /// scheduler in the `CasConfig::schedulers`'s map key.
@@ -541,18 +541,6 @@ pub struct LocalWorkerConfig {
 pub enum WorkerConfig {
     /// A worker type that executes jobs locally on this machine.
     local(LocalWorkerConfig),
-}
-
-#[allow(non_camel_case_types)]
-#[derive(Deserialize, Debug, Clone, Copy)]
-pub enum ConfigDigestHashFunction {
-    /// Use the sha256 hash function.
-    /// <https://en.wikipedia.org/wiki/SHA-2>
-    sha256,
-
-    /// Use the blake3 hash function.
-    /// <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
-    blake3,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -21,6 +21,18 @@ use crate::serde_utils::{convert_numeric_with_shellexpand, convert_string_with_s
 pub type StoreRefName = String;
 
 #[allow(non_camel_case_types)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum ConfigDigestHashFunction {
+    /// Use the sha256 hash function.
+    /// <https://en.wikipedia.org/wiki/SHA-2>
+    sha256,
+
+    /// Use the blake3 hash function.
+    /// <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
+    blake3,
+}
+
+#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum StoreConfig {
     /// Memory store will store all data in a hashmap in memory.
@@ -329,12 +341,13 @@ pub struct VerifyStore {
     #[serde(default)]
     pub verify_size: bool,
 
-    /// If set this store will hash the contents and verify it matches the
-    /// digest hash before writing the entry to underlying store.
+    /// The digest hash function to hash the contents and to verify if the digest hash is
+    /// matching before writing the entry to underlying store.
     ///
-    /// This should be set to false for AC, but true for CAS stores.
-    #[serde(default)]
-    pub verify_hash: bool,
+    /// If None, the hash verification will be disabled.
+    ///
+    /// This should be set to None for AC, but hashing function like `sha256` for CAS stores.
+    pub hash_verification_function: Option<ConfigDigestHashFunction>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -17,17 +17,18 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use nativelink_config::stores::ConfigDigestHashFunction;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_util::buf_channel::{make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::metrics_utils::{Collector, CollectorState, CounterWithTime, MetricsComponent, Registry};
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
-use sha2::{Digest, Sha256};
 
 pub struct VerifyStore {
     inner_store: Arc<dyn Store>,
     verify_size: bool,
-    verify_hash: bool,
+    hash_verification_function: Option<ConfigDigestHashFunction>,
 
     // Metrics.
     size_verification_failures: CounterWithTime,
@@ -39,7 +40,7 @@ impl VerifyStore {
         VerifyStore {
             inner_store,
             verify_size: config.verify_size,
-            verify_hash: config.verify_hash,
+            hash_verification_function: config.hash_verification_function,
             size_verification_failures: CounterWithTime::default(),
             hash_verification_failures: CounterWithTime::default(),
         }
@@ -54,7 +55,8 @@ impl VerifyStore {
         mut tx: DropCloserWriteHalf,
         mut rx: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-        mut maybe_hasher: Option<([u8; 32], Sha256)>,
+        original_hash: [u8; 32],
+        mut maybe_hasher: Option<DigestHasher>,
     ) -> Result<(), Error> {
         let mut sum_size: u64 = 0;
         loop {
@@ -76,8 +78,9 @@ impl VerifyStore {
                         ));
                     }
                 }
-                if let Some((original_hash, hasher)) = maybe_hasher {
-                    let hash_result: [u8; 32] = hasher.finalize().into();
+                if let Some(hasher) = maybe_hasher.as_mut() {
+                    // We are passing -1 here because we just need to get the hashing result not the size.
+                    let hash_result: [u8; 32] = hasher.finalize_digest(-1).packed_hash;
                     if original_hash != hash_result {
                         self.hash_verification_failures.inc();
                         return Err(make_input_err!(
@@ -94,7 +97,7 @@ impl VerifyStore {
             // This will allows us to hash while sending data to another thread.
             let write_future = tx.send(chunk.clone());
 
-            if let Some((_, hasher)) = maybe_hasher.as_mut() {
+            if let Some(hasher) = maybe_hasher.as_mut() {
                 hasher.update(chunk.as_ref());
             }
 
@@ -135,15 +138,14 @@ impl Store for VerifyStore {
             }
         }
 
-        let mut hasher = None;
-        if self.verify_hash {
-            hasher = Some((digest.packed_hash, Sha256::new()));
-        }
+        let hasher = self
+            .hash_verification_function
+            .map(|v| DigestHasher::from(DigestHasherFunc::from(v)));
 
         let (tx, rx) = make_buf_channel_pair();
 
         let update_fut = self.pin_inner().update(digest, rx, size_info);
-        let check_fut = self.inner_check_update(tx, reader, size_info, hasher);
+        let check_fut = self.inner_check_update(tx, reader, size_info, digest.packed_hash, hasher);
 
         let (update_res, check_res) = tokio::join!(update_fut, check_fut);
 
@@ -181,9 +183,9 @@ impl MetricsComponent for VerifyStore {
             "If the verification store is verifying the size of the data",
         );
         c.publish(
-            "verify_hash_enabled",
-            &self.verify_hash,
-            "If the verification store is verifying the hash of the data",
+            "hash_verification_function",
+            &format!("{:?}", self.hash_verification_function),
+            "Hash verification function to verify the contents of the data",
         );
         c.publish(
             "size_verification_failures_total",

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -15,7 +15,7 @@
 use std::sync::OnceLock;
 
 use blake3::Hasher as Blake3Hasher;
-use nativelink_config::cas_server::ConfigDigestHashFunction;
+use nativelink_config::stores::ConfigDigestHashFunction;
 use nativelink_error::{make_err, make_input_err, Code, Error};
 use nativelink_proto::build::bazel::remote::execution::v2::digest_function::Value as ProtoDigestFunction;
 use sha2::{Digest, Sha256};

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -25,8 +25,9 @@ use futures::FutureExt;
 use hyper::server::conn::Http;
 use hyper::{Response, StatusCode};
 use nativelink_config::cas_server::{
-    CasConfig, CompressionAlgorithm, ConfigDigestHashFunction, GlobalConfig, ListenerConfig, ServerConfig, WorkerConfig,
+    CasConfig, CompressionAlgorithm, GlobalConfig, ListenerConfig, ServerConfig, WorkerConfig,
 };
+use nativelink_config::stores::ConfigDigestHashFunction;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_scheduler::default_scheduler_factory::scheduler_factory;
 use nativelink_scheduler::worker::WorkerId;


### PR DESCRIPTION
# Description

I've added Blake3 hash support Verify Store.
I just used the `digest_hasher` utiliy module to keep consistency.
For simplicity, I just used the default hash function which is set from the global config.
I've done integration tests on my machine to verify blake3 function actually works.
But since the global hash function is `OnceLock` and it can't be set twice, I couldn't add specific unit tests for blake3 and sha256 separately.
May it would be better if we add hash function config variable for the Verify Store Config?
Or is it just adding extra complexity?
I'd like to make this clear.

Fixes #444 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/575)
<!-- Reviewable:end -->
