### PR TITLE
Optimize hashing files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "memmap2",
 ]
 
 [[package]]
@@ -1594,6 +1595,15 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memory-stats"

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -10,7 +10,7 @@ nativelink-proto = { path = "../nativelink-proto" }
 
 async-lock = "3.3.0"
 async-trait = "0.1.77"
-blake3 = "1.5.0"
+blake3 = { version = "1.5.0", features = ["mmap"] }
 bytes = "1.5.0"
 futures = "0.3.30"
 hex = "0.4.3"

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -15,12 +15,16 @@
 use std::sync::OnceLock;
 
 use blake3::Hasher as Blake3Hasher;
+use bytes::BytesMut;
+use futures::Future;
 use nativelink_config::stores::ConfigDigestHashFunction;
-use nativelink_error::{make_err, make_input_err, Code, Error};
+use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::digest_function::Value as ProtoDigestFunction;
 use sha2::{Digest, Sha256};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::common::DigestInfo;
+use crate::common::{DigestInfo, JoinHandleDropGuard};
+use crate::fs;
 
 static DEFAULT_DIGEST_HASHER_FUNC: OnceLock<DigestHasherFunc> = OnceLock::new();
 
@@ -115,6 +119,38 @@ pub trait DigestHasher {
 
     /// Finalize the hash function and collect the results into a digest.
     fn finalize_digest(&mut self) -> DigestInfo;
+
+    /// Specialized version of the hashing function that is optimized for
+    /// handling files. These optimizations take into account things like,
+    /// the file size and the hasher algorithm to decide how to best process
+    /// the file and feed it into the hasher.
+    fn digest_for_file(
+        self,
+        file: fs::ResumeableFileSlot<'static>,
+        size_hint: Option<u64>,
+    ) -> impl Future<Output = Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error>>;
+
+    /// Utility function to compute a hash from a generic reader.
+    fn compute_from_reader<R: AsyncRead + Unpin + Send>(
+        &mut self,
+        mut reader: R,
+    ) -> impl Future<Output = Result<DigestInfo, Error>> {
+        async move {
+            let mut chunk = BytesMut::with_capacity(fs::DEFAULT_READ_BUFF_SIZE);
+            loop {
+                reader
+                    .read_buf(&mut chunk)
+                    .await
+                    .err_tip(|| "Could not read chunk during compute_from_reader")?;
+                if chunk.is_empty() {
+                    break; // EOF.
+                }
+                DigestHasher::update(self, &chunk);
+                chunk.clear();
+            }
+            Ok(DigestHasher::finalize_digest(self))
+        }
+    }
 }
 
 pub enum DigestHasherFuncImpl {
@@ -126,6 +162,21 @@ pub enum DigestHasherFuncImpl {
 pub struct DigestHasherImpl {
     hashed_size: i64,
     hash_func_impl: DigestHasherFuncImpl,
+}
+
+impl DigestHasherImpl {
+    #[inline]
+    async fn hash_file(
+        &mut self,
+        mut file: fs::ResumeableFileSlot<'static>,
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+        let reader = file.as_reader().await.err_tip(|| "In digest_for_file")?;
+        let digest = self
+            .compute_from_reader(reader)
+            .await
+            .err_tip(|| "In digest_for_file")?;
+        Ok((digest, file))
+    }
 }
 
 impl DigestHasher for DigestHasherImpl {
@@ -147,5 +198,39 @@ impl DigestHasher for DigestHasherImpl {
             DigestHasherFuncImpl::Blake3(h) => h.finalize().into(),
         };
         DigestInfo::new(hash, self.hashed_size)
+    }
+
+    async fn digest_for_file(
+        mut self,
+        mut file: fs::ResumeableFileSlot<'static>,
+        size_hint: Option<u64>,
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+        let file_position = file
+            .stream_position()
+            .await
+            .err_tip(|| "Couldn't get stream position in digest_for_file")?;
+        if file_position != 0 {
+            return self.hash_file(file).await;
+        }
+        // If we are a small file, it's faster to just do it the "slow" way.
+        // Great read: https://github.com/david-slatinek/c-read-vs.-mmap
+        if let Some(size_hint) = size_hint {
+            if size_hint <= fs::DEFAULT_READ_BUFF_SIZE as u64 {
+                return self.hash_file(file).await;
+            }
+        }
+        match self.hash_func_impl {
+            DigestHasherFuncImpl::Sha256(_) => self.hash_file(file).await,
+            DigestHasherFuncImpl::Blake3(mut hasher) => {
+                JoinHandleDropGuard::new(tokio::task::spawn_blocking(move || {
+                    hasher
+                        .update_mmap(file.get_path())
+                        .map_err(|e| make_err!(Code::Internal, "Error in blake3's update_mmap: {e:?}"))?;
+                    Result::<_, Error>::Ok((DigestInfo::new(hasher.finalize().into(), hasher.count() as i64), file))
+                }))
+                .await
+                .err_tip(|| "Could not spawn blocking task in digest_for_file")?
+            }
+        }
     }
 }


### PR DESCRIPTION
Computing the digest now happens using mmap when using blake3 and changes default read size to 16k instead of 4k.

Towards: #409

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/720)
<!-- Reviewable:end -->
