### PR TITLE
Implement worker api for killing running actions

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -131,6 +131,12 @@ message ConnectionResult {
     reserved 2; // NextId.
 }
 
+/// Request to kill a running action sent from the scheduler to a worker.
+message KillActionRequest {
+    /// The the hex encoded unique qualifier for the action to be killed.
+    string action_id = 1;
+    reserved 2; // NextId.
+}
 /// Communication from the scheduler to the worker.
 message UpdateForWorker {
     oneof update {
@@ -152,8 +158,11 @@ message UpdateForWorker {
         /// Informs the worker that it has been disconnected from the pool.
         /// The worker may discard any outstanding work that is being executed.
         google.protobuf.Empty disconnect = 4;
+
+        /// Instructs the worker to kill a specific running action.
+        KillActionRequest kill_action_request = 5;
     }
-    reserved 5; // NextId.
+    reserved 6; // NextId.
 }
 
 message StartExecute {

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -102,11 +102,19 @@ pub struct ConnectionResult {
     #[prost(string, tag = "1")]
     pub worker_id: ::prost::alloc::string::String,
 }
+/// / Request to kill a running action sent from the scheduler to a worker.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KillActionRequest {
+    /// / The the hex encoded unique qualifier for the action to be killed.
+    #[prost(string, tag = "1")]
+    pub action_id: ::prost::alloc::string::String,
+}
 /// / Communication from the scheduler to the worker.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateForWorker {
-    #[prost(oneof = "update_for_worker::Update", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "update_for_worker::Update", tags = "1, 2, 3, 4, 5")]
     pub update: ::core::option::Option<update_for_worker::Update>,
 }
 /// Nested message and enum types in `UpdateForWorker`.
@@ -133,6 +141,9 @@ pub mod update_for_worker {
         /// / The worker may discard any outstanding work that is being executed.
         #[prost(message, tag = "4")]
         Disconnect(()),
+        /// / Instructs the worker to kill a specific running action.
+        #[prost(message, tag = "5")]
+        KillActionRequest(super::KillActionRequest),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -70,6 +70,7 @@ rust_test_suite(
         "//nativelink-util",
         "@crates//:async-lock",
         "@crates//:futures",
+        "@crates//:hex",
         "@crates//:hyper",
         "@crates//:once_cell",
         "@crates//:pretty_assertions",


### PR DESCRIPTION
# Description
Implements worker api for requesting a currently running action to be killed. Allows for action cancellation requests to be sent from the scheduler during scenarios such as client disconnection.

towards: #338

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a new test case to confirm that the request to kill an action is received and handled accordingly.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/840)
<!-- Reviewable:end -->
