### PR TITLE
Add nativelink_test macro for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -785,7 +785,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1233,7 +1233,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1786,6 +1786,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nativelink-macro"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "nativelink-proto"
 version = "0.3.0"
 dependencies = [
@@ -1808,6 +1817,7 @@ dependencies = [
  "lru",
  "nativelink-config",
  "nativelink-error",
+ "nativelink-macro",
  "nativelink-proto",
  "nativelink-store",
  "nativelink-util",
@@ -1833,6 +1843,7 @@ dependencies = [
  "maplit",
  "nativelink-config",
  "nativelink-error",
+ "nativelink-macro",
  "nativelink-proto",
  "nativelink-scheduler",
  "nativelink-store",
@@ -1879,6 +1890,7 @@ dependencies = [
  "memory-stats",
  "nativelink-config",
  "nativelink-error",
+ "nativelink-macro",
  "nativelink-proto",
  "nativelink-util",
  "once_cell",
@@ -1914,6 +1926,7 @@ dependencies = [
  "mock_instant",
  "nativelink-config",
  "nativelink-error",
+ "nativelink-macro",
  "nativelink-proto",
  "parking_lot",
  "pin-project-lite",
@@ -1945,6 +1958,7 @@ dependencies = [
  "hyper",
  "nativelink-config",
  "nativelink-error",
+ "nativelink-macro",
  "nativelink-proto",
  "nativelink-scheduler",
  "nativelink-store",
@@ -2137,7 +2151,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2178,7 +2192,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2227,12 +2241,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2261,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2288,7 +2302,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2318,7 +2332,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.60",
+ "syn 2.0.52",
  "tempfile",
 ]
 
@@ -2332,7 +2346,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2346,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2755,7 +2769,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2946,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2990,7 +3004,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3086,7 +3100,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3215,7 +3229,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3270,7 +3284,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3641,7 +3655,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/nativelink-macro/BUILD.bazel
+++ b/nativelink-macro/BUILD.bazel
@@ -1,0 +1,23 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_proc_macro",
+)
+
+rust_proc_macro(
+    name = "nativelink-macro",
+    srcs = [
+        "src/lib.rs",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:proc-macro2",
+        "@crates//:quote",
+        "@crates//:syn",
+    ],
+)
+
+rust_doc(
+    name = "docs",
+    crate = ":nativelink-macro",
+)

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nativelink-macro"
+version = "0.3.0"
+edition = "2021"
+
+[lib]
+crate_type = ["proc-macro"]
+
+[dependencies]
+# TODO(allada) We currently need to pin these to specific version.
+# Some down-stream can't be upgraded just yet.
+proc-macro2 = "=1.0.78"
+quote = "=1.0.35"
+syn = "=2.0.52"

--- a/nativelink-macro/src/lib.rs
+++ b/nativelink-macro/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+#[proc_macro_attribute]
+pub fn nativelink_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
+    let input_fn = parse_macro_input!(item as ItemFn);
+
+    let fn_name = &input_fn.sig.ident;
+    let fn_block = &input_fn.block;
+    let fn_inputs = &input_fn.sig.inputs;
+    let fn_output = &input_fn.sig.output;
+    let fn_attr = &input_fn.attrs;
+
+    let expanded = quote! {
+        #(#fn_attr)*
+        #[tokio::test(#attr)]
+        async fn #fn_name(#fn_inputs) #fn_output {
+            #fn_block
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -61,6 +61,7 @@ rust_test_suite(
         "tests/utils/scheduler_utils.rs",
     ],
     proc_macro_deps = [
+        "//nativelink-macro",
         "@crates//:async-trait",
     ],
     deps = [

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -30,4 +30,6 @@ tonic = { version = "0.11.0", features = ["gzip", "tls"] }
 tracing = "0.1.40"
 
 [dev-dependencies]
+nativelink-macro = { path = "../nativelink-macro" }
+
 pretty_assertions = "1.4.0"

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ExecuteResponse;
 use nativelink_proto::google::longrunning::{operation, Operation};
 use nativelink_proto::google::rpc::Status;
@@ -41,7 +42,7 @@ mod action_messages_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn action_state_any_url_test() -> Result<(), Error> {
         let action_state = ActionState {
             unique_qualifier: ActionInfoHashKey {
@@ -68,7 +69,7 @@ mod action_messages_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn execute_response_status_message_is_some_on_success_test() -> Result<(), Error> {
         let execute_response: ExecuteResponse = ActionStage::Completed(ActionResult {
             output_files: vec![],
@@ -102,7 +103,7 @@ mod action_messages_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn highest_priority_action_first() -> Result<(), Error> {
         const INSTANCE_NAME: &str = "foobar_instance_name";
 
@@ -158,7 +159,7 @@ mod action_messages_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn equal_priority_earliest_first() -> Result<(), Error> {
         const INSTANCE_NAME: &str = "foobar_instance_name";
 

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -24,6 +24,7 @@ mod utils {
 
 use futures::join;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::cache_lookup_scheduler::CacheLookupScheduler;
@@ -63,7 +64,7 @@ mod cache_lookup_scheduler_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn platform_property_manager_call_passed() -> Result<(), Error> {
         let context = make_cache_scheduler()?;
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
@@ -84,7 +85,7 @@ mod cache_lookup_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_handles_skip_cache() -> Result<(), Error> {
         let context = make_cache_scheduler()?;
         let action_info = make_base_action_info(UNIX_EPOCH);
@@ -109,7 +110,7 @@ mod cache_lookup_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn find_existing_action_call_passed() -> Result<(), Error> {
         let context = make_cache_scheduler()?;
         let action_name = ActionInfoHashKey {

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -24,6 +24,7 @@ mod utils {
 use futures::join;
 use nativelink_config::schedulers::{PlatformPropertyAddition, PropertyModification, PropertyType};
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
@@ -60,7 +61,7 @@ mod property_modifier_scheduler_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_adds_property() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
@@ -95,7 +96,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_overwrites_property() -> Result<(), Error> {
         let name = "name".to_string();
         let original_value = "value".to_string();
@@ -135,7 +136,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_property_added_after_remove() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
@@ -172,7 +173,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_property_remove_after_add() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
@@ -209,7 +210,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn add_action_property_remove() -> Result<(), Error> {
         let name = "name".to_string();
         let value = "value".to_string();
@@ -241,7 +242,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn find_existing_action_call_passed() -> Result<(), Error> {
         let context = make_modifier_scheduler(vec![]);
         let action_name = ActionInfoHashKey {
@@ -260,7 +261,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
         let name = "name".to_string();
         let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
@@ -281,7 +282,7 @@ mod property_modifier_scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
         let name = "name".to_string();
         let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use nativelink_error::{make_err, Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_util::action_messages::{
     ActionInfoHashKey, ActionResult, ActionStage, ActionState, DirectoryInfo, ExecutionMetadata,
@@ -101,7 +102,7 @@ mod scheduler_tests {
 
     const WORKER_TIMEOUT_S: u64 = 100;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -154,7 +155,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn find_executing_action() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -215,7 +216,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Error> {
         const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
         const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
@@ -361,7 +362,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -435,7 +436,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), Error> {
         const WORKER_ID1: WorkerId = WorkerId(0x0010_0001);
         const WORKER_ID2: WorkerId = WorkerId(0x0010_0002);
@@ -518,7 +519,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x0010_0009);
 
@@ -620,7 +621,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x0010_0010);
         let scheduler = SimpleScheduler::new_with_callback(
@@ -657,7 +658,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
         const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
@@ -759,7 +760,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_action_sends_completed_result_to_client_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -862,7 +863,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_action_sends_completed_result_after_disconnect() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -964,7 +965,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         const GOOD_WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
         const ROGUE_WORKER_ID: WorkerId = WorkerId(0x0009_8765_4321);
@@ -1060,7 +1061,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x0010_000f);
 
@@ -1188,7 +1189,7 @@ mod scheduler_tests {
 
     /// This tests to ensure that platform property restrictions allow jobs to continue to run after
     /// a job finished on a specific worker (eg: restore platform properties).
-    #[tokio::test]
+    #[nativelink_test]
     async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> Result<(), Error>
     {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
@@ -1333,7 +1334,7 @@ mod scheduler_tests {
     }
 
     /// This tests that actions are performed in the order they were queued.
-    #[tokio::test]
+    #[nativelink_test]
     async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -1385,7 +1386,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
@@ -1502,7 +1503,7 @@ mod scheduler_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
         struct DropChecker {
             dropped: Arc<AtomicBool>,
@@ -1541,7 +1542,7 @@ mod scheduler_tests {
     }
 
     /// Regression test for: https://github.com/TraceMachina/nativelink/issues/257.
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_task_or_worker_change_notification_received_test() -> Result<(), Error> {
         const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
         const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -51,6 +51,9 @@ rust_test_suite(
         "tests/cas_server_test.rs",
         "tests/worker_api_server_test.rs",
     ],
+    proc_macro_deps = [
+        "//nativelink-macro",
+    ],
     deps = [
         "//nativelink-config",
         "//nativelink-error",

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -26,6 +26,8 @@ tracing = "0.1.40"
 uuid = { version = "1.8.0", features = ["v4"] }
 
 [dev-dependencies]
+nativelink-macro = { path = "../nativelink-macro" }
+
 hyper = "0.14.28"
 maplit = "1.0.2"
 pretty_assertions = "1.4.0"

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use bytes::BytesMut;
 use maplit::hashmap;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::action_cache_server::ActionCache;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     digest_function, ActionResult, Digest,
@@ -117,7 +118,7 @@ mod get_action_result {
             .await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let ac_server = make_ac_server(&store_manager)?;
@@ -133,7 +134,7 @@ mod get_action_result {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_single_item() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let ac_server = make_ac_server(&store_manager)?;
@@ -156,7 +157,7 @@ mod get_action_result {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let ac_server = make_ac_server(&store_manager)?;
@@ -210,7 +211,7 @@ mod update_action_result {
             .await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn one_item_update_test() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let ac_server = make_ac_server(&store_manager)?;

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -20,6 +20,7 @@ use futures::task::Poll;
 use hyper::body::Sender;
 use maplit::hashmap;
 use nativelink_error::{make_err, Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_proto::google::bytestream::WriteResponse;
 use nativelink_service::bytestream_server::ByteStreamServer;
 use nativelink_store::default_store_factory::store_factory;
@@ -79,7 +80,7 @@ pub mod write_tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -171,7 +172,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -267,7 +268,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -369,7 +370,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -471,7 +472,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn ensure_write_is_not_done_until_write_request_is_set(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
@@ -562,7 +563,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn out_of_order_data_fails() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -645,7 +646,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -712,7 +713,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -770,7 +771,7 @@ pub mod write_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn out_of_sequence_write() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -840,7 +841,7 @@ pub mod read_tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn std::error::Error>>
     {
         let store_manager = make_store_manager().await?;
@@ -877,7 +878,7 @@ pub mod read_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
@@ -928,7 +929,7 @@ pub mod read_tests {
     /// store backend resulted in an error. This was because we were not shutting down the stream
     /// when on the backend store error which caused the AsyncReader to block forever because the
     /// stream was never shutdown.
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn read_with_not_found_does_not_deadlock() -> Result<(), Error> {
         let store_manager = make_store_manager()
             .await
@@ -986,7 +987,7 @@ pub mod query_tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = Arc::new(make_bytestream_server(store_manager.as_ref())?);

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use maplit::hashmap;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::content_addressable_storage_server::ContentAddressableStorage;
 use nativelink_proto::build::bazel::remote::execution::v2::{compressor, digest_function, Digest};
 use nativelink_proto::google::rpc::Status as GrpcStatus;
@@ -68,7 +69,7 @@ mod find_missing_blobs {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let cas_server = make_cas_server(&store_manager)?;
@@ -89,7 +90,7 @@ mod find_missing_blobs {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn store_one_item_existence() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let cas_server = make_cas_server(&store_manager)?;
@@ -117,7 +118,7 @@ mod find_missing_blobs {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let cas_server = make_cas_server(&store_manager)?;
@@ -168,7 +169,7 @@ mod batch_update_blobs {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_existing_item() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let cas_server = make_cas_server(&store_manager)?;
@@ -236,7 +237,7 @@ mod batch_read_blobs {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn batch_read_blobs_read_two_blobs_success_one_fail(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
@@ -333,7 +334,7 @@ mod end_to_end {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn batch_update_blobs_two_items_existence_with_third_missing(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use nativelink_config::cas_server::WorkerApiConfig;
 use nativelink_error::{Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     ActionResult as ProtoActionResult, ExecuteResponse, ExecutedActionMetadata, LogFile,
     OutputDirectory, OutputFile, OutputSymlink,
@@ -116,7 +117,7 @@ async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestCont
 pub mod connect_worker_tests {
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn connect_worker_adds_worker_to_scheduler_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
@@ -136,7 +137,7 @@ pub mod keep_alive_tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::Error>> {
         let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
@@ -169,7 +170,7 @@ pub mod keep_alive_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn server_does_not_timeout_if_keep_alive_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let now_timestamp = Arc::new(Mutex::new(BASE_NOW_S));
@@ -223,7 +224,7 @@ pub mod keep_alive_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std::error::Error>>
     {
         let mut test_context =
@@ -262,7 +263,7 @@ pub mod keep_alive_tests {
 pub mod going_away_tests {
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn going_away_removes_worker_test() -> Result<(), Box<dyn std::error::Error>> {
         let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
@@ -298,7 +299,7 @@ pub mod execution_response_tests {
         UNIX_EPOCH.checked_add(Duration::from_secs(time)).unwrap()
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error::Error>> {
         let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -92,6 +92,7 @@ rust_test_suite(
         "tests/verify_store_test.rs",
     ],
     proc_macro_deps = [
+        "//nativelink-macro",
         "@crates//:async-trait",
     ],
     deps = [
@@ -122,6 +123,7 @@ rust_test_suite(
         "@crates//:sha2",
         "@crates//:tokio",
         "@crates//:tokio-stream",
+        "@crates//:tracing",
         "@crates//:uuid",
     ],
 )

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -42,6 +42,8 @@ tracing = "0.1.40"
 uuid = { version = "1.8.0", features = ["v4"] }
 
 [dev-dependencies]
+nativelink-macro = { path = "../nativelink-macro" }
+
 redis-test = { version = "0.4.0", features = ["aio"] }
 pretty_assertions = "1.4.0"
 memory-stats = "1.1.0"

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -18,6 +18,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use nativelink_error::{Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
@@ -48,7 +49,7 @@ mod ac_utils_tests {
     // Regression test for bug created when implementing ResumeableFileSlot
     // where the timeout() success condition was breaking out of the outer
     // loop resulting in the file always being created with <= 4096 bytes.
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
         let filepath = make_temp_path("test.txt").await;
         let expected_data = vec![0x88; 1024 * 1024]; // 1MB.

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use nativelink_config::stores::MemoryStore as MemoryStoreConfig;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     ActionResult as ProtoActionResult, Directory, DirectoryNode, FileNode, OutputDirectory,
     OutputFile, Tree,
@@ -116,7 +117,7 @@ mod completeness_checking_store_tests {
         Ok((ac_owned, cas_store, action_result_digest))
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
         {
             // Completeness check should succeed when all digests exist in CAS.
@@ -229,7 +230,7 @@ mod completeness_checking_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_completeness_get() -> Result<(), Error> {
         {
             // Completeness check in get call should succeed when all digests exist in CAS.

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
 use nativelink_error::{make_err, Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::compression_store::{
     CompressionStore, Footer, Lz4Config, SliceIndex, CURRENT_STREAM_FORMAT_VERSION,
     DEFAULT_BLOCK_SIZE, FOOTER_FRAME_TYPE,
@@ -71,7 +72,7 @@ mod compression_store_tests {
     const DUMMY_DATA_SIZE: usize = 100; // Some dummy size to populate DigestInfo with.
     const MEGABYTE_SZ: usize = 1024 * 1024;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_smoke_test() -> Result<(), Error> {
         let store_owned = CompressionStore::new(
             nativelink_config::stores::CompressionStore {
@@ -108,7 +109,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn partial_reads_test() -> Result<(), Error> {
         let store_owned = CompressionStore::new(
             nativelink_config::stores::CompressionStore {
@@ -167,7 +168,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn rand_5mb_smoke_test() -> Result<(), Error> {
         let store_owned = CompressionStore::new(
             nativelink_config::stores::CompressionStore {
@@ -203,7 +204,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -258,7 +259,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn check_header_test() -> Result<(), Error> {
         const BLOCK_SIZE: u32 = 150;
         const MAX_SIZE_INPUT: usize = 1024 * 1024; // 1MB.
@@ -348,7 +349,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn check_footer_test() -> Result<(), Error> {
         const BLOCK_SIZE: u32 = 32 * 1024;
         let inner_store = Arc::new(MemoryStore::new(
@@ -495,7 +496,7 @@ mod compression_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_is_zero_digest() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use nativelink_error::{Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::dedup_store::DedupStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::DigestInfo;
@@ -55,7 +56,7 @@ mod dedup_store_tests {
     const VALID_HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
     const MEGABYTE_SZ: usize = 1024 * 1024;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_round_trip_test() -> Result<(), Error> {
         let store_owned = DedupStore::new(
             &make_default_config(),
@@ -85,7 +86,7 @@ mod dedup_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn check_missing_last_chunk_test() -> Result<(), Error> {
         let content_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -131,7 +132,7 @@ mod dedup_store_tests {
     /// Test to ensure if we upload a bit of data then request just a slice of it, we get the
     /// proper data out. Internal to DedupStore we only download the slices that contain the
     /// requested data; this test covers that use case.
-    #[tokio::test]
+    #[nativelink_test]
     async fn fetch_part_test() -> Result<(), Error> {
         let store_owned = DedupStore::new(
             &make_default_config(),
@@ -172,7 +173,7 @@ mod dedup_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn check_length_not_set_with_chunk_read_beyond_first_chunk_regression_test(
     ) -> Result<(), Error> {
         let store_owned = DedupStore::new(
@@ -226,7 +227,7 @@ mod dedup_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
         let store_owned = DedupStore::new(
             &nativelink_config::stores::DedupStore {
@@ -305,7 +306,7 @@ mod dedup_store_tests {
 
     /// Ensure that when we run a `.has()` on a dedup store it will check to ensure all indexed
     /// content items exist instead of just checking the entry in the index store.
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_checks_content_store() -> Result<(), Error> {
         let index_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -378,7 +379,7 @@ mod dedup_store_tests {
 
     /// Ensure that when we run a `.has()` on a dedup store and the index does not exist it will
     /// properly return None.
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
         let index_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use nativelink_config::stores::{ExistenceCacheStore as ExistenceCacheStoreConfig, StoreConfig};
 use nativelink_error::{Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::existence_cache_store::ExistenceCacheStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::DigestInfo;
@@ -28,7 +29,7 @@ mod verify_store_tests {
 
     const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_exist_cache_test() -> Result<(), Error> {
         const VALUE: &str = "123";
         let config = ExistenceCacheStoreConfig {
@@ -69,7 +70,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_flags_existance_cache_test() -> Result<(), Error> {
         const VALUE: &str = "123";
         let config = ExistenceCacheStoreConfig {
@@ -94,7 +95,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_caches_if_exact_size_set() -> Result<(), Error> {
         const VALUE: &str = "123";
         let config = ExistenceCacheStoreConfig {

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_store::noop_store::NoopStore;
@@ -90,7 +91,7 @@ mod fast_slow_store_tests {
 
     const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_large_amount_to_both_stores_test() -> Result<(), Error> {
         let (store, fast_store, slow_store) = make_stores();
         let store = Pin::new(store.as_ref());
@@ -120,7 +121,7 @@ mod fast_slow_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn fetch_slow_store_puts_in_fast_store_test() -> Result<(), Error> {
         let (fast_slow_store, fast_store, slow_store) = make_stores();
         let fast_slow_store = Pin::new(fast_slow_store.as_ref());
@@ -150,7 +151,7 @@ mod fast_slow_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn partial_reads_copy_full_to_fast_store_test() -> Result<(), Error> {
         let (fast_slow_store, fast_store, slow_store) = make_stores();
         let fast_slow_store = Pin::new(fast_slow_store.as_ref());
@@ -255,7 +256,7 @@ mod fast_slow_store_tests {
         }
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
         struct DropCheckStore {
             drop_flag: Arc<AtomicBool>,
@@ -407,7 +408,7 @@ mod fast_slow_store_tests {
         get_res.merge(read_res)
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ignore_value_in_fast_store() -> Result<(), Error> {
         let fast_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -442,7 +443,7 @@ mod fast_slow_store_tests {
     }
 
     // Regression test for https://github.com/TraceMachina/nativelink/issues/665
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
         let fast_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -33,6 +33,7 @@ use futures::executor::block_on;
 use futures::task::Poll;
 use futures::{poll, Future, FutureExt};
 use nativelink_error::{Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::filesystem_store::{
     digest_from_filename, EncodedFilePath, FileEntry, FileEntryImpl, FilesystemStore,
 };
@@ -231,7 +232,7 @@ mod filesystem_store_tests {
     const VALUE1: &str = "0123456789";
     const VALUE2: &str = "9876543210";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn valid_results_after_shutdown_test() -> Result<(), Error> {
         let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
         let content_path = make_temp_path("content_path");
@@ -281,7 +282,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
         let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
         let content_path = make_temp_path("content_path");
@@ -371,7 +372,7 @@ mod filesystem_store_tests {
     // This test ensures that if a file is overridden and an open stream to the file already
     // exists, the open stream will continue to work properly and when the stream is done the
     // temporary file (of the object that was deleted) is cleaned up.
-    #[tokio::test]
+    #[nativelink_test]
     async fn file_continues_to_stream_on_content_replace_test() -> Result<(), Error> {
         let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
         let content_path = make_temp_path("content_path");
@@ -500,7 +501,7 @@ mod filesystem_store_tests {
     // Eviction has a different code path than a file replacement, so we check that if a
     // file is evicted and has an open stream on it, it will stay alive and eventually
     // get deleted.
-    #[tokio::test]
+    #[nativelink_test]
     async fn file_gets_cleans_up_on_cache_eviction() -> Result<(), Error> {
         let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
         let digest2 = DigestInfo::try_new(HASH2, VALUE2.len())?;
@@ -611,7 +612,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn atime_updates_on_get_part_test() -> Result<(), Error> {
         let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
@@ -660,7 +661,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn oldest_entry_evicted_with_access_times_loaded_from_disk() -> Result<(), Error> {
         // Note these are swapped to ensure they aren't in numerical order.
         let digest1 = DigestInfo::try_new(HASH2, VALUE2.len())?;
@@ -714,7 +715,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn eviction_drops_file_test() -> Result<(), Error> {
         let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
@@ -766,7 +767,7 @@ mod filesystem_store_tests {
     // Test to ensure that if we are holding a reference to `FileEntry` and the contents are
     // replaced, the `FileEntry` continues to use the old data.
     // `FileEntry` file contents should be immutable for the lifetime of the object.
-    #[tokio::test]
+    #[nativelink_test]
     async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error> {
         let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
@@ -812,7 +813,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn eviction_on_insert_calls_unref_once() -> Result<(), Error> {
         const SMALL_VALUE: &str = "01";
         const BIG_VALUE: &str = "0123";
@@ -873,8 +874,8 @@ mod filesystem_store_tests {
         Ok(())
     }
 
+    #[nativelink_test]
     #[allow(clippy::await_holding_refcell_ref)]
-    #[tokio::test]
     async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens(
     ) -> Result<(), Error> {
         let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
@@ -1011,7 +1012,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_timeout_test() -> Result<(), Error> {
         let large_value = "x".repeat(1024);
         let digest = DigestInfo::try_new(HASH1, large_value.len())?;
@@ -1063,7 +1064,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_is_zero_digest() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),
@@ -1107,7 +1108,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_results_on_zero_digests() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),
@@ -1178,7 +1179,7 @@ mod filesystem_store_tests {
     }
 
     /// Regression test for: https://github.com/TraceMachina/nativelink/issues/495.
-    #[tokio::test(flavor = "multi_thread")]
+    #[nativelink_test(flavor = "multi_thread")]
     async fn update_file_future_drops_before_rename() -> Result<(), Error> {
         let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
@@ -1268,7 +1269,7 @@ mod filesystem_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn deleted_file_removed_from_store() -> Result<(), Error> {
         let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
         let content_path = make_temp_path("content_path");
@@ -1313,7 +1314,7 @@ mod filesystem_store_tests {
     // assume block size 4K
     // 1B data size = 4K size on disk
     // 5K data size = 8K size on disk
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_file_size_uses_block_size() -> Result<(), Error> {
         let content_path = make_temp_path("content_path");
         let temp_path = make_temp_path("temp_path");
@@ -1362,7 +1363,7 @@ mod filesystem_store_tests {
 
     // Ensure that update_with_whole_file() moves the file without making a copy.
     #[cfg(target_family = "unix")]
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_with_whole_file_uses_same_inode() -> Result<(), Error> {
         use std::os::unix::fs::MetadataExt;
         let content_path = make_temp_path("content_path");

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use bytes::{BufMut, Bytes, BytesMut};
 use memory_stats::memory_stats;
 use nativelink_error::{Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
@@ -34,12 +35,11 @@ const INVALID_HASH: &str = "g111111111111111111111111111111111111111111111111111
 
 #[cfg(test)]
 mod memory_store_tests {
-
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_one_item_then_update() -> Result<(), Error> {
         const VALUE1: &str = "13";
         const VALUE2: &str = "23";
@@ -87,7 +87,7 @@ mod memory_store_tests {
     }
 
     // Regression test for: https://github.com/TraceMachina/nativelink/issues/289.
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
         // Arbitrary value, this may be increased if we find out that this is
         // too low for some kernels/operating systems.
@@ -132,7 +132,7 @@ mod memory_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_partial() -> Result<(), Error> {
         const VALUE1: &str = "1234";
         let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
@@ -155,7 +155,7 @@ mod memory_store_tests {
 
     // A bug was found where reading an empty value from memory store would result in an error
     // due to internal EOF handling. This is an edge case test.
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_zero_size_item_test() -> Result<(), Error> {
         const VALUE: &str = "";
         let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
@@ -175,7 +175,7 @@ mod memory_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn errors_with_invalid_inputs() -> Result<(), Error> {
         const VALUE1: &str = "123";
         let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
@@ -242,7 +242,7 @@ mod memory_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_is_zero_digest() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),
@@ -273,7 +273,7 @@ mod memory_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_results_on_zero_digests() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 
 use bytes::Bytes;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_store::cas_utils::ZERO_BYTE_DIGESTS;
 use nativelink_store::redis_store::{LazyConnection, RedisStore};
 use nativelink_util::common::DigestInfo;
@@ -84,7 +85,7 @@ mod redis_store_tests {
         }
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_and_get_data() -> Result<(), Error> {
         let data = Bytes::from_static(b"14");
 
@@ -132,7 +133,7 @@ mod redis_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_empty_data() -> Result<(), Error> {
         let data = Bytes::from_static(b"");
 
@@ -157,7 +158,7 @@ mod redis_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn test_uploading_large_data() -> Result<(), Error> {
         // Requires multiple chunks as data is larger than 64K
         let data: Bytes = Bytes::from(vec![0u8; 65 * 1024]);
@@ -227,7 +228,7 @@ mod redis_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
         let data = Bytes::from(vec![0u8; 10 * 1024]);
         let data_p1 = Bytes::from(vec![0u8; 6 * 1024]);

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 #[cfg(test)]
 mod ref_store_tests {
     use nativelink_error::Error;
+    use nativelink_macro::nativelink_test;
     use nativelink_store::memory_store::MemoryStore;
     use nativelink_store::ref_store::RefStore;
     use nativelink_store::store_manager::StoreManager;
@@ -47,7 +48,7 @@ mod ref_store_tests {
         (store_manager, memory_store_owned, ref_store_owned)
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_test() -> Result<(), Error> {
         let (_store_manager, memory_store_owned, ref_store_owned) = setup_stores();
 
@@ -76,7 +77,7 @@ mod ref_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_test() -> Result<(), Error> {
         let (_store_manager, memory_store_owned, ref_store_owned) = setup_stores();
 
@@ -106,7 +107,7 @@ mod ref_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_test() -> Result<(), Error> {
         let (_store_manager, memory_store_owned, ref_store_owned) = setup_stores();
 
@@ -136,7 +137,7 @@ mod ref_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn inner_store_test() -> Result<(), Error> {
         let store_manager = Arc::new(StoreManager::new());
 

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -27,6 +27,7 @@ use http::header;
 use http::status::StatusCode;
 use hyper::Body;
 use nativelink_error::{make_input_err, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_store::s3_store::S3Store;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
@@ -45,7 +46,7 @@ mod s3_store_tests {
     const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
     const REGION: &str = "testregion";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_has_object_found() -> Result<(), Error> {
         let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
             http::Request::builder().body(SdkBody::empty()).unwrap(),
@@ -80,7 +81,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_has_object_not_found() -> Result<(), Error> {
         let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
             http::Request::builder().body(SdkBody::empty()).unwrap(),
@@ -114,7 +115,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_has_retries() -> Result<(), Error> {
         let mock_client = StaticReplayClient::new(vec![
             ReplayEvent::new(
@@ -181,7 +182,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_update_ac() -> Result<(), Error> {
         const AC_ENTRY_SIZE: u64 = 199;
         const CONTENT_LENGTH: usize = 50;
@@ -275,7 +276,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_get_ac() -> Result<(), Error> {
         const VALUE: &str = "23";
         const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not VALUE.len().
@@ -314,7 +315,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn smoke_test_get_part() -> Result<(), Error> {
         const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not raw_send_data.len().
         const OFFSET: usize = 105;
@@ -360,7 +361,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_simple_retries() -> Result<(), Error> {
         let mock_client = StaticReplayClient::new(vec![
             ReplayEvent::new(
@@ -420,7 +421,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn multipart_update_large_cas() -> Result<(), Error> {
         // Same as in s3_store.
         const MIN_MULTIPART_SIZE: usize = 5 * 1024 * 1024; // 5mb.
@@ -541,7 +542,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
         const CAS_ENTRY_SIZE: usize = 10; // Length of "helloworld".
         let (mut tx, channel_body) = Body::channel();
@@ -596,7 +597,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_is_zero_digest() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),
@@ -638,7 +639,7 @@ mod s3_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_results_on_zero_digests() -> Result<(), Error> {
         let digest = DigestInfo {
             packed_hash: Sha256::new().finalize().into(),

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_store::shard_store::ShardStore;
 use nativelink_util::common::DigestInfo;
@@ -115,7 +116,7 @@ mod shard_store_tests {
     const STORE0_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
     const STORE1_HASH: &str = "00000000EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_one_digest() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -134,7 +135,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_many_digests_both_missing() -> Result<(), Error> {
         let (shard_store, _stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -151,7 +152,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_many_digests_one_missing() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -174,7 +175,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_with_many_digests_both_exist() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -201,7 +202,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_reads_store0() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -223,7 +224,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_part_reads_store1() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -245,7 +246,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_store0() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -267,7 +268,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_store1() -> Result<(), Error> {
         let (shard_store, stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -289,7 +290,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_download_has_check() -> Result<(), Error> {
         let (shard_store, _stores) = make_stores(&[1, 1]);
         let shard_store = Pin::new(shard_store.as_ref());
@@ -309,7 +310,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn weights_send_to_proper_store() -> Result<(), Error> {
         // Very low chance anything will ever go to second store due to weights being so much diff.
         let (shard_store, stores) = make_stores(&[100000, 1]);
@@ -330,7 +331,7 @@ mod shard_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_weights_even_weights() -> Result<(), Error> {
         verify_weights(
             &[1, 1, 1, 1, 1, 1],
@@ -341,22 +342,22 @@ mod shard_store_tests {
         .await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_weights_mid_right_bias() -> Result<(), Error> {
         verify_weights(&[1, 1, 1, 100, 1, 1], &[5, 13, 12, 956, 4, 10], 1000, false).await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_weights_mid_left_bias() -> Result<(), Error> {
         verify_weights(&[1, 1, 100, 1, 1, 1], &[5, 13, 962, 6, 4, 10], 1000, false).await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_weights_left_bias() -> Result<(), Error> {
         verify_weights(&[100, 1, 1, 1, 1, 1], &[961, 11, 8, 6, 4, 10], 1000, false).await
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_weights_right_bias() -> Result<(), Error> {
         verify_weights(&[1, 1, 1, 1, 1, 100], &[5, 13, 12, 5, 11, 954], 1000, false).await
     }

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 #[cfg(test)]
 mod ref_store_tests {
     use nativelink_error::Error;
+    use nativelink_macro::nativelink_test;
     use nativelink_store::memory_store::MemoryStore;
     use nativelink_store::size_partitioning_store::SizePartitioningStore;
     use nativelink_util::common::DigestInfo;
@@ -58,7 +59,7 @@ mod ref_store_tests {
         (size_part_store, lower_memory_store, upper_memory_store)
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn has_test() -> Result<(), Error> {
         let (size_part_store, lower_memory_store, upper_memory_store) =
             setup_stores(BASE_SIZE_PART);
@@ -107,7 +108,7 @@ mod ref_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_test() -> Result<(), Error> {
         let (size_part_store, lower_memory_store, upper_memory_store) =
             setup_stores(BASE_SIZE_PART);
@@ -158,7 +159,7 @@ mod ref_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn update_test() -> Result<(), Error> {
         let (size_part_store, lower_memory_store, upper_memory_store) =
             setup_stores(BASE_SIZE_PART);

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -20,6 +20,7 @@ use futures::try_join;
 #[cfg(test)]
 mod verify_store_tests {
     use nativelink_error::{Error, ResultExt};
+    use nativelink_macro::nativelink_test;
     use nativelink_store::memory_store::MemoryStore;
     use nativelink_store::verify_store::VerifyStore;
     use nativelink_util::buf_channel::make_buf_channel_pair;
@@ -31,7 +32,7 @@ mod verify_store_tests {
 
     const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_size_false_passes_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -65,7 +66,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_size_true_fails_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -108,7 +109,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_size_true_suceeds_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -137,7 +138,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_size_true_suceeds_on_multi_chunk_stream_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -175,7 +176,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_sha256_hash_true_suceeds_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -208,7 +209,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_sha256_hash_true_fails_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -249,7 +250,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_blake3_hash_true_suceeds_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
@@ -282,7 +283,7 @@ mod verify_store_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn verify_blake3_hash_true_fails_on_update() -> Result<(), Error> {
         let inner_store = Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -74,6 +74,7 @@ rust_test_suite(
         "tests/data/SekienAkashita.jpg",
     ],
     proc_macro_deps = [
+        "//nativelink-macro",
         "@crates//:async-trait",
     ],
     deps = [

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -30,6 +30,8 @@ tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
 
 [dev-dependencies]
+nativelink-macro = { path = "../nativelink-macro" }
+
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 mock_instant = "0.3.2"

--- a/nativelink-util/tests/buf_channel_test.rs
+++ b/nativelink-util/tests/buf_channel_test.rs
@@ -17,6 +17,7 @@ use std::task::Poll;
 use bytes::{Bytes, BytesMut};
 use futures::poll;
 use nativelink_error::{make_err, Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use tokio::try_join;
 
@@ -30,7 +31,7 @@ mod buf_channel_tests {
     const DATA2: &str = "bar";
     const DATA3: &str = "foobar1234";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn smoke_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         tx.send(DATA1.into()).await?;
@@ -40,7 +41,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn bytes_written_test() -> Result<(), Error> {
         let (mut tx, _rx) = make_buf_channel_pair();
         tx.send(DATA1.into()).await?;
@@ -50,7 +51,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn sending_eof_sets_pipe_broken_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let tx_fut = async move {
@@ -69,7 +70,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn consume_all_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let tx_fut = async move {
@@ -93,7 +94,7 @@ mod buf_channel_tests {
 
     /// Test to ensure data is optimized so that the exact same pointer is received
     /// when calling `collect_all_with_size_hint` when a copy is not needed.
-    #[tokio::test]
+    #[nativelink_test]
     async fn consume_all_is_optimized_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let sent_data = Bytes::from(DATA1);
@@ -114,7 +115,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn consume_some_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let tx_fut = async move {
@@ -141,7 +142,7 @@ mod buf_channel_tests {
     /// This test ensures that when we are taking just one message in the stream,
     /// we don't need to concat the data together and instead return a view to
     /// the original data instead of making a copy.
-    #[tokio::test]
+    #[nativelink_test]
     async fn consume_some_optimized_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let first_chunk = Bytes::from(DATA1);
@@ -162,7 +163,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn consume_some_reads_eof() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         tx.send(DATA1.into()).await?;
@@ -179,7 +180,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_stream_test() -> Result<(), Error> {
         use futures::StreamExt;
         let (mut tx, mut rx) = make_buf_channel_pair();
@@ -215,7 +216,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn send_and_take_fuzz_test() -> Result<(), Error> {
         const DATA3_END_POS: usize = DATA3.len() + 1;
         for data_size in 1..DATA3_END_POS {
@@ -252,7 +253,7 @@ mod buf_channel_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn rx_gets_error_if_tx_drops_test() -> Result<(), Error> {
         let (mut tx, mut rx) = make_buf_channel_pair();
         let tx_fut = async move {

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -21,6 +21,7 @@ use bytes::Bytes;
 use mock_instant::{Instant as MockInstant, MockClock};
 use nativelink_config::stores::EvictionPolicy;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::evicting_map::{EvictingMap, InstantWrapper, LenEntry};
 
@@ -72,7 +73,7 @@ mod evicting_map_tests {
     const HASH3: &str = "23456789abcdef000000000000000000000000000000000123456789abcdef12";
     const HASH4: &str = "3456789abcdef000000000000000000000000000000000123456789abcdef012";
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_purges_at_max_count() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -128,7 +129,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_purges_at_max_bytes() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -185,7 +186,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -242,7 +243,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_purges_at_max_seconds() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -303,7 +304,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_refreshes_time() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -355,7 +356,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn unref_called_on_replace() -> Result<(), Error> {
         #[derive(Debug)]
         struct MockEntry {
@@ -428,7 +429,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn contains_key_refreshes_time() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -482,7 +483,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -535,7 +536,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn build_lru_index_and_reload() -> Result<(), Error> {
         let mut evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -620,7 +621,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn get_evicts_on_time() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {
@@ -652,7 +653,7 @@ mod evicting_map_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn remove_evicts_on_time() -> Result<(), Error> {
         let evicting_map = EvictingMap::<BytesWrapper, MockInstantWrapped>::new(
             &EvictionPolicy {

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -17,6 +17,7 @@ use std::io::Cursor;
 
 use bytes::Bytes;
 use futures::stream::StreamExt;
+use nativelink_macro::nativelink_test;
 use nativelink_util::fastcdc::FastCDC;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -43,7 +44,7 @@ mod fastcdc_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn test_all_zeros() -> Result<(), std::io::Error> {
         // For all zeros, always returns chunks of maximum size.
         const ZERO_DATA: [u8; 10240] = [0u8; 10240];
@@ -60,7 +61,7 @@ mod fastcdc_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn test_sekien_16k_chunks() -> Result<(), Box<dyn std::error::Error>> {
         let contents = include_bytes!("data/SekienAkashita.jpg");
         let mut cursor = Cursor::new(&contents);
@@ -84,7 +85,7 @@ mod fastcdc_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn test_random_20mb_16k_chunks() -> Result<(), std::io::Error> {
         let data = {
             let mut data = vec![0u8; 20 * MEGABYTE_SZ];
@@ -103,7 +104,7 @@ mod fastcdc_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn insert_garbage_check_boundarys_recover_test() -> Result<(), std::io::Error> {
         let mut rand_data = {
             let mut data = vec![0u8; 100_000];

--- a/nativelink-util/tests/fs_test.rs
+++ b/nativelink-util/tests/fs_test.rs
@@ -18,6 +18,7 @@ use std::io::SeekFrom;
 use std::str::from_utf8;
 
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_util::common::fs;
 use rand::{thread_rng, Rng};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
@@ -43,7 +44,7 @@ mod fs_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn resumeable_file_slot_write_close_write_test() -> Result<(), Error> {
         let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
         let filename = make_temp_path("test_file.txt").await;
@@ -69,7 +70,7 @@ mod fs_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn resumeable_file_slot_read_close_read_test() -> Result<(), Error> {
         let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
         const DUMMYDATA: &str = "DummyDataTest";
@@ -103,7 +104,7 @@ mod fs_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn resumeable_file_slot_read_close_read_with_take_test() -> Result<(), Error> {
         let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
         const DUMMYDATA: &str = "DummyDataTest";
@@ -141,7 +142,7 @@ mod fs_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn resumeable_file_slot_read_close_read_with_take_and_seek_test() -> Result<(), Error> {
         let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
         const DUMMYDATA: &str = "DummyDataTest";

--- a/nativelink-util/tests/health_utils_test.rs
+++ b/nativelink-util/tests/health_utils_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_util::health_utils::{
     HealthRegistryBuilder, HealthStatus, HealthStatusDescription, HealthStatusIndicator,
     HealthStatusReporter,
@@ -29,7 +30,7 @@ mod health_utils_tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn create_empty_indicator() -> Result<(), Error> {
         let mut health_registry_builder = HealthRegistryBuilder::new("nativelink".into());
         let health_registry = health_registry_builder.build();
@@ -39,7 +40,7 @@ mod health_utils_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn create_register_indicator() -> Result<(), Error> {
         generate_health_status_indicator!(MockComponentImpl, Ok, "ok");
 
@@ -66,7 +67,7 @@ mod health_utils_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn create_sub_registry() -> Result<(), Error> {
         generate_health_status_indicator!(MockComponentImpl, Ok, "ok");
 
@@ -105,7 +106,7 @@ mod health_utils_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn create_multiple_indicators_same_registry() -> Result<(), Error> {
         generate_health_status_indicator!(MockComponentImpl1, Ok, "ok");
         generate_health_status_indicator!(MockComponentImpl2, Ok, "ok");
@@ -151,7 +152,7 @@ mod health_utils_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn create_multiple_indicators_with_sub_registry() -> Result<(), Error> {
         generate_health_status_indicator!(MockComponentImpl1, Ok, "ok");
         generate_health_status_indicator!(MockComponentImpl2, Ok, "ok");

--- a/nativelink-util/tests/proto_stream_utils_test.rs
+++ b/nativelink-util/tests/proto_stream_utils_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::StreamExt;
 use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
 use nativelink_proto::google::bytestream::WriteRequest;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::proto_stream_utils::{
@@ -34,7 +35,7 @@ mod proto_stream_utils_tests {
     const INSTANCE_NAME: &str = "test-instance";
 
     // Regression test for TraceMachina/nativelink#745.
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Result<(), Error> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<WriteRequest, Error>>();
 

--- a/nativelink-util/tests/resource_info_test.rs
+++ b/nativelink-util/tests/resource_info_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use nativelink_macro::nativelink_test;
 use nativelink_util::resource_info::ResourceInfo;
 
 #[cfg(test)]
@@ -20,7 +21,7 @@ mod resource_info_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -37,7 +38,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/blake3/hash/12345";
@@ -53,7 +54,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345/optional_metadata";
@@ -69,7 +70,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_blobs_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345";
@@ -85,7 +86,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
@@ -101,7 +102,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_compressed_blobs_compressor_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345";
@@ -116,7 +117,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "blobs/blake3/hash/12345/optional_metadata";
@@ -132,7 +133,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "blobs/blake3/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -147,7 +148,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -164,7 +165,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_compressed_blobs_compressor_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345";
@@ -180,7 +181,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_blobs_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345/optional_metadata";
@@ -196,7 +197,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -211,7 +212,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345/optional_metadata";
@@ -227,7 +228,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_compressed_blobs_compressor_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345";
@@ -243,7 +244,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std::error::Error>>
     {
         const RESOURCE_NAME: &str = "blobs/hash/12345/optional_metadata";
@@ -259,7 +260,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -274,7 +275,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "my/instance/name/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -289,7 +290,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "blobs/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -304,21 +305,21 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "BLOBS/hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
         assert!(ResourceInfo::new("", false).is_err());
         assert!(ResourceInfo::new("/", false).is_err());
@@ -332,7 +333,7 @@ mod resource_info_tests {
 
     // Begin write tests.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -349,7 +350,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -366,7 +367,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -383,7 +384,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
@@ -399,7 +400,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -416,7 +417,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
@@ -432,7 +433,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
@@ -448,7 +449,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_blobs_digest_function_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
@@ -464,7 +465,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -481,7 +482,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
@@ -497,7 +498,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
@@ -513,7 +514,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_uploads_uuid_blobs_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
@@ -529,7 +530,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str =
@@ -546,7 +547,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
@@ -562,7 +563,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std::error::Error>>
     {
         const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/INVALID/hash/12345";
@@ -570,7 +571,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
@@ -586,7 +587,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -601,7 +602,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -616,7 +617,7 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -631,35 +632,35 @@ mod resource_info_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_missing() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uuid/compressed-blobs/hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_invalid() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "UPLOADS/uuid/compressed-blobs/hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/BLOBS/hash/12345";
         assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn write_invalid_size_test() -> Result<(), Box<dyn std::error::Error>> {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/INVALID";
         assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -20,6 +20,7 @@ use futures::future::ready;
 use futures::stream::repeat_with;
 use nativelink_config::stores::Retry;
 use nativelink_error::{make_err, Code, Error};
+use nativelink_macro::nativelink_test;
 use nativelink_util::retry::{Retrier, RetryResult};
 use tokio::time::Duration;
 
@@ -29,7 +30,7 @@ mod retry_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn retry_simple_success() -> Result<(), Error> {
         let retrier = Retrier::new(
             Arc::new(|_duration| Box::pin(ready(()))),
@@ -57,7 +58,7 @@ mod retry_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn retry_fails_after_3_runs() -> Result<(), Error> {
         let retrier = Retrier::new(
             Arc::new(|_duration| Box::pin(ready(()))),
@@ -88,7 +89,7 @@ mod retry_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn retry_success_after_2_runs() -> Result<(), Error> {
         let retrier = Retrier::new(
             Arc::new(|_duration| Box::pin(ready(()))),
@@ -119,7 +120,7 @@ mod retry_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn retry_calls_sleep_fn() -> Result<(), Error> {
         const EXPECTED_MS: u64 = 71;
         let sleep_fn_run_count = Arc::new(AtomicI32::new(0));

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -58,6 +58,7 @@ rust_test_suite(
         "tests/utils/mock_running_actions_manager.rs",
     ],
     proc_macro_deps = [
+        "//nativelink-macro",
         "@crates//:async-trait",
     ],
     deps = [

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -35,6 +35,8 @@ tracing = "0.1.40"
 uuid = { version = "1.8.0", features = ["v4"] }
 
 [dev-dependencies]
+nativelink-macro = { path = "../nativelink-macro" }
+
 hyper = "0.14.28"
 once_cell = "1.19.0"
 pretty_assertions = "1.4.0"

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -31,6 +31,7 @@ mod utils {
 
 use nativelink_config::cas_server::{LocalWorkerConfig, WorkerProperty};
 use nativelink_error::{make_err, make_input_err, Code, Error};
+use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
@@ -76,7 +77,7 @@ mod local_worker_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn platform_properties_smoke_test() -> Result<(), Error> {
         let mut platform_properties = HashMap::new();
         platform_properties.insert(
@@ -130,7 +131,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn reconnect_on_server_disconnect_test() -> Result<(), Box<dyn std::error::Error>> {
         let mut test_context = setup_local_worker(HashMap::new()).await;
         let streaming_response = test_context.maybe_streaming_response.take().unwrap();
@@ -160,7 +161,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn kill_all_called_on_disconnect() -> Result<(), Box<dyn std::error::Error>> {
         let mut test_context = setup_local_worker(HashMap::new()).await;
         let streaming_response = test_context.maybe_streaming_response.take().unwrap();
@@ -196,7 +197,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::error::Error>> {
         const SALT: u64 = 1000;
 
@@ -282,7 +283,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Error>> {
         const SALT: u64 = 1000;
 
@@ -414,7 +415,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn std::error::Error>>
     {
         let cas_store = Arc::new(FastSlowStore::new(
@@ -462,7 +463,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn new_local_worker_removes_work_directory_before_start_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let cas_store = Arc::new(FastSlowStore::new(
@@ -518,7 +519,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::error::Error>> {
         let temp_path = make_temp_path("scripts");
         fs::create_dir_all(temp_path.clone()).await?;
@@ -640,7 +641,7 @@ mod local_worker_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Error>> {
         const SALT: u64 = 1000;
 

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -29,6 +29,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use nativelink_config::cas_server::EnvironmentSource;
 use nativelink_error::{make_input_err, Code, Error, ResultExt};
+use nativelink_macro::nativelink_test;
 #[cfg_attr(target_family = "windows", allow(unused_imports))]
 use nativelink_proto::build::bazel::remote::execution::v2::{
     digest_function::Value as ProtoDigestFunction, platform::Property, Action,
@@ -146,7 +147,7 @@ mod running_actions_manager_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn download_to_directory_file_download_test() -> Result<(), Box<dyn std::error::Error>> {
         const FILE1_NAME: &str = "file1.txt";
         const FILE1_CONTENT: &str = "HELLOFILE1";
@@ -244,7 +245,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn std::error::Error>>
     {
         const DIRECTORY1_NAME: &str = "folder1";
@@ -343,7 +344,7 @@ mod running_actions_manager_tests {
 
     // Windows does not support symlinks.
     #[cfg(not(target_family = "windows"))]
-    #[tokio::test]
+    #[nativelink_test]
     async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn std::error::Error>>
     {
         const FILE_NAME: &str = "file.txt";
@@ -415,7 +416,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_output_files_full_directories_are_created_no_working_directory_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
@@ -529,7 +530,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_output_files_full_directories_are_created_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
@@ -646,7 +647,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -818,7 +819,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -991,7 +992,7 @@ mod running_actions_manager_tests {
 
     // Windows does not support symlinks.
     #[cfg(not(target_family = "windows"))]
-    #[tokio::test]
+    #[nativelink_test]
     async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -1190,7 +1191,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -1321,7 +1322,7 @@ mod running_actions_manager_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
         const SALT: u64 = 55;
@@ -1428,7 +1429,7 @@ mod running_actions_manager_tests {
     // The wrapper script will print a constant string to stderr, and the test itself will
     // print to stdout. We then check the results of both to make sure the shell script was
     // invoked and the actual command was invoked under the shell script.
-    #[tokio::test]
+    #[nativelink_test]
     async fn entrypoint_does_invoke_if_set() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_family = "unix")]
         const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
@@ -1571,7 +1572,7 @@ exit 0
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn entrypoint_injects_properties() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_family = "unix")]
         const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
@@ -1747,7 +1748,7 @@ exit 0
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn entrypoint_sends_timeout_via_side_channel() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_family = "unix")]
         const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
@@ -1870,7 +1871,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error::Error>> {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
@@ -1942,7 +1943,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn std::error::Error>>
     {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
@@ -2015,7 +2016,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
@@ -2115,7 +2116,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>>
     {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
@@ -2156,7 +2157,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn infra_failure_does_cache_in_historical_results(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
@@ -2222,7 +2223,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::Error>> {
         let (_, _, cas_store, ac_store) = setup_stores().await?;
 
@@ -2274,7 +2275,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn std::error::Error>>
     {
         const WORKER_ID: &str = "foo_worker_id";
@@ -2550,7 +2551,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -2678,7 +2679,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -2836,7 +2837,7 @@ exit 1
 
     /// Regression Test for Issue #675
     #[cfg(target_family = "unix")]
-    #[tokio::test]
+    #[nativelink_test]
     async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
         const FILE_1_NAME: &str = "file1";
@@ -2931,7 +2932,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
 
@@ -3024,7 +3025,7 @@ exit 1
     // Be default this test is ignored because it *must* be run single threaded... to run this
     // test execute:
     // cargo test -p nativelink-worker --test running_actions_manager_test -- --test-threads=1 --ignored
-    #[tokio::test]
+    #[nativelink_test]
     #[ignore]
     async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";
@@ -3209,7 +3210,7 @@ exit 1
         Ok(())
     }
 
-    #[tokio::test]
+    #[nativelink_test]
     async fn running_actions_manager_respects_action_timeout(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const WORKER_ID: &str = "foo_worker_id";


### PR DESCRIPTION
This macro is to replace the tokio::test macro. It will allow us to do some setup & cleanup on all tests without burdening the dev with wrappers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/888)
<!-- Reviewable:end -->
