### PR TITLE
Reenable caching for nix workflows

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,16 +23,15 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- # v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
 
-      # TODO(aaronmondal): Caching is flaky for this workflow.
-      # See: https://github.com/DeterminateSystems/magic-nix-cache/issues/32
-      # - name: Cache Nix derivations
-      #   uses: >- # Custom commit, last pinned at 2023-11-17.
-      #     DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+      - name: Cache Nix derivations
+        uses: >- # Custom commit, last pinned at 2023-11-17.
+          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
 
       - name: Test image
         run: |

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -24,8 +24,11 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- #v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
 
       - name: Cache Nix derivations
         uses: >- # Custom commit, last pinned at 2023-11-17.
@@ -52,14 +55,15 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- #v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
 
-      # TODO(aaronmondal): Caching is flaky for this workflow.
-      # See: https://github.com/DeterminateSystems/magic-nix-cache/issues/32
-      # - name: Cache Nix derivations
-      #   uses: >- # Custom commit, last pinned at 2023-11-17.
-      #     DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+      - name: Cache Nix derivations
+        uses: >- # Custom commit, last pinned at 2023-11-17.
+          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
 
       - name: Start Kubernetes cluster (Infra)
         run: >

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -24,8 +24,11 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- #v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
 
       - name: Cache Nix derivations
         uses: >- # Custom commit, last pinned at 2023-11-17.
@@ -56,8 +59,11 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- #v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
 
       - name: Cache Nix derivations
         uses: >- # Custom commit, last pinned at 2023-11-17.

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,11 +17,17 @@ jobs:
       - name: Checkout
         uses: >- # v3.5.3
           actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
       - name: Install Nix
-        uses: >- #v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
+
       - name: Cache Nix derivations
         uses: >- # Custom commit, last pinned at 2023-11-17.
           DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+
       - name: Run pre-commit hooks
         run: nix flake check

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -20,10 +20,15 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
-        uses: >- # v7
-          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+        uses: >- # v9
+          DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-installer-tag: v0.16.1
+
+      - name: Cache Nix derivations
+        uses: >- # Custom commit, last pinned at 2023-11-17.
+          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
 
       - name: Test image
         run: |


### PR DESCRIPTION
This has been fixed upstream. Pull the change in early to speed up
workflows significantly. This also includes missing `github-token`
fields which increase the API rate limit.

Fixes: https://github.com/TraceMachina/nativelink/issues/464

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/631)
<!-- Reviewable:end -->
