### PR TITLE
Allow variables in platform property values

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -20,6 +20,7 @@ use crate::schedulers::SchedulerConfig;
 use crate::serde_utils::{
     convert_numeric_with_shellexpand, convert_optional_numeric_with_shellexpand,
     convert_optional_string_with_shellexpand, convert_string_with_shellexpand,
+    convert_vec_string_with_shellexpand,
 };
 use crate::stores::{ClientTlsConfig, ConfigDigestHashFunction, StoreConfig, StoreRefName};
 
@@ -378,6 +379,7 @@ pub enum WorkerProperty {
     /// List of static values.
     /// Note: Generally there should only ever be 1 value, but if the platform
     /// property key is PropertyType::Priority it may have more than one value.
+    #[serde(deserialize_with = "convert_vec_string_with_shellexpand")]
     values(Vec<String>),
 
     /// A dynamic configuration. The string will be executed as a command

--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -111,6 +111,20 @@ pub fn convert_string_with_shellexpand<'de, D: Deserializer<'de>>(
     Ok((*(shellexpand::env(&value).map_err(de::Error::custom)?)).to_string())
 }
 
+/// Same as convert_string_with_shellexpand, but supports Vec<String>.
+pub fn convert_vec_string_with_shellexpand<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<String>, D::Error> {
+    let vec = Vec::<String>::deserialize(deserializer)?;
+    vec.into_iter()
+        .map(|s| {
+            shellexpand::env(&s)
+                .map_err(de::Error::custom)
+                .map(|expanded| expanded.into_owned())
+        })
+        .collect()
+}
+
 /// Same as convert_string_with_shellexpand, but supports Option<String>.
 pub fn convert_optional_string_with_shellexpand<'de, D: Deserializer<'de>>(
     deserializer: D,


### PR DESCRIPTION
This lets us use a combination of init-contaiers and entrypoint scripts to pass dynamic container image tags and other values into workers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/809)
<!-- Reviewable:end -->
