### PR TITLE
Reduce verbosity of ping message

### DIFF
--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -259,7 +259,7 @@ impl WorkerApi for WorkerApiServer {
     #[instrument(
         err,
         ret(level = Level::INFO),
-        level = Level::ERROR,
+        level = Level::WARN,
         skip_all,
         fields(request = ?grpc_request.get_ref())
     )]


### PR DESCRIPTION
# Description

I improved the flexibility by reducing the warning level of the KEEPALIVE log message.
So when we look at the log output in the k8s examples, there are a lot of ping error messages for KEEPALIVE, but I tracked down the right one and reduced it to a lower log level(Warning) should make that output more readable

Fixes [#(764)](https://github.com/TraceMachina/nativelink/issues/764)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
