### PR TITLE
Refactor fs.rs to use call_with_permit scheme

### DIFF
--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -207,9 +207,9 @@ impl Store for FastSlowStore {
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::ResumeableFileSlot<'static>>, Error> {
+    ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
         let fast_store = self.fast_store.inner_store(Some(digest));
         let slow_store = self.slow_store.inner_store(Some(digest));
         if fast_store.optimized_for(StoreOptimizations::FileUpdates) {

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -77,7 +77,7 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
     async fn make_and_open_file(
         block_size: u64,
         encoded_file_path: EncodedFilePath,
-    ) -> Result<(Self, fs::ResumeableFileSlot<'static>, OsString), Error> {
+    ) -> Result<(Self, fs::ResumeableFileSlot, OsString), Error> {
         let (inner, file_slot, path) = FileEntryImpl::make_and_open_file(block_size, encoded_file_path).await?;
         Ok((
             Self {
@@ -101,7 +101,7 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
         self.inner.as_ref().unwrap().get_encoded_file_path()
     }
 
-    async fn read_file_part<'a>(&'a self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot<'a>, Error> {
+    async fn read_file_part(&self, offset: u64, length: u64) -> Result<fs::ResumeableFileSlot, Error> {
         self.inner.as_ref().unwrap().read_file_part(offset, length).await
     }
 

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -126,9 +126,9 @@ pub trait DigestHasher {
     /// the file and feed it into the hasher.
     fn digest_for_file(
         self,
-        file: fs::ResumeableFileSlot<'static>,
+        file: fs::ResumeableFileSlot,
         size_hint: Option<u64>,
-    ) -> impl Future<Output = Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error>>;
+    ) -> impl Future<Output = Result<(DigestInfo, fs::ResumeableFileSlot), Error>>;
 
     /// Utility function to compute a hash from a generic reader.
     fn compute_from_reader<R: AsyncRead + Unpin + Send>(
@@ -168,8 +168,8 @@ impl DigestHasherImpl {
     #[inline]
     async fn hash_file(
         &mut self,
-        mut file: fs::ResumeableFileSlot<'static>,
-    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+        mut file: fs::ResumeableFileSlot,
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot), Error> {
         let reader = file.as_reader().await.err_tip(|| "In digest_for_file")?;
         let digest = self
             .compute_from_reader(reader)
@@ -202,9 +202,9 @@ impl DigestHasher for DigestHasherImpl {
 
     async fn digest_for_file(
         mut self,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         size_hint: Option<u64>,
-    ) -> Result<(DigestInfo, fs::ResumeableFileSlot<'static>), Error> {
+    ) -> Result<(DigestInfo, fs::ResumeableFileSlot), Error> {
         let file_position = file
             .stream_position()
             .await

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
-use std::ffi::OsStr;
 use std::fs::Metadata;
 use std::io::IoSlice;
 use std::path::{Path, PathBuf};
@@ -58,25 +56,25 @@ enum MaybeFileSlot {
 /// the file. To simplify the code significantly we always require the
 /// file to be a `Take<FileSlot>`.
 #[derive(Debug)]
-pub struct ResumeableFileSlot<'a> {
+pub struct ResumeableFileSlot {
     maybe_file_slot: MaybeFileSlot,
-    path: Cow<'a, OsStr>,
+    path: PathBuf,
     is_write: bool,
 }
 
-impl<'a> ResumeableFileSlot<'a> {
-    pub fn new(file: FileSlot, path: impl Into<Cow<'a, OsStr>>, is_write: bool) -> Self {
+impl ResumeableFileSlot {
+    pub fn new(file: FileSlot, path: PathBuf, is_write: bool) -> Self {
         Self {
             maybe_file_slot: MaybeFileSlot::Open(file.take(u64::MAX)),
-            path: path.into(),
+            path,
             is_write,
         }
     }
 
-    pub fn new_with_take(file: Take<FileSlot>, path: impl Into<Cow<'a, OsStr>>, is_write: bool) -> Self {
+    pub fn new_with_take(file: Take<FileSlot>, path: PathBuf, is_write: bool) -> Self {
         Self {
             maybe_file_slot: MaybeFileSlot::Open(file),
-            path: path.into(),
+            path,
             is_write,
         }
     }
@@ -263,14 +261,27 @@ const DEFAULT_OPEN_FILE_PERMITS: usize = 10;
 static TOTAL_FILE_SEMAPHORES: AtomicUsize = AtomicUsize::new(DEFAULT_OPEN_FILE_PERMITS);
 pub static OPEN_FILE_SEMAPHORE: Semaphore = Semaphore::const_new(DEFAULT_OPEN_FILE_PERMITS);
 
-/// Acquire a permit from the open file semaphore and call a raw function.
+/// Try to acquire a permit from the open file semaphore.
+/// This function will block, so it must be run from a thread that
+/// can be blocked.
 #[inline]
-pub async fn call_with_permit<R>(func: impl FnOnce() -> Result<R, Error>) -> Result<R, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
+async fn get_permit() -> Result<SemaphorePermit<'static>, Error> {
+    OPEN_FILE_SEMAPHORE
         .acquire()
         .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    (func)()
+        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))
+}
+/// Acquire a permit from the open file semaphore and call a raw function.
+#[inline]
+pub async fn call_with_permit<F, T>(f: F) -> Result<T, Error>
+where
+    F: FnOnce(SemaphorePermit<'static>) -> Result<T, Error> + Send + 'static,
+    T: Send + 'static,
+{
+    let permit = get_permit().await?;
+    tokio::task::spawn_blocking(move || f(permit))
+        .await
+        .unwrap_or_else(|e| Err(make_err!(Code::Internal, "background task failed: {e:?}")))
 }
 
 pub fn set_open_file_limit(limit: usize) {
@@ -302,18 +313,20 @@ pub fn set_idle_file_descriptor_timeout(timeout: Duration) -> Result<(), Error> 
         .map_err(|_| make_err!(Code::Internal, "idle_file_descriptor_timeout already set"))
 }
 
-pub async fn open_file<'a>(path: impl Into<Cow<'a, OsStr>>, limit: u64) -> Result<ResumeableFileSlot<'a>, Error> {
-    let permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    let path = path.into();
+pub async fn open_file(path: impl AsRef<Path>, limit: u64) -> Result<ResumeableFileSlot, Error> {
+    let path = path.as_ref().to_owned();
+    let (permit, os_file, path) = call_with_permit(move |permit| {
+        Ok((
+            permit,
+            std::fs::File::open(&path).err_tip(|| format!("Could not open {:?}", path))?,
+            path,
+        ))
+    })
+    .await?;
     Ok(ResumeableFileSlot::new_with_take(
         FileSlot {
             _permit: permit,
-            inner: tokio::fs::File::open(&path)
-                .await
-                .err_tip(|| format!("Could not open {:?}", path))?,
+            inner: tokio::fs::File::from_std(os_file),
         }
         .take(limit),
         path,
@@ -321,18 +334,20 @@ pub async fn open_file<'a>(path: impl Into<Cow<'a, OsStr>>, limit: u64) -> Resul
     ))
 }
 
-pub async fn create_file<'a>(path: impl Into<Cow<'a, OsStr>>) -> Result<ResumeableFileSlot<'a>, Error> {
-    let permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    let path = path.into();
+pub async fn create_file(path: impl AsRef<Path>) -> Result<ResumeableFileSlot, Error> {
+    let path = path.as_ref().to_owned();
+    let (permit, os_file, path) = call_with_permit(move |permit| {
+        Ok((
+            permit,
+            std::fs::File::create(&path).err_tip(|| format!("Could not open {:?}", path))?,
+            path,
+        ))
+    })
+    .await?;
     Ok(ResumeableFileSlot::new(
         FileSlot {
             _permit: permit,
-            inner: tokio::fs::File::create(&path)
-                .await
-                .err_tip(|| format!("Could not open {:?}", path))?,
+            inner: tokio::fs::File::from_std(os_file),
         },
         path,
         true, /* is_write */
@@ -340,141 +355,113 @@ pub async fn create_file<'a>(path: impl Into<Cow<'a, OsStr>>) -> Result<Resumeab
 }
 
 pub async fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::hard_link(src, dst).await.map_err(|e| e.into())
+    let src = src.as_ref().to_owned();
+    let dst = dst.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::hard_link(src, dst).map_err(Into::<Error>::into)).await
 }
 
 pub async fn set_permissions(src: impl AsRef<Path>, perm: std::fs::Permissions) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::set_permissions(src, perm).await.map_err(|e| e.into())
+    let src = src.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::set_permissions(src, perm).map_err(Into::<Error>::into)).await
 }
 
 pub async fn create_dir(path: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::create_dir(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::create_dir(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn create_dir_all(path: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::create_dir_all(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::create_dir_all(path).map_err(Into::<Error>::into)).await
 }
 
 #[cfg(target_family = "unix")]
 pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::symlink(src, dst).await.map_err(|e| e.into())
+    let src = src.as_ref().to_owned();
+    let dst = dst.as_ref().to_owned();
+    call_with_permit(move |_| {
+        tokio::runtime::Handle::current()
+            .block_on(tokio::fs::symlink(src, dst))
+            .map_err(Into::<Error>::into)
+    })
+    .await
 }
 
 pub async fn read_link(path: impl AsRef<Path>) -> Result<std::path::PathBuf, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::read_link(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::read_link(path).map_err(Into::<Error>::into)).await
 }
 
-pub struct ReadDir<'a> {
+pub struct ReadDir {
     // We hold the permit because once it is dropped it goes back into the queue.
-    permit: SemaphorePermit<'a>,
+    permit: SemaphorePermit<'static>,
     inner: tokio::fs::ReadDir,
 }
 
-impl<'a> ReadDir<'a> {
-    pub fn into_inner(self) -> (SemaphorePermit<'a>, tokio::fs::ReadDir) {
+impl ReadDir {
+    pub fn into_inner(self) -> (SemaphorePermit<'static>, tokio::fs::ReadDir) {
         (self.permit, self.inner)
     }
 }
 
-impl<'a> AsRef<tokio::fs::ReadDir> for ReadDir<'a> {
+impl AsRef<tokio::fs::ReadDir> for ReadDir {
     fn as_ref(&self) -> &tokio::fs::ReadDir {
         &self.inner
     }
 }
 
-impl<'a> AsMut<tokio::fs::ReadDir> for ReadDir<'a> {
+impl AsMut<tokio::fs::ReadDir> for ReadDir {
     fn as_mut(&mut self) -> &mut tokio::fs::ReadDir {
         &mut self.inner
     }
 }
 
-pub async fn read_dir(path: impl AsRef<Path>) -> Result<ReadDir<'static>, Error> {
-    let permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    Ok(ReadDir {
-        permit,
-        inner: tokio::fs::read_dir(path).await.map_err(Into::<Error>::into)?,
+pub async fn read_dir(path: impl AsRef<Path>) -> Result<ReadDir, Error> {
+    let path = path.as_ref().to_owned();
+    let (permit, inner) = call_with_permit(move |permit| {
+        Ok((
+            permit,
+            tokio::runtime::Handle::current()
+                .block_on(tokio::fs::read_dir(path))
+                .map_err(Into::<Error>::into)?,
+        ))
     })
+    .await?;
+    Ok(ReadDir { permit, inner })
 }
 
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::rename(from, to).await.map_err(|e| e.into())
+    let from = from.as_ref().to_owned();
+    let to = to.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::rename(from, to).map_err(Into::<Error>::into)).await
 }
 
 pub async fn remove_file(path: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::remove_file(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::remove_file(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::canonicalize(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::canonicalize(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn metadata(path: impl AsRef<Path>) -> Result<Metadata, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::metadata(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::metadata(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::read(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::read(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn symlink_metadata(path: impl AsRef<Path>) -> Result<Metadata, Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::symlink_metadata(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::symlink_metadata(path).map_err(Into::<Error>::into)).await
 }
 
 pub async fn remove_dir_all(path: impl AsRef<Path>) -> Result<(), Error> {
-    let _permit = OPEN_FILE_SEMAPHORE
-        .acquire()
-        .await
-        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
-    tokio::fs::remove_dir_all(path).await.map_err(|e| e.into())
+    let path = path.as_ref().to_owned();
+    call_with_permit(move |_| std::fs::remove_dir_all(path).map_err(Into::<Error>::into)).await
 }

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -71,7 +71,7 @@ pub enum UploadSizeInfo {
 pub async fn slow_update_store_with_file<S: Store + ?Sized>(
     store: Pin<&S>,
     digest: DigestInfo,
-    file: &mut fs::ResumeableFileSlot<'static>,
+    file: &mut fs::ResumeableFileSlot,
     upload_size: UploadSizeInfo,
 ) -> Result<(), Error> {
     let (tx, rx) = make_buf_channel_pair();
@@ -173,9 +173,9 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
-        mut file: fs::ResumeableFileSlot<'static>,
+        mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::ResumeableFileSlot<'static>>, Error> {
+    ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
         let inner_store = self.inner_store(Some(digest));
         if inner_store.optimized_for(StoreOptimizations::FileUpdates) {
             error_if!(

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -226,7 +226,7 @@ fn is_executable(metadata: &std::fs::Metadata, _full_path: &impl AsRef<Path>) ->
 }
 
 async fn upload_file(
-    mut resumeable_file: fs::ResumeableFileSlot<'static>,
+    mut resumeable_file: fs::ResumeableFileSlot,
     cas_store: Pin<&dyn Store>,
     full_path: impl AsRef<Path> + Debug,
     hasher: DigestHasherFunc,


### PR DESCRIPTION
# Description
Refactor fs.rs to use call_with_permit scheme

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/741)
<!-- Reviewable:end -->
