### PR TITLE
Set `rust-version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 name = "nativelink"
 version = "0.2.0"
 edition = "2021"
+rust-version = "1.76"
 
 [profile.release]
 lto = true

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,8 @@
         system,
         ...
       }: let
-        stable-rust = pkgs.rust-bin.stable."1.75.0";
-        nightly-rust = pkgs.rust-bin.nightly."2024-01-01";
+        stable-rust = pkgs.rust-bin.stable."1.76.0";
+        nightly-rust = pkgs.rust-bin.nightly."2024-03-01";
 
         maybeDarwinDeps = pkgs.lib.optionals pkgs.stdenv.isDarwin [
           pkgs.darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
The Cargo build now raises an error if the Rust version doesn't match.

Fixes a bug where the flake version wasn't in sync with the Bazel build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/734)
<!-- Reviewable:end -->
