### PR TITLE
Max concurrent GrpcStore streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
 name = "nativelink-scheduler"
 version = "0.2.0"
 dependencies = [
+ "async-lock",
  "async-trait",
  "blake3",
  "futures",

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Native Link Authors. All rights reserved.
+// Copyright 2023-2024 The Native Link Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,6 +134,12 @@ pub struct GrpcScheduler {
     /// Retry configuration to use when a network request fails.
     #[serde(default)]
     pub retry: Retry,
+
+    /// Limit the number of simultaneous upstream requests to this many.  A
+    /// value of zero is treated as unlimited.  If the limit is reached the
+    /// request is queued.
+    #[serde(default)]
+    pub max_concurrent_requests: usize,
 }
 
 #[derive(Deserialize, Debug)]

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Native Link Authors. All rights reserved.
+// Copyright 2023-2024 The Native Link Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -546,6 +546,12 @@ pub struct GrpcStore {
     /// Retry configuration to use when a network request fails.
     #[serde(default)]
     pub retry: Retry,
+
+    /// Limit the number of simultaneous upstream requests to this many.  A
+    /// value of zero is treated as unlimited.  If the limit is reached the
+    /// request is queued.
+    #[serde(default)]
+    pub max_concurrent_requests: usize,
 }
 
 /// The possible error codes that might occur on an upstream request.

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -30,6 +30,7 @@ rust_library(
         "//nativelink-proto",
         "//nativelink-store",
         "//nativelink-util",
+        "@crates//:async-lock",
         "@crates//:blake3",
         "@crates//:futures",
         "@crates//:hashbrown",

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -13,6 +13,7 @@ nativelink-proto = { path = "../nativelink-proto" }
 #                    files somewhere else.
 nativelink-store = { path = "../nativelink-store" }
 
+async-lock = "3.2.0"
 async-trait = "0.1.74"
 blake3 = "1.5.0"
 prost = "0.12.3"

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
         "src/evicting_map.rs",
         "src/fastcdc.rs",
         "src/fs.rs",
+        "src/grpc_utils.rs",
         "src/lib.rs",
         "src/metrics_utils.rs",
         "src/platform_properties.rs",

--- a/nativelink-util/src/grpc_utils.rs
+++ b/nativelink-util/src/grpc_utils.rs
@@ -1,0 +1,107 @@
+// Copyright 2024 The Native Link Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_lock::{Semaphore, SemaphoreGuard};
+use nativelink_error::{Code, Error};
+use parking_lot::Mutex;
+use tonic::transport::{Channel, Endpoint};
+
+/// A helper utility that enables management of a suite of connections to an
+/// upstream gRPC endpoint using Tonic.
+pub struct ConnectionManager {
+    /// The endpoints to establish Channels for.
+    endpoints: Vec<Endpoint>,
+    /// A balance channel over the above endpoints which is kept with a
+    /// monotonic index to ensure we only re-create a channel on the first error
+    /// received on it.
+    channel: Mutex<(usize, Channel)>,
+    /// If a maximum number of upstream requests are allowed at a time, this
+    /// is a Semaphore to manage that.
+    request_semaphore: Option<Semaphore>,
+}
+
+impl ConnectionManager {
+    /// Create a connection manager that creates a balance list between a given
+    /// set of Endpoints.  This will restrict the number of concurrent requests
+    /// assuming that the user of this connection manager uses the connection
+    /// only once and reports all errors.
+    pub fn new(endpoints: impl IntoIterator<Item = Endpoint>, max_concurrent_requests: usize) -> Self {
+        let endpoints = Vec::from_iter(endpoints);
+        let channel = Channel::balance_list(endpoints.iter().cloned());
+        Self {
+            endpoints,
+            channel: Mutex::new((0, channel)),
+            request_semaphore: (max_concurrent_requests > 0).then_some(Semaphore::new(max_concurrent_requests)),
+        }
+    }
+
+    /// Get a connection slot for an Endpoint, this contains a Channel which
+    /// should be used once and any errors should be reported back to the
+    /// on_error method to ensure that the Channel is re-connected on error.
+    pub async fn get_connection(&self) -> (Connection<'_>, Channel) {
+        let _permit = if let Some(semaphore) = &self.request_semaphore {
+            Some(semaphore.acquire().await)
+        } else {
+            None
+        };
+        let channel_lock = self.channel.lock();
+        (
+            Connection {
+                channel_id: channel_lock.0,
+                parent: self,
+                _permit,
+            },
+            channel_lock.1.clone(),
+        )
+    }
+}
+
+/// An instance of this is obtained for every communication with the gGRPC
+/// service.  This handles the permit for limiting concurrency, and also
+/// re-connecting the underlying channel on error.  It depends on users
+/// reporting all errors.
+pub struct Connection<'a> {
+    channel_id: usize,
+    parent: &'a ConnectionManager,
+    _permit: Option<SemaphoreGuard<'a>>,
+}
+
+impl<'a> Connection<'a> {
+    pub fn on_error(self, err: &Error) {
+        // Usually Tonic reconnects on upstream errors (like Unavailable) but
+        // if there are protocol errors (such as GoAway) then it will not
+        // attempt to re-connect, and therefore we are forced to manually do
+        // that.
+        if err.code != Code::Internal {
+            return;
+        }
+        // Create a new channel for future requests to use upon a new request
+        // to ConnectionManager::get_connection().  In order to ensure we only
+        // do this for the first error on a cloned Channel we check the ID
+        // matches the current ID when we get the lock.
+        let mut channel_lock = self.parent.channel.lock();
+        if channel_lock.0 != self.channel_id {
+            // The connection was already re-established by another user getting
+            // and error on a clone of this Channel, so don't make another one.
+            return;
+        }
+        // Create a new channel with a unique ID to track if it gets an error.
+        // This new Channel will be used when a new request comes into
+        // ConnectionManager::get_connection() as this request has been and gone
+        // with an error now and it's up to the user whether they retry by
+        // getting a new connection.
+        channel_lock.0 += 1;
+        channel_lock.1 = Channel::balance_list(self.parent.endpoints.iter().cloned());
+    }
+}

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -19,6 +19,7 @@ pub mod digest_hasher;
 pub mod evicting_map;
 pub mod fastcdc;
 pub mod fs;
+pub mod grpc_utils;
 pub mod metrics_utils;
 pub mod platform_properties;
 pub mod resource_info;

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -20,7 +20,7 @@ use futures::future::Future;
 use futures::stream::StreamExt;
 use nativelink_config::stores::{ErrorCode, Retry};
 use nativelink_error::{make_err, Code, Error};
-use tracing::debug;
+use tracing::info;
 
 struct ExponentialBackoff {
     current: Duration,
@@ -148,7 +148,7 @@ impl Retrier {
                     Some(RetryResult::Err(e)) => return Err(e.append(format!("On attempt {attempt}"))),
                     Some(RetryResult::Retry(e)) => {
                         if !self.should_retry(&e.code) {
-                            debug!("Not retrying permanent error on attempt {attempt}: {e:?}");
+                            info!("Not retrying permanent error on attempt {attempt}: {e:?}");
                             return Err(e);
                         }
                         (self.sleep_fn)(iter.next().ok_or(e.append(format!("On attempt {attempt}")))?).await


### PR DESCRIPTION
# Description

Add a configuration option to limit the number of concurrent streams that are active with the upstream GrpcStore.

With this, we also introduce reconnection on error since Tonic doesn't do that.

Towards #602

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/656)
<!-- Reviewable:end -->
