### PR TITLE
Bump Rust toolchains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 name = "nativelink"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,19 +26,26 @@ zig_toolchains = use_extension(
 )
 use_repo(zig_toolchains, "zig_sdk")
 
-bazel_dep(name = "rules_rust", version = "0.40.0")
+bazel_dep(name = "rules_rust", version = "0.41.1")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
+    sha256s = {
+        "2024-04-03/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz": "0b2164f91906a2fde9b3a518c4d5652c5265ef0b5ba7b1b3573884f16ee02508",
+        "2024-04-03/clippy-nightly-x86_64-unknown-linux-gnu.tar.xz": "905e3714f811d0efb1f0836c12c1db424de3d194259fa01b853dad30a37f1abe",
+        "2024-04-03/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz": "aff8ab9422a234d48c7dd65b752c1443678387f61c22f273f4a723895ab4ab69",
+        "2024-04-03/llvm-tools-nightly-x86_64-unknown-linux-gnu.tar.xz": "4e183c1baabd75198c870d59357cc1992cbd2184fae08edb36a541774eaa15dc",
+        "2024-04-03/rust-std-nightly-x86_64-unknown-linux-gnu.tar.xz": "aaa22601f3106224ecf35ec67ad0e6481838b6ec4cae506f11c5bbf79e94cb65",
+    },
     versions = [
-        "1.76.0",
-        "nightly/2024-03-01",
+        "1.77.0",
+        "nightly/2024-04-03",
     ],
 )
 rust.host_tools(
     edition = "2021",
-    version = "1.76.0",
+    version = "1.77.0",
 )
 use_repo(rust, "rust_toolchains")
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,8 +46,8 @@
         system,
         ...
       }: let
-        stable-rust-version = "1.76.0";
-        nightly-rust-version = "2024-03-01";
+        stable-rust-version = "1.77.0";
+        nightly-rust-version = "2024-04-03";
 
         # TODO(aaronmondal): Make musl builds work on Darwin.
         # See: https://github.com/TraceMachina/nativelink/issues/751


### PR DESCRIPTION
- rules_rust: 0.40.0 -> 0.41.1
- rust-stable: 1.76 -> 1.77
- rust-nightly: 2024-03-01 -> 2024-04-03

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/837)
<!-- Reviewable:end -->
