### PR TITLE
Fix incorrect bazel version 6.4.0+ in documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ nix run github:TraceMachina/nativelink/<revision> ./basic_cas.json
 
 **Build requirements:**
 
-* Bazel 6.4.0+
+* Bazel 7.0.2+
 * A recent C++ toolchain with LLD as linker
 
 > [!TIP]


### PR DESCRIPTION
# Description

The documentation says it supports Bazel 6.4.0+, but the project actually supports bazel 7.0.2+.
I think the documentation needs to be updated.

Here's the bazel version talking in the documenation.

https://github.com/TraceMachina/nativelink/blob/646253dec285868263ce77b60c26c9e69daaf1ae/README.md?plain=1#L114

Here's the actual bazel version supported from the `.bazelversion` file.

https://github.com/TraceMachina/nativelink/blob/646253dec285868263ce77b60c26c9e69daaf1ae/.bazelversion#L1

Fixes #800 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/801)
<!-- Reviewable:end -->
