### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -865,7 +865,6 @@ pub mod read_tests {
             .into_inner();
         {
             let mut roundtrip_data = Vec::with_capacity(VALUE1.len());
-            assert!(!VALUE1.is_empty(), "Expected at least one byte to be sent");
             while let Some(result_read_response) = read_stream.next().await {
                 roundtrip_data.append(&mut result_read_response?.data.to_vec());
             }

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -143,7 +143,7 @@ impl GrpcStore {
         );
 
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ContentAddressableStorageClient::new(channel)
@@ -168,7 +168,7 @@ impl GrpcStore {
         );
 
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ContentAddressableStorageClient::new(channel)
@@ -193,7 +193,7 @@ impl GrpcStore {
         );
 
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ContentAddressableStorageClient::new(channel)
@@ -218,7 +218,7 @@ impl GrpcStore {
         );
 
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ContentAddressableStorageClient::new(channel)
@@ -377,7 +377,7 @@ impl GrpcStore {
         grpc_request: Request<GetActionResultRequest>,
     ) -> Result<Response<ActionResult>, Error> {
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ActionCacheClient::new(channel)
@@ -397,7 +397,7 @@ impl GrpcStore {
         grpc_request: Request<UpdateActionResultRequest>,
     ) -> Result<Response<ActionResult>, Error> {
         let mut request = grpc_request.into_inner();
-        request.instance_name = self.instance_name.clone();
+        request.instance_name.clone_from(&self.instance_name);
         self.perform_request(request, |request| async move {
             let (connection, channel) = self.connection_manager.get_connection().await;
             let result = ActionCacheClient::new(channel)

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -237,7 +237,7 @@ where
     }
 
     pub fn resume(&mut self) {
-        self.resume_queue = self.cached_messages.clone();
+        self.resume_queue.clone_from(&self.cached_messages);
         self.is_resumed = true;
     }
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1545,7 +1545,7 @@ impl UploadActionResults {
                 .await;
             match maybe_message {
                 Ok(message) => {
-                    action_result.message = message.clone();
+                    action_result.message.clone_from(&message);
                     execute_response.message = message;
                     Ok(())
                 }
@@ -1555,7 +1555,7 @@ impl UploadActionResults {
             match Self::format_execute_response_message(message_template, action_info, None, hasher)
             {
                 Ok(message) => {
-                    action_result.message = message.clone();
+                    action_result.message.clone_from(&message);
                     execute_response.message = message;
                     Ok(())
                 }


### PR DESCRIPTION
Implements suggested performance refactors and prevents future clippy warnings.

# Description

Using clippy for the nightly rust toolchain is currently showing warnings in a number of spots. This implements the suggested changes so that all builds will not suddenly start failing if the toolchain version used by precommit-hooks is updated.

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/817)
<!-- Reviewable:end -->
