### PR TITLE
Don't retry permanent failures

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -548,6 +548,28 @@ pub struct GrpcStore {
     pub retry: Retry,
 }
 
+/// The possible error codes that might occur on an upstream request.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum ErrorCode {
+    Cancelled = 1,
+    Unknown = 2,
+    InvalidArgument = 3,
+    DeadlineExceeded = 4,
+    NotFound = 5,
+    AlreadyExists = 6,
+    PermissionDenied = 7,
+    ResourceExhausted = 8,
+    FailedPrecondition = 9,
+    Aborted = 10,
+    OutOfRange = 11,
+    Unimplemented = 12,
+    Internal = 13,
+    Unavailable = 14,
+    DataLoss = 15,
+    Unauthenticated = 16,
+    // Note: This list is duplicated from nativelink-error/lib.rs.
+}
+
 /// Retry configuration. This configuration is exponential and each iteration
 /// a jitter as a percentage is applied of the calculated delay. For example:
 /// ```rust,ignore
@@ -591,4 +613,18 @@ pub struct Retry {
     /// ```
     #[serde(default)]
     pub jitter: f32,
+
+    /// A list of error codes to retry on, if this is not set then the default
+    /// error codes to retry on are used.  These default codes are the most
+    /// likely to be non-permanent.
+    ///  - Unknown
+    ///  - Cancelled
+    ///  - DeadlineExceeded
+    ///  - ResourceExhausted
+    ///  - Aborted
+    ///  - Internal
+    ///  - Unavailable
+    ///  - DataLoss
+    #[serde(default)]
+    pub retry_on_errors: Option<Vec<ErrorCode>>,
 }

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -312,6 +312,8 @@ pub enum Code {
     Unavailable = 14,
     DataLoss = 15,
     Unauthenticated = 16,
+    // NOTE: Additional codes must be added to stores.rs in ErrorCodes and also
+    // in both match statements in retry.rs.
 }
 
 impl From<i32> for Code {

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -148,6 +148,7 @@ mod s3_store_tests {
                     max_retries: 1024,
                     delay: 0.,
                     jitter: 0.,
+                    ..Default::default()
                 },
                 ..Default::default()
             },
@@ -339,6 +340,7 @@ mod s3_store_tests {
                     max_retries: 1024,
                     delay: 0.,
                     jitter: 0.,
+                    ..Default::default()
                 },
                 ..Default::default()
             },

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Native Link Authors. All rights reserved.
+// Copyright 2023-2024 The Native Link Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,14 +18,16 @@ use std::time::Duration;
 
 use futures::future::Future;
 use futures::stream::StreamExt;
+use nativelink_config::stores::{ErrorCode, Retry};
 use nativelink_error::{make_err, Code, Error};
+use tracing::debug;
 
