### PR TITLE
Re-add cacerts to nativelink image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,9 @@
           nativelink-worker-lre-java = createWorker lre-java;
           image = buildImage {
             name = "nativelink";
+            copyToRoot = [
+              pkgs.cacert
+            ];
             config = {
               Entrypoint = [(pkgs.lib.getExe' nativelink "nativelink")];
               Labels = {


### PR DESCRIPTION
It's unclear whether this is the "right" way to bring the CA into the cas and scheduler images, but it should fix problems with TLS encryption on those two deployments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/810)
<!-- Reviewable:end -->
