### PR TITLE
Check for slow store to be noop and conditionally replace with fast

### DIFF
--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{join, FutureExt};
+use nativelink_config::stores::StoreConfig;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
@@ -44,11 +45,21 @@ impl FastSlowStore {
         fast_store: Arc<dyn Store>,
         slow_store: Arc<dyn Store>,
     ) -> Self {
+        let slow_store = if matches!(_config.slow, StoreConfig::noop) {
+            fast_store.clone()
+        } else {
+            slow_store
+        };
+
         Self { fast_store, slow_store }
     }
 
     pub fn fast_store(&self) -> &Arc<dyn Store> {
         &self.fast_store
+    }
+
+    pub fn slow_store(&self) -> &Arc<dyn Store> {
+        &self.slow_store
     }
 
     /// Ensure our fast store is populated. This should be kept as a low


### PR DESCRIPTION
# Description

FastSlow store now checks if the slow store is a no-op and replaces it with the fast store if it is.

Fixes #665

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checks if the slow store is replaced with the fast store if it is configured as a noop.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/670)
<!-- Reviewable:end -->
