### PR TITLE
GrpcStore Stream Retry

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -377,18 +377,20 @@ impl ByteStreamServer {
             expected_size: u64,
         ) -> Result<(), Error> {
             loop {
-                let write_request = match stream.next().await {
+                // Pulling StreamExt into this file breaks elsewhere, so we do
+                // this manually using poll_fn.
+                let write_request = match futures::future::poll_fn(|cx| Pin::new(&mut stream).poll_next(cx)).await {
                     // Code path for when client tries to gracefully close the stream.
                     // If this happens it means there's a problem with the data sent,
                     // because we always close the stream from our end before this point
                     // by counting the number of bytes sent from the client. If they send
                     // less than the amount they said they were going to send and then
                     // close the stream, we know there's a problem.
-                    Ok(None) => return Err(make_input_err!("Client closed stream before sending all data")),
+                    None => return Err(make_input_err!("Client closed stream before sending all data")),
                     // Code path for client stream error. Probably client disconnect.
-                    Err(err) => return Err(err),
+                    Some(Err(err)) => return Err(err),
                     // Code path for received chunk of data.
-                    Ok(Some(write_request)) => write_request,
+                    Some(Ok(write_request)) => write_request,
                 };
                 if write_request.write_offset as u64 != tx.get_bytes_written() {
                     return Err(make_input_err!(

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -235,7 +235,7 @@ pub mod write_tests {
             // Now disconnect our stream.
             drop(tx);
             let (result, _bs_server) = join_handle.await?;
-            assert!(result.is_ok(), "Expected success to be returned");
+            result?;
         }
         {
             // Check to make sure our store recorded the data properly.

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -15,6 +15,7 @@
 use std::marker::Send;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -278,75 +279,122 @@ impl GrpcStore {
             E: Into<Error> + 'static,
         {
             instance_name: String,
-            error: Mutex<Option<Error>>,
-            read_stream: Mutex<Option<WriteRequestStreamWrapper<T, E>>>,
+            error: Option<Error>,
+            read_stream: WriteRequestStreamWrapper<T, E>,
             client: ByteStreamClient<Channel>,
         }
 
-        let local_state = Arc::new(LocalState {
+        struct StateWrapper<T, E>
+        where
+            T: Stream<Item = Result<WriteRequest, E>> + Unpin + Send + 'static,
+            E: Into<Error> + 'static,
+        {
+            local_state: Arc<Mutex<Option<LocalState<T, E>>>>,
+        }
+
+        impl<T, E> Stream for StateWrapper<T, E>
+        where
+            T: Stream<Item = Result<WriteRequest, E>> + Unpin + Send + 'static,
+            E: Into<Error> + 'static,
+        {
+            type Item = WriteRequest;
+
+            fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                let Some(mut local_state) = self.local_state.lock().take() else {
+                    error!("Local state was not replaced in GrpcStore::write");
+                    return Poll::Ready(None);
+                };
+                let Poll::Ready(maybe_message) = Pin::new(&mut local_state.read_stream).poll_next(cx) else {
+                    *self.local_state.lock() = Some(local_state);
+                    return Poll::Pending;
+                };
+                let result = match maybe_message {
+                    Some(Ok(mut message)) => {
+                        // `resource_name` pattern is: "{instance_name}/uploads/{uuid}/blobs/{hash}/{size}".
+                        if let Some(first_slash_pos) = message.resource_name.find('/') {
+                            message.resource_name = format!(
+                                "{}/{}",
+                                &local_state.instance_name,
+                                message.resource_name.get((first_slash_pos + 1)..).unwrap()
+                            );
+                            Some(message)
+                        } else {
+                            error!("{}", "Resource name should follow pattern {instance_name}/uploads/{uuid}/blobs/{hash}/{size}");
+                            None
+                        }
+                    }
+                    Some(Err(err)) => {
+                        local_state.error = Some(err);
+                        None
+                    }
+                    None => None,
+                };
+                *self.local_state.lock() = Some(local_state);
+                Poll::Ready(result)
+            }
+        }
+
+        let local_state = LocalState {
             instance_name: self.instance_name.clone(),
-            error: Mutex::new(None),
-            read_stream: Mutex::new(Some(stream)),
+            error: None,
+            read_stream: stream,
             client: self.bytestream_client.clone(),
-        });
+        };
 
         let retry_config = self.get_retry_config();
         let result = self
             .retrier
             .retry(
                 retry_config,
-                unfold(local_state, move |local_state| async move {
-                    let stream = unfold((None, local_state.clone()), move |(stream, local_state)| async {
-                        // Only consume the stream on the first request to read,
-                        // then pass it for future requests in the unfold.
-                        let mut stream = stream.or_else(|| local_state.read_stream.lock().take())?;
-                        let maybe_message = stream.next().await;
-                        if let Ok(maybe_message) = maybe_message {
-                            if let Some(mut message) = maybe_message {
-                                // `resource_name` pattern is: "{instance_name}/uploads/{uuid}/blobs/{hash}/{size}".
-                                let first_slash_pos = match message.resource_name.find('/') {
-                                    Some(pos) => pos,
-                                    None => {
-                                        error!("{}", "Resource name should follow pattern {instance_name}/uploads/{uuid}/blobs/{hash}/{size}");
-                                        return None;
-                                    }
-                                };
-                                message.resource_name = format!(
-                                    "{}/{}",
-                                    &local_state.instance_name,
-                                    message.resource_name.get((first_slash_pos + 1)..).unwrap()
-                                );
-                                return Some((message, (Some(stream), local_state)));
-                            }
-                            return None;
-                        }
-                        // TODO(allada) I'm sure there's a way to do this without a mutex, but rust can be super
-                        // picky with borrowing through a stream await.
-                        *local_state.error.lock() = Some(maybe_message.unwrap_err());
-                        None
-                    });
+                unfold(Some(local_state), move |local_state| async move {
+                    let Some(local_state) = local_state else {
+                        return Some((
+                            RetryResult::Err(make_input_err!("State not returned in GrpcStore::write")),
+                            None,
+                        ));
+                    };
 
-                    let result = local_state.client.clone()
-                            .write(stream)
-                            .await
-                            .err_tip(|| "in GrpcStore::write");
+                    let mut client = local_state.client.clone();
+                    // The client write may occur on a separate thread and
+                    // therefore in order to share the state with it we have to
+                    // wrap it in a Mutex and retrieve it after the write
+                    // has completed.  There is no way to get the value back
+                    // from the client.
+                    let shared_state = Arc::new(Mutex::new(Some(local_state)));
+                    let result = client
+                        .write(StateWrapper {
+                            local_state: shared_state.clone(),
+                        })
+                        .await
+                        .err_tip(|| "in GrpcStore::write");
+
+                    let Some(mut local_state) = shared_state.lock().take() else {
+                        return Some((
+                            RetryResult::Err(make_input_err!("State not returned in GrpcStore::write")),
+                            None,
+                        ));
+                    };
 
                     // If the stream has been consumed, don't retry, but
                     // otherwise it's ok to try again.
-                    let result = if local_state.read_stream.lock().is_some() {
-                        result.map_or_else(RetryResult::Retry, RetryResult::Ok)
+                    let result = if result.is_err() && local_state.read_stream.reset_for_retry() {
+                        result
+                            .err_tip(|| "Retry is possible in GrpcStore::write")
+                            .map_or_else(RetryResult::Retry, RetryResult::Ok)
                     } else {
-                        result.map_or_else(RetryResult::Err, RetryResult::Ok)
+                        result
+                            .err_tip(|| "Retry was not possible in GrpcStore::write")
+                            .map_or_else(RetryResult::Err, RetryResult::Ok)
                     };
 
                     // If there was an error with the stream, then don't retry.
-                    let result = if let Some(err) = local_state.error.lock().take() {
-                        RetryResult::Err(err)
+                    let result = if let Some(err) = &local_state.error {
+                        RetryResult::Err(err.clone())
                     } else {
                         result
                     };
 
-                    Some((result, local_state))
+                    Some((result, Some(local_state)))
                 }),
             )
             .await?;

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -78,7 +78,9 @@ impl Retrier {
                     None => return Err(make_err!(Code::Internal, "Retry stream ended abruptly",)),
                     Some(RetryResult::Ok(value)) => return Ok(value),
                     Some(RetryResult::Err(e)) => return Err(e),
-                    Some(RetryResult::Retry(e)) => (self.sleep_fn)(iter.next().ok_or(e)?).await,
+                    Some(RetryResult::Retry(e)) => {
+                        (self.sleep_fn)(iter.next().ok_or(e.append("Retry attempts exhausted"))?).await
+                    }
                 }
             }
         })

--- a/nativelink-util/src/write_request_stream_wrapper.rs
+++ b/nativelink-util/src/write_request_stream_wrapper.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use futures::{Stream, StreamExt};
-use nativelink_error::{error_if, Error, ResultExt};
+use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_proto::google::bytestream::WriteRequest;
 
 use crate::resource_info::ResourceInfo;
@@ -31,6 +34,8 @@ where
     pub bytes_received: usize,
     stream: T,
     first_msg: Option<WriteRequest>,
+    second_msg: Option<WriteRequest>,
+    message_count: usize,
     write_finished: bool,
 }
 
@@ -56,7 +61,6 @@ where
         let hash = resource_info.hash.to_string();
         let expected_size = resource_info.expected_size;
         let uuid = resource_info.uuid.map(|v| v.to_string());
-        let write_finished = first_msg.finish_write;
 
         Ok(WriteRequestStreamWrapper {
             instance_name,
@@ -66,39 +70,102 @@ where
             bytes_received: 0,
             stream,
             first_msg: Some(first_msg),
-            write_finished,
+            // Since Tonic reads the second message before determining a failure
+            // with the first message, we need to keep both in memory until the
+            // third message.  This is unfortunate, but should not be too
+            // expensive as each write request is fairly small and the backing
+            // Bytes is shared between the cloned instances.
+            second_msg: None,
+            message_count: 0,
+            write_finished: false,
         })
     }
 
-    pub async fn next(&mut self) -> Result<Option<WriteRequest>, Error> {
-        if let Some(first_msg) = self.first_msg.take() {
-            self.bytes_received += first_msg.data.len();
-            return Ok(Some(first_msg));
+    pub fn reset_for_retry(&mut self) -> bool {
+        if self.first_msg.is_some() {
+            self.bytes_received = 0;
+            self.write_finished = false;
+            self.message_count = 0;
+            true
+        } else {
+            false
         }
-        if self.write_finished {
-            error_if!(
-                self.bytes_received != self.expected_size,
-                "Did not send enough data. Expected {}, but so far received {}",
-                self.expected_size,
-                self.bytes_received
-            );
-            return Ok(None); // Previous message said it was the last msg.
-        }
-        error_if!(
-            self.bytes_received > self.expected_size,
-            "Sent too much data. Expected {}, but so far received {}",
-            self.expected_size,
-            self.bytes_received
-        );
-        let next_msg = self
-            .stream
-            .next()
-            .await
-            .err_tip(|| format!("Stream error at byte {}", self.bytes_received))?
-            .err_tip(|| "Expected WriteRequest struct in stream")?;
-        self.write_finished = next_msg.finish_write;
-        self.bytes_received += next_msg.data.len();
+    }
+}
 
-        Ok(Some(next_msg))
+impl<T, E> Stream for WriteRequestStreamWrapper<T, E>
+where
+    E: Into<Error>,
+    T: Stream<Item = Result<WriteRequest, E>> + Unpin,
+{
+    type Item = Result<WriteRequest, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<WriteRequest, Error>>> {
+        // If the stream said that the previous message was the last one, then
+        // return a stream EOF (i.e. None).
+        if self.write_finished {
+            if self.bytes_received != self.expected_size {
+                return Poll::Ready(Some(Err(make_input_err!(
+                    "Did not send enough data. Expected {}, but so far received {}",
+                    self.expected_size,
+                    self.bytes_received
+                ))));
+            }
+            return Poll::Ready(None);
+        }
+
+        // Gets the next message, this is either the cached first or second
+        // message or a subsequent message from the wrapped Stream.
+        let maybe_message = if self.message_count == 0 {
+            if let Some(first_msg) = self.first_msg.clone() {
+                Ok(first_msg)
+            } else {
+                Err(make_input_err!("First message was lost in write stream wrapper"))
+            }
+        } else if self.message_count == 1 && self.second_msg.is_some() {
+            Ok(self.second_msg.clone().unwrap())
+        } else {
+            match Pin::new(&mut self.stream).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(maybe_message)) => {
+                    maybe_message.err_tip(|| format!("Stream error at byte {}", self.bytes_received))
+                }
+                Poll::Ready(None) => Err(make_input_err!("Expected WriteRequest struct in stream")),
+            }
+        };
+
+        // If we successfully got a message, update our internal state with the
+        // message meta data.
+        let maybe_message = match maybe_message {
+            Ok(message) => {
+                if self.message_count == 1 && self.second_msg.is_none() {
+                    self.second_msg = Some(message.clone());
+                }
+                if self.message_count == 2 {
+                    // Upon a successful third message, we discard the first
+                    // and second messages.
+                    self.first_msg.take();
+                    self.second_msg.take();
+                }
+                self.write_finished = message.finish_write;
+                self.bytes_received += message.data.len();
+                self.message_count += 1;
+
+                // Check that we haven't read past the expected end.
+                if self.bytes_received > self.expected_size {
+                    Err(make_input_err!(
+                        "Sent too much data. Expected {}, but so far received {}",
+                        self.expected_size,
+                        self.bytes_received
+                    ))
+                } else {
+                    Ok(message)
+                }
+            }
+            error => error,
+        };
+
+        // Return the message.
+        Poll::Ready(Some(maybe_message))
     }
 }

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -90,7 +90,7 @@ mod retry_tests {
         assert_eq!(result.is_err(), true, "Expected result to error");
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Error { code: Unavailable, messages: [\"Dummy failure\"] }"
+            "Error { code: Unavailable, messages: [\"Dummy failure\", \"Retry attempts exhausted\"] }"
         );
 
         Ok(())


### PR DESCRIPTION
# Description

The way that we handle the retry in GrpcStore is awkward, so refactor it so that it's all just Streams.  This should allow us to correctly assess whether the internal first message has been taken or not.

Now we are able to keep the first message in a WriteRequest until the second message is requested by performing a .clone().  This means that if we recieve a GoAway from the upstream GrpcStore the request is able to continue and not break the upload.

Fixes #320

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Using our remote proxy, I can see GoAway messages being sent by the upstream storage server, but there are no longer any failures in the upload and they are simply retried.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/632)
<!-- Reviewable:end -->
