### PR TITLE
Remove zig-cc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,24 +75,6 @@ build:windows --enable_runfiles
 # toolchains are resolved before the rust toolchains.
 build --extra_toolchains=@rust_toolchains//:all
 
-# Option to test the zig toolchain on Linux. Prefer the default `linux`
-# toolchain which builds cc targets roughly twice as fast.
-#
-# WARNING:
-#
-# We're using an incredibly old target glibc here. Builds created with this
-# toolchain have maximum compatibility (theoretically down to Ubuntu 18), but
-# miss out on half a decade of optimizations. Don't use this for production
-# builds if you're running a non-ancient OS and care about performance.
-#
-# TODO(aaronmondal): Migrate to a statically linked musl as soon as rules_rust
-#                    supports it. This way we get to keep (or even improve)
-#                    backwards compatibility without sacrificing performance.
-build:linux_zig --host_platform=@zig_sdk//platform:linux_amd64
-build:linux_zig --extra_toolchains=@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28
-build:linux_zig --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-
-
 # Local Remote Execution.
 build:lre --extra_execution_platforms=@local-remote-execution//generated-cc/config:platform
 build:lre --extra_toolchains=@local-remote-execution//generated-cc/config:cc-toolchain"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         cd ../../ && \
         docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
           bazel clean && \
-          bazel test --config=linux_zig //... \
+          bazel test //... \
           --remote_instance_name=main \
           --remote_cache=grpc://127.0.0.1:50051 \
           --remote_executor=grpc://127.0.0.1:50052 \
@@ -66,7 +66,7 @@ jobs:
         ' && \
         docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
           bazel clean && \
-          bazel test --config=linux_zig //... \
+          bazel test //... \
           --remote_instance_name=main \
           --remote_cache=grpc://127.0.0.1:50051 \
           --remote_executor=grpc://127.0.0.1:50052 \

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -69,37 +69,3 @@ jobs:
             exit 1
           fi
         shell: bash
-
-  zig-cc-unit-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    name: zig-cc ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-
-      - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-
-      - name: Setup Bazelisk
-        uses: >- # v0.8.1
-          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
-        with:
-          bazelisk-cache: true
-
-      - name: Mount bazel cache
-        uses: >- # v4.0.1
-          actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
-        with:
-          path: |
-            ~/.cache/bazel
-          key: |
-            ${{ matrix.os }}-bazel-legacy-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ matrix.os }}-bazel-legacy-
-
-      - name: Run Bazel tests
-        run: |
-          bazel test --config=linux_zig //... --verbose_failures

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             nix develop --impure --command \
-            bash -c "bazel test --config=linux_zig ... --verbose_failures"
+            bash -c "bazel test ... --verbose_failures"
           elif [ "$RUNNER_OS" == "macOS" ]; then
             nix develop --impure --command \
             bash -c "bazel test //... --verbose_failures"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,14 +18,6 @@ python.toolchain(
 )
 use_repo(python, python = "python_versions")
 
-bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1")
-
-zig_toolchains = use_extension(
-    "@hermetic_cc_toolchain//toolchain:ext.bzl",
-    "toolchains",
-)
-use_repo(zig_toolchains, "zig_sdk")
-
 bazel_dep(name = "rules_rust", version = "0.42.1")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")


### PR DESCRIPTION
The zig-cc toolchain blocks updating the `cc` crate, which in turn blocks updating a bunch of other crates. We originally had it for backwards compatibility on older systems. Now that NativeLink's production builds are statically linked against musl this build has become obsolete.

Closes #694

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/876)
<!-- Reviewable:end -->
