### PR TITLE
Completeness checking store should not check if directory digests exist

### DIFF
--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -86,16 +86,11 @@ async fn check_output_directories(
             let tree = get_and_decode_digest::<ProtoTree>(cas_store, &tree_digest).await?;
             // TODO(allada) When `try_collect()` is stable we can use it instead.
             // https://github.com/rust-lang/rust/issues/94047
-            let mut digest_iter = tree.children.into_iter().chain(tree.root).flat_map(|dir| {
-                dir.files
-                    .into_iter()
-                    .filter_map(|f| f.digest.map(DigestInfo::try_from))
-                    .chain(
-                        dir.directories
-                            .into_iter()
-                            .filter_map(|d| d.digest.map(DigestInfo::try_from)),
-                    )
-            });
+            let mut digest_iter = tree
+                .children
+                .into_iter()
+                .chain(tree.root)
+                .flat_map(|dir| dir.files.into_iter().filter_map(|f| f.digest.map(DigestInfo::try_from)));
 
             let mut digest_infos = Vec::with_capacity(digest_iter.size_hint().1.unwrap_or(0));
             digest_iter

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -46,7 +46,7 @@ mod completeness_checking_store_tests {
         let pinned_cas: Pin<&dyn Store> = Pin::new(cas_store.as_ref());
 
         pinned_cas.update_oneshot(ROOT_FILE, "".into()).await?;
-        pinned_cas.update_oneshot(ROOT_DIRECTORY, "".into()).await?;
+        // Note: Explicitly not uploading `ROOT_DIRECTORY`. See: TraceMachina/nativelink#747.
         pinned_cas.update_oneshot(CHILD_FILE, "".into()).await?;
         pinned_cas.update_oneshot(OUTPUT_FILE, "".into()).await?;
         pinned_cas.update_oneshot(STDOUT, "".into()).await?;


### PR DESCRIPTION
REv2 does not require clients to upload directory digests. Instead they are only required to upload the tree root which has all the directories in it.

closes #747

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/748)
<!-- Reviewable:end -->
