### PR TITLE
Update h2 to 0.3.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
See https://seanmonstar.com/blog/hyper-http2-continuation-flood/ for further information.

Fixes GHSA-q6cp-qfwq-4gcv

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/835)
<!-- Reviewable:end -->
