### PR TITLE
Ignore .direnv for bazel builds

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,7 @@
 .cache
 .config
+.direnv
+.devenv
 bazel-bin
 bazel-out
 bazel-remote-bin


### PR DESCRIPTION
When building with //..., bazel will traverse down .direnv, which contains symlinks to the main source tree, so everything gets built twice.

Without this change:
```
➜  nativelink git:(a651f2c) bazel query //... | grep direnv
Loading: 0 packages loaded
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source:dummy_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source:dummy_test_sh
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source:nativelink
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/examples:hello_lre
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:cc-compiler-armeabi-v7a
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:cc-compiler-k8
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:cc_wrapper
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:compiler_deps
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:empty
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:empty_lib
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:link_extra_lib
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:link_extra_libs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:local
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:malloc
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:stub_armeabi-v7a
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/cc:toolchain
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/config:cc-toolchain
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/config:platform
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:bootstrap_runtime_toolchain_definition
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:jdk
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:rbe_jdk
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:rbe_jdk_name_setting
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:rbe_jdk_name_version_setting
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:rbe_jdk_settings_alias
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:rbe_jdk_version_setting
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/local-remote-execution/generated/java:runtime_toolchain_definition
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-config:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-config:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-config:nativelink-config
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-error:nativelink-error
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:gen_lib_rs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:gen_lib_rs_tool
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:gen_protos_tool
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:gen_rs_protos
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:nativelink-proto
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:update_protos
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-proto:update_protos_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:integration
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:integration_tests/action_messages_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:integration_tests/cache_lookup_scheduler_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:integration_tests/property_modifier_scheduler_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:integration_tests/simple_scheduler_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-scheduler:nativelink-scheduler
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:integration
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:integration_tests/ac_server_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:integration_tests/bytestream_server_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:integration_tests/cas_server_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:integration_tests/worker_api_server_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-service:nativelink-service
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/ac_utils_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/completeness_checking_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/compression_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/dedup_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/existence_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/fast_slow_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/filesystem_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/memory_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/ref_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/s3_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/shard_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/size_partitioning_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:integration_tests/verify_store_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-store:nativelink-store
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/buf_channel_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/evicting_map_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/fastcdc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/fs_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/health_utils_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/proto_stream_utils_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/resource_info_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:integration_tests/retry_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-util:nativelink-util
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:doc_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:docs
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:integration
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:integration_tests/local_worker_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:integration_tests/running_actions_manager_test
//.direnv/flake-inputs/d7skygm91pd5xj8q368y063ss7fhys3a-source/nativelink-worker:nativelink-worker
```

With:
```
➜  nativelink git:(direnv) bazel query //... | grep direnv
Loading: 0 packages loaded
```

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

bazel build //... doesn't build stuff in //.direnv/... anymore.

## Checklist

- [x] Updated documentation if needed (N/A)
- [x] Tests added/amended (N/A)
- [x] `bazel test //...`  passes locally (tests still pass)
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/756)
<!-- Reviewable:end -->
