### PR TITLE
Nix: Add nativelink-debug target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,14 @@
             inherit cargoArtifacts;
           });
 
+        nativelink-debug = craneLib.buildPackage (commonArgs
+          // {
+            inherit cargoArtifacts;
+            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static --cfg tokio_unstable";
+            CARGO_PROFILE = "smol";
+            cargoExtraArgs = "--features enable_tokio_console";
+          });
+
         hooks = import ./tools/pre-commit-hooks.nix {inherit pkgs;};
 
         publish-ghcr = import ./tools/publish-ghcr.nix {inherit pkgs;};
@@ -143,7 +151,7 @@
           };
         };
         packages = rec {
-          inherit publish-ghcr local-image-test nativelink;
+          inherit publish-ghcr local-image-test nativelink nativelink-debug;
           default = nativelink;
 
           lre-cc = import ./local-remote-execution/lre-cc.nix {inherit pkgs buildImage;};


### PR DESCRIPTION
# Description

Adding a nix target that allows for enabling console or other features as needed for debugging nativelink images. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/811)
<!-- Reviewable:end -->
