### PR TITLE
All tokio::spawn and related functions must use nativelink's version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,7 +44,8 @@ build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 
 # TODO(aaronmondal): Extend these flags until we can run with clippy::pedantic.
-build --@rules_rust//:clippy_flags=-D,clippy::uninlined_format_args
+build --@rules_rust//:clippy_flags=-Dwarnings,-Dclippy::uninlined_format_args
+build --@rules_rust//:clippy.toml=//:clippy.toml
 
 test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 exports_files(
     [
         ".rustfmt.toml",
+        "clippy.toml",
     ],
     visibility = ["//visibility:public"],
 )

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,16 @@
+disallowed-methods = [
+    { path = "tokio::spawn", reason = "use `nativelink-util::task::spawn` or `nativelink-util::task::background_spawn` instead" },
+    { path = "tokio::task::spawn", reason = "use `nativelink-util::task::spawn` or `nativelink-util::task::background_spawn` instead" },
+    { path = "tokio::task::spawn_blocking", reason = "use `nativelink-util::task::spawn_blocking` instead" },
+    { path = "tokio::task::block_in_place", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::task::spawn_local", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Builder::new_current_thread", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Builder::new_multi_thread", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Builder::new_multi_thread_alt", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Runtime::new", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Runtime::spawn", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Runtime::spawn_blocking", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "tokio::runtime::Runtime::block_on", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "std::thread::spawn", reason = "use one of the `nativelink-util::task` functions instead" },
+    { path = "std::thread::Builder::new", reason = "use one of the `nativelink-util::task` functions instead" },
+]

--- a/nativelink-macro/src/lib.rs
+++ b/nativelink-macro/src/lib.rs
@@ -31,9 +31,13 @@ pub fn nativelink_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         #(#fn_attr)*
+        #[allow(clippy::disallowed_methods)]
         #[tokio::test(#attr)]
         async fn #fn_name(#fn_inputs) #fn_output {
-            #fn_block
+            #[warn(clippy::disallowed_methods)]
+            {
+                #fn_block
+            }
         }
     };
 

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -27,6 +27,7 @@ use nativelink_store::grpc_store::GrpcStore;
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState,
 };
+use nativelink_util::background_spawn;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::Store;
 use parking_lot::{Mutex, MutexGuard};
