### PR TITLE
Update Bazel-tracked toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
 dependencies = [
  "rustc_version",
 ]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_python", version = "0.29.0")
+bazel_dep(name = "rules_python", version = "0.31.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
@@ -18,7 +18,7 @@ python.toolchain(
 )
 use_repo(python, python = "python_versions")
 
-bazel_dep(name = "hermetic_cc_toolchain", version = "2.2.1")
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1")
 
 zig_toolchains = use_extension(
     "@hermetic_cc_toolchain//toolchain:ext.bzl",
@@ -26,33 +26,19 @@ zig_toolchains = use_extension(
 )
 use_repo(zig_toolchains, "zig_sdk")
 
-bazel_dep(name = "rules_rust", version = "0.36.2")
-git_override(
-    module_name = "rules_rust",
-    commit = "4136f6fedd033108294138a657b4ccd8ac57c8ef",
-    patch_strip = 1,
-    patches = [
-        # TODO(aaronmondal): Remove this after:
-        # https://github.com/bazelbuild/rules_rust/pull/2428
-        "//tools:rules_rust_deduplicate_sysroot.diff",
-        # TODO(aaronmondal): Remove this after:
-        # https://github.com/bazelbuild/rules_rust/pull/2422
-        "//tools:rules_rust_bindgen_linkopts.diff",
-    ],
-    remote = "https://github.com/bazelbuild/rules_rust",
-)
+bazel_dep(name = "rules_rust", version = "0.40.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
     versions = [
-        "1.75.0",
-        "nightly/2024-01-01",
+        "1.76.0",
+        "nightly/2024-03-01",
     ],
 )
 rust.host_tools(
     edition = "2021",
-    version = "1.75.0",
+    version = "1.76.0",
 )
 use_repo(rust, "rust_toolchains")
 

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::result::Result;
-
 use prost_types::TimestampError;
 
 #[macro_export]

--- a/nativelink-proto/gen_protos_tool.rs
+++ b/nativelink-proto/gen_protos_tool.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::vec::Vec;
 
 use clap::{Arg, ArgAction, Command};
 use prost_build::Config;

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 

--- a/nativelink-service/src/ac_server.rs
+++ b/nativelink-service/src/ac_server.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -14,7 +14,6 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
 use std::pin::Pin;
 use std::sync::Arc;
 

--- a/nativelink-store/src/ac_utils.rs
+++ b/nativelink-store/src/ac_utils.rs
@@ -17,7 +17,6 @@
 //                    THREADSAFETY. FIGURE OUT WHY AND MOVE IT TO UTILS.
 // @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-use std::default::Default;
 use std::pin::Pin;
 
 use bytes::{Bytes, BytesMut};

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bincode::config::{FixintEncoding, WithOtherIntEncoding};
-use bincode::{self, DefaultOptions, Options};
+use bincode::{DefaultOptions, Options};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::future::FutureExt;

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bincode::config::{FixintEncoding, WithOtherIntEncoding};
-use bincode::{self, DefaultOptions, Options};
+use bincode::{DefaultOptions, Options};
 use futures::stream::{self, FuturesOrdered, StreamExt, TryStreamExt};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf, StreamReader};

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem::size_of;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -33,7 +32,7 @@ struct ExistanceItem(usize);
 impl LenEntry for ExistanceItem {
     #[inline]
     fn len(&self) -> usize {
-        size_of::<Self>()
+        self.0
     }
 
     #[inline]

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::Send;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -14,7 +14,6 @@
 
 use std::borrow::Cow;
 use std::future::Future;
-use std::marker::Send;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
 use std::pin::Pin;
 use std::sync::Arc;
 

--- a/nativelink-util/src/common.rs
+++ b/nativelink-util/src/common.rs
@@ -14,7 +14,6 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -15,7 +15,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::marker::Send;
 use std::pin::Pin;
 use std::sync::Arc;
 

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -15,7 +15,6 @@
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher as StdHasher;
 use std::hash::{Hash, Hasher};
-use std::marker::Send;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -14,7 +14,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
-use std::marker::Unpin;
 
 use bytes::Bytes;
 use futures::stream::StreamExt;

--- a/nativelink-util/tests/health_utils_test.rs
+++ b/nativelink-util/tests/health_utils_test.rs
@@ -14,7 +14,6 @@
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use futures::StreamExt;


### PR DESCRIPTION
Includes Rust 1.76.0, Rust nightly, zig-cc and python.

Fixes a bug in `ExistenceItem` where we didn't properly return the content length.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/690)
<!-- Reviewable:end -->
