### PR TITLE
Don't cache sanitizer workflows

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -25,12 +25,15 @@ jobs:
       - uses: >- # Custom commit at 2023-10-23
           bazelbuild/setup-bazelisk@5bc144ec07bd24eaa9b5c3e8c9af4006b033b629
 
-      - name: Mount bazel cache
-        uses: >- # v3.3.2
-          actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-        with:
-          path: ~/.cache/bazel
-          key: ${{ matrix.os }}-bazel-${{ matrix.sanitizer }}
+      # TODO(aaronmondal): This cache is ~4 gigabytes in size and potentially
+      #                    leads to `no space left on device` errors. Find a
+      #                    more robust solution.
+      # - name: Mount bazel cache
+      #   uses: >- # v3.3.2
+      #     actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+      #   with:
+      #     path: ~/.cache/bazel
+      #     key: ${{ matrix.os }}-bazel-${{ matrix.sanitizer }}
 
       - name: Run Bazel tests
         run: bazel test --config=${{ matrix.sanitizer }} //...


### PR DESCRIPTION
This workflow eats up ~40% of our GHA cache. This potentially slows down all other jobs and introduces flakiness in the form of `no space left on device` errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