-pub struct ExponentialBackoff {
+struct ExponentialBackoff {
     current: Duration,
 }
 
 impl ExponentialBackoff {
-    pub fn new(base: Duration) -> Self {
+    fn new(base: Duration) -> Self {
         ExponentialBackoff { current: base }
     }
 }
@@ -40,6 +42,7 @@ impl Iterator for ExponentialBackoff {
 }
 
 type SleepFn = Arc<dyn Fn(Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> + Sync + Send>;
+type JitterFn = Arc<dyn Fn(Duration) -> Duration + Send + Sync>;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum RetryResult<T> {
@@ -52,33 +55,104 @@ pub enum RetryResult<T> {
 #[derive(Clone)]
 pub struct Retrier {
     sleep_fn: SleepFn,
+    jitter_fn: JitterFn,
+    config: Retry,
+}
+
+fn to_error_code(code: &Code) -> ErrorCode {
+    match code {
+        Code::Cancelled => ErrorCode::Cancelled,
+        Code::Unknown => ErrorCode::Unknown,
+        Code::InvalidArgument => ErrorCode::InvalidArgument,
+        Code::DeadlineExceeded => ErrorCode::DeadlineExceeded,
+        Code::NotFound => ErrorCode::NotFound,
+        Code::AlreadyExists => ErrorCode::AlreadyExists,
+        Code::PermissionDenied => ErrorCode::PermissionDenied,
+        Code::ResourceExhausted => ErrorCode::ResourceExhausted,
+        Code::FailedPrecondition => ErrorCode::FailedPrecondition,
+        Code::Aborted => ErrorCode::Aborted,
+        Code::OutOfRange => ErrorCode::OutOfRange,
+        Code::Unimplemented => ErrorCode::Unimplemented,
+        Code::Internal => ErrorCode::Internal,
+        Code::Unavailable => ErrorCode::Unavailable,
+        Code::DataLoss => ErrorCode::DataLoss,
+        Code::Unauthenticated => ErrorCode::Unauthenticated,
+        _ => ErrorCode::Unknown,
+    }
 }
 
 impl Retrier {
-    pub fn new(sleep_fn: SleepFn) -> Self {
-        Retrier { sleep_fn }
+    pub fn new(sleep_fn: SleepFn, jitter_fn: JitterFn, config: Retry) -> Self {
+        Retrier {
+            sleep_fn,
+            jitter_fn,
+            config,
+        }
     }
 
-    pub fn retry<'a, T, Fut, I>(
-        &'a self,
-        duration_iter: I,
-        operation: Fut,
-    ) -> Pin<Box<dyn Future<Output = Result<T, Error>> + 'a + Send>>
+    /// This should only return true if the error code should be interpreted as
+    /// temporary.
+    fn should_retry(&self, code: &Code) -> bool {
+        if *code == Code::Ok {
+            false
+        } else if let Some(retry_codes) = &self.config.retry_on_errors {
+            retry_codes.contains(&to_error_code(code))
+        } else {
+            match code {
+                Code::InvalidArgument => false,
+                Code::FailedPrecondition => false,
+                Code::OutOfRange => false,
+                Code::Unimplemented => false,
+                Code::NotFound => false,
+                Code::AlreadyExists => false,
+                Code::PermissionDenied => false,
+                Code::Unauthenticated => false,
+                Code::Cancelled => true,
+                Code::Unknown => true,
+                Code::DeadlineExceeded => true,
+                Code::ResourceExhausted => true,
+                Code::Aborted => true,
+                Code::Internal => true,
+                Code::Unavailable => true,
+                Code::DataLoss => true,
+                _ => true,
+            }
+        }
+    }
+
+    fn get_retry_config(&self) -> impl Iterator<Item = Duration> + '_ {
+        ExponentialBackoff::new(Duration::from_millis(self.config.delay as u64))
+            .map(|d| (self.jitter_fn)(d))
+            .take(self.config.max_retries) // Remember this is number of retries, so will run max_retries + 1.
+    }
+
+    pub fn retry<'a, T, Fut>(&'a self, operation: Fut) -> Pin<Box<dyn Future<Output = Result<T, Error>> + 'a + Send>>
     where
         Fut: futures::stream::Stream<Item = RetryResult<T>> + Send + 'a,
-        I: IntoIterator<Item = Duration> + Send + 'a,
-        <I as IntoIterator>::IntoIter: Send,
         T: Send,
     {
         Box::pin(async move {
-            let mut iter = duration_iter.into_iter();
+            let mut iter = self.get_retry_config();
             let mut operation = Box::pin(operation);
+            let mut attempt = 0;
             loop {
+                attempt += 1;
                 match operation.next().await {
-                    None => return Err(make_err!(Code::Internal, "Retry stream ended abruptly",)),
+                    None => {
+                        return Err(make_err!(
+                            Code::Internal,
+                            "Retry stream ended abruptly on attempt {attempt}",
+                        ))
+                    }
                     Some(RetryResult::Ok(value)) => return Ok(value),
-                    Some(RetryResult::Err(e)) => return Err(e),
-                    Some(RetryResult::Retry(e)) => (self.sleep_fn)(iter.next().ok_or(e)?).await,
+                    Some(RetryResult::Err(e)) => return Err(e.append(format!("On attempt {attempt}"))),
+                    Some(RetryResult::Retry(e)) => {
+                        if !self.should_retry(&e.code) {
+                            debug!("Not retrying permanent error on attempt {attempt}: {e:?}");
+                            return Err(e);
+                        }
+                        (self.sleep_fn)(iter.next().ok_or(e.append(format!("On attempt {attempt}")))?).await
+                    }
                 }
             }
         })

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -18,27 +18,10 @@ use std::sync::Arc;
 
 use futures::future::ready;
 use futures::stream::repeat_with;
+use nativelink_config::stores::Retry;
 use nativelink_error::{make_err, Code, Error};
 use nativelink_util::retry::{Retrier, RetryResult};
 use tokio::time::Duration;
-
-struct MockDurationIterator {
-    duration: Duration,
-}
-
-impl MockDurationIterator {
-    pub fn new(duration: Duration) -> Self {
-        MockDurationIterator { duration }
-    }
-}
-
-impl Iterator for MockDurationIterator {
-    type Item = Duration;
-
-    fn next(&mut self) -> Option<Duration> {
-        Some(self.duration)
-    }
-}
 
 #[cfg(test)]
 mod retry_tests {
@@ -48,18 +31,21 @@ mod retry_tests {
 
     #[tokio::test]
     async fn retry_simple_success() -> Result<(), Error> {
-        let retrier = Retrier::new(Arc::new(|_duration| Box::pin(ready(()))));
-        let retry_config = MockDurationIterator::new(Duration::from_millis(1));
+        let retrier = Retrier::new(
+            Arc::new(|_duration| Box::pin(ready(()))),
+            Arc::new(move |_delay| Duration::from_millis(1)),
+            Retry {
+                max_retries: 5,
+                ..Default::default()
+            },
+        );
         let run_count = Arc::new(AtomicI32::new(0));
 
         let result = Pin::new(&retrier)
-            .retry(
-                retry_config,
-                repeat_with(|| {
-                    run_count.fetch_add(1, Ordering::Relaxed);
-                    RetryResult::Ok(true)
-                }),
-            )
+            .retry(repeat_with(|| {
+                run_count.fetch_add(1, Ordering::Relaxed);
+                RetryResult::Ok(true)
+            }))
             .await?;
         assert_eq!(
             run_count.load(Ordering::Relaxed),
@@ -73,24 +59,26 @@ mod retry_tests {
 
     #[tokio::test]
     async fn retry_fails_after_3_runs() -> Result<(), Error> {
-        let retrier = Retrier::new(Arc::new(|_duration| Box::pin(ready(()))));
-        let retry_config = MockDurationIterator::new(Duration::from_millis(1)).take(2); // .take() will run X times + 1.
+        let retrier = Retrier::new(
+            Arc::new(|_duration| Box::pin(ready(()))),
+            Arc::new(move |_delay| Duration::from_millis(1)),
+            Retry {
+                max_retries: 2,
+                ..Default::default()
+            },
+        );
         let run_count = Arc::new(AtomicI32::new(0));
-
         let result = Pin::new(&retrier)
-            .retry(
-                retry_config,
-                repeat_with(|| {
-                    run_count.fetch_add(1, Ordering::Relaxed);
-                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
-                }),
-            )
+            .retry(repeat_with(|| {
+                run_count.fetch_add(1, Ordering::Relaxed);
+                RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+            }))
             .await;
         assert_eq!(run_count.load(Ordering::Relaxed), 3, "Expected function to be called");
         assert_eq!(result.is_err(), true, "Expected result to error");
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Error { code: Unavailable, messages: [\"Dummy failure\"] }"
+            "Error { code: Unavailable, messages: [\"Dummy failure\", \"On attempt 3\"] }"
         );
 
         Ok(())
@@ -98,21 +86,24 @@ mod retry_tests {
 
     #[tokio::test]
     async fn retry_success_after_2_runs() -> Result<(), Error> {
-        let retrier = Retrier::new(Arc::new(|_duration| Box::pin(ready(()))));
-        let retry_config = MockDurationIterator::new(Duration::from_millis(1)).take(5); // .take() will run X times + 1.
+        let retrier = Retrier::new(
+            Arc::new(|_duration| Box::pin(ready(()))),
+            Arc::new(move |_delay| Duration::from_millis(1)),
+            Retry {
+                max_retries: 3,
+                ..Default::default()
+            },
+        );
         let run_count = Arc::new(AtomicI32::new(0));
 
         let result = Pin::new(&retrier)
-            .retry(
-                retry_config,
-                repeat_with(|| {
-                    run_count.fetch_add(1, Ordering::Relaxed);
-                    if run_count.load(Ordering::Relaxed) == 2 {
-                        return RetryResult::Ok(true);
-                    }
-                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
-                }),
-            )
+            .retry(repeat_with(|| {
+                run_count.fetch_add(1, Ordering::Relaxed);
+                if run_count.load(Ordering::Relaxed) == 2 {
+                    return RetryResult::Ok(true);
+                }
+                RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+            }))
             .await?;
         assert_eq!(run_count.load(Ordering::Relaxed), 2, "Expected function to be called");
         assert_eq!(result, true, "Expected result to succeed");
@@ -125,24 +116,29 @@ mod retry_tests {
         const EXPECTED_MS: u64 = 71;
         let sleep_fn_run_count = Arc::new(AtomicI32::new(0));
         let sleep_fn_run_count_copy = sleep_fn_run_count.clone();
-        let retrier = Retrier::new(Arc::new(move |duration| {
-            // Note: Need to make another copy to make the compiler happy.
-            let sleep_fn_run_count_copy = sleep_fn_run_count_copy.clone();
-            Box::pin(async move {
-                // Remember: This function is called only on retries, not the first run.
-                sleep_fn_run_count_copy.fetch_add(1, Ordering::Relaxed);
-                assert_eq!(duration, Duration::from_millis(EXPECTED_MS));
-            })
-        }));
+        let retrier = Retrier::new(
+            Arc::new(move |duration| {
+                // Note: Need to make another copy to make the compiler happy.
+                let sleep_fn_run_count_copy = sleep_fn_run_count_copy.clone();
+                Box::pin(async move {
+                    // Remember: This function is called only on retries, not the first run.
+                    sleep_fn_run_count_copy.fetch_add(1, Ordering::Relaxed);
+                    assert_eq!(duration, Duration::from_millis(EXPECTED_MS));
+                })
+            }),
+            Arc::new(move |_delay| Duration::from_millis(EXPECTED_MS)),
+            Retry {
+                max_retries: 5,
+                ..Default::default()
+            },
+        );
 
         {
             // Try with retry limit hit.
-            let retry_config = MockDurationIterator::new(Duration::from_millis(EXPECTED_MS)).take(5);
             let result = Pin::new(&retrier)
-                .retry(
-                    retry_config,
-                    repeat_with(|| RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))),
-                )
+                .retry(repeat_with(|| {
+                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+                }))
                 .await;
 
             assert_eq!(result.is_err(), true, "Expected the retry to fail");
@@ -155,21 +151,17 @@ mod retry_tests {
         sleep_fn_run_count.store(0, Ordering::Relaxed); // Reset our counter.
         {
             // Try with 3 retries.
-            let retry_config = MockDurationIterator::new(Duration::from_millis(EXPECTED_MS)).take(5);
             let run_count = Arc::new(AtomicI32::new(0));
             let result = Pin::new(&retrier)
-                .retry(
-                    retry_config,
-                    repeat_with(|| {
-                        run_count.fetch_add(1, Ordering::Relaxed);
-                        // Remember: This function is only called every time, not just retries.
-                        // We run the first time, then retry 2 additional times meaning 3 runs.
-                        if run_count.load(Ordering::Relaxed) == 3 {
-                            return RetryResult::Ok(true);
-                        }
-                        RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
-                    }),
-                )
+                .retry(repeat_with(|| {
+                    run_count.fetch_add(1, Ordering::Relaxed);
+                    // Remember: This function is only called every time, not just retries.
+                    // We run the first time, then retry 2 additional times meaning 3 runs.
+                    if run_count.load(Ordering::Relaxed) == 3 {
+                        return RetryResult::Ok(true);
+                    }
+                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+                }))
                 .await?;
 
             assert_eq!(result, true, "Expected results to pass");


### PR DESCRIPTION
# Description

The retrier always retries on error.  However, some errors are permanent, for example NotFound.  This means that if a request is made to get something from the CAS (or GrpcStore AC) which is not there, it keeps trying even though it's still not there.  This defines the set of errors which shoudl be retried and fails otherwise.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Remote proxy getting data from the action cache now doesn't retry ad infinitum.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/634)
<!-- Reviewable:end -->
