### PR TITLE
Create workflow for syncing Notion database and issues

### DIFF
--- a/.github/workflows/issues-notion-sync.yml
+++ b/.github/workflows/issues-notion-sync.yml
@@ -1,0 +1,36 @@
+name: Notion Sync
+
+on:
+  workflow_dispatch:
+  issues:
+    types:
+      [
+        opened,
+        edited,
+        labeled,
+        unlabeled,
+        assigned,
+        unassigned,
+        milestoned,
+        demilestoned,
+        reopened,
+        closed,
+      ]
+
+permissions: read-all
+
+jobs:
+  notion_job:
+    runs-on: ubuntu-latest
+    name: Add GitHub Issues to Notion
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Add GitHub Issues to Notion
+        uses: tryfabric/notion-github-action@10c6b128faeb9a1f16efc65a0b388b7595047e62 # v1.2.3
+        with:
+          notion-token: ${{ secrets.NOTION_TOKEN }}
+          notion-db: ${{ secrets.NOTION_DATABASE }}


### PR DESCRIPTION
# Description
Allows notion to sync with issues in our public repo.
Secrets that will have to be set by an admin:
- NOTION_TOKEN
- NOTION_DATABASE

Database will likely get changed to task board if we decide to make task tracking based out of the repo (Dump into backlog by default and can be moved by user) but will be separate for now.

Fixes #639

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/642)
<!-- Reviewable:end -->
