### PR TITLE
Use jemalloc on non-windows to reduce memory fragmentation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,7 +38,12 @@ rust_binary(
         "@crates//:tower",
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
-    ],
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "@crates//:tikv-jemallocator",
+        ],
+    }),
 )
 
 genrule(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "rustls-pemfile 2.1.1",
  "scopeguard",
  "serde_json5",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls 0.25.0",
  "tonic 0.11.0",
@@ -2862,6 +2863,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ tonic = { version = "0.11.0", features = ["gzip", "tls"] }
 tower = "0.4.13"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5.4"

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -66,6 +66,13 @@ use tower::util::ServiceExt;
 use tracing::{error, warn};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
+// We use jemalloc because our program is frequently long-lived and memory fragmentation
+// happens often with memory store. Jemalloc nearly completely removes memory fragmentation
+// issues.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// Note: This must be kept in sync with the documentation in `PrometheusConfig::path`.
 const DEFAULT_PROMETHEUS_METRICS_PATH: &str = "/metrics";
 


### PR DESCRIPTION
To help reduce/remove memory fragmentation caused by memory store we are switching our allocator to jemalloc. This should make our memory compaction significantly more efficient.

closes #621

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/738)
<!-- Reviewable:end -->
