### PR TITLE
Optimize file uploads when source is file

### DIFF
--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -20,7 +20,7 @@ use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreOptimizations, UploadSizeInfo};
 
 #[derive(Default)]
 pub struct NoopStore;
@@ -52,6 +52,10 @@ impl Store for NoopStore {
         // the connection prematurely.
         reader.drain().await.err_tip(|| "In NoopStore::update")?;
         Ok(())
+    }
+
+    fn optimized_for(&self, optimization: StoreOptimizations) -> bool {
+        optimization == StoreOptimizations::NoopUpdates || optimization == StoreOptimizations::NoopDownloads
     }
 
     async fn get_part_ref(

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -18,10 +18,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use nativelink_error::{Error, ResultExt};
-use nativelink_store::ac_utils::upload_file_to_store;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::{fs, DigestInfo};
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::{Store, UploadSizeInfo};
 use rand::{thread_rng, Rng};
 use tokio::io::AsyncWriteExt;
 
@@ -70,7 +69,9 @@ mod ac_utils_tests {
         {
             // Upload our file.
             let resumeable_file = fs::open_file(filepath, u64::MAX).await?;
-            upload_file_to_store(store_pin, digest, resumeable_file).await?;
+            store_pin
+                .update_with_whole_file(digest, resumeable_file, UploadSizeInfo::ExactSize(expected_data.len()))
+                .await?;
         }
         {
             // Check to make sure the file was saved correctly to the store.


### PR DESCRIPTION
When using nativelink with a local worker/CAS setup, adds optimizations which make it faster to upload files from the worker to the CAS.

This is specifically useful for Buck2 for users that want to build hermetically.

closes: #409

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/723)
<!-- Reviewable:end -->
