### PR TITLE
Remove old actions with no listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand",
+ "scopeguard",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -119,6 +119,12 @@ pub struct SimpleScheduler {
     /// The strategy used to assign workers jobs.
     #[serde(default)]
     pub allocation_strategy: WorkerAllocationStrategy,
+
+    /// Remove action from queue after this much time has elapsed without a listener
+    /// amount of time in seconds.
+    /// Default: 60 (seconds)
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
+    pub disconnect_timeout_s: u64,
 }
 
 /// A scheduler that simply forwards requests to an upstream scheduler.  This

--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -47,6 +47,9 @@ pub trait ActionScheduler: Sync + Send + Unpin {
     /// Cleans up the cache of recently completed actions.
     async fn clean_recently_completed_actions(&self);
 
+    /// Inform the scheduler a client has disconnected
+    fn notify_client_disconnected(&self, unique_qualifier: &ActionInfoHashKey);
+
     /// Register the metrics for the action scheduler.
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {}
 }

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -151,6 +151,8 @@ impl CacheLookupScheduler {
 
 #[async_trait]
 impl ActionScheduler for CacheLookupScheduler {
+    fn notify_client_disconnected(&self, _unique_qualifier: &ActionInfoHashKey) {}
+
     async fn get_platform_property_manager(
         &self,
         instance_name: &str,

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -152,6 +152,8 @@ impl GrpcScheduler {
 
 #[async_trait]
 impl ActionScheduler for GrpcScheduler {
+    fn notify_client_disconnected(&self, _unique_qualifier: &ActionInfoHashKey) {}
+
     async fn get_platform_property_manager(
         &self,
         instance_name: &str,

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -47,6 +47,8 @@ impl PropertyModifierScheduler {
 
 #[async_trait]
 impl ActionScheduler for PropertyModifierScheduler {
+    fn notify_client_disconnected(&self, _unique_qualifier: &ActionInfoHashKey) {}
+
     async fn get_platform_property_manager(
         &self,
         instance_name: &str,

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -31,7 +31,7 @@ use nativelink_proto::build::bazel::remote::execution::v2::{digest_function, Exe
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
     update_for_worker, ConnectionResult, StartExecute, UpdateForWorker,
 };
-use nativelink_scheduler::simple_scheduler::SimpleScheduler;
+use nativelink_scheduler::simple_scheduler::{Callbacks, SimpleScheduler};
 use nativelink_scheduler::worker::{Worker, WorkerId};
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
 use nativelink_util::common::DigestInfo;
@@ -95,6 +95,8 @@ async fn setup_action(
 
 #[cfg(test)]
 mod scheduler_tests {
+    use std::time::Instant;
+
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -107,6 +109,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -160,6 +163,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -224,6 +228,7 @@ mod scheduler_tests {
                 worker_timeout_s: WORKER_TIMEOUT_S,
                 ..Default::default()
             },
+            Callbacks::default(),
             || async move {},
         );
         let action_digest1 = DigestInfo::new([99u8; 32], 512);
@@ -367,6 +372,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -442,6 +448,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -524,6 +531,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -625,6 +633,7 @@ mod scheduler_tests {
         const WORKER_ID: WorkerId = WorkerId(0x0010_0010);
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -666,6 +675,7 @@ mod scheduler_tests {
                 worker_timeout_s: WORKER_TIMEOUT_S,
                 ..Default::default()
             },
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -765,6 +775,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -868,6 +879,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -971,6 +983,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -1066,6 +1079,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -1195,6 +1209,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest1 = DigestInfo::new([11u8; 32], 512);
@@ -1339,6 +1354,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest1 = DigestInfo::new([11u8; 32], 512);
@@ -1394,6 +1410,7 @@ mod scheduler_tests {
                 max_job_retries: 2,
                 ..Default::default()
             },
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -1523,6 +1540,7 @@ mod scheduler_tests {
         // DropChecker.
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             move || {
                 // This will ensure dropping happens if this function is ever dropped.
                 let _drop_checker = drop_checker.clone();
@@ -1548,6 +1566,7 @@ mod scheduler_tests {
 
         let scheduler = SimpleScheduler::new_with_callback(
             &nativelink_config::schedulers::SimpleScheduler::default(),
+            Callbacks::default(),
             || async move {},
         );
         let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -1602,4 +1621,202 @@ mod scheduler_tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn ensure_actions_with_disconnected_clients_are_dropped() -> Result<(), Error> {
+        const DISCONNECT_TIMEOUT_S: u64 = 1;
+
+        let scheduler = SimpleScheduler::new_with_callback(
+            &nativelink_config::schedulers::SimpleScheduler {
+                disconnect_timeout_s: DISCONNECT_TIMEOUT_S,
+                ..Default::default()
+            },
+            Callbacks::new(Instant::now, |_| Box::pin(futures::future::ready(()))),
+            || async move {},
+        );
+
+        let client_rx = setup_action(
+            &scheduler,
+            DigestInfo::new([98u8; 32], 512),
+            PlatformProperties::default(),
+            make_system_time(1),
+        )
+        .await?;
+
+        // Drop our receiver.
+        let unique_qualifier = client_rx.borrow().unique_qualifier.clone();
+        drop(client_rx);
+        // Inform the scheduler the client has been dropped.
+        // Normally this would happen automatically in the service api.
+        scheduler.notify_client_disconnected(&unique_qualifier);
+
+        // Allow the action removal spawn to run.
+        tokio::task::yield_now().await;
+
+        // Check to make sure that the action was removed.
+        assert!(
+            scheduler
+                .find_existing_action(&unique_qualifier)
+                .await
+                .is_none(),
+            "Expected action to be removed"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ensure_notify_disconnected_does_not_block() -> Result<(), Error> {
+        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+        const DISCONNECT_TIMEOUT_S: u64 = 1;
+
+        let scheduler = SimpleScheduler::new_with_callback(
+            &nativelink_config::schedulers::SimpleScheduler {
+                disconnect_timeout_s: DISCONNECT_TIMEOUT_S,
+                ..Default::default()
+            },
+            Callbacks::new(Instant::now, |_| Box::pin(futures::future::pending())),
+            || async move {},
+        );
+        let action1_digest = DigestInfo::new([98u8; 32], 512);
+        let action2_digest = DigestInfo::new([99u8; 32], 512);
+
+        let mut rx_from_worker =
+            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+        let insert_timestamp = make_system_time(1);
+
+        let client_rx = setup_action(
+            &scheduler,
+            action1_digest,
+            PlatformProperties::default(),
+            insert_timestamp,
+        )
+        .await?;
+
+        // Drop our receiver.
+        let unique_qualifier_1 = client_rx.borrow().unique_qualifier.clone();
+        drop(client_rx);
+
+        scheduler.notify_client_disconnected(&unique_qualifier_1);
+
+        {
+            // Other tests check full data. We only care if we got StartAction.
+            match rx_from_worker.recv().await.unwrap().update {
+                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+                v => panic!("Expected StartAction, got : {v:?}"),
+            }
+        }
+
+        // Setup a second action so matching engine is scheduled to rerun.
+        let client_rx = setup_action(
+            &scheduler,
+            action2_digest,
+            PlatformProperties::default(),
+            insert_timestamp,
+        )
+        .await?;
+
+        {
+            // Make sure the action sent after dropping the first reciever is registered.
+            match rx_from_worker.recv().await.unwrap().update {
+                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+                v => panic!("Expected StartAction, got : {v:?}"),
+            }
+        }
+
+        // Check to make sure that the first action was not removed.
+        assert!(
+            scheduler
+                .find_existing_action(&unique_qualifier_1)
+                .await
+                .is_some(),
+            "Expected action to be removed"
+        );
+
+        let unique_qualifier_2 = client_rx.borrow().unique_qualifier.clone();
+        // Check to make sure that the first action was not removed.
+        assert!(
+            scheduler
+                .find_existing_action(&unique_qualifier_2)
+                .await
+                .is_some(),
+            "Expected action to be removed"
+        );
+        Ok(())
+    }
+
+    // #[tokio::test]
+    // async fn ensure_active_actions_with_client_disconnect_are_dropped() -> Result<(), Error> {
+    //     const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+    //     const DISCONNECT_TIMEOUT_S: u64 = 1;
+
+    //     let scheduler = SimpleScheduler::new_with_callback(
+    //         &nativelink_config::schedulers::SimpleScheduler {
+    //             disconnect_timeout_s: DISCONNECT_TIMEOUT_S,
+    //             ..Default::default()
+    //         },
+    //         Callbacks::new(Instant::now, |_| Box::pin(futures::future::ready(()))),
+    //         || async move {},
+    //     );
+    //     let action_digest = DigestInfo::new([98u8; 32], 512);
+    //     let action_digest = DigestInfo::new([98u8; 32], 512);
+
+    //     let mut rx_from_worker =
+    //         setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    //     let insert_timestamp = make_system_time(1);
+
+    //     let client_rx = setup_action(
+    //         &scheduler,
+    //         action1_digest,
+    //         PlatformProperties::default(),
+    //         insert_timestamp,
+    //     )
+    //     .await?;
+
+    //     // Drop our receiver.
+    //     let unique_qualifier = client_rx.borrow().unique_qualifier.clone();
+    //     drop(client_rx);
+
+    //     // Allow task<->worker matcher to run.
+    //     tokio::task::yield_now().await;
+
+    //     // Inform the scheduler the client has been dropped.
+    //     // Normally this would happen automatically due to Tonic.
+    //     scheduler.notify_client_disconnected(&unique_qualifier);
+
+    //     {
+    //         // Other tests check full data. We only care if we got StartAction.
+    //         match rx_from_worker.recv().await.unwrap().update {
+    //             Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+    //             v => panic!("Expected StartAction, got : {v:?}"),
+    //         }
+    //     }
+
+    //     // Setup a second action so matching engine is scheduled to rerun.
+    //     let client_rx = setup_action(
+    //         &scheduler,
+    //         action2_digest,
+    //         PlatformProperties::default(),
+    //         insert_timestamp,
+    //     )
+    //     .await?;
+    // println!("About to drop rx");
+    //     drop(client_rx);
+    //     // scheduler.notify_client_disconnected_for_test(&unique_qualifier).await;
+
+    //     // Allow task<->worker matcher to run.
+    //     tokio::task::yield_now().await;
+    //     println!("yield did run");
+
+    //     // Check to make sure that the action was removed.
+    //     assert!(
+    //         scheduler
+    //             .find_existing_action(&unique_qualifier)
+    //             .await
+    //             .is_none(),
+    //         "Expected action to be removed"
+    //     );
+
+    //     Ok(())
+    // }
 }

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -120,6 +120,8 @@ impl MockActionScheduler {
 
 #[async_trait]
 impl ActionScheduler for MockActionScheduler {
+    fn notify_client_disconnected(&self, _unique_qualifier: &ActionInfoHashKey) {}
+
     async fn get_platform_property_manager(
         &self,
         instance_name: &str,

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -31,6 +31,7 @@ rust_library(
         "@crates//:parking_lot",
         "@crates//:prost",
         "@crates//:rand",
+        "@crates//:scopeguard",
         "@crates//:tokio",
         "@crates//:tokio-stream",
         "@crates//:tonic",

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.21"
 parking_lot = "0.12.1"
 prost = "0.12.3"
 rand = "0.8.5"
+scopeguard = "1.2.0"
 tokio = { version = "1.37.0", features = ["sync", "rt"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tonic = { version = "0.11.0", features = ["gzip", "tls"] }

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -38,11 +38,11 @@ use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::store_trait::Store;
 use rand::{thread_rng, Rng};
+use scopeguard::guard;
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tonic::{Request, Response, Status};
 use tracing::{error, info};
-
 struct InstanceInfo {
     scheduler: Arc<dyn ActionScheduler>,
     cas_store: Arc<dyn Store>,
@@ -182,11 +182,26 @@ impl ExecutionServer {
         Server::new(self)
     }
 
-    fn to_execute_stream(receiver: watch::Receiver<Arc<ActionState>>) -> Response<ExecuteStream> {
-        let receiver_stream = Box::pin(WatchStream::new(receiver).map(|action_update| {
+    fn to_execute_stream(
+        &self,
+        receiver: watch::Receiver<Arc<ActionState>>,
+        unique_qualifier: ActionInfoHashKey,
+    ) -> Response<ExecuteStream> {
+        let scheduler = self
+            .instance_infos
+            .get(&unique_qualifier.instance_name)
+            .unwrap()
+            .scheduler
+            .clone();
+        let scope_guard = guard(scheduler, move |scheduler| {
+            scheduler.notify_client_disconnected(&unique_qualifier)
+        });
+        let receiver_stream = Box::pin(WatchStream::new(receiver).map(move |action_update| {
+            let _scope_guard = &scope_guard;
             info!("\x1b[0;31mexecute Resp Stream\x1b[0m: {:?}", action_update);
             Ok(Into::<Operation>::into(action_update.as_ref().clone()))
         }));
+
         tonic::Response::new(receiver_stream)
     }
 
@@ -230,11 +245,11 @@ impl ExecutionServer {
 
         let rx = instance_info
             .scheduler
-            .add_action(action_info)
+            .add_action(action_info.clone())
             .await
             .err_tip(|| "Failed to schedule task")?;
 
-        Ok(Self::to_execute_stream(rx))
+        Ok(self.to_execute_stream(rx, action_info.unique_qualifier))
     }
 
     async fn inner_wait_execution(
@@ -256,7 +271,7 @@ impl ExecutionServer {
         else {
             return Err(Status::not_found("Failed to find existing task"));
         };
-        Ok(Self::to_execute_stream(rx))
+        Ok(self.to_execute_stream(rx, unique_qualifier))
     }
 }
 


### PR DESCRIPTION
# Description

Implement scheduler side removal of actions with no listeners. Adds disconnect_timeout_s configuration field with default of 60s. If the client waiting on a given action is disconnected for longer than this duration without reconnecting the scheduler will stop tracking it. This does not remove it from the worker if the job has already been dispatched.

Fixes #338 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

A test has been added to ensure that requested actions are removed if a client is found to be disconnected for `disconnect_timeout_s`

## Checklist
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/778)
<!-- Reviewable:end -->
