### PR TITLE
backport v0.1 changes

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -421,6 +421,12 @@ pub enum EnvironmentSource {
     /// All fields are optional, file does not need to be created and may be
     /// empty.
     side_channel_file,
+
+    /// A "root" directory for the action. This directory can be used to
+    /// store temporary files that are not needed after the action has
+    /// completed. This directory will be purged after the action has
+    /// completed.
+    action_directory,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -31,7 +31,7 @@ serde = "1.0.197"
 sha2 = "0.10.8"
 shellexpand = "3.1.0"
 tempfile = "3.10.1"
-tokio = { version = "1.36.0" }
+tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tokio-util = { version = "0.7.10" }
 tonic = { version = "0.11.0", features = ["gzip", "tls"] }

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -207,9 +207,9 @@ impl Store for FastSlowStore {
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::ResumeableFileSlot<'static>>, Error> {
+    ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
         let fast_store = self.fast_store.inner_store(Some(digest));
         let slow_store = self.slow_store.inner_store(Some(digest));
         if fast_store.optimized_for(StoreOptimizations::FileUpdates) {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -135,7 +135,7 @@ pub trait FileEntry: LenEntry + Send + Sync + Debug + 'static {
     async fn make_and_open_file(
         block_size: u64,
         encoded_file_path: EncodedFilePath,
-    ) -> Result<(Self, fs::ResumeableFileSlot<'static>, OsString), Error>
+    ) -> Result<(Self, fs::ResumeableFileSlot, OsString), Error>
     where
         Self: Sized;
 
@@ -149,7 +149,7 @@ pub trait FileEntry: LenEntry + Send + Sync + Debug + 'static {
     fn get_encoded_file_path(&self) -> &RwLock<EncodedFilePath>;
 
     /// Returns a reader that will read part of the underlying file.
-    async fn read_file_part<'a>(&'a self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot<'a>, Error>;
+    async fn read_file_part(&self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot, Error>;
 
     /// This function is a safe way to extract the file name of the underlying file. To protect users from
     /// accidentally creating undefined behavior we encourage users to do the logic they need to do with
@@ -191,7 +191,7 @@ impl FileEntry for FileEntryImpl {
     async fn make_and_open_file(
         block_size: u64,
         encoded_file_path: EncodedFilePath,
-    ) -> Result<(FileEntryImpl, fs::ResumeableFileSlot<'static>, OsString), Error> {
+    ) -> Result<(FileEntryImpl, fs::ResumeableFileSlot, OsString), Error> {
         let temp_full_path = encoded_file_path.get_file_path().to_os_string();
         let temp_file_result = fs::create_file(temp_full_path.clone())
             .or_else(|mut err| async {
@@ -229,7 +229,7 @@ impl FileEntry for FileEntryImpl {
         &self.encoded_file_path
     }
 
-    async fn read_file_part<'a>(&'a self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot<'a>, Error> {
+    async fn read_file_part(&self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot, Error> {
         let (mut file, full_content_path_for_debug_only) = self
             .get_file_path_locked(|full_content_path| async move {
                 let file = fs::open_file(full_content_path.clone(), length)
@@ -544,7 +544,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
     async fn update_file<'a>(
         self: Pin<&'a Self>,
         mut entry: Fe,
-        mut resumeable_temp_file: fs::ResumeableFileSlot<'a>,
+        mut resumeable_temp_file: fs::ResumeableFileSlot,
         final_digest: DigestInfo,
         mut reader: DropCloserReadHalf,
     ) -> Result<(), Error> {
@@ -576,6 +576,13 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
                 .await
                 .err_tip(|| "Failed to write data into filesystem store")?;
             data_size += data_len as u64;
+        }
+        if data_size == 0 && !is_zero_digest(&final_digest) {
+            warn!("Received empty file for digest {final_digest:?}");
+            return Err(make_err!(
+                Code::InvalidArgument,
+                "Cannot save empty files that are not zero digests"
+            ));
         }
 
         resumeable_temp_file
@@ -626,11 +633,8 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             // Internally tokio spawns fs commands onto a blocking thread anyways.
             // Since we are already on a blocking thread, we just need the `fs` wrapper to manage
             // an open-file permit (ensure we don't open too many files at once).
-            let result = fs::call_with_permit(|| {
-                (rename_fn)(from_path.as_ref(), final_path.as_ref())
-                    .err_tip(|| format!("Failed to rename temp file to final path {final_path:?}"))
-            })
-            .await;
+            let result = (rename_fn)(&from_path, &final_path)
+                .err_tip(|| format!("Failed to rename temp file to final path {final_path:?}"));
 
             // In the event our move from temp file to final file fails we need to ensure we remove
             // the entry from our map.
@@ -715,9 +719,9 @@ impl<Fe: FileEntry> Store for FilesystemStore<Fe> {
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::ResumeableFileSlot<'static>>, Error> {
+    ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
         let path = file.get_path().as_os_str().to_os_string();
         let file_size = match upload_size {
             UploadSizeInfo::ExactSize(size) => size as u64,

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -126,9 +126,9 @@ pub trait DigestHasher {
     /// the file and feed it into the hasher.
     fn digest_for_file(
         self,
-        file: fs::ResumeableFileSlot<'static>,
+        file: fs::ResumeableFileSlot,
         size_hint: Option<u64>,
-    ) -> impl Future<Output = Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error>>;
+    ) -> impl Future<Output = Result<(DigestInfo, fs::ResumeableFileSlot), Error>>;
 
     /// Utility function to compute a hash from a generic reader.
     fn compute_from_reader<R: AsyncRead + Unpin + Send>(
@@ -168,8 +168,8 @@ impl DigestHasherImpl {
     #[inline]
     async fn hash_file(
         &mut self,
-        mut file: fs::ResumeableFileSlot<'static>,
-    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+        mut file: fs::ResumeableFileSlot,
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot), Error> {
         let reader = file.as_reader().await.err_tip(|| "In digest_for_file")?;
         let digest = self
             .compute_from_reader(reader)
@@ -202,9 +202,9 @@ impl DigestHasher for DigestHasherImpl {
 
     async fn digest_for_file(
         mut self,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         size_hint: Option<u64>,
-    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot), Error> {
         let file_position = file
             .stream_position()
             .await

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -71,7 +71,7 @@ pub enum UploadSizeInfo {
 pub async fn slow_update_store_with_file<S: Store + ?Sized>(
     store: Pin<&S>,
     digest: DigestInfo,
-    file: &mut fs::ResumeableFileSlot<'static>,
+    file: &mut fs::ResumeableFileSlot,
     upload_size: UploadSizeInfo,
 ) -> Result<(), Error> {
     let (tx, rx) = make_buf_channel_pair();
@@ -173,9 +173,9 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::ResumeableFileSlot<'static>>, Error> {
+    ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
         let inner_store = self.inner_store(Some(digest));
         if inner_store.optimized_for(StoreOptimizations::FileUpdates) {
             error_if!(

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -358,7 +358,7 @@ pub async fn new_local_worker(
         Duration::from_secs(config.max_action_timeout as u64)
     };
     let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-        root_work_directory: config.work_directory.clone(),
+        root_action_directory: config.work_directory.clone(),
         execution_configuration: ExecutionConfiguration {
             entrypoint,
             additional_environment: config.additional_environment.clone(),

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -419,12 +419,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory,
+                root_action_directory,
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -520,12 +520,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory,
+                root_action_directory,
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -628,12 +628,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory,
+                root_action_directory,
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -788,12 +788,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory,
+                root_action_directory,
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -949,12 +949,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory,
+                root_action_directory,
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1127,12 +1127,12 @@ mod running_actions_manager_tests {
         }
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory: root_work_directory.clone(),
+                root_action_directory: root_action_directory.clone(),
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1232,10 +1232,10 @@ mod running_actions_manager_tests {
                 message: String::new(),
             }
         );
-        let mut dir_stream = fs::read_dir(&root_work_directory).await?;
+        let mut dir_stream = fs::read_dir(&root_action_directory).await?;
         assert!(
             dir_stream.as_mut().next_entry().await?.is_none(),
-            "Expected empty directory at {root_work_directory}"
+            "Expected empty directory at {root_action_directory}"
         );
         Ok(())
     }
@@ -1246,11 +1246,11 @@ mod running_actions_manager_tests {
         const SALT: u64 = 55;
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: root_work_directory.clone(),
+            root_action_directory: root_action_directory.clone(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1357,8 +1357,8 @@ exit 0
         const EXPECTED_STDOUT: &str = "Action did run";
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let test_wrapper_script = {
             let test_wrapper_dir = make_temp_path("wrapper_dir");
@@ -1386,7 +1386,7 @@ exit 0
         tokio::time::sleep(Duration::from_millis(250)).await;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: root_work_directory.clone(),
+            root_action_directory: root_action_directory.clone(),
             execution_configuration: ExecutionConfiguration {
                 entrypoint: Some(test_wrapper_script.into_string().unwrap()),
                 additional_environment: None,
@@ -1488,8 +1488,8 @@ exit 0
         const EXPECTED_STDOUT: &str = "Action did run";
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let test_wrapper_script = {
             let test_wrapper_dir = make_temp_path("wrapper_dir");
@@ -1517,7 +1517,7 @@ exit 0
         tokio::time::sleep(Duration::from_millis(250)).await;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: root_work_directory.clone(),
+            root_action_directory: root_action_directory.clone(),
             execution_configuration: ExecutionConfiguration {
                 entrypoint: Some(test_wrapper_script.into_string().unwrap()),
                 additional_environment: Some(HashMap::from([
@@ -1634,8 +1634,8 @@ exit 1
         const SALT: u64 = 66;
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let test_wrapper_script = {
             let test_wrapper_dir = make_temp_path("wrapper_dir");
@@ -1663,7 +1663,7 @@ exit 1
         tokio::time::sleep(Duration::from_millis(250)).await;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: root_work_directory.clone(),
+            root_action_directory: root_action_directory.clone(),
             execution_configuration: ExecutionConfiguration {
                 entrypoint: Some(test_wrapper_script.into_string().unwrap()),
                 additional_environment: Some(HashMap::from([(
@@ -1732,7 +1732,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1791,7 +1791,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1850,7 +1850,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1932,7 +1932,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -1966,7 +1966,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2025,7 +2025,7 @@ exit 1
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_work_directory: String::new(),
+            root_action_directory: String::new(),
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: Pin::into_inner(cas_store.clone()),
             ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2076,8 +2076,8 @@ exit 1
             monotonic_clock(&CLOCK)
         }
 
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
@@ -2122,7 +2122,7 @@ exit 1
 
             let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
                 RunningActionsManagerArgs {
-                    root_work_directory: root_work_directory.clone(),
+                    root_action_directory: root_action_directory.clone(),
                     execution_configuration: ExecutionConfiguration::default(),
                     cas_store: Pin::into_inner(cas_store.clone()),
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2191,7 +2191,7 @@ exit 1
 
             let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
                 RunningActionsManagerArgs {
-                    root_work_directory: root_work_directory.clone(),
+                    root_action_directory: root_action_directory.clone(),
                     execution_configuration: ExecutionConfiguration::default(),
                     cas_store: Pin::into_inner(cas_store.clone()),
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2263,7 +2263,7 @@ exit 1
 
             let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
                 RunningActionsManagerArgs {
-                    root_work_directory: root_work_directory.clone(),
+                    root_action_directory: root_action_directory.clone(),
                     execution_configuration: ExecutionConfiguration::default(),
                     cas_store: Pin::into_inner(cas_store.clone()),
                     ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2329,13 +2329,13 @@ exit 1
             let (tx, rx) = oneshot::channel();
             Mutex::new((Some(tx), Some(rx)))
         });
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory: root_work_directory.clone(),
+                root_action_directory: root_action_directory.clone(),
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),
@@ -2437,13 +2437,13 @@ exit 1
             monotonic_clock(&CLOCK)
         }
 
-        let root_work_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_work_directory).await?;
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
 
         let (_, _, cas_store, ac_store) = setup_stores().await?;
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_work_directory: root_work_directory.clone(),
+                root_action_directory: root_action_directory.clone(),
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: Pin::into_inner(cas_store.clone()),
                 ac_store: Some(Pin::into_inner(ac_store.clone())),


### PR DESCRIPTION
# Description
Includes the following changes from v0.1 PR:
- Minor refactor of functionally same code
- Refactor fs.rs to use call_with_permit scheme
- Add timeout function for filesystem_store::FilesystemStore rename call
- Add safe request timeout for running actions manager 
- Add root directory for action

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/733)
<!-- Reviewable:end -->
