### PR TITLE
Publish nativelink-worker image for C++

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -12,10 +12,16 @@ permissions: read-all
 
 jobs:
   publish-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [image, nativelink-worker-lre-cc]
+    name: Publish ${{ matrix.image }}
     runs-on: large-ubuntu-22.04
     permissions:
       packages: write
       id-token: write
+      security-events: write
     steps:
 
       - name: Checkout
@@ -35,14 +41,20 @@ jobs:
 
       - name: Test image
         run: |
-          nix run .#local-image-test
+          nix run .#local-image-test ${{ matrix.image }}
 
       - name: Upload image
         run: |
-          nix run .#publish-ghcr
+          nix run .#publish-ghcr ${{ matrix.image }}
         env:
-          GHCR_REGISTRY: ghcr.io
+          GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          GHCR_IMAGE_NAME: ${{ github.repository }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Upload trivy scan results to GitHub Security tab
+        uses: >- # v2.16.3
+          github/codeql-action/upload-sarif@592977e6ae857384aa79bb31e7a1d62d63449ec5
+        with:
+          sarif_file: 'trivy-results.sarif'
         if: github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 result
 .bazelrc.user
 MODULE.bazel.lock
+trivy-results.sarif

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
         inherit (nix2container.packages.${system}.nix2container) buildImage;
 
         rbe-autogen = import ./local-remote-execution/rbe-autogen.nix {inherit pkgs nativelink buildImage;};
-        createWorker = import ./tools/create-worker.nix {inherit pkgs nativelink buildImage;};
+        createWorker = import ./tools/create-worker.nix {inherit pkgs nativelink buildImage self;};
       in rec {
         _module.args.pkgs = import self.inputs.nixpkgs {
           inherit system;
@@ -203,6 +203,7 @@
               pkgs.cilium-cli
               pkgs.yarn
               pkgs.vale
+              pkgs.trivy
 
               # Additional tools from within our development environment.
               local-image-test

--- a/tools/create-worker.nix
+++ b/tools/create-worker.nix
@@ -2,6 +2,7 @@
   pkgs,
   nativelink,
   buildImage,
+  self,
   ...
 }: let
   # A temporary directory. Note that this doesn't set any permissions. Those
@@ -99,5 +100,14 @@ in
       config = {
         User = user;
         WorkingDir = "/home/${user}";
+        Labels = {
+          "org.opencontainers.image.description" = "NativeLink worker generated from ${image.imageName}.";
+          "org.opencontainers.image.documentation" = "https://github.com/TraceMachina/nativelink";
+          "org.opencontainers.image.licenses" = "Apache-2.0";
+          "org.opencontainers.image.revision" = "${self.rev or self.dirtyRev or "dirty"}";
+          "org.opencontainers.image.source" = "https://github.com/TraceMachina/nativelink";
+          "org.opencontainers.image.title" = "NativeLink worker for ${image.imageName}";
+          "org.opencontainers.image.vendor" = "Trace Machina, Inc.";
+        };
       };
     }

--- a/tools/local-image-test.nix
+++ b/tools/local-image-test.nix
@@ -2,18 +2,23 @@
 pkgs.writeShellScriptBin "local-image-test" ''
   set -xeuo pipefail
 
+  echo "Testing image: $1"
+
   # Commit hashes would not be a good choice here as they are not
   # fully dependent on the inputs to the image. For instance, amending
   # nothing would still lead to a new hash. Instead we use the
   # derivation hash as the tag so that the tag is reused if the image
   # didn't change.
-  IMAGE_TAG=$(nix eval .#image.imageTag --raw)
+  IMAGE_TAG=$(nix eval .#$1.imageTag --raw)
+  IMAGE_NAME=$(nix eval .#$1.imageName --raw)
 
   nix run .#image.copyTo \
-    docker-daemon:nativelink:''${IMAGE_TAG}
+    docker-daemon:''${IMAGE_NAME}:''${IMAGE_TAG}
 
   # Ensure that the image has minimal closure size.
   CI=1 ${pkgs.dive}/bin/dive \
-    nativelink:''${IMAGE_TAG} \
+    ''${IMAGE_NAME}:''${IMAGE_TAG} \
     --highestWastedBytes=0
+
+  ${pkgs.trivy}/bin/trivy image ''${IMAGE_NAME}:''${IMAGE_TAG}
 ''

--- a/tools/publish-ghcr.nix
+++ b/tools/publish-ghcr.nix
@@ -13,13 +13,12 @@ pkgs.writeShellScriptBin "publish-ghcr" ''
   # nothing would still lead to a new hash. Instead we use the
   # derivation hash as the tag so that the tag is reused if the image
   # didn't change.
-  #
-  # If a positional argument is passed it overrides the tag value.
-  IMAGE_TAG=''${1:-$(nix eval .#image.imageTag --raw)}
+  IMAGE_TAG=$(nix eval .#$1.imageTag --raw)
+  IMAGE_NAME=$(nix eval .#$1.imageName --raw)
 
-  TAGGED_IMAGE=''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME,,}:''${IMAGE_TAG}
+  TAGGED_IMAGE=''${GHCR_REGISTRY,,}/''${IMAGE_NAME}:''${IMAGE_TAG}
 
-  nix run .#image.copyTo docker://''${TAGGED_IMAGE}
+  nix run .#$1.copyTo docker://''${TAGGED_IMAGE}
 
   echo $GHCR_PASSWORD | ${pkgs.cosign}/bin/cosign \
     login \
@@ -30,10 +29,16 @@ pkgs.writeShellScriptBin "publish-ghcr" ''
   ${pkgs.cosign}/bin/cosign \
     sign \
     --yes \
-    ''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME,,}@$( \
+    ''${GHCR_REGISTRY,,}/''${IMAGE_NAME}@$( \
       ${pkgs.skopeo}/bin/skopeo \
         inspect \
         --format "{{ .Digest }}" \
         docker://''${TAGGED_IMAGE} \
   )
+
+  ${pkgs.trivy}/bin/trivy \
+    image \
+    --format sarif \
+    ''${TAGGED_IMAGE} \
+  > trivy-results.sarif
 ''


### PR DESCRIPTION
This should make it easier to spin up test instances for C++ projects. The nativelink worker image may now be fetched from:

```
ghcr.io/tracemachina/nativelink-worker-lre-cc:<sometag>
```

Since the toolchain images are somewhat more complex than the minimal `nativelink` image, we now use trivy to scan images for vulnerabilities. The database for these scans is fetched dynamically. This breaks perfect reproducibility for the image publishing workflow when rolling back/reverting, but ensures that new commits aren't checked against outdated vulnerability databases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/794)
<!-- Reviewable:end -->
