### PR TITLE
Span tracing

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a6b16863ad5d0a1a72b20d57a7b103696e736e78f865de8cee087e4876a07970",
+  "checksum": "0537a3af4c115d803aa31489688679acfecd43a5d05b79d2e6cb5e8f1dc21951",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -8522,6 +8522,10 @@
             {
               "id": "shellexpand 3.1.0",
               "target": "shellexpand"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -8572,6 +8576,10 @@
             {
               "id": "tonic 0.10.2",
               "target": "tonic"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             }
           ],
           "selects": {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
 ]
 
@@ -1682,6 +1683,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "shellexpand",
+ "tracing",
 ]
 
 [[package]]
@@ -1694,6 +1696,7 @@ dependencies = [
  "prost-types",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
@@ -3072,6 +3075,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.46",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "nativelink"
 
 [features]
 enable_tokio_console = []
+tracing_chrome = ["dep:tracing-chrome"]
 
 [dependencies]
 nativelink-error = { path = "nativelink-error" }
@@ -42,4 +43,5 @@ tokio-rustls = "0.25.0"
 tonic = { version = "0.10.2", features = ["gzip"] }
 tower = "0.4.13"
 tracing = "0.1.40"
+tracing-chrome = { version = "0.7.1", optional = true}
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.193", features = ["derive"] }
 shellexpand = "3.1.0"
+tracing = "0.1.40"

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -15,3 +15,4 @@ prost = "0.12.3"
 prost-types = "0.12.3"
 tokio = { version = "1.35.1" }
 tonic = { version = "0.10.2", features = ["gzip"] }
+tracing = "0.1.40"

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -52,6 +52,7 @@ pub fn make_buf_channel_pair() -> (DropCloserWriteHalf, DropCloserReadHalf) {
 }
 
 /// Writer half of the pair.
+#[derive(Debug)]
 pub struct DropCloserWriteHalf {
     tx: Option<mpsc::Sender<Result<Bytes, Error>>>,
     bytes_written: u64,

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -139,6 +139,7 @@ impl<'a> ResumeableFileSlot<'a> {
     where
         F: (FnMut((BytesMut, T)) -> Fut) + 'b,
         Fut: Future<Output = Result<(BytesMut, T), Error>> + 'b,
+        T: std::fmt::Debug,
     {
         loop {
             buf.clear();

--- a/tools/patch_tracing.sh
+++ b/tools/patch_tracing.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2024 The Native Link Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+RUST_MAIN_CODE=("nativelink-config/src/"
+"nativelink-error/src/"
+"nativelink-scheduler/src/"
+"nativelink-service/src/"
+"nativelink-store/src/"
+"nativelink-util/src/"
+"nativelink-worker/src/"
+"src/bin/");
+CFG_ATTR="tracing"
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+function run_clippy_tracing() {
+  action="$1"
+  for path in "${RUST_MAIN_CODE[@]}"; do
+    echo "$action: $path"
+    clippy-tracing --action "$action" --cfg-attr="$CFG_ATTR" --path "$path"
+  done
+}
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <command>"
+  exit 1
+fi
+
+command="$1"
+pushd $GIT_ROOT
+case "$command" in
+  "strip")
+    run_clippy_tracing "strip"
+    ;;
+  "check")
+    run_clippy_tracing "check"
+    ;;
+  "fix")
+    run_clippy_tracing "fix"
+    ;;
+  *)
+    echo "Invalid command: $command"
+    popd
+    exit 1
+    ;;
+esac
+popd


### PR DESCRIPTION
# Description

Adding feature to enable/disable builds of nativelink to include trace spans. 

Trace spans can be use for instrumenting historical call paths of the tokio workers. Implementation provided shunts enabling/disabling at the cfg/features flags level. Enabling this feature would have performance runtime impact and should be used in debugging/introspection scenarios. Applying the instrumentation updates the source tree and not expected to be checked in (atm). The span format uses chrome tracing json and can be viewed in `chrome://tracing` (or https://ui.perfetto.dev/). Trace snapshots are collected upon sever exit.

Output traces upon server exit are dumped in the cwd of the nativelink bin in the format `trace-*.json`

## Example

```bash
# Apply instrumentation
./tools/patch_tracing.sh fix
# Build/Run
RUST_LOG=INFO cargo --config 'build.rustflags=["--cfg", "tokio_unstable", "--cfg", "enable_tracing"]' run --features enable_tokio_console,enable_tracing -- nativelink-config/examples/basic_cas.json
# Unapply instrumentation
./tools/patch_tracing.sh strip
```

<img width="1539" alt="Screenshot 2024-01-03 at 6 24 14 PM" src="https://github.com/TraceMachina/nativelink/assets/654526/8e2312ec-e80c-4600-a8a1-4424dc5a1ddd">


## Open Questions

Should trace snapshots be collected upon server exit, client requests or external signal to admin ports?  

Should `clippy-tracing` be a preinstalled expectation or configured/added in nix?

Should we checkin the tracing macro and create linting that auto lints (fix) the source tree when instrumentation is missing?


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/589)
<!-- Reviewable:end -->
