### PR TITLE
Improve the error message in resource info parsing failure

### DIFF
--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -95,10 +95,11 @@ impl<'a> ResourceInfo<'a> {
         let mut rparts = resource_name.rsplitn(7, '/');
         let mut output = ResourceInfo::default();
         let mut end_bytes_processed = 0;
-        let end_state = recursive_parse(&mut rparts, &mut output, State::Unknown, &mut end_bytes_processed)?;
+        let end_state = recursive_parse(&mut rparts, &mut output, State::Unknown, &mut end_bytes_processed)
+            .err_tip(|| format!("{} in {}", ERROR_MSG, resource_name))?;
         error_if!(
             end_state != State::OptionalMetadata,
-            "Expected the final state to be OptionalMetadata. Got: {end_state:?}"
+            "Expected the final state to be OptionalMetadata. Got: {end_state:?} for {resource_name} is_upload: {is_upload}"
         );
 
         // Slice off the processed parts of `resource_name`.
@@ -117,11 +118,14 @@ impl<'a> ResourceInfo<'a> {
         // Remember, `instance_name` can contain slashes and/or special names
         // like "blobs" or "uploads".
         let mut parts = beginning_part.rsplitn(3, '/');
-        output.uuid = Some(parts.next().err_tip(|| ERROR_MSG)?);
+        output.uuid = Some(parts.next().err_tip(|| format!("{} in {}", ERROR_MSG, resource_name))?);
         {
             // Sanity check that our next item is "uploads".
-            let uploads = parts.next().err_tip(|| ERROR_MSG)?;
-            error_if!(uploads != "uploads", "Expected part to be 'uploads'. Got: {uploads}");
+            let uploads = parts.next().err_tip(|| format!("{} in {}", ERROR_MSG, resource_name))?;
+            error_if!(
+                uploads != "uploads",
+                "Expected part to be 'uploads'. Got: {uploads} for {resource_name} is_upload: {is_upload}"
+            );
         }
 
         // `instance_name` is optional.
@@ -171,7 +175,7 @@ fn recursive_parse<'a>(
     mut state: State,
     bytes_processed: &mut usize,
 ) -> Result<State, Error> {
-    let part = rparts.next().err_tip(|| ERROR_MSG)?;
+    let part = rparts.next().err_tip(|| "on rparts.next()")?;
     if state == State::Unknown {
         if part == "blobs" {
             *bytes_processed = part.len() + SLASH_SIZE;


### PR DESCRIPTION
Prints out what was supplied by the user if a failure happens when parsing out the resource info string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/742)
<!-- Reviewable:end -->
