### PR TITLE
Forbid binary files in commits

### DIFF
--- a/tools/pre-commit-hooks.nix
+++ b/tools/pre-commit-hooks.nix
@@ -51,6 +51,29 @@ in {
     entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/detect-private-key";
     types = ["text"];
   };
+  forbid-binary-files = {
+    excludes = [
+      # Landing page image for the website.
+      "nativelink-docs/static/img/hero-dark.png"
+
+      # Testdata for fastcdc.
+      "nativelink-util/tests/data/SekienAkashita.jpg"
+    ];
+    enable = true;
+    types = ["binary"];
+    entry = let
+      script = pkgs.writeShellScriptBin "forbid-binary-files" ''
+        set -eu
+
+        if [ $# -gt 0 ]; then
+          for filename in "''${@}"; do
+            printf "[\033[31mERROR\033[0m] Found binary file: ''${filename}"
+          done
+          exit 1
+        fi
+      '';
+    in "${script}/bin/forbid-binary-files";
+  };
 
   # Documentation
   vale.enable = true;


### PR DESCRIPTION
This hook triggers on all non-excluded binary files.

Should prevent issues like #791 in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/792)
<!-- Reviewable:end -->
