### PR TITLE
Add backend store metrics to VerifyStore

### DIFF
--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -188,6 +188,8 @@ impl Store for VerifyStore {
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
+        let backend_store = registry.sub_registry_with_prefix("backend");
+        self.inner_store.clone().register_metrics(backend_store);
         registry.register_collector(Box::new(Collector::new(&self)));
     }
 }


### PR DESCRIPTION
Metrics of underlying VerifyStore are now forwarded for metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/897)
<!-- Reviewable:end -->
