### PR TITLE
Fix a potential bug in DropCloserReadHalf::take()

### DIFF
--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -303,11 +303,21 @@ impl DropCloserReadHalf {
         let (first_chunk, second_chunk) = {
             // This is an optimization for a relatively common case when the first chunk in the
             // stream satisfies all the requirements to fill this `take()`.
-            // This will us from needing to copy the data into a new buffer and instead we can
+            // This will prevent us from needing to copy the data into a new buffer and instead we can
             // just forward on the original Bytes object. If we need more than the first chunk
             // we will then go the slow path and actually copy our data.
+
+            // 1. Read some data from our stream (or self.partial).
             let mut first_chunk = self.recv().await.err_tip(|| "During first buf_channel::take()")?;
+            assert!(
+                self.partial.is_none(),
+                "Partial should have been consumed during the recv()"
+            );
+            // 2. Split our data so `first_chunk` is <= `size` and puts any remaining
+            //    in `self.partial` (or set it to None).
             populate_partial_if_needed(0, size, &mut first_chunk, &mut self.partial);
+            // 3a. If our `first_chunk` is EOF, we are done.
+            // 3b. If our `first_chunk` is exactly `size` we can return our current state.
             if first_chunk.is_empty() || first_chunk.len() >= size {
                 assert!(
                     first_chunk.is_empty() || first_chunk.len() == size,
@@ -315,6 +325,10 @@ impl DropCloserReadHalf {
                 );
                 return Ok(first_chunk);
             }
+            assert!(
+                self.partial.is_none(),
+                "If `first_chunk`'s len is < size and not EOF, partial should be None"
+            );
 
             let mut second_chunk = self.recv().await.err_tip(|| "During second buf_channel::take()")?;
             if second_chunk.is_empty() {
@@ -333,20 +347,29 @@ impl DropCloserReadHalf {
 
         loop {
             let mut chunk = self.recv().await.err_tip(|| "During buf_channel::take()")?;
+            assert!(
+                self.partial.is_none(),
+                "Partial should have been consumed during the recv()"
+            );
             if chunk.is_empty() {
-                break; // EOF.
+                // Forward EOF to next recv() and return our current buffer.
+                self.partial = Some(Ok(chunk));
+                return Ok(output.freeze());
             }
 
             populate_partial_if_needed(output.len(), size, &mut chunk, &mut self.partial);
 
             output.put(chunk);
 
-            if output.len() >= size {
-                assert!(output.len() == size); // Length should never be larger than size here.
-                break;
+            if output.len() == size {
+                return Ok(output.freeze());
             }
+            assert!(output.len() < size, "Length should never be larger than size in take()");
+            assert!(
+                self.partial.is_none(),
+                "Partial shouldn't be set if chunk < size in take()"
+            );
         }
-        Ok(output.freeze())
     }
 }
 


### PR DESCRIPTION
# Description

I fixed a potential bug in DropCloserReadHalf::take() function.
I mainly applied @allada's recommendations.
Though, I kept the previous `second_chunk` logic because we need to check `second_chunk` is empty or not in order to return `first_chunk` without copying stuff.
Detailed context can be found in the issue below.

Fixes #578 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/605)
<!-- Reviewable:end -->
