### PR TITLE
Unify validate_output logic in CompletenessCheckingStore and CacheLookupScheduler

### DIFF
--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -22,7 +22,11 @@ use nativelink_error::Error;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     digest_function, ActionResult as ProtoActionResult, GetActionResultRequest,
 };
+<<<<<<< Updated upstream
 use nativelink_store::ac_utils::{get_and_decode_digest, get_digests_info};
+=======
+use nativelink_store::ac_utils::{get_and_decode_digest, get_digests_info, DigestInputType};
+>>>>>>> Stashed changes
 use nativelink_store::grpc_store::GrpcStore;
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState,
@@ -90,6 +94,7 @@ async fn validate_outputs_exist(
     action_result: &ProtoActionResult,
 ) -> bool {
     // Verify that output_files and output_directories are available in the cas.
+<<<<<<< Updated upstream
     let Ok(mut digest_infos) =
         get_digests_info(action_result.output_files.clone(), &move |digests| {
             Box::new(
@@ -99,6 +104,26 @@ async fn validate_outputs_exist(
             )
         })
     else {
+=======
+
+    let Ok(mut digest_infos) = get_digests_info(
+        action_result,
+        DigestInputType::OutputFiles(&action_result.output_files),
+        false,
+    ) else {
+        return false;
+    };
+    let Ok(mut digest_output_infos) = get_digests_info(
+        action_result,
+        DigestInputType::OutputDirectories(&action_result.output_directories),
+        false,
+    ) else {
+        return false;
+    };
+    digest_infos.append(&mut digest_output_infos);
+
+    let Ok(sizes) = Pin::new(cas_store.as_ref()).has_many(&digest_infos).await else {
+>>>>>>> Stashed changes
         return false;
     };
 

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -22,7 +22,7 @@ use nativelink_error::Error;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     digest_function, ActionResult as ProtoActionResult, GetActionResultRequest,
 };
-use nativelink_store::ac_utils::get_and_decode_digest;
+use nativelink_store::ac_utils::{get_and_decode_digest, get_digests_info};
 use nativelink_store::grpc_store::GrpcStore;
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState,
@@ -90,30 +90,34 @@ async fn validate_outputs_exist(
     action_result: &ProtoActionResult,
 ) -> bool {
     // Verify that output_files and output_directories are available in the cas.
-    let mut required_digests = Vec::with_capacity(
-        action_result.output_files.len() + action_result.output_directories.len(),
-    );
-    for digest in action_result
-        .output_files
-        .iter()
-        .filter_map(|output_file| output_file.digest.as_ref())
-        .chain(
-            action_result
-                .output_directories
-                .iter()
-                .filter_map(|output_file| output_file.tree_digest.as_ref()),
-        )
-    {
-        let Ok(digest) = DigestInfo::try_from(digest) else {
-            return false;
-        };
-        required_digests.push(digest);
-    }
-
-    let Ok(sizes) = Pin::new(cas_store.as_ref())
-        .has_many(&required_digests)
-        .await
+    let Ok(mut digest_infos) =
+        get_digests_info(action_result.output_files.clone(), &move |digests| {
+            Box::new(
+                digests
+                    .into_iter()
+                    .filter_map(|file| file.digest.map(DigestInfo::try_from)),
+            )
+        })
     else {
+        return false;
+    };
+
+    let Ok(mut output_directories) = get_digests_info(
+        action_result.output_directories.clone(),
+        &move |directories| {
+            Box::new(
+                directories
+                    .into_iter()
+                    .filter_map(|output_dir| output_dir.tree_digest.map(DigestInfo::try_from)),
+            )
+        },
+    ) else {
+        return false;
+    };
+
+    digest_infos.append(&mut output_directories);
+
+    let Ok(sizes) = Pin::new(cas_store.as_ref()).has_many(&digest_infos).await else {
         return false;
     };
     sizes.into_iter().all(|size| size.is_some())


### PR DESCRIPTION
# Description

We have duplicated work in CacheLookupScheduler and CompletenessCheckingStore.
I made CacheLookupScheduler to be pointed to a CompletenessCheckingStore to simplify the logic.
I added a new method in the ac_utils so that we can point the validate_output logic with CacheLookupScheduler as well.

Fixes #677

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/814)
<!-- Reviewable:end -->
