### PR TITLE
[BREAKING] Add concurrency limit to GRPC

### DIFF
--- a/deployment-examples/docker-compose/scheduler.json
+++ b/deployment-examples/docker-compose/scheduler.json
@@ -4,7 +4,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "cas"
       }
     },
@@ -12,7 +14,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "ac"
       }
     }

--- a/deployment-examples/docker-compose/worker.json
+++ b/deployment-examples/docker-compose/worker.json
@@ -4,7 +4,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "cas"
       }
     },
@@ -12,7 +14,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "ac"
       }
     },

--- a/deployment-examples/kubernetes/scheduler.json
+++ b/deployment-examples/kubernetes/scheduler.json
@@ -4,7 +4,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "cas"
       }
     },
@@ -12,7 +14,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "ac"
       }
     }

--- a/deployment-examples/kubernetes/worker.json.template
+++ b/deployment-examples/kubernetes/worker.json.template
@@ -4,7 +4,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "cas"
       }
     },
@@ -12,7 +14,9 @@
       // Note: This file is used to test GRPC store.
       "grpc": {
         "instance_name": "main",
-        "endpoints": ["grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"],
+        "endpoints": [
+          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+        ],
         "store_type": "ac"
       }
     },

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::serde_utils::{convert_numeric_with_shellexpand, convert_string_with_shellexpand};
-use crate::stores::{ClientTlsConfig, Retry, StoreRefName};
+use crate::serde_utils::convert_numeric_with_shellexpand;
+use crate::stores::{GrpcEndpoint, Retry, StoreRefName};
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
@@ -125,19 +125,15 @@ pub struct SimpleScheduler {
 /// is useful to use when doing some kind of local action cache or CAS away from
 /// the main cluster of workers.  In general, it's more efficient to point the
 /// build at the main scheduler directly though.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GrpcScheduler {
     /// The upstream scheduler to forward requests to.
-    #[serde(deserialize_with = "convert_string_with_shellexpand")]
-    pub endpoint: String,
+    pub endpoint: GrpcEndpoint,
 
     /// Retry configuration to use when a network request fails.
     #[serde(default)]
     pub retry: Retry,
-
-    /// The TLS configuration to use to connect to the endpoint.
-    pub tls_config: Option<ClientTlsConfig>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -520,14 +520,25 @@ pub struct ClientTlsConfig {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
+pub struct GrpcEndpoint {
+    /// The endpoint address (i.e. grpc(s)://example.com:443).
+    #[serde(deserialize_with = "convert_string_with_shellexpand")]
+    pub address: String,
+    /// The TLS configuration to use to connect to the endpoint (if grpcs).
+    pub tls_config: Option<ClientTlsConfig>,
+    /// The maximum concurrency to allow on this endpoint.
+    pub concurrency_limit: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct GrpcStore {
     /// Instance name for GRPC calls. Proxy calls will have the instance_name changed to this.
     #[serde(default, deserialize_with = "convert_string_with_shellexpand")]
     pub instance_name: String,
 
     /// The endpoint of the grpc connection.
-    #[serde(default)]
-    pub endpoints: Vec<String>,
+    pub endpoints: Vec<GrpcEndpoint>,
 
     /// The type of the upstream store, this ensures that the correct server calls are made.
     pub store_type: StoreType,
@@ -535,9 +546,6 @@ pub struct GrpcStore {
     /// Retry configuration to use when a network request fails.
     #[serde(default)]
     pub retry: Retry,
-
-    /// The TLS configuration to use to connect to the endpoints.
-    pub tls_config: Option<ClientTlsConfig>,
 }
 
 /// Retry configuration. This configuration is exponential and each iteration

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -71,10 +71,7 @@ impl GrpcScheduler {
         config: &nativelink_config::schedulers::GrpcScheduler,
         jitter_fn: Box<dyn Fn(Duration) -> Duration + Send + Sync>,
     ) -> Result<Self, Error> {
-        let channel = transport::Channel::balance_list(std::iter::once(tls_utils::endpoint_from(
-            &config.endpoint,
-            tls_utils::load_client_config(&config.tls_config)?,
-        )?));
+        let channel = transport::Channel::balance_list(std::iter::once(tls_utils::endpoint(&config.endpoint)?));
         Ok(Self {
             capabilities_client: CapabilitiesClient::new(channel.clone()),
             execution_client: ExecutionClient::new(channel),

--- a/nativelink-util/src/tls_utils.rs
+++ b/nativelink-util/src/tls_utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nativelink_config::stores::ClientTlsConfig;
+use nativelink_config::stores::{ClientTlsConfig, GrpcEndpoint};
 use nativelink_error::{make_err, make_input_err, Code, Error};
 use tonic::transport::Uri;
 
@@ -85,4 +85,16 @@ pub fn endpoint_from(
     };
 
     Ok(endpoint_transport)
+}
+
+pub fn endpoint(endpoint_config: &GrpcEndpoint) -> Result<tonic::transport::Endpoint, Error> {
+    let endpoint = endpoint_from(
+        &endpoint_config.address,
+        load_client_config(&endpoint_config.tls_config)?,
+    )?;
+    if let Some(concurrency_limit) = endpoint_config.concurrency_limit {
+        Ok(endpoint.concurrency_limit(concurrency_limit))
+    } else {
+        Ok(endpoint)
+    }
 }


### PR DESCRIPTION
# Description

Currently we apply no concurrency limits for GRPC calls to GrpcStore or GrpcScheduler.  This can cause issues for a heavily loaded upstream service that will start to build up reset streams and break.

This change modifies the configuration to have configuration per endpoint and adds an optional configuration to allow for setting a limit to the upstream concurrency.

Fixes #320

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local cluster.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/627)
<!-- Reviewable:end -->
