### PR TITLE
Achieve perfect reproducibility for dev setups

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,5 +87,19 @@ build:lre --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 #                    is resolved.
 build:lre --define=EXECUTOR=remote
 
+# rules_rust doesn't properly work with remote execution.
+#
+# Note(aaronmondal): It's technically possible to run this build in some remote
+# execution images, such as ubuntu-based images. Those images only pretend to be
+# reproducible (think /usr/bin/clang which could be any version of clang). This
+# disables anything that doesn't "properly" execute remotely.
+common:lre --strategy=Rustc=local
+common:lre --strategy=CargoBuildScriptRun=local
+common:lre --strategy=Rustfmt=local
+common:lre --strategy=Clippy=local
+common:lre --strategy=TestRunner=local
+common:lre --strategy=Rustdoc=local
+common:lre --strategy=Genrule=local # Genrules break remotely as well.
+
 # Allow user-side customization.
 try-import %workspace%/.bazelrc.user

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -42,6 +42,15 @@ jobs:
            --verbose_failures \
            @local-remote-execution//examples:hello_lre"
 
+      - name: Build NativeLink with LRE.
+        run: >
+          nix develop --impure --command
+          bash -c "bazel test \
+           --config=lre \
+           --verbose_failures \
+           ..."
+
+
   remote:
     strategy:
       fail-fast: false
@@ -109,3 +118,14 @@ jobs:
             --remote_executor=grpc://$scheduler_ip:50052 \
             --verbose_failures \
             @local-remote-execution//examples:hello_lre"
+
+      - name: Build NativeLink with LRE.
+        run: >
+          nix develop --impure --command
+          bash -c "bazel test \
+            --config=lre \
+            --remote_instance_name=main \
+            --remote_cache=grpc://$cache_ip:50051 \
+            --remote_executor=grpc://$scheduler_ip:50052 \
+            --verbose_failures \
+            ..."

--- a/tools/nixpkgs_link_libunwind_and_libcxx.diff
+++ b/tools/nixpkgs_link_libunwind_and_libcxx.diff
@@ -1,0 +1,34 @@
+diff --git a/pkgs/development/compilers/llvm/18/default.nix b/pkgs/development/compilers/llvm/18/default.nix
+index 4d2b160a23ff..f0d4a52f09d9 100644
+--- a/pkgs/development/compilers/llvm/18/default.nix
++++ b/pkgs/development/compilers/llvm/18/default.nix
+@@ -211,19 +211,25 @@ in let
+         targetLlvmLibraries.compiler-rt
+       ] ++ lib.optionals (!stdenv.targetPlatform.isWasm) [
+         targetLlvmLibraries.libunwind
++        targetLlvmLibraries.libcxx
+       ];
+       extraBuildCommands = mkExtraBuildCommands cc;
+       nixSupport.cc-cflags =
+         [ "-rtlib=compiler-rt"
+           "-Wno-unused-command-line-argument"
+           "-B${targetLlvmLibraries.compiler-rt}/lib"
++          "-stdlib=libc++"
+         ]
+-        ++ lib.optional (!stdenv.targetPlatform.isWasm) "--unwindlib=libunwind"
+-        ++ lib.optional
+-          (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false)
++        ++ lib.optionals (!stdenv.targetPlatform.isWasm) [
++          "--unwindlib=libunwind"
+           "-lunwind"
++          "-lc++"
++        ]
+         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+-      nixSupport.cc-ldflags = lib.optionals (!stdenv.targetPlatform.isWasm) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
++      nixSupport.cc-ldflags = lib.optionals (!stdenv.targetPlatform.isWasm) [
++        "-L${targetLlvmLibraries.libunwind}/lib"
++        "-L${targetLlvmLibraries.libcxx}/lib"
++      ];
+     };
+
+     clangNoLibcxx = wrapCCWith rec {


### PR DESCRIPTION
This commit changes the default C++ toolchain to the custom nix-backed clang toolchain.

- Update custom stdenv to use Clang/LLVM 18
- Regenerate LRE toolchains.
- Remove obsolete zig_cc toolchain
- Expand LRE CI to build C++ parts of NativeLink remotely in K8s and the rest of rules_rust locally.

Fixes #694
Closes #477

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/874)
<!-- Reviewable:end -->
