### PR TITLE
Add OSFamily property in basic_cas.json

### DIFF
--- a/nativelink-config/examples/basic_cas.json
+++ b/nativelink-config/examples/basic_cas.json
@@ -51,6 +51,8 @@
           "cpu_arch": "exact",
           "cpu_model": "exact",
           "kernel_version": "exact",
+          "OSFamily": "priority",
+          "container-image": "priority",
           // Example of how to set which docker images are available and set
           // them in the platform properties.
           // "docker_image": "priority",
@@ -80,6 +82,12 @@
         },
         "cpu_arch": {
           "values": ["x86_64"],
+        },
+        "OSFamily": {
+          "values": [""]
+        },
+        "container-image": {
+          "values": [""]
         },
         // Example of how to set which docker images are available and set
         // them in the platform properties.


### PR DESCRIPTION
# Description

I think we missed to add `OSFamily` and `container-image` property in `basic_cas.json` file.
I added `OSFamily` and `container-image` property for `local_worker` and `scheduler` in the configuration JSON file.

Fixes #576 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/577)
<!-- Reviewable:end -->
