### PR TITLE
Evict on touch failure

### DIFF
--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -266,7 +266,7 @@ impl LenEntry for FileEntryImpl {
     }
 
     #[inline]
-    async fn touch(&self) {
+    async fn touch(&self) -> bool {
         let result = self
             .get_file_path_locked(move |full_content_path| async move {
                 spawn_blocking(move || {
@@ -284,8 +284,10 @@ impl LenEntry for FileEntryImpl {
             })
             .await;
         if let Err(e) = result {
-            error!("{}", e);
+            error!("{e}");
+            return false;
         }
+        true
     }
 
     // unref() only triggers when an item is removed from the eviction_map. It is possible

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -336,8 +336,9 @@ mod evicting_map_tests {
                 unreachable!("We are not testing this functionality");
             }
 
-            async fn touch(&self) {
+            async fn touch(&self) -> bool {
                 // Do nothing. We are not testing this functionality.
+                true
             }
 
             async fn unref(&self) {


### PR DESCRIPTION
# Description

There's an unknown failure occuring under load where the filesystem store ends up with an entry in the temp path that doesn't exist.  I can't find that fault, but rather than persisting, it makes sense to avoid the failure persisting by removing it from the eviciting map in that case.

Therefore, this change introduces a change to the LenEntry such that touch() returns a bool.  If it returns false then it is removed from the EvictingMap immediately.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running the code up on my cluster.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/613)
<!-- Reviewable:end -->
