### PR TITLE
Add S3 http2 toggle flag

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -480,6 +480,16 @@ pub struct S3Store {
     /// Default: false
     #[serde(default)]
     pub insecure_allow_http: bool,
+
+    /// Disable http/2 connections and only use http/1.1. Default client
+    /// configuration will have http/1.1 and http/2 enabled for connection
+    /// schemes. Http/2 should be disabled if environments have poor support
+    /// or performance related to http/2. Safe to keep default unless
+    /// underlying network environment or S3 API servers specify otherwise.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub disable_http2: bool,
 }
 
 #[allow(non_camel_case_types)]

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -82,7 +82,11 @@ impl TlsConnector {
             connector_with_roots.https_only()
         };
 
-        let connector = connector_with_schemes.enable_http1().enable_http2().build();
+        let connector = if config.disable_http2 {
+            connector_with_schemes.enable_http1().build()
+        } else {
+            connector_with_schemes.enable_http1().enable_http2().build()
+        };
 
         Self {
             connector,


### PR DESCRIPTION
# Description

Add S3 TLS configuration to disable http2 in favor for http.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/604)
<!-- Reviewable:end -->
