### PR TITLE
Start automated aggregation and surfacing of internal documentation with Rustdoc

### DIFF
--- a/deployment-examples/kubernetes/BUILD.bazel
+++ b/deployment-examples/kubernetes/BUILD.bazel
@@ -1,0 +1,12 @@
+filegroup(
+    name = "kubernetes",
+    srcs = [
+        "README.md",
+        "cas.json",
+        "cas.yaml",
+        "scheduler.json",
+        "scheduler.yaml",
+        "worker.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
         src = pkgs.lib.cleanSourceWith {
           src = craneLib.path ./.;
           filter = path: type:
-            (builtins.match "^.+/data/SekienAkashita\\.jpg" path != null)
+            (builtins.match "^.+/(data/SekienAkashita\\.jpg|deployment-examples/kubernetes/(README\\.md|cas\\.json|cas\\.yaml|scheduler\\.json|scheduler\\.yaml|worker\\.json)|README\\.md|examples/README\\.md)" path != null)
             || (craneLib.filterCargoSources path type);
         };
 

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -14,6 +14,11 @@ rust_library(
         "src/serde_utils.rs",
         "src/stores.rs",
     ],
+    compile_data = [
+        "README.md",
+        "examples/README.md",
+        "//deployment-examples/kubernetes",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:serde",

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.197", features = ["derive"] }
 shellexpand = "3.1.0"
+
+[package.metadata.docs.rs]
+readme = "./README.md"

--- a/nativelink-config/src/lib.rs
+++ b/nativelink-config/src/lib.rs
@@ -12,6 +12,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc = include_str!("../README.md")]
+#![doc = "\n\n"] // Add some spacing between the two README files
+#![doc = "
+<details>
+  <summary>Example Configuration Breakdown</summary>
+"]
+#![doc = include_str!("../examples/README.md")]
+#![doc = "</details>"]
+#![doc = "
+<details>
+  <summary>Example Kubernetes Configuraton Breakdown</summary>
+"]
+#![doc = "
+<details>
+  <summary>CAS JSON Config</summary>
+"]
+#![doc = "\n"]
+#![doc = "```json"]
+#![doc = include_str!("../../deployment-examples/kubernetes/cas.json")]
+#![doc = "```"]
+#![doc = "\n"]
+#![doc = "</details>"]
+#![doc = "
+<details>
+  <summary>Scheduler JSON Config</summary>
+"]
+#![doc = "\n"]
+#![doc = "```json"]
+#![doc = include_str!("../../deployment-examples/kubernetes/scheduler.json")]
+#![doc = "```"]
+#![doc = "\n"]
+#![doc = "</details>"]
+#![doc = "
+<details>
+  <summary>Scheduler YAML</summary>
+"]
+#![doc = "\n"]
+#![doc = "```yaml"]
+#![doc = "# Test"]
+#![doc = include_str!("../../deployment-examples/kubernetes/scheduler.yaml")]
+#![doc = "```"]
+#![doc = "\n"]
+#![doc = "</details>"]
+#![doc = "
+<details>
+  <summary>Worker JSON</summary>
+"]
+#![doc = "\n"]
+#![doc = "```yaml"]
+#![doc = "# Test"]
+#![doc = include_str!("../../deployment-examples/kubernetes/worker.json")]
+#![doc = "```"]
+#![doc = "\n"]
+#![doc = "</details>"]
+#![doc = "
+<details>
+  <summary>CAS YAML</summary>
+"]
+#![doc = "\n"]
+#![doc = "```yaml"]
+#![doc = include_str!("../../deployment-examples/kubernetes/cas.yaml")]
+#![doc = "```"]
+#![doc = "\n"]
+#![doc = "</details>"]
+#![doc = include_str!("../../deployment-examples/kubernetes/README.md")]
+#![doc = "</details>"]
+#![doc = "\n\n"] // Add some spacing between the two README files
+#![doc = "</details>"]
+
 pub mod cas_server;
 pub mod schedulers;
 mod serde_utils;


### PR DESCRIPTION
First PR for leveraging rustdoc to surface existing documentation in the code. This reduces the need for redundant documentation on complex and quickly-evolving systems such as configuration files and stores.

This PR focuses on requested improvements and aggregation of information on configuring Nativelink, as well as establishing rustdoc patterns to use on the rest of the monorepo as it is continuously documented.

The change surfaces the below information from the existing `nativelink-config` documentation for the rust doc:

- Example READMEs (For examples from [In-flight PR from @MarcusSorealheis](https://github.com/TraceMachina/nativelink/pull/680) & Kubernetes deployment examples)
  - In order to thoroughly document the requested `cas.json` , `scheduler.json`, `cas.yaml`,  and `scheduler.yaml` examples they require updating in one place
  
After running `cargo doc` in the repository, this page can be reviewed in the browser at:
`file:///Path/to/repo/nativelink/target/doc/nativelink_config/index.html`

This change also surfaces existing documentation and mildly enhances with examples for:

- `nativelink-config/stores.rs` -> `enum StoreConfig`

After running `cargo doc` in the repository, this page can be reviewed in the browser at:
`file:///Users/blakehatch/Projects/nativelink/target/doc/nativelink_config/stores/enum.StoreConfig.html`

Upcoming PRs will focus on improving the existing now surfaced and aggregated documentation as well as the formatting of the generated Markdown in `nativelink-config/src/lib.rs`

#681 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/688)
<!-- Reviewable:end -->
