### PR TITLE
Build nativelink with musl

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+ignore = ["nativelink-proto/genproto/lib.rs"]
 max_width = 120
 reorder_imports = true
 imports_granularity = "Module"

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -145,7 +145,9 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -170,8 +172,33 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703815866,
+        "narHash": "sha256-CFIGDfX1GpNpfKwe/eezKLhgT/oc2VcgjqDTlCLBkJE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2b24e1f369f00f5ae9876e15e12f77e12c9c2374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/tools/llvmStdenv.nix
+++ b/tools/llvmStdenv.nix
@@ -1,12 +1,8 @@
-{
-  pkgs,
-  isDarwin ? false,
-  ...
-}: let
+{pkgs}: let
   llvmPackages = pkgs.llvmPackages_17;
 
   toolchain =
-    if isDarwin
+    if pkgs.stdenv.isDarwin
     then
       (
         pkgs.overrideCC (

--- a/tools/pre-commit-hooks.nix
+++ b/tools/pre-commit-hooks.nix
@@ -1,5 +1,5 @@
 {pkgs, ...}: let
-  excludes = ["^gencargo/" "^nativelink-proto/genproto"];
+  excludes = ["^nativelink-proto/genproto"];
 in {
   # Default hooks
   trailing-whitespace-fixer = {
@@ -56,6 +56,9 @@ in {
   alejandra.enable = true;
   statix.enable = true;
   deadnix.enable = true;
+
+  # Rust
+  rustfmt.enable = true;
 
   # Starlark
   bazel-buildifier-format = {


### PR DESCRIPTION
Reduce container image sizes by over 50% to about 28 megabytes.

The nativelink executable is now fully self-contained and portable across linux systems regardless of the host's libc.

This change introduces new Rust toolchains on the nix side that mirror the Bazel toolchains. The new toolchains enable `cargo clippy` invocations without Bazel and allow invoking the same nightly `rustfmt` that is used in the Bazel build via pre-commit hooks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/583)
<!-- Reviewable:end -->
