### PR TITLE
Rename missing `turbo-cache` to `nativelink`

### DIFF
--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -78,7 +78,7 @@ mod memory_store_tests {
         Ok(())
     }
 
-    // Regression test for: https://github.com/TraceMachina/turbo-cache/issues/289.
+    // Regression test for: https://github.com/TraceMachina/nativelink/issues/289.
     #[tokio::test]
     async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
         // Arbitrary value, this may be increased if we find out that this is

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -98,7 +98,7 @@ mkdir -p "$NATIVELINK_DIR"
 for pattern in "${TEST_PATTERNS[@]}"; do
   find "$SELF_DIR/integration_tests/" -name "$pattern" -type f -print0 | while IFS= read -r -d $'\0' fullpath; do
     # Cleanup.
-    echo "Cleaning up cache directories TURBOC_CACHE_DIR: $NATIVELINK_DIR"
+    echo "Cleaning up cache directories NATIVELINK_DIR: $NATIVELINK_DIR"
     echo "Checking for existince of the NATIVELINK_DIR"
     if [ -d "$NATIVELINK_DIR" ]; then
       sudo find "$NATIVELINK_DIR" -delete


### PR DESCRIPTION
# Description

There are still remaining occurrences `turbo-cache` inside the project.
Detailed description can be found in the issue link below.

Fixes #662 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
