### PR TITLE
Migrate Bazelisk actions to new variant

### DIFF
--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -24,8 +24,10 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Bazelisk
-        uses: >- # Custom commit at 2023-10-23
-          bazelbuild/setup-bazelisk@5bc144ec07bd24eaa9b5c3e8c9af4006b033b629
+        uses: >- # v0.8.1
+          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+        with:
+          bazelisk-cache: true
 
       - name: Determine Bazel cache mountpoint
         id: bazel-cache
@@ -41,8 +43,8 @@ jobs:
         shell: bash
 
       - name: Mount bazel cache
-        uses: >- # v3.3.2
-          actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: >- # v4.0.1
+          actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
         with:
           path: |
             ${{ steps.bazel-cache.outputs.mountpoint }}
@@ -82,12 +84,14 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Bazelisk
-        uses: >- # Custom commit at 2023-10-23
-          bazelbuild/setup-bazelisk@5bc144ec07bd24eaa9b5c3e8c9af4006b033b629
+        uses: >- # v0.8.1
+          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+        with:
+          bazelisk-cache: true
 
       - name: Mount bazel cache
-        uses: >- # v3.3.2
-          actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: >- # v4.0.1
+          actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
         with:
           path: |
             ~/.cache/bazel

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -34,13 +34,12 @@ jobs:
         uses: >- # Custom commit, last pinned at 2024-03-03.
           DeterminateSystems/magic-nix-cache-action@742d8701e54851d2136f71b61d31382a4f4d0788
 
-      # TODO(aaronmondal): Reenable after https://github.com/TraceMachina/nativelink/pull/690
-      # - name: Mount bazel cache
-      #   uses: >- # v3.3.2
-      #     actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-      #   with:
-      #     path: "~/.cache/bazel"
-      #     key: ${{ runner.os }}-bazel-nix
+      - name: Mount bazel cache
+        uses: >- # v4.0.1
+          actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
+        with:
+          path: "~/.cache/bazel"
+          key: ${{ runner.os }}-bazel-nix
 
       - name: Invoke Bazel build in Nix shell
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: >- # v3.5.3
-          actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
         uses: >- # v9

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -22,18 +22,12 @@ jobs:
       - uses: >- # v4.1.1
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - uses: >- # Custom commit at 2023-10-23
-          bazelbuild/setup-bazelisk@5bc144ec07bd24eaa9b5c3e8c9af4006b033b629
-
-      # TODO(aaronmondal): This cache is ~4 gigabytes in size and potentially
-      #                    leads to `no space left on device` errors. Find a
-      #                    more robust solution.
-      # - name: Mount bazel cache
-      #   uses: >- # v3.3.2
-      #     actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-      #   with:
-      #     path: ~/.cache/bazel
-      #     key: ${{ matrix.os }}-bazel-${{ matrix.sanitizer }}
+      - name: Setup Bazelisk
+        uses: >- # v0.8.1
+          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+        with:
+          bazelisk-cache: true
+          repository-cache: true
 
       - name: Run Bazel tests
         run: bazel test --config=${{ matrix.sanitizer }} --verbose_failures //...


### PR DESCRIPTION
This should fix remaining outdated node versions in CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/760)
<!-- Reviewable:end -->