@@ -158,7 +159,7 @@ impl ActionScheduler for CacheLookupScheduler {
         let ac_store = self.ac_store.clone();
         let action_scheduler = self.action_scheduler.clone();
         // We need this spawn because we are returning a stream and this spawn will populate the stream's data.
-        tokio::spawn(async move {
+        background_spawn!("cache_lookup_scheduler_add_action", async move {
             // If our spawn ever dies, we will remove the action from the cache_check_actions map.
             let _scope_guard = scope_guard;
 

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use nativelink_config::schedulers::SchedulerConfig;
 use nativelink_error::{Error, ResultExt};
 use nativelink_store::store_manager::StoreManager;
+use nativelink_util::background_spawn;
 use nativelink_util::metrics_utils::Registry;
 use tokio::time::interval;
 
@@ -117,7 +118,7 @@ fn inner_scheduler_factory(
 
 fn start_cleanup_timer(action_scheduler: &Arc<dyn ActionScheduler>) {
     let weak_scheduler = Arc::downgrade(action_scheduler);
-    tokio::spawn(async move {
+    background_spawn!("default_scheduler_factory_cleanup_timer", async move {
         let mut ticker = interval(Duration::from_secs(1));
         loop {
             ticker.tick().await;

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -32,7 +32,7 @@ use nativelink_util::action_messages::{
 };
 use nativelink_util::connection_manager::ConnectionManager;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::tls_utils;
+use nativelink_util::{background_spawn, tls_utils};
 use parking_lot::Mutex;
 use rand::rngs::OsRng;
 use rand::Rng;
@@ -40,7 +40,7 @@ use tokio::select;
 use tokio::sync::watch;
 use tokio::time::sleep;
 use tonic::{Request, Streaming};
-use tracing::{error_span, event, Instrument, Level};
+use tracing::{event, Level};
 
 use crate::action_scheduler::ActionScheduler;
 use crate::platform_property_manager::PlatformPropertyManager;
@@ -119,7 +119,7 @@ impl GrpcScheduler {
             .err_tip(|| "Recieving response from upstream scheduler")?
         {
             let (tx, rx) = watch::channel(Arc::new(initial_response.try_into()?));
-            tokio::spawn(async move {
+            background_spawn!("grpc_scheduler_stream_state", async move {
                 loop {
                     select!(
                         _ = tx.closed() => {
@@ -157,8 +157,7 @@ impl GrpcScheduler {
                         }
                     )
                 }
-            }
-            .instrument(error_span!("stream_state")));
+            });
             return Ok(rx);
         }
         Err(make_err!(

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -34,9 +34,10 @@ use nativelink_util::metrics_utils::{
     MetricsComponent, Registry,
 };
 use nativelink_util::platform_properties::PlatformPropertyValue;
+use nativelink_util::spawn;
+use nativelink_util::task::JoinHandleDropGuard;
 use parking_lot::{Mutex, MutexGuard};
 use tokio::sync::{watch, Notify};
-use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tracing::{event, Level};
 
@@ -689,8 +690,9 @@ impl SimpleSchedulerImpl {
 pub struct SimpleScheduler {
     inner: Arc<Mutex<SimpleSchedulerImpl>>,
     platform_property_manager: Arc<PlatformPropertyManager>,
-    task_worker_matching_future: JoinHandle<()>,
     metrics: Arc<Metrics>,
+    // Triggers `drop()`` call if scheduler is dropped.
+    _task_worker_matching_future: JoinHandleDropGuard<()>,
 }
 
 impl SimpleScheduler {
@@ -758,29 +760,32 @@ impl SimpleScheduler {
         Self {
             inner,
             platform_property_manager,
-            task_worker_matching_future: tokio::spawn(async move {
-                // Break out of the loop only when the inner is dropped.
-                loop {
-                    tasks_or_workers_change_notify.notified().await;
-                    match weak_inner.upgrade() {
-                        // Note: According to `parking_lot` documentation, the default
-                        // `Mutex` implementation is eventual fairness, so we don't
-                        // really need to worry about this thread taking the lock
-                        // starving other threads too much.
-                        Some(inner_mux) => {
-                            let mut inner = inner_mux.lock();
-                            let timer = metrics_for_do_try_match.do_try_match.begin_timer();
-                            inner.do_try_match();
-                            timer.measure();
-                        }
-                        // If the inner went away it means the scheduler is shutting
-                        // down, so we need to resolve our future.
-                        None => return,
-                    };
-                    on_matching_engine_run().await;
+            _task_worker_matching_future: spawn!(
+                "simple_scheduler_task_worker_matching",
+                async move {
+                    // Break out of the loop only when the inner is dropped.
+                    loop {
+                        tasks_or_workers_change_notify.notified().await;
+                        match weak_inner.upgrade() {
+                            // Note: According to `parking_lot` documentation, the default
+                            // `Mutex` implementation is eventual fairness, so we don't
+                            // really need to worry about this thread taking the lock
+                            // starving other threads too much.
+                            Some(inner_mux) => {
+                                let mut inner = inner_mux.lock();
+                                let timer = metrics_for_do_try_match.do_try_match.begin_timer();
+                                inner.do_try_match();
+                                timer.measure();
+                            }
+                            // If the inner went away it means the scheduler is shutting
+                            // down, so we need to resolve our future.
+                            None => return,
+                        };
+                        on_matching_engine_run().await;
+                    }
+                    // Unreachable.
                 }
-                // Unreachable.
-            }),
+            ),
             metrics,
         }
     }
@@ -979,12 +984,6 @@ impl WorkerScheduler for SimpleScheduler {
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {
         // We do not register anything here because we only want to register metrics
         // once and we rely on the `ActionScheduler::register_metrics()` to do that.
-    }
-}
-
-impl Drop for SimpleScheduler {
-    fn drop(&mut self) {
-        self.task_worker_matching_future.abort();
     }
 }
 

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -40,9 +40,10 @@ use nativelink_util::buf_channel::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::proto_stream_utils::WriteRequestStreamWrapper;
 use nativelink_util::resource_info::ResourceInfo;
+use nativelink_util::spawn;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::task::JoinHandleDropGuard;
 use parking_lot::Mutex;
-use tokio::task::AbortHandle;
 use tokio::time::sleep;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{enabled, error_span, event, instrument, Instrument, Level};
@@ -110,15 +111,14 @@ impl<'a> Drop for ActiveStreamGuard<'a> {
         let sleep_fn = self.bytestream_server.sleep_fn.clone();
         active_uploads_slot.1 = Some(IdleStream {
             stream_state,
-            abort_timeout_handle: tokio::spawn(async move {
+            _timeout_streaam_drop_guard: spawn!("bytestream_idle_stream_timeout", async move {
                 (*sleep_fn)().await;
                 if let Some(active_uploads) = weak_active_uploads.upgrade() {
                     let mut active_uploads = active_uploads.lock();
                     event!(Level::INFO, msg = "Removing idle stream", uuid = ?uuid);
                     active_uploads.remove(&uuid);
                 }
-            })
-            .abort_handle(),
+            }),
         });
     }
 }
@@ -129,7 +129,7 @@ impl<'a> Drop for ActiveStreamGuard<'a> {
 #[derive(Debug)]
 struct IdleStream {
     stream_state: StreamState,
-    abort_timeout_handle: AbortHandle,
+    _timeout_streaam_drop_guard: JoinHandleDropGuard<()>,
 }
 
 impl IdleStream {
@@ -138,7 +138,6 @@ impl IdleStream {
         bytes_received: Arc<AtomicU64>,
         bytestream_server: &ByteStreamServer,
     ) -> ActiveStreamGuard<'_> {
-        self.abort_timeout_handle.abort();
         ActiveStreamGuard {
             stream_state: Some(self.stream_state),
             bytes_received,

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -27,9 +27,10 @@ use nativelink_error::{error_if, make_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{
     make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf,
 };
-use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
+use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::Registry;
+use nativelink_util::spawn;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
 use serde::{Deserialize, Serialize};
 
@@ -262,7 +263,7 @@ impl Store for CompressionStore {
         let (mut tx, rx) = make_buf_channel_pair();
 
         let inner_store = self.inner_store.clone();
-        let update_fut = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let update_fut = spawn!("compression_store_update_spawn", async move {
             Pin::new(inner_store.as_ref())
                 .update(
                     digest,
@@ -271,15 +272,15 @@ impl Store for CompressionStore {
                 )
                 .await
                 .err_tip(|| "Inner store update in compression store failed")
-        }))
-        .map(|result| {
-            match result.err_tip(|| "Failed to run compression update spawn") {
+        })
+        .map(
+            |result| match result.err_tip(|| "Failed to run compression update spawn") {
                 Ok(inner_result) => {
                     inner_result.err_tip(|| "Compression underlying store update failed")
                 }
                 Err(e) => Err(e),
-            }
-        });
+            },
+        );
 
         let write_fut = async move {
             {
@@ -405,12 +406,12 @@ impl Store for CompressionStore {
         let (tx, mut rx) = make_buf_channel_pair();
 
         let inner_store = self.inner_store.clone();
-        let get_part_fut = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let get_part_fut = spawn!("compression_store_get_part_spawn", async move {
             Pin::new(inner_store.as_ref())
                 .get_part(digest, tx, 0, None)
                 .await
                 .err_tip(|| "Inner store get in compression store failed")
-        }))
+        })
         .map(
             |result| match result.err_tip(|| "Failed to run compression get spawn") {
                 Ok(inner_result) => {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -35,11 +35,11 @@ use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
 use nativelink_util::metrics_utils::{Collector, CollectorState, MetricsComponent, Registry};
 use nativelink_util::store_trait::{Store, StoreOptimizations, UploadSizeInfo};
+use nativelink_util::{background_spawn, spawn_blocking};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
-use tokio::task::spawn_blocking;
 use tokio::time::{sleep, timeout, Sleep};
 use tokio_stream::wrappers::ReadDirStream;
-use tracing::{event, trace_span, Instrument, Level};
+use tracing::{event, Level};
 
 use crate::cas_utils::is_zero_digest;
 
@@ -112,21 +112,18 @@ impl Drop for EncodedFilePath {
         shared_context
             .active_drop_spawns
             .fetch_add(1, Ordering::Relaxed);
-        tokio::spawn(
-            async move {
-                event!(Level::INFO, ?file_path, "File deleted",);
-                let result = fs::remove_file(&file_path)
-                    .await
-                    .err_tip(|| format!("Failed to remove file {file_path:?}"));
-                if let Err(err) = result {
-                    event!(Level::ERROR, ?file_path, ?err, "Failed to delete file",);
-                }
-                shared_context
-                    .active_drop_spawns
-                    .fetch_sub(1, Ordering::Relaxed);
+        background_spawn!("filesystem_delete_file", async move {
+            event!(Level::INFO, ?file_path, "File deleted",);
+            let result = fs::remove_file(&file_path)
+                .await
+                .err_tip(|| format!("Failed to remove file {file_path:?}"));
+            if let Err(err) = result {
+                event!(Level::ERROR, ?file_path, ?err, "Failed to delete file",);
             }
-            .instrument(trace_span!("delete_file")),
-        );
+            shared_context
+                .active_drop_spawns
+                .fetch_sub(1, Ordering::Relaxed);
+        });
     }
 }
 
@@ -326,7 +323,7 @@ impl LenEntry for FileEntryImpl {
         let result = self
             .get_file_path_locked(move |full_content_path| async move {
                 let full_content_path = full_content_path.to_os_string();
-                spawn_blocking(move || {
+                spawn_blocking!("filesystem_touch_set_mtime", move || {
                     set_file_atime(&full_content_path, FileTime::now()).err_tip(|| {
                         format!("Failed to touch file in filesystem store {full_content_path:?}")
                     })
@@ -668,52 +665,49 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
 
         // We need to guarantee that this will get to the end even if the parent future is dropped.
         // See: https://github.com/TraceMachina/nativelink/issues/495
-        tokio::spawn(
-            async move {
-                let mut encoded_file_path = entry.get_encoded_file_path().write().await;
-                let final_path = get_file_path_raw(
-                    &PathType::Content,
-                    encoded_file_path.shared_context.as_ref(),
-                    &digest,
+        background_spawn!("filesystem_store_emplace_file", async move {
+            let mut encoded_file_path = entry.get_encoded_file_path().write().await;
+            let final_path = get_file_path_raw(
+                &PathType::Content,
+                encoded_file_path.shared_context.as_ref(),
+                &digest,
+            );
+
+            evicting_map.insert(digest, entry.clone()).await;
+
+            let from_path = encoded_file_path.get_file_path();
+            // Internally tokio spawns fs commands onto a blocking thread anyways.
+            // Since we are already on a blocking thread, we just need the `fs` wrapper to manage
+            // an open-file permit (ensure we don't open too many files at once).
+            let result = (rename_fn)(&from_path, &final_path)
+                .err_tip(|| format!("Failed to rename temp file to final path {final_path:?}"));
+
+            // In the event our move from temp file to final file fails we need to ensure we remove
+            // the entry from our map.
+            // Remember: At this point it is possible for another thread to have a reference to
+            // `entry`, so we can't delete the file, only drop() should ever delete files.
+            if let Err(err) = result {
+                event!(
+                    Level::ERROR,
+                    ?err,
+                    ?from_path,
+                    ?final_path,
+                    "Failed to rename file",
                 );
-
-                evicting_map.insert(digest, entry.clone()).await;
-
-                let from_path = encoded_file_path.get_file_path();
-                // Internally tokio spawns fs commands onto a blocking thread anyways.
-                // Since we are already on a blocking thread, we just need the `fs` wrapper to manage
-                // an open-file permit (ensure we don't open too many files at once).
-                let result = (rename_fn)(&from_path, &final_path)
-                    .err_tip(|| format!("Failed to rename temp file to final path {final_path:?}"));
-
-                // In the event our move from temp file to final file fails we need to ensure we remove
-                // the entry from our map.
-                // Remember: At this point it is possible for another thread to have a reference to
-                // `entry`, so we can't delete the file, only drop() should ever delete files.
-                if let Err(err) = result {
-                    event!(
-                        Level::ERROR,
-                        ?err,
-                        ?from_path,
-                        ?final_path,
-                        "Failed to rename file",
-                    );
-                    // Warning: To prevent deadlock we need to release our lock or during `remove_if()`
-                    // it will call `unref()`, which triggers a write-lock on `encoded_file_path`.
-                    drop(encoded_file_path);
-                    // It is possible that the item in our map is no longer the item we inserted,
-                    // So, we need to conditionally remove it only if the pointers are the same.
-                    evicting_map
-                        .remove_if(&digest, |map_entry| Arc::<Fe>::ptr_eq(map_entry, &entry))
-                        .await;
-                    return Err(err);
-                }
-                encoded_file_path.path_type = PathType::Content;
-                encoded_file_path.digest = digest;
-                Ok(())
+                // Warning: To prevent deadlock we need to release our lock or during `remove_if()`
+                // it will call `unref()`, which triggers a write-lock on `encoded_file_path`.
+                drop(encoded_file_path);
+                // It is possible that the item in our map is no longer the item we inserted,
+                // So, we need to conditionally remove it only if the pointers are the same.
+                evicting_map
+                    .remove_if(&digest, |map_entry| Arc::<Fe>::ptr_eq(map_entry, &entry))
+                    .await;
+                return Err(err);
             }
-            .instrument(trace_span!("emplace_file")),
-        )
+            encoded_file_path.path_type = PathType::Content;
+            encoded_file_path.digest = digest;
+            Ok(())
+        })
         .await
         .err_tip(|| "Failed to create spawn in filesystem store update_file")?
     }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::{BoxFuture, FutureExt, Shared};
 use nativelink_error::{error_if, make_err, Code, Error, ResultExt};
+use nativelink_util::background_spawn;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
@@ -29,7 +30,6 @@ use nativelink_util::metrics_utils::{Collector, CollectorState, MetricsComponent
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
 use redis::aio::{ConnectionLike, ConnectionManager};
 use redis::AsyncCommands;
-use tracing::{error_span, Instrument};
 
 use crate::cas_utils::is_zero_digest;
 
@@ -74,14 +74,11 @@ impl RedisStore {
 
         let conn_fut_clone = conn_fut.clone();
         // Start connecting to redis, but don't block our construction on it.
-        tokio::spawn(
-            async move {
-                if let Err(e) = conn_fut_clone.await {
-                    make_err!(Code::Unavailable, "Failed to connect to Redis: {:?}", e);
-                }
+        background_spawn!("redis_initial_connection", async move {
+            if let Err(e) = conn_fut_clone.await {
+                make_err!(Code::Unavailable, "Failed to connect to Redis: {:?}", e);
             }
-            .instrument(error_span!("redis_initial_connection")),
-        );
+        });
 
         let lazy_conn = LazyConnection::Future(conn_fut);
 

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -28,7 +28,8 @@ use nativelink_store::compression_store::{
 };
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
-use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::spawn;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -526,13 +527,13 @@ mod compression_store_tests {
 
         let (mut writer, mut reader) = make_buf_channel_pair();
 
-        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let _drop_guard = spawn!("get_part_is_zero_digest", async move {
             let _ = store
                 .as_ref()
                 .get_part_ref(digest, &mut writer, 0, None)
                 .await
                 .err_tip(|| "Failed to get_part_ref");
-        }));
+        });
 
         let file_data = reader
             .consume(Some(1024))

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -38,9 +38,11 @@ use nativelink_store::filesystem_store::{
     digest_from_filename, EncodedFilePath, FileEntry, FileEntryImpl, FilesystemStore,
 };
 use nativelink_util::buf_channel::make_buf_channel_pair;
-use nativelink_util::common::{fs, DigestInfo, JoinHandleDropGuard};
+use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::evicting_map::LenEntry;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::task::instrument_future;
+use nativelink_util::{background_spawn, spawn};
 use once_cell::sync::Lazy;
 use rand::{thread_rng, Rng};
 use sha2::{Digest, Sha256};
@@ -165,19 +167,26 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> Drop for TestFileEntry<Hooks
         // command that will wait for all tasks and sub spawns to complete.
         // Sadly we need to rely on `active_drop_spawns` to hit zero to ensure that
         // all tasks have completed.
-        let thread_handle = std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .unwrap();
-            rt.block_on(async move {
+        let fut = instrument_future(
+            async move {
                 // Drop the FileEntryImpl in a controlled setting then wait for the
                 // `active_drop_spawns` to hit zero.
                 drop(inner);
-                while shared_context.active_drop_spawns.load(Ordering::Relaxed) > 0 {
+                while shared_context.active_drop_spawns.load(Ordering::Acquire) > 0 {
                     tokio::task::yield_now().await;
                 }
-            });
-        });
+            },
+            tracing::error_span!("test_file_entry_drop"),
+        );
+        #[allow(clippy::disallowed_methods)]
+        let thread_handle = {
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+                rt.block_on(fut)
+            })
+        };
         thread_handle.join().unwrap();
         // At this point we can guarantee our file drop spawn has completed.
         Hooks::on_drop(self);
@@ -412,11 +421,14 @@ mod filesystem_store_tests {
         let (writer, mut reader) = make_buf_channel_pair();
         let store_clone = store.clone();
         let digest1_clone = digest1;
-        tokio::spawn(async move {
-            Pin::new(store_clone.as_ref())
-                .get(digest1_clone, writer)
-                .await
-        });
+        background_spawn!(
+            "file_continues_to_stream_on_content_replace_test_store_get",
+            async move {
+                Pin::new(store_clone.as_ref())
+                    .get(digest1_clone, writer)
+                    .await
+            },
+        );
 
         {
             // Check to ensure our first byte has been received. The future should be stalled here.
@@ -542,7 +554,10 @@ mod filesystem_store_tests {
         let mut reader = {
             let (writer, reader) = make_buf_channel_pair();
             let store_clone = store.clone();
-            tokio::spawn(async move { Pin::new(store_clone.as_ref()).get(digest1, writer).await });
+            background_spawn!(
+                "file_gets_cleans_up_on_cache_eviction_store_get",
+                async move { Pin::new(store_clone.as_ref()).get(digest1, writer).await },
+            );
             reader
         };
         // Ensure we have received 1 byte in our buffer. This will ensure we have a reference to
@@ -888,7 +903,7 @@ mod filesystem_store_tests {
         struct LocalHooks {}
         impl FileEntryHooks for LocalHooks {
             fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
-                tokio::spawn(FILE_DELETED_BARRIER.wait());
+                background_spawn!("rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_local_hooks_on_drop", FILE_DELETED_BARRIER.wait());
             }
         }
 
@@ -976,9 +991,12 @@ mod filesystem_store_tests {
         fs::remove_dir_all(&content_path).await?;
 
         // Because send_eof() waits for shutdown of the rx side, we cannot just await in this thread.
-        tokio::spawn(async move {
-            tx.send_eof().unwrap();
-        });
+        background_spawn!(
+            "rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_send_eof",
+            async move {
+                tx.send_eof().unwrap();
+            },
+        );
 
         // Now finish waiting on update(). This should reuslt in an error because we deleted our dest
         // folder.
@@ -1008,7 +1026,6 @@ mod filesystem_store_tests {
             None,
             "Entry should not be in store"
         );
-
         Ok(())
     }
 
@@ -1044,11 +1061,11 @@ mod filesystem_store_tests {
         let store_clone = store.clone();
         let digest_clone = digest;
 
-        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let _drop_guard = spawn!("get_part_timeout_test_get", async move {
             Pin::new(store_clone.as_ref())
                 .get(digest_clone, writer)
                 .await
-        }));
+        });
 
         let file_data = reader
             .consume(Some(1024))
@@ -1090,12 +1107,12 @@ mod filesystem_store_tests {
         let store_clone = store.clone();
         let (mut writer, mut reader) = make_buf_channel_pair();
 
-        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let _drop_guard = spawn!("get_part_is_zero_digest_get_part_ref", async move {
             let _ = Pin::new(store_clone.as_ref())
                 .get_part_ref(digest, &mut writer, 0, None)
                 .await
                 .err_tip(|| "Failed to get_part_ref");
-        }));
+        });
 
         let file_data = reader
             .consume(Some(1024))

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -21,7 +21,8 @@ use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
-use nativelink_util::common::{DigestInfo, JoinHandleDropGuard};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::spawn;
 use nativelink_util::store_trait::Store;
 use sha2::{Digest, Sha256};
 
@@ -255,12 +256,12 @@ mod memory_store_tests {
         let store_clone = store.clone();
         let (mut writer, mut reader) = make_buf_channel_pair();
 
-        let _drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move {
+        let _drop_guard = spawn!("get_part_is_zero_digest", async move {
             let _ = Pin::new(store_clone.as_ref())
                 .get_part_ref(digest, &mut writer, 0, None)
                 .await
                 .err_tip(|| "Failed to get_part_ref");
-        }));
+        });
 
         let file_data = reader
             .consume(Some(1024))

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -25,6 +25,7 @@ rust_library(
         "src/resource_info.rs",
         "src/retry.rs",
         "src/store_trait.rs",
+        "src/task.rs",
         "src/tls_utils.rs",
         "src/write_counter.rs",
     ],

--- a/nativelink-util/src/connection_manager.rs
+++ b/nativelink-util/src/connection_manager.rs
@@ -26,6 +26,7 @@ use tokio::sync::{mpsc, oneshot};
 use tonic::transport::{channel, Channel, Endpoint};
 use tracing::{event, Level};
 
+use crate::background_spawn;
 use crate::retry::{self, Retrier, RetryResult};
 
 /// A helper utility that enables management of a suite of connections to an
@@ -148,7 +149,7 @@ impl ConnectionManager {
                 retry,
             ),
         };
-        tokio::spawn(async move {
+        background_spawn!("connection_manager_worker_spawn", async move {
             worker
                 .service_requests(connections_per_endpoint, worker_rx, connection_rx)
                 .await;

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -35,6 +35,8 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::time::timeout;
 use tracing::{event, Level};
 
+use crate::spawn_blocking;
+
 /// Default read buffer size when reading to/from disk.
 pub const DEFAULT_READ_BUFF_SIZE: usize = 16384;
 
@@ -302,7 +304,7 @@ where
     T: Send + 'static,
 {
     let permit = get_permit().await?;
-    tokio::task::spawn_blocking(move || f(permit))
+    spawn_blocking!("fs_call_with_permit", move || f(permit))
         .await
         .unwrap_or_else(|e| Err(make_err!(Code::Internal, "background task failed: {e:?}")))
 }

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -27,5 +27,6 @@ pub mod proto_stream_utils;
 pub mod resource_info;
 pub mod retry;
 pub mod store_trait;
+pub mod task;
 pub mod tls_utils;
 pub mod write_counter;

--- a/nativelink-util/src/task.rs
+++ b/nativelink-util/src/task.rs
@@ -1,0 +1,119 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Future;
+use tokio::task::{spawn_blocking, JoinError, JoinHandle};
+pub use tracing::error_span as __error_span;
+use tracing::{Instrument, Span};
+
+#[inline(always)]
+pub fn instrument_future<F, T>(f: F, span: Span) -> impl Future<Output = T>
+where
+    F: Future<Output = T> + Send + 'static,
+{
+    f.instrument(span)
+}
+
+#[inline(always)]
+pub fn __spawn_with_span<F, T>(f: F, span: Span) -> JoinHandle<T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn(instrument_future(f, span))
+}
+
+#[inline(always)]
+pub fn __spawn_blocking<F, T>(f: F, span: Span) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    #[allow(clippy::disallowed_methods)]
+    spawn_blocking(move || span.in_scope(f))
+}
+
+#[macro_export]
+macro_rules! background_spawn {
+    ($name:expr, $fut:expr) => {{
+        $crate::task::__spawn_with_span($fut, $crate::task::__error_span!($name))
+    }};
+    ($name:expr, $fut:expr, $($fields:tt)*) => {{
+        $crate::task::__spawn_with_span($fut, $crate::task::__error_span!($name, $($fields)*))
+    }};
+    (name: $name:expr, fut: $fut:expr, target: $target:expr, $($fields:tt)*) => {{
+        $crate::task::__spawn_with_span($fut, $crate::task::__error_span!(target: $target, $name, $($fields)*))
+    }};
+}
+
+#[macro_export]
+macro_rules! spawn {
+    ($name:expr, $fut:expr) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::background_spawn!($name, $fut))
+    }};
+    ($name:expr, $fut:expr, $($fields:tt)*) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::background_spawn!($name, $fut, $($fields)*))
+    }};
+    (name: $name:expr, fut: $fut:expr, target: $target:expr, $($fields:tt)*) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::background_spawn!($name, $fut, target: $target, $($fields)*))
+    }};
+}
+
+#[macro_export]
+macro_rules! spawn_blocking {
+    ($name:expr, $fut:expr) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::task::__spawn_blocking($fut, $crate::task::__error_span!($name)))
+    }};
+    ($name:expr, $fut:expr, $($fields:tt)*) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::task::__spawn_blocking($fut, $crate::task::__error_span!($name, $($fields)*)))
+    }};
+    ($name:expr, $fut:expr, target: $target:expr) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::task::__spawn_blocking($fut, $crate::task::__error_span!(target: $target, $name)))
+    }};
+    ($name:expr, $fut:expr, target: $target:expr, $($fields:tt)*) => {{
+        $crate::task::JoinHandleDropGuard::new($crate::task::__spawn_blocking($fut, $crate::task::__error_span!(target: $target, $name, $($fields)*)))
+    }};
+}
+
+/// Simple wrapper that will abort a future that is running in another spawn in the
+/// event that this handle gets dropped.
+#[derive(Debug)]
+#[must_use]
+pub struct JoinHandleDropGuard<T> {
+    inner: JoinHandle<T>,
+}
+
+impl<T> JoinHandleDropGuard<T> {
+    pub fn new(inner: JoinHandle<T>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T> Future for JoinHandleDropGuard<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}
+
+impl<T> Drop for JoinHandleDropGuard<T> {
+    fn drop(&mut self) {
+        self.inner.abort();
+    }
+}

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -23,7 +23,8 @@ use nativelink_error::Error;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
     ExecuteResult, GoingAwayRequest, KeepAliveRequest, SupportedProperties, UpdateForWorker,
 };
-use nativelink_util::common::JoinHandleDropGuard;
+use nativelink_util::spawn;
+use nativelink_util::task::JoinHandleDropGuard;
 use nativelink_worker::local_worker::LocalWorker;
 use nativelink_worker::worker_api_client_wrapper::WorkerApiClientTrait;
 use tokio::sync::mpsc;
@@ -192,7 +193,7 @@ pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConf
         }),
         Box::new(move |_| Box::pin(async move { /* No sleep */ })),
     );
-    let drop_guard = JoinHandleDropGuard::new(tokio::spawn(async move { worker.run().await }));
+    let drop_guard = spawn!("local_worker_spawn", async move { worker.run().await });
 
     let (tx_stream, streaming_response) = setup_grpc_stream();
     TestContext {

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -51,6 +51,7 @@ use nativelink_util::metrics_utils::{
 use nativelink_util::store_trait::{
     set_default_digest_size_health_check, DEFAULT_DIGEST_SIZE_HEALTH_CHECK_CFG,
 };
+use nativelink_util::{background_spawn, spawn, spawn_blocking};
 use nativelink_worker::local_worker::new_local_worker;
 use parking_lot::Mutex;
 use rustls_pemfile::{certs as extract_certs, crls as extract_crls};
@@ -58,7 +59,6 @@ use scopeguard::guard;
 use tokio::net::TcpListener;
 #[cfg(target_family = "unix")]
 use tokio::signal::unix::{signal, SignalKind};
-use tokio::task::spawn_blocking;
 use tokio_rustls::rustls::pki_types::{CertificateDer, CertificateRevocationListDer};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig as TlsServerConfig};
@@ -66,7 +66,7 @@ use tokio_rustls::TlsAcceptor;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::Server as TonicServer;
 use tower::util::ServiceExt;
-use tracing::{error_span, event, Instrument, Level};
+use tracing::{event, Level};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
 #[global_allocator]
@@ -428,7 +428,7 @@ async fn inner_main(
                     // We spawn on a thread that can block to give more freedom to our metrics
                     // collection. This allows it to call functions like `tokio::block_in_place`
                     // if it needs to wait on a future.
-                    spawn_blocking(move || {
+                    spawn_blocking!("prometheus_metrics", move || {
                         let mut buf = String::new();
                         let root_metrics_registry_guard =
                             futures::executor::block_on(root_metrics_registry.lock());
@@ -705,8 +705,9 @@ async fn inner_main(
                     },
                     Ok,
                 );
-                tokio::spawn(
-                    async move {
+                background_spawn!(
+                    name: "http_connection",
+                    fut: async move {
                         // Move it into our spawn, so if our spawn dies the cleanup happens.
                         let _guard = scope_guard;
                         if let Err(err) = fut.await {
@@ -717,13 +718,10 @@ async fn inner_main(
                                 "Failed running service"
                             );
                         }
-                    }
-                    .instrument(error_span!(
-                        target: "nativelink::services",
-                        "http_connection",
-                        ?remote_addr,
-                        ?socket_addr
-                    )),
+                    },
+                    target: "nativelink::services",
+                    ?remote_addr,
+                    ?socket_addr,
                 );
             }
         }));
@@ -794,7 +792,7 @@ async fn inner_main(
                     let worker_metrics = root_worker_metrics.sub_registry_with_prefix(&name);
                     local_worker.register_metrics(worker_metrics);
                     worker_names.insert(name.clone());
-                    tokio::spawn(local_worker.run().instrument(error_span!("worker", ?name)))
+                    spawn!("worker", local_worker.run(), ?name)
                 }
             };
             root_futures.push(Box::pin(spawn_fut.map_ok_or_else(|e| Err(e.into()), |v| v)));
@@ -900,29 +898,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(max_blocking_threads)
-        .enable_all()
-        .on_thread_start(move || set_metrics_enabled_for_this_thread(metrics_enabled))
-        .build()?;
+    #[allow(clippy::disallowed_methods)]
+    {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .max_blocking_threads(max_blocking_threads)
+            .enable_all()
+            .on_thread_start(move || set_metrics_enabled_for_this_thread(metrics_enabled))
+            .build()?;
+        runtime.spawn(async move {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("Failed to listen to SIGINT");
+            eprintln!("User terminated process via SIGINT");
+            std::process::exit(130);
+        });
 
-    runtime.spawn(async move {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("Failed to listen to SIGINT");
-        eprintln!("User terminated process via SIGINT");
-        std::process::exit(130);
-    });
+        #[cfg(target_family = "unix")]
+        runtime.spawn(async move {
+            signal(SignalKind::terminate())
+                .expect("Failed to listen to SIGTERM")
+                .recv()
+                .await;
+            eprintln!("Process terminated via SIGTERM");
+            std::process::exit(143);
+        });
 
-    #[cfg(target_family = "unix")]
-    runtime.spawn(async move {
-        signal(SignalKind::terminate())
-            .expect("Failed to listen to SIGTERM")
-            .recv()
-            .await;
-        eprintln!("Process terminated via SIGTERM");
-        std::process::exit(143);
-    });
-
-    runtime.block_on(inner_main(cfg, server_start_time))
+        runtime.block_on(inner_main(cfg, server_start_time))
+    }
 }


### PR DESCRIPTION
We now enforce all locations in our code base to use one of the `nativelink-util::task` when trying to do a task that might require an operation that changes threads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/890)
<!-- Reviewable:end -->
