### PR TITLE
Fix `.gitignore` after 1a43ef9

### DIFF
--- a/deployment-examples/kubernetes/.gitignore
+++ b/deployment-examples/kubernetes/.gitignore
@@ -1,1 +1,2 @@
-worker.json
+worker-lre-cc.json
+worker-lre-java.json


### PR DESCRIPTION
The worker files have been renamed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/797)
<!-- Reviewable:end -->
