### PR TITLE
Ensure nested working directory from command proto are created

### DIFF
--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -70,6 +70,7 @@ rust_test_suite(
         "//nativelink-util",
         "@crates//:async-lock",
         "@crates//:futures",
+        "@crates//:hex",
         "@crates//:hyper",
         "@crates//:once_cell",
         "@crates//:pretty_assertions",


### PR DESCRIPTION
The command protocol spec allows for clients to send `Command.working_directory` that could be nested and not downloaded from other digests. This behavior has been seen with reclient implementations. This change will now create all directories from `Command.working_directory` at the root of `RunningActionImpl.work_directory`.

# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tested.
Reclient setup with chromium on macosx.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/678)
<!-- Reviewable:end -->
