### PR TITLE
Rename buf_channel::take() to buf_channel::consume()

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -311,7 +311,7 @@ impl ByteStreamServer {
             let mut state = state?; // If None our stream is done.
             loop {
                 tokio::select! {
-                    read_result = state.rx.take(state.max_bytes_per_stream) => {
+                    read_result = state.rx.consume(Some(state.max_bytes_per_stream)) => {
                         match read_result {
                             Ok(bytes) => {
                                 if bytes.is_empty() {

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -183,11 +183,9 @@ impl CasServer {
             .into_iter()
             .map(|digest| async move {
                 let digest_copy = DigestInfo::try_from(digest.clone())?;
-                let size_bytes = usize::try_from(digest_copy.size_bytes)
-                    .err_tip(|| "Digest size_bytes was not convertible to usize")?;
                 // TODO(allada) There is a security risk here of someone taking all the memory on the instance.
                 let result = store_pin
-                    .get_part_unchunked(digest_copy, 0, None, Some(size_bytes))
+                    .get_part_unchunked(digest_copy, 0, None)
                     .await
                     .err_tip(|| "Error reading from store");
                 let (status, data) = result.map_or_else(

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -241,7 +241,7 @@ mod update_action_result {
 
         let digest = DigestInfo::try_new(HASH1, size_bytes)?;
         let ac_store = Pin::new(ac_store_owned.as_ref());
-        let raw_data = ac_store.get_part_unchunked(digest, 0, None, None).await?;
+        let raw_data = ac_store.get_part_unchunked(digest, 0, None).await?;
 
         let decoded_action_result = ActionResult::decode(raw_data)?;
         assert_eq!(decoded_action_result, action_result);

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -160,7 +160,7 @@ pub mod write_tests {
                 "Not found in store",
             );
             let store_data = store
-                .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None, None)
+                .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None)
                 .await?;
             assert_eq!(
                 std::str::from_utf8(&store_data),
@@ -259,7 +259,7 @@ pub mod write_tests {
             // Check to make sure our store recorded the data properly.
             let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
             assert_eq!(
-                store.get_part_unchunked(digest, 0, None, None).await?,
+                store.get_part_unchunked(digest, 0, None).await?,
                 WRITE_DATA,
                 "Data written to store did not match expected data",
             );
@@ -361,7 +361,7 @@ pub mod write_tests {
             // Check to make sure our store recorded the data properly.
             let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
             assert_eq!(
-                store.get_part_unchunked(digest, 0, None, None).await?,
+                store.get_part_unchunked(digest, 0, None).await?,
                 WRITE_DATA,
                 "Data written to store did not match expected data",
             );
@@ -463,7 +463,7 @@ pub mod write_tests {
             // Check to make sure our store recorded the data properly.
             let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
             assert_eq!(
-                store.get_part_unchunked(digest, 0, None, None).await?,
+                store.get_part_unchunked(digest, 0, None).await?,
                 WRITE_DATA,
                 "Data written to store did not match expected data",
             );
@@ -554,7 +554,7 @@ pub mod write_tests {
             // Check to make sure our store recorded the data properly.
             let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
             assert_eq!(
-                store.get_part_unchunked(digest, 0, None, None).await?,
+                store.get_part_unchunked(digest, 0, None).await?,
                 WRITE_DATA,
                 "Data written to store did not match expected data",
             );
@@ -705,7 +705,7 @@ pub mod write_tests {
         {
             // Check to make sure our store recorded the data properly.
             let data = store
-                .get_part_unchunked(DigestInfo::try_new(HASH1, 0)?, 0, None, None)
+                .get_part_unchunked(DigestInfo::try_new(HASH1, 0)?, 0, None)
                 .await?;
             assert_eq!(data, "", "Expected data to exist and be empty");
         }

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -214,7 +214,7 @@ mod batch_update_blobs {
             }
         );
         let new_data = store
-            .get_part_unchunked(DigestInfo::try_new(HASH1, VALUE1.len())?, 0, None, None)
+            .get_part_unchunked(DigestInfo::try_new(HASH1, VALUE1.len())?, 0, None)
             .await
             .expect("Get should have succeeded");
         assert_eq!(

--- a/nativelink-store/src/ac_utils.rs
+++ b/nativelink-store/src/ac_utils.rs
@@ -52,12 +52,7 @@ pub async fn get_size_and_decode_digest<T: Message + Default>(
     digest: &DigestInfo,
 ) -> Result<(T, usize), Error> {
     let mut store_data_resp = store
-        .get_part_unchunked(
-            *digest,
-            0,
-            Some(MAX_ACTION_MSG_SIZE),
-            Some(ESTIMATED_DIGEST_SIZE),
-        )
+        .get_part_unchunked(*digest, 0, Some(MAX_ACTION_MSG_SIZE))
         .await;
     if let Err(err) = &mut store_data_resp {
         if err.code == Code::NotFound {

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -299,7 +299,7 @@ impl Store for CompressionStore {
             let mut index_count: u32 = 0;
             for index in &mut output_state.footer.indexes {
                 let chunk = reader
-                    .take(self.config.block_size as usize)
+                    .consume(Some(self.config.block_size as usize))
                     .await
                     .err_tip(|| "Failed to read take in update in compression store")?;
                 if chunk.is_empty() {
@@ -431,7 +431,7 @@ impl Store for CompressionStore {
                 };
                 let header_size = self.bincode_options.serialized_size(&EMPTY_HEADER).unwrap();
                 let chunk = rx
-                    .take(header_size as usize)
+                    .consume(Some(header_size as usize))
                     .await
                     .err_tip(|| "Failed to read header in get_part compression store")?;
                 error_if!(
@@ -462,7 +462,7 @@ impl Store for CompressionStore {
             );
 
             let mut chunk = rx
-                .take(1 + 4)
+                .consume(Some(1 + 4))
                 .await
                 .err_tip(|| "Failed to read init frame info in compression store")?;
             error_if!(
@@ -485,7 +485,7 @@ impl Store for CompressionStore {
                 );
 
                 let chunk = rx
-                    .take(frame_sz as usize)
+                    .consume(Some(frame_sz as usize))
                     .await
                     .err_tip(|| "Failed to read chunk in get_part compression store")?;
                 if chunk.len() < frame_sz as usize {
@@ -537,7 +537,7 @@ impl Store for CompressionStore {
                 chunks_count += 1;
 
                 let mut chunk = rx
-                    .take(1 + 4)
+                    .consume(Some(1 + 4))
                     .await
                     .err_tip(|| "Failed to read frame info in compression store")?;
                 error_if!(
@@ -553,7 +553,7 @@ impl Store for CompressionStore {
             {
                 // Read and validate footer.
                 let chunk = rx
-                    .take(frame_sz as usize)
+                    .consume(Some(frame_sz as usize))
                     .await
                     .err_tip(|| "Failed to read chunk in get_part compression store")?;
                 error_if!(

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -99,7 +99,7 @@ impl DedupStore {
         let index_entries = {
             let maybe_data = self
                 .pin_index_store()
-                .get_part_unchunked(digest, 0, None, Some(self.upload_normal_size))
+                .get_part_unchunked(digest, 0, None)
                 .await
                 .err_tip(|| "Failed to read index store in dedup store");
             let data = match maybe_data {
@@ -246,7 +246,7 @@ impl Store for DedupStore {
         let index_entries = {
             let data = self
                 .pin_index_store()
-                .get_part_unchunked(digest, 0, None, Some(self.upload_normal_size))
+                .get_part_unchunked(digest, 0, None)
                 .await
                 .err_tip(|| "Failed to read index store in dedup store")?;
 
@@ -304,15 +304,7 @@ impl Store for DedupStore {
 
                 async move {
                     let data = Pin::new(content_store.as_ref())
-                        .get_part_unchunked(
-                            index_entry,
-                            0,
-                            None,
-                            Some(
-                                usize::try_from(index_entry.size_bytes)
-                                    .err_tip(|| "Failed to convert to usize in DedupStore")?,
-                            ),
-                        )
+                        .get_part_unchunked(index_entry, 0, None)
                         .await
                         .err_tip(|| "Failed to get_part in content_store in dedup_store")?;
 

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -97,7 +97,7 @@ impl Store for MemoryStore {
     async fn update(
         self: Pin<&Self>,
         digest: DigestInfo,
-        reader: DropCloserReadHalf,
+        mut reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
         let max_size = match size_info {
@@ -109,7 +109,7 @@ impl Store for MemoryStore {
         // this potential case, we make a full copy of our data for long-term storage.
         let final_buffer = {
             let buffer = reader
-                .collect_all_with_size_hint(max_size)
+                .consume(Some(max_size))
                 .await
                 .err_tip(|| "Failed to collect all bytes from reader in memory_store::update")?;
             let mut new_buffer = BytesMut::with_capacity(buffer.len());

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -81,7 +81,7 @@ mod ac_utils_tests {
         }
         {
             // Check to make sure the file was saved correctly to the store.
-            let store_data = store_pin.get_part_unchunked(digest, 0, None, None).await?;
+            let store_data = store_pin.get_part_unchunked(digest, 0, None).await?;
             assert_eq!(store_data.len(), expected_data.len());
             assert_eq!(store_data, expected_data);
         }

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -240,7 +240,7 @@ mod completeness_checking_store_tests {
 
             assert!(
                 pinned_store
-                    .get_part_unchunked(action_result_digest, 0, None, None)
+                    .get_part_unchunked(action_result_digest, 0, None)
                     .await
                     .is_ok(),
                 ".get() should succeed with all items in CAS",
@@ -258,7 +258,7 @@ mod completeness_checking_store_tests {
 
             assert!(
                 pinned_store
-                    .get_part_unchunked(action_result_digest, 0, None, None)
+                    .get_part_unchunked(action_result_digest, 0, None)
                     .await
                     .is_err(),
                 ".get() should fail with item missing in CAS",

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -77,7 +77,7 @@ mod dedup_store_tests {
             .err_tip(|| "Failed to write data to dedup store")?;
 
         let rt_data = store
-            .get_part_unchunked(digest, 0, None, Some(original_data.len()))
+            .get_part_unchunked(digest, 0, None)
             .await
             .err_tip(|| "Failed to get_part from dedup store")?;
 
@@ -118,7 +118,7 @@ mod dedup_store_tests {
 
         assert_eq!(did_delete, true, "Expected item to exist in store");
 
-        let result = store.get_part_unchunked(digest, 0, None, None).await;
+        let result = store.get_part_unchunked(digest, 0, None).await;
         assert!(result.is_err(), "Expected result to be an error");
         assert_eq!(
             result.unwrap_err().code,
@@ -155,7 +155,7 @@ mod dedup_store_tests {
 
         const ONE_THIRD_SZ: usize = DATA_SIZE / 3;
         let rt_data = store
-            .get_part_unchunked(digest, ONE_THIRD_SZ, Some(ONE_THIRD_SZ), None)
+            .get_part_unchunked(digest, ONE_THIRD_SZ, Some(ONE_THIRD_SZ))
             .await
             .err_tip(|| "Failed to get_part from dedup store")?;
 
@@ -209,7 +209,7 @@ mod dedup_store_tests {
         // This value must be larger than `max_size` in the config above.
         const START_READ_BYTE: usize = 7;
         let rt_data = store
-            .get_part_unchunked(digest, START_READ_BYTE, None, None)
+            .get_part_unchunked(digest, START_READ_BYTE, None)
             .await
             .err_tip(|| "Failed to get_part from dedup store")?;
 
@@ -265,7 +265,7 @@ mod dedup_store_tests {
                 let len = if maybe_len.is_none() { DATA_SIZE } else { len };
 
                 let rt_data = store
-                    .get_part_unchunked(digest, offset, maybe_len, None)
+                    .get_part_unchunked(digest, offset, maybe_len)
                     .await
                     .err_tip(|| "Failed to get_part from dedup store")?;
 
@@ -286,7 +286,7 @@ mod dedup_store_tests {
         // This value must be larger than `max_size` in the config above.
         const START_READ_BYTE: usize = 10;
         let rt_data = store
-            .get_part_unchunked(digest, START_READ_BYTE, None, None)
+            .get_part_unchunked(digest, START_READ_BYTE, None)
             .await
             .err_tip(|| "Failed to get_part from dedup store")?;
 

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -112,7 +112,7 @@ mod verify_store_tests {
         let store = ExistenceCacheStore::new(&config, inner_store.clone());
 
         let _ = Pin::new(&store)
-            .get_part_unchunked(digest, 0, None, None)
+            .get_part_unchunked(digest, 0, None)
             .await
             .err_tip(|| "Expected get_part to succeed")?;
 

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -66,9 +66,7 @@ async fn check_data<S: Store>(
         "Expected data to exist in {debug_name} store"
     );
 
-    let store_data = check_store
-        .get_part_unchunked(digest, 0, None, None)
-        .await?;
+    let store_data = check_store.get_part_unchunked(digest, 0, None).await?;
     assert_eq!(
         store_data, original_data,
         "Expected data to match in {debug_name} store"
@@ -143,9 +141,7 @@ mod fast_slow_store_tests {
         assert_eq!(slow_store.has(digest).await, Ok(Some(original_data.len())));
 
         // This get() request should place the data in fast_store too.
-        fast_slow_store
-            .get_part_unchunked(digest, 0, None, None)
-            .await?;
+        fast_slow_store.get_part_unchunked(digest, 0, None).await?;
 
         // Now the data should exist in all the stores.
         check_data(fast_store, digest, &original_data, "fast_store").await?;
@@ -171,7 +167,7 @@ mod fast_slow_store_tests {
         assert_eq!(
             original_data[10..60],
             fast_slow_store
-                .get_part_unchunked(digest, 10, Some(50), None)
+                .get_part_unchunked(digest, 10, Some(50))
                 .await?
         );
 
@@ -486,7 +482,7 @@ mod fast_slow_store_tests {
 
         assert_eq!(
             Pin::new(fast_slow_store.as_ref())
-                .get_part_unchunked(digest, 0, None, None)
+                .get_part_unchunked(digest, 0, None)
                 .await,
             Ok(data.into()),
             "Data read from store is not correct"

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -93,12 +93,7 @@ mod ref_store_tests {
         {
             // Now check if we read it from ref_store it has same data.
             let data = Pin::new(ref_store_owned.as_ref())
-                .get_part_unchunked(
-                    DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(
@@ -128,12 +123,7 @@ mod ref_store_tests {
         {
             // Now check if we read it from memory_store it has same data.
             let data = Pin::new(memory_store_owned.as_ref())
-                .get_part_unchunked(
-                    DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -217,7 +217,7 @@ mod shard_store_tests {
             .await?;
 
         assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None, None).await,
+            shard_store.get_part_unchunked(digest1, 0, None).await,
             Ok(original_data1.into())
         );
         Ok(())
@@ -239,7 +239,7 @@ mod shard_store_tests {
             .await?;
 
         assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None, None).await,
+            shard_store.get_part_unchunked(digest1, 0, None).await,
             Ok(original_data1.into())
         );
         Ok(())
@@ -261,7 +261,7 @@ mod shard_store_tests {
             .await?;
 
         assert_eq!(
-            stores[0].get_part_unchunked(digest1, 0, None, None).await,
+            stores[0].get_part_unchunked(digest1, 0, None).await,
             Ok(original_data1.into())
         );
         Ok(())
@@ -283,7 +283,7 @@ mod shard_store_tests {
             .await?;
 
         assert_eq!(
-            stores[1].get_part_unchunked(digest1, 0, None, None).await,
+            stores[1].get_part_unchunked(digest1, 0, None).await,
             Ok(original_data1.into())
         );
         Ok(())
@@ -302,7 +302,7 @@ mod shard_store_tests {
             .update_oneshot(digest1, original_data1.clone().into())
             .await?;
         assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None, None).await,
+            shard_store.get_part_unchunked(digest1, 0, None).await,
             Ok(original_data1.into())
         );
         assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -132,12 +132,7 @@ mod ref_store_tests {
         {
             // Read the partition store small data.
             let data = Pin::new(&size_part_store)
-                .get_part_unchunked(
-                    DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(
@@ -150,12 +145,7 @@ mod ref_store_tests {
         {
             // Read the partition store big data.
             let data = Pin::new(&size_part_store)
-                .get_part_unchunked(
-                    DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(
@@ -193,12 +183,7 @@ mod ref_store_tests {
         {
             // Check if we read small data from size_partition_store it has same data.
             let data = Pin::new(lower_memory_store.as_ref())
-                .get_part_unchunked(
-                    DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(
@@ -211,12 +196,7 @@ mod ref_store_tests {
         {
             // Check if we read big data from size_partition_store it has same data.
             let data = Pin::new(upper_memory_store.as_ref())
-                .get_part_unchunked(
-                    DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
-                    0,
-                    None,
-                    None,
-                )
+                .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
                 .await
                 .expect("Get should have succeeded");
             assert_eq!(

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -761,17 +761,17 @@ mod running_actions_manager_tests {
         };
         let file_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None, None)
+            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&file_content)?, "123 ");
         let stdout_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None, None)
+            .get_part_unchunked(action_result.stdout_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
         let stderr_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None, None)
+            .get_part_unchunked(action_result.stderr_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
         let mut clock_time = make_system_time(0);
@@ -932,17 +932,17 @@ mod running_actions_manager_tests {
         };
         let file_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None, None)
+            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&file_content)?, "123 ");
         let stdout_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None, None)
+            .get_part_unchunked(action_result.stdout_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
         let stderr_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None, None)
+            .get_part_unchunked(action_result.stderr_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
         let mut clock_time = make_system_time(0);
@@ -1737,7 +1737,7 @@ exit 0
 
         let actual_stderr: prost::bytes::Bytes = cas_store
             .as_ref()
-            .get_part_unchunked(result.stderr_digest, 0, None, Some(expected_stderr.len()))
+            .get_part_unchunked(result.stderr_digest, 0, None)
             .await?;
         let actual_stderr_decoded = std::str::from_utf8(&actual_stderr)?;
         assert_eq!(expected_stderr, actual_stderr_decoded);
@@ -3146,17 +3146,17 @@ exit 1
         };
         let file_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None, None)
+            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&file_content)?, "123 ");
         let stdout_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None, None)
+            .get_part_unchunked(action_result.stdout_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
         let stderr_content = slow_store
             .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None, None)
+            .get_part_unchunked(action_result.stderr_digest, 0, None)
             .await?;
         assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
         let mut clock_time = make_system_time(0);


### PR DESCRIPTION
This is to remove some of the confusion of what .take() can mean. In rust .take() often is used to denote "taking ownership" but can also mean "take data". To remove any ambiguity it's renamed .consume() to ensure the user either knows what the api does or has to look it up.

Also removes .collect_all_with_size_hint() and replaces with
.consume()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/848)
<!-- Reviewable:end -->
