### PR TITLE
Add API so stores can get Arc<Store> or &Store

### DIFF
--- a/nativelink-service/src/ac_server.rs
+++ b/nativelink-service/src/ac_server.rs
@@ -88,9 +88,8 @@ impl AcServer {
             .try_into()?;
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store_info.store.clone().inner_store(Some(digest)).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store_info.store.inner_store(Some(digest)).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store.get_action_result(Request::new(get_action_request)).await;
         }
 
@@ -125,10 +124,8 @@ impl AcServer {
             .try_into()?;
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store_info.store.clone().inner_store(Some(digest)).as_any();
-
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store_info.store.inner_store(Some(digest)).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store
                 .update_action_result(Request::new(update_action_request))
                 .await;

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -260,9 +260,8 @@ impl ByteStreamServer {
         let digest = DigestInfo::try_new(resource_info.hash, resource_info.expected_size)?;
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().inner_store(Some(digest)).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store.inner_store(Some(digest)).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             let stream = grpc_store.read(Request::new(read_request)).await?;
             return Ok(Response::new(Box::pin(stream)));
         }
@@ -369,9 +368,8 @@ impl ByteStreamServer {
             .err_tip(|| "Invalid digest input in ByteStream::write")?;
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().inner_store(Some(digest)).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store.inner_store(Some(digest)).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store.write(stream).await;
         }
 
@@ -497,9 +495,8 @@ impl ByteStreamServer {
         let digest = DigestInfo::try_new(resource_info.hash, resource_info.expected_size)?;
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store_clone.clone().inner_store(Some(digest)).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store_clone.inner_store(Some(digest)).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store.query_write_status(Request::new(query_request.clone())).await;
         }
 

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -107,9 +107,8 @@ impl CasServer {
         // If we are a GrpcStore we shortcut here, as this is a special store.
         // Note: We don't know the digests here, so we try perform a very shallow
         // check to see if it's a grpc store.
-        let any_store = store.clone().inner_store(None).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store.inner_store(None).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store.batch_update_blobs(Request::new(inner_request)).await;
         }
 
@@ -162,9 +161,8 @@ impl CasServer {
         // If we are a GrpcStore we shortcut here, as this is a special store.
         // Note: We don't know the digests here, so we try perform a very shallow
         // check to see if it's a grpc store.
-        let any_store = store.clone().inner_store(None).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store.inner_store(None).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             return grpc_store.batch_read_blobs(Request::new(inner_request)).await;
         }
 
@@ -221,10 +219,8 @@ impl CasServer {
         // If we are a GrpcStore we shortcut here, as this is a special store.
         // Note: We don't know the digests here, so we try perform a very shallow
         // check to see if it's a grpc store.
-        let any_store = store.clone().inner_store(None).as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-
-        if let Some(grpc_store) = maybe_grpc_store {
+        let any_store = store.inner_store(None).as_any();
+        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             let stream = grpc_store.get_tree(Request::new(inner_request)).await?.into_inner();
             return Ok(Response::new(Box::pin(stream)));
         }

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -354,12 +354,20 @@ impl Store for CompletenessCheckingStore {
         ac_store.get_part_ref(digest, writer, offset, length).await
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -578,12 +578,20 @@ impl Store for CompressionStore {
         Ok(())
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -342,12 +342,20 @@ impl Store for DedupStore {
         Ok(())
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -180,12 +180,20 @@ impl Store for ExistenceCacheStore {
         result
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -254,12 +254,20 @@ impl Store for FastSlowStore {
         }
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -778,12 +778,20 @@ impl<Fe: FileEntry> Store for FilesystemStore<Fe> {
         Ok(())
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -837,12 +837,20 @@ impl Store for GrpcStore {
             .await
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -153,12 +153,20 @@ impl Store for MemoryStore {
         Ok(())
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -64,12 +64,20 @@ impl Store for NoopStore {
         Err(make_err!(Code::NotFound, "Not found in noop store"))
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -124,9 +124,9 @@ impl Store for RefStore {
             .await
     }
 
-    fn inner_store(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn Store {
         match self.get_store() {
-            Ok(store) => store.clone().inner_store(digest),
+            Ok(store) => store.inner_store(digest),
             Err(e) => {
                 error!("Failed to get store for digest: {e:?}");
                 self
@@ -134,8 +134,22 @@ impl Store for RefStore {
         }
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        match self.get_store() {
+            Ok(store) => store.clone().inner_store_arc(digest),
+            Err(e) => {
+                error!("Failed to get store for digest: {e:?}");
+                self
+            }
+        }
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -527,12 +527,20 @@ impl Store for S3Store {
             .await
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 }
 

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -163,12 +163,20 @@ impl Store for VerifyStore {
         self.pin_inner().get_part_ref(digest, writer, offset, length).await
     }
 
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
         self
     }
 
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-        Box::new(self)
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
+    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        self
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -285,12 +285,20 @@ mod fast_slow_store_tests {
                 writer.send_eof().await
             }
 
-            fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+            fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
                 self
             }
 
-            fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
-                Box::new(self)
+            fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+                self
+            }
+
+            fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+                self
+            }
+
+            fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+                self
             }
 
             fn register_metrics(self: Arc<Self>, _registry: &mut nativelink_util::metrics_utils::Registry) {}

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -150,7 +150,7 @@ mod ref_store_tests {
 
         // Ensure the result of inner_store() points to exact same memory store.
         assert_eq!(
-            Arc::as_ptr(&ref_store_outer.inner_store(None)) as *const (),
+            Arc::as_ptr(&ref_store_outer.inner_store_arc(None)) as *const (),
             Arc::as_ptr(&memory_store) as *const (),
             "Expected inner store to be memory store"
         );

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -66,7 +66,7 @@ pub enum UploadSizeInfo {
 }
 
 #[async_trait]
-pub trait Store: Sync + Send + Unpin + HealthStatusIndicator {
+pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
     /// Look up a digest in the store and return None if it does not exist in
     /// the store, or Some(size) if it does.
     /// Note: On an AC store the size will be incorrect and should not be used!
@@ -266,10 +266,13 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator {
     /// A caller might want to use this to obtain a reference to the "real" underlying store
     /// (if applicable) and check if it implements some special traits that allow optimizations.
     /// Note: If the store performs complex operations on the data, it should return itself.
-    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store>;
+    // fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ (dyn std::any::Any + Sync + Send + 'static);
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store;
+    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store>;
 
-    /// Expect the returned Any to be `Arc<Self>`.
-    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send>;
+    /// Returns an Any variation of whatever Self is.
+    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static);
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static>;
 
     /// Register any metrics that this store wants to expose to the Prometheus.
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {}

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -69,6 +69,7 @@ rust_test_suite(
         "//nativelink-store",
         "//nativelink-util",
         "@crates//:async-lock",
+        "@crates//:bytes",
         "@crates//:futures",
         "@crates//:hyper",
         "@crates//:once_cell",

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -333,12 +333,10 @@ pub async fn new_local_worker(
     ac_store: Option<Arc<dyn Store>>,
     historical_store: Arc<dyn Store>,
 ) -> Result<LocalWorker<WorkerApiClientWrapper, RunningActionsManagerImpl>, Error> {
-    let fast_slow_store = cas_store
-        .inner_store(None)
-        .as_any()
-        .downcast_ref::<Arc<FastSlowStore>>()
-        .err_tip(|| "Expected store for LocalWorker's store to be a FastSlowStore")?
-        .clone();
+    let any_store = cas_store.inner_store_arc(None).as_any_arc();
+    let fast_slow_store = any_store
+        .downcast::<FastSlowStore>()
+        .map_err(|_| make_input_err!("Expected store for LocalWorker's store to be a FastSlowStore"))?;
 
     if let Ok(path) = fs::canonicalize(&config.work_directory).await {
         fs::remove_dir_all(path)


### PR DESCRIPTION
A little bit of cleanup to remove the need have an Arc<Store> when a user wants to up/down-cast to another store. Users can now do this by reference if they don't have an Arc<Store>.
