### PR TITLE
Digest function now auto-detected from request

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -368,13 +368,13 @@ pub struct VerifyStore {
     #[serde(default)]
     pub verify_size: bool,
 
-    /// The digest hash function to hash the contents and to verify if the digest hash is
-    /// matching before writing the entry to underlying store.
-    ///
-    /// If None, the hash verification will be disabled.
+    /// If the data should be hashed and verify that the key matches the
+    /// computed hash. The hash function is automatically determined based
+    /// request and if not set will use the global default.
     ///
     /// This should be set to None for AC, but hashing function like `sha256` for CAS stores.
-    pub hash_verification_function: Option<ConfigDigestHashFunction>,
+    #[serde(default)]
+    pub verify_hash: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -109,6 +109,16 @@ message ExecuteResult {
     /// are running or cached.
     uint64 salt = 3;
 
+    // The digest function that was used to compute the action digest
+    // and all related blobs.
+    //
+    // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+    // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+    // that case the server SHOULD infer the digest function using the
+    // length of the action digest hash and the digest functions announced
+    // in the server's capabilities.
+    build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 7;
+
     /// The actual response data.
     oneof result {
         /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
@@ -121,7 +131,7 @@ message ExecuteResult {
         google.rpc.Status internal_error = 5;
     }
 
-    reserved 7; // NextId.
+    reserved 8; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/gen_lib_rs_tool.py
+++ b/nativelink-proto/gen_lib_rs_tool.py
@@ -35,7 +35,7 @@ _HEADER = """\
 
 // *** DO NOT MODIFY ***
 // This file is auto-generated. To update it, run:
-// `bazel run proto:update_protos`
+// `bazel run nativelink-proto:update_protos`
 """
 
 

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -72,6 +72,19 @@ pub struct ExecuteResult {
     /// / are running or cached.
     #[prost(uint64, tag = "3")]
     pub salt: u64,
+    /// The digest function that was used to compute the action digest
+    /// and all related blobs.
+    ///
+    /// If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+    /// SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+    /// that case the server SHOULD infer the digest function using the
+    /// length of the action digest hash and the digest functions announced
+    /// in the server's capabilities.
+    #[prost(
+        enumeration = "super::super::super::super::super::build::bazel::remote::execution::v2::digest_function::Value",
+        tag = "7"
+    )]
+    pub digest_function: i32,
     /// / The actual response data.
     #[prost(oneof = "execute_result::Result", tags = "4, 5")]
     pub result: ::core::option::Option<execute_result::Result>,

--- a/nativelink-proto/genproto/lib.rs
+++ b/nativelink-proto/genproto/lib.rs
@@ -14,7 +14,7 @@
 
 // *** DO NOT MODIFY ***
 // This file is auto-generated. To update it, run:
-// `bazel run proto:update_protos`
+// `bazel run nativelink-proto:update_protos`
 
 pub mod build {
     pub mod bazel {

--- a/nativelink-proto/update_protos.py
+++ b/nativelink-proto/update_protos.py
@@ -103,7 +103,7 @@ def check(proto_packages):
         failed = True
 
     if failed:
-        print("To update, run: 'bazel run proto:update_protos'")
+        print("To update, run: 'bazel run nativelink-proto:update_protos'")
         raise SystemExit(1)
 
 

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -24,7 +24,7 @@ use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::capabilities_client::CapabilitiesClient;
 use nativelink_proto::build::bazel::remote::execution::v2::execution_client::ExecutionClient;
 use nativelink_proto::build::bazel::remote::execution::v2::{
-    digest_function, ExecuteRequest, ExecutionPolicy, GetCapabilitiesRequest, WaitExecutionRequest,
+    ExecuteRequest, ExecutionPolicy, GetCapabilitiesRequest, WaitExecutionRequest,
 };
 use nativelink_proto::google::longrunning::Operation;
 use nativelink_util::action_messages::{
@@ -234,7 +234,11 @@ impl ActionScheduler for GrpcScheduler {
             execution_policy,
             // TODO: Get me from the original request, not very important as we ignore it.
             results_cache_policy: None,
-            digest_function: digest_function::Value::Sha256.into(),
+            digest_function: action_info
+                .unique_qualifier
+                .digest_function
+                .proto_digest_func()
+                .into(),
         };
         let result_stream = self
             .perform_request(request, |request| async move {

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -469,14 +469,14 @@ impl SimpleSchedulerImpl {
                     Level::WARN,
                     ?worker_id,
                     ?action_info,
+                    ?notify_worker_result,
                     "Worker command failed, removing worker",
                 );
                 self.immediate_evict_worker(
                     &worker_id,
                     make_err!(
                         Code::Internal,
-                        "Worker command failed, removing worker {}",
-                        worker_id
+                        "Worker command failed, removing worker {worker_id} -- {notify_worker_result:?}",
                     ),
                 );
                 return;

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -47,6 +47,7 @@ mod action_messages_tests {
         let action_state = ActionState {
             unique_qualifier: ActionInfoHashKey {
                 instance_name: "foo_instance".to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::new([1u8; 32], 5),
                 salt: 0,
             },
@@ -119,11 +120,11 @@ mod action_messages_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         });
         let lowest_priority_action = Arc::new(ActionInfo {
             command_digest: DigestInfo::new([0u8; 32], 0),
@@ -137,11 +138,11 @@ mod action_messages_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         });
         let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
         action_set.insert(lowest_priority_action.clone());
@@ -175,11 +176,11 @@ mod action_messages_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         });
         let current_action = Arc::new(ActionInfo {
             command_digest: DigestInfo::new([0u8; 32], 0),
@@ -193,11 +194,11 @@ mod action_messages_tests {
             insert_timestamp: make_system_time(0),
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         });
         let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
         action_set.insert(current_action.clone());

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -32,6 +32,7 @@ use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::action_messages::{ActionInfoHashKey, ActionResult, ActionStage, ActionState};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::Store;
 use prost::Message;
 use tokio::sync::watch;
@@ -115,6 +116,7 @@ mod cache_lookup_scheduler_tests {
         let context = make_cache_scheduler()?;
         let action_name = ActionInfoHashKey {
             instance_name: "instance".to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: DigestInfo::new([8; 32], 1),
             salt: 1000,
         };

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -57,6 +57,7 @@ fn make_modifier_scheduler(modifications: Vec<PropertyModification>) -> TestCont
 
 #[cfg(test)]
 mod property_modifier_scheduler_tests {
+    use nativelink_util::digest_hasher::DigestHasherFunc;
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -247,6 +248,7 @@ mod property_modifier_scheduler_tests {
         let context = make_modifier_scheduler(vec![]);
         let action_name = ActionInfoHashKey {
             instance_name: "instance".to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: DigestInfo::new([8; 32], 1),
             salt: 1000,
         };

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -96,6 +96,7 @@ async fn setup_action(
 
 #[cfg(test)]
 mod scheduler_tests {
+    use nativelink_util::digest_hasher::DigestHasherFunc;
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -251,6 +252,7 @@ mod scheduler_tests {
 
         let unique_qualifier = ActionInfoHashKey {
             instance_name: "".to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: DigestInfo::zero_digest(),
             salt: 0,
         };
@@ -532,6 +534,7 @@ mod scheduler_tests {
         let mut expected_action_state = ActionState {
             unique_qualifier: ActionInfoHashKey {
                 instance_name: "".to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::zero_digest(),
                 salt: 0,
             }, // Will be filled later.
@@ -691,6 +694,7 @@ mod scheduler_tests {
             // Name is a random string, so we ignore it and just make it the same.
             unique_qualifier: ActionInfoHashKey {
                 instance_name: "".to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::zero_digest(),
                 salt: 0,
             },
@@ -793,6 +797,7 @@ mod scheduler_tests {
 
         let action_info_hash_key = ActionInfoHashKey {
             instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
             salt: 0,
         };
@@ -898,6 +903,7 @@ mod scheduler_tests {
 
         let action_info_hash_key = ActionInfoHashKey {
             instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
             salt: 0,
         };
@@ -999,6 +1005,7 @@ mod scheduler_tests {
 
         let action_info_hash_key = ActionInfoHashKey {
             instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
             salt: 0,
         };
@@ -1074,6 +1081,7 @@ mod scheduler_tests {
         let mut expected_action_state = ActionState {
             unique_qualifier: ActionInfoHashKey {
                 instance_name: "".to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::zero_digest(),
                 salt: 0,
             }, // Will be filled later.
@@ -1148,6 +1156,7 @@ mod scheduler_tests {
                 &WORKER_ID,
                 &ActionInfoHashKey {
                     instance_name: INSTANCE_NAME.to_string(),
+                    digest_function: DigestHasherFunc::Sha256,
                     digest: action_digest,
                     salt: 0,
                 },
@@ -1265,6 +1274,7 @@ mod scheduler_tests {
                 &WORKER_ID,
                 &ActionInfoHashKey {
                     instance_name: INSTANCE_NAME.to_string(),
+                    digest_function: DigestHasherFunc::Sha256,
                     digest: action_digest1,
                     salt: 0,
                 },
@@ -1310,6 +1320,7 @@ mod scheduler_tests {
                 &WORKER_ID,
                 &ActionInfoHashKey {
                     instance_name: INSTANCE_NAME.to_string(),
+                    digest_function: DigestHasherFunc::Sha256,
                     digest: action_digest2,
                     salt: 0,
                 },
@@ -1422,6 +1433,7 @@ mod scheduler_tests {
 
         let action_info_hash_key = ActionInfoHashKey {
             instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
             salt: 0,
         };
@@ -1581,6 +1593,7 @@ mod scheduler_tests {
                 &WORKER_ID1,
                 &ActionInfoHashKey {
                     instance_name: INSTANCE_NAME.to_string(),
+                    digest_function: DigestHasherFunc::Sha256,
                     digest: action_digest,
                     salt: 0,
                 },

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -35,10 +35,10 @@ pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
         insert_timestamp,
         unique_qualifier: ActionInfoHashKey {
             instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
             digest: DigestInfo::new([0u8; 32], 0),
             salt: 0,
         },
         skip_cache_lookup: false,
-        digest_function: DigestHasherFunc::Sha256,
     }
 }

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -34,9 +34,10 @@ use nativelink_store::ac_utils::get_and_decode_digest;
 use nativelink_store::grpc_store::GrpcStore;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::make_ctx_for_hash_func;
 use nativelink_util::store_trait::Store;
 use tonic::{Request, Response, Status};
-use tracing::{event, instrument, Level};
+use tracing::{error_span, event, instrument, Level};
 
 pub struct CasServer {
     stores: HashMap<String, Arc<dyn Store>>,
@@ -65,19 +66,17 @@ impl CasServer {
 
     async fn inner_find_missing_blobs(
         &self,
-        grpc_request: Request<FindMissingBlobsRequest>,
+        request: FindMissingBlobsRequest,
     ) -> Result<Response<FindMissingBlobsResponse>, Error> {
-        let inner_request = grpc_request.into_inner();
-
-        let instance_name = &inner_request.instance_name;
+        let instance_name = &request.instance_name;
         let store = self
             .stores
             .get(instance_name)
             .err_tip(|| format!("'instance_name' not configured for '{instance_name}'"))?
             .clone();
 
-        let mut requested_blobs = Vec::with_capacity(inner_request.blob_digests.len());
-        for digest in inner_request.blob_digests.iter() {
+        let mut requested_blobs = Vec::with_capacity(request.blob_digests.len());
+        for digest in request.blob_digests.iter() {
             requested_blobs.push(DigestInfo::try_from(digest.clone())?);
         }
         let sizes = Pin::new(store.as_ref())
@@ -86,7 +85,7 @@ impl CasServer {
             .err_tip(|| "In find_missing_blobs")?;
         let missing_blob_digests = sizes
             .into_iter()
-            .zip(inner_request.blob_digests)
+            .zip(request.blob_digests)
             .filter_map(|(maybe_size, digest)| maybe_size.map_or_else(|| Some(digest), |_| None))
             .collect();
 
@@ -97,10 +96,9 @@ impl CasServer {
 
     async fn inner_batch_update_blobs(
         &self,
-        grpc_request: Request<BatchUpdateBlobsRequest>,
+        request: BatchUpdateBlobsRequest,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Error> {
-        let inner_request = grpc_request.into_inner();
-        let instance_name = &inner_request.instance_name;
+        let instance_name = &request.instance_name;
 
         let store = self
             .stores
@@ -113,13 +111,11 @@ impl CasServer {
         // check to see if it's a grpc store.
         let any_store = store.inner_store(None).as_any();
         if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
-            return grpc_store
-                .batch_update_blobs(Request::new(inner_request))
-                .await;
+            return grpc_store.batch_update_blobs(Request::new(request)).await;
         }
 
         let store_pin = Pin::new(store.as_ref());
-        let update_futures: FuturesUnordered<_> = inner_request
+        let update_futures: FuturesUnordered<_> = request
             .requests
             .into_iter()
             .map(|request| async move {
@@ -156,10 +152,9 @@ impl CasServer {
 
     async fn inner_batch_read_blobs(
         &self,
-        grpc_request: Request<BatchReadBlobsRequest>,
+        request: BatchReadBlobsRequest,
     ) -> Result<Response<BatchReadBlobsResponse>, Error> {
-        let inner_request = grpc_request.into_inner();
-        let instance_name = &inner_request.instance_name;
+        let instance_name = &request.instance_name;
 
         let store = self
             .stores
@@ -172,13 +167,11 @@ impl CasServer {
         // check to see if it's a grpc store.
         let any_store = store.inner_store(None).as_any();
         if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
-            return grpc_store
-                .batch_read_blobs(Request::new(inner_request))
-                .await;
+            return grpc_store.batch_read_blobs(Request::new(request)).await;
         }
 
         let store_pin = Pin::new(store.as_ref());
-        let read_futures: FuturesUnordered<_> = inner_request
+        let read_futures: FuturesUnordered<_> = request
             .digests
             .into_iter()
             .map(|digest| async move {
@@ -217,10 +210,9 @@ impl CasServer {
 
     async fn inner_get_tree(
         &self,
-        grpc_request: Request<GetTreeRequest>,
+        request: GetTreeRequest,
     ) -> Result<Response<GetTreeStream>, Error> {
-        let inner_request = grpc_request.into_inner();
-        let instance_name = &inner_request.instance_name;
+        let instance_name = &request.instance_name;
 
         let store = self
             .stores
@@ -234,13 +226,13 @@ impl CasServer {
         let any_store = store.inner_store(None).as_any();
         if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
             let stream = grpc_store
-                .get_tree(Request::new(inner_request))
+                .get_tree(Request::new(request))
                 .await?
                 .into_inner();
             return Ok(Response::new(Box::pin(stream)));
         }
         let store_pin = Pin::new(store.as_ref());
-        let root_digest: DigestInfo = inner_request
+        let root_digest: DigestInfo = request
             .root_digest
             .err_tip(|| "Expected root_digest to exist in GetTreeRequest")?
             .try_into()
@@ -249,7 +241,7 @@ impl CasServer {
         let mut deque: VecDeque<DigestInfo> = VecDeque::new();
         let mut directories: Vec<Directory> = Vec::new();
         // `page_token` will return the `{hash_str}-{size_bytes}` of the current request's first directory digest.
-        let mut page_token_parts = inner_request.page_token.split("-");
+        let mut page_token_parts = request.page_token.split("-");
         let page_token_digest = DigestInfo::try_new(
             page_token_parts
                 .next()
@@ -261,7 +253,7 @@ impl CasServer {
                 .err_tip(|| "Failed to parse `size_bytes` as i64")?,
         )
         .err_tip(|| "Failed to parse `page_token` as `Digest` in `GetTreeRequest`")?;
-        let page_size = inner_request.page_size;
+        let page_size = request.page_size;
         // If `page_size` is 0, paging is not necessary.
         let mut page_token_matched = page_size == 0;
         deque.push_back(root_digest);
@@ -323,7 +315,13 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<FindMissingBlobsRequest>,
     ) -> Result<Response<FindMissingBlobsResponse>, Status> {
-        self.inner_find_missing_blobs(grpc_request)
+        let request = grpc_request.into_inner();
+        make_ctx_for_hash_func(request.digest_function)
+            .err_tip(|| "In CasServer::find_missing_blobs")?
+            .wrap_async(
+                error_span!("cas_server_find_missing_blobs"),
+                self.inner_find_missing_blobs(request),
+            )
             .await
             .err_tip(|| "Failed on find_missing_blobs() command")
             .map_err(|e| e.into())
@@ -341,7 +339,13 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<BatchUpdateBlobsRequest>,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Status> {
-        self.inner_batch_update_blobs(grpc_request)
+        let request = grpc_request.into_inner();
+        make_ctx_for_hash_func(request.digest_function)
+            .err_tip(|| "In CasServer::batch_update_blobs")?
+            .wrap_async(
+                error_span!("cas_server_batch_update_blobs"),
+                self.inner_batch_update_blobs(request),
+            )
             .await
             .err_tip(|| "Failed on batch_update_blobs() command")
             .map_err(|e| e.into())
@@ -359,7 +363,13 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<BatchReadBlobsRequest>,
     ) -> Result<Response<BatchReadBlobsResponse>, Status> {
-        self.inner_batch_read_blobs(grpc_request)
+        let request = grpc_request.into_inner();
+        make_ctx_for_hash_func(request.digest_function)
+            .err_tip(|| "In CasServer::batch_read_blobs")?
+            .wrap_async(
+                error_span!("cas_server_batch_read_blobs"),
+                self.inner_batch_read_blobs(request),
+            )
             .await
             .err_tip(|| "Failed on batch_read_blobs() command")
             .map_err(|e| e.into())
@@ -376,8 +386,13 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<GetTreeRequest>,
     ) -> Result<Response<Self::GetTreeStream>, Status> {
-        let resp = self
-            .inner_get_tree(grpc_request)
+        let request = grpc_request.into_inner();
+        let resp = make_ctx_for_hash_func(request.digest_function)
+            .err_tip(|| "In CasServer::get_tree")?
+            .wrap_async(
+                error_span!("cas_server_get_tree"),
+                self.inner_get_tree(request),
+            )
             .await
             .err_tip(|| "Failed on get_tree() command")
             .map_err(|e| e.into());

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -34,14 +34,14 @@ use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionState, DEFAULT_EXECUTION_PRIORITY,
 };
 use nativelink_util::common::DigestInfo;
-use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::digest_hasher::{make_ctx_for_hash_func, DigestHasherFunc};
 use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::store_trait::Store;
 use rand::{thread_rng, Rng};
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tonic::{Request, Response, Status};
-use tracing::{event, instrument, Level};
+use tracing::{error_span, event, instrument, Level};
 
 struct InstanceInfo {
     scheduler: Arc<dyn ActionScheduler>,
@@ -125,6 +125,7 @@ impl InstanceInfo {
             insert_timestamp: SystemTime::now(),
             unique_qualifier: ActionInfoHashKey {
                 instance_name,
+                digest_function,
                 digest: action_digest,
                 salt: if action.do_not_cache {
                     thread_rng().gen::<u64>()
@@ -133,7 +134,6 @@ impl InstanceInfo {
                 },
             },
             skip_cache_lookup,
-            digest_function,
         })
     }
 }
@@ -192,10 +192,9 @@ impl ExecutionServer {
 
     async fn inner_execute(
         &self,
-        request: Request<ExecuteRequest>,
+        request: ExecuteRequest,
     ) -> Result<Response<ExecuteStream>, Error> {
-        let execute_req = request.into_inner();
-        let instance_name = execute_req.instance_name;
+        let instance_name = request.instance_name;
 
         let instance_info = self
             .instance_infos
@@ -203,13 +202,13 @@ impl ExecutionServer {
             .err_tip(|| "Instance name '{}' not configured")?;
 
         let digest = DigestInfo::try_from(
-            execute_req
+            request
                 .action_digest
                 .err_tip(|| "Expected action_digest to exist")?,
         )
         .err_tip(|| "Failed to unwrap action cache")?;
 
-        let priority = execute_req
+        let priority = request
             .execution_policy
             .map_or(DEFAULT_EXECUTION_PRIORITY, |p| p.priority);
 
@@ -220,8 +219,8 @@ impl ExecutionServer {
                 digest,
                 &action,
                 priority,
-                execute_req.skip_cache_lookup,
-                execute_req
+                request.skip_cache_lookup,
+                request
                     .digest_function
                     .try_into()
                     .err_tip(|| "Could not convert digest function in inner_execute()")?,
@@ -276,7 +275,13 @@ impl Execution for ExecutionServer {
         &self,
         grpc_request: Request<ExecuteRequest>,
     ) -> Result<Response<ExecuteStream>, Status> {
-        self.inner_execute(grpc_request)
+        let request = grpc_request.into_inner();
+        make_ctx_for_hash_func(request.digest_function)
+            .err_tip(|| "In ExecutionServer::execute")?
+            .wrap_async(
+                error_span!("execution_server_execute"),
+                self.inner_execute(request),
+            )
             .await
             .err_tip(|| "Failed on execute() command")
             .map_err(|e| e.into())

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -196,6 +196,10 @@ impl WorkerApiServer {
         &self,
         execute_result: ExecuteResult,
     ) -> Result<Response<()>, Error> {
+        let digest_function = execute_result
+            .digest_function()
+            .try_into()
+            .err_tip(|| "In inner_execution_response")?;
         let worker_id: WorkerId = execute_result.worker_id.try_into()?;
         let action_digest: DigestInfo = execute_result
             .action_digest
@@ -203,6 +207,7 @@ impl WorkerApiServer {
             .try_into()?;
         let action_info_hash_key = ActionInfoHashKey {
             instance_name: execute_result.instance_name,
+            digest_function,
             digest: action_digest,
             salt: execute_result.salt,
         };

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -319,11 +319,11 @@ pub mod execution_response_tests {
             insert_timestamp: make_system_time(0),
             unique_qualifier: ActionInfoHashKey {
                 instance_name: instance_name.clone(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         };
         let mut client_action_state_receiver =
             test_context.scheduler.add_action(action_info).await?;
@@ -341,6 +341,7 @@ pub mod execution_response_tests {
             worker_id: test_context.worker_id.to_string(),
             action_digest: Some(action_digest.into()),
             salt: SALT,
+            digest_function: DigestHasherFunc::Sha256.proto_digest_func().into(),
             result: Some(execute_result::Result::ExecuteResponse(ExecuteResponse {
                 result: Some(ProtoActionResult {
                     output_files: vec![OutputFile {

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -16,23 +16,25 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nativelink_config::stores::ConfigDigestHashFunction;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_util::buf_channel::{
     make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf,
 };
 use nativelink_util::common::DigestInfo;
-use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
+use nativelink_util::digest_hasher::{
+    default_digest_hasher_func, DigestHasher, ACTIVE_HASHER_FUNC,
+};
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::{
     Collector, CollectorState, CounterWithTime, MetricsComponent, Registry,
 };
+use nativelink_util::origin_context::ActiveOriginContext;
 use nativelink_util::store_trait::{Store, UploadSizeInfo};
 
 pub struct VerifyStore {
     inner_store: Arc<dyn Store>,
     verify_size: bool,
-    hash_verification_function: Option<ConfigDigestHashFunction>,
+    verify_hash: bool,
 
     // Metrics.
     size_verification_failures: CounterWithTime,
@@ -47,7 +49,7 @@ impl VerifyStore {
         VerifyStore {
             inner_store,
             verify_size: config.verify_size,
-            hash_verification_function: config.hash_verification_function,
+            verify_hash: config.verify_hash,
             size_verification_failures: CounterWithTime::default(),
             hash_verification_failures: CounterWithTime::default(),
         }
@@ -144,9 +146,16 @@ impl Store for VerifyStore {
             }
         }
 
-        let mut hasher = self
-            .hash_verification_function
-            .map(|v| DigestHasherFunc::from(v).hasher());
+        let mut hasher = if self.verify_hash {
+            Some(
+                ActiveOriginContext::get_value(&ACTIVE_HASHER_FUNC)
+                    .err_tip(|| "In verify_store::update")?
+                    .map_or_else(default_digest_hasher_func, |v| *v)
+                    .hasher(),
+            )
+        } else {
+            None
+        };
 
         let (tx, rx) = make_buf_channel_pair();
 
@@ -202,9 +211,9 @@ impl MetricsComponent for VerifyStore {
             "If the verification store is verifying the size of the data",
         );
         c.publish(
-            "hash_verification_function",
-            &format!("{:?}", self.hash_verification_function),
-            "Hash verification function to verify the contents of the data",
+            "verify_hash_enabled",
+            &self.verify_hash,
+            "If the verification store is verifying the hash of the data",
         );
         c.publish(
             "size_verification_failures_total",

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -25,9 +25,11 @@ mod verify_store_tests {
     use nativelink_store::verify_store::VerifyStore;
     use nativelink_util::buf_channel::make_buf_channel_pair;
     use nativelink_util::common::DigestInfo;
+    use nativelink_util::digest_hasher::{make_ctx_for_hash_func, DigestHasherFunc};
     use nativelink_util::spawn;
     use nativelink_util::store_trait::{Store, UploadSizeInfo};
     use pretty_assertions::assert_eq; // Must be declared in every module.
+    use tracing::info_span;
 
     use super::*;
 
@@ -44,7 +46,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: false,
-                hash_verification_function: None,
+                verify_hash: false,
             },
             inner_store.clone(),
         );
@@ -78,7 +80,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: true,
-                hash_verification_function: None,
+                verify_hash: false,
             },
             inner_store.clone(),
         );
@@ -121,7 +123,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: true,
-                hash_verification_function: None,
+                verify_hash: false,
             },
             inner_store.clone(),
         );
@@ -150,7 +152,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: true,
-                hash_verification_function: None,
+                verify_hash: false,
             },
             inner_store.clone(),
         );
@@ -191,9 +193,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: false,
-                hash_verification_function: Some(
-                    nativelink_config::stores::ConfigDigestHashFunction::sha256,
-                ),
+                verify_hash: true,
             },
             inner_store.clone(),
         );
@@ -224,9 +224,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: false,
-                hash_verification_function: Some(
-                    nativelink_config::stores::ConfigDigestHashFunction::sha256,
-                ),
+                verify_hash: true,
             },
             inner_store.clone(),
         );
@@ -265,9 +263,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: false,
-                hash_verification_function: Some(
-                    nativelink_config::stores::ConfigDigestHashFunction::blake3,
-                ),
+                verify_hash: true,
             },
             inner_store.clone(),
         );
@@ -277,7 +273,13 @@ mod verify_store_tests {
         const HASH: &str = "b3d4f8803f7e24b8f389b072e75477cdbcfbe074080fb5e500e53e26e054158e";
         const VALUE: &str = "123";
         let digest = DigestInfo::try_new(HASH, 3).unwrap();
-        let result = store.update_oneshot(digest, VALUE.into()).await;
+        let result = make_ctx_for_hash_func(DigestHasherFunc::Blake3)?
+            .wrap_async(
+                info_span!("update_oneshot"),
+                store.update_oneshot(digest, VALUE.into()),
+            )
+            .await;
+
         assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
         assert_eq!(
             Pin::new(inner_store.as_ref()).has(digest).await,
@@ -298,9 +300,7 @@ mod verify_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
                 verify_size: false,
-                hash_verification_function: Some(
-                    nativelink_config::stores::ConfigDigestHashFunction::blake3,
-                ),
+                verify_hash: true,
             },
             inner_store.clone(),
         );
@@ -310,7 +310,15 @@ mod verify_store_tests {
         const HASH: &str = "b944a0a3b20cf5927e594ff306d256d16cd5b0ba3e27b3285f40d7ef5e19695b";
         const VALUE: &str = "123";
         let digest = DigestInfo::try_new(HASH, 3).unwrap();
-        let result = store.update_oneshot(digest, VALUE.into()).await;
+
+        let result = make_ctx_for_hash_func(DigestHasherFunc::Blake3)?
+            .wrap_async(
+                info_span!("update_oneshot"),
+                store.update_oneshot(digest, VALUE.into()),
+            )
+            .await;
+
+        // let result = store.update_oneshot(digest, VALUE.into()).await;
         let err = result.unwrap_err().to_string();
         const ACTUAL_HASH: &str =
             "b3d4f8803f7e24b8f389b072e75477cdbcfbe074080fb5e500e53e26e054158e";

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use nativelink_error::{error_if, make_input_err, Error, ResultExt};
 
 const ERROR_MSG: &str = concat!(
@@ -79,14 +81,14 @@ const SLASH_SIZE: usize = 1;
 // Useful utility struct for converting bazel's (uri-like path) into it's parts.
 #[derive(Debug, Default)]
 pub struct ResourceInfo<'a> {
-    pub instance_name: &'a str,
-    pub uuid: Option<&'a str>,
-    pub compressor: Option<&'a str>,
-    pub digest_function: Option<&'a str>,
-    pub hash: &'a str,
-    size: &'a str,
+    pub instance_name: Cow<'a, str>,
+    pub uuid: Option<Cow<'a, str>>,
+    pub compressor: Option<Cow<'a, str>>,
+    pub digest_function: Option<Cow<'a, str>>,
+    pub hash: Cow<'a, str>,
+    size: Cow<'a, str>,
     pub expected_size: usize,
-    pub optional_metadata: Option<&'a str>,
+    pub optional_metadata: Option<Cow<'a, str>>,
 }
 
 impl<'a> ResourceInfo<'a> {
@@ -114,7 +116,7 @@ impl<'a> ResourceInfo<'a> {
             &resource_name[..resource_name.len() - end_bytes_processed - SLASH_SIZE]
         };
         if !is_upload {
-            output.instance_name = beginning_part;
+            output.instance_name = Cow::Borrowed(beginning_part);
             return Ok(output);
         }
 
@@ -123,11 +125,11 @@ impl<'a> ResourceInfo<'a> {
         // Remember, `instance_name` can contain slashes and/or special names
         // like "blobs" or "uploads".
         let mut parts = beginning_part.rsplitn(3, '/');
-        output.uuid = Some(
+        output.uuid = Some(Cow::Borrowed(
             parts
                 .next()
                 .err_tip(|| format!("{ERROR_MSG} in {resource_name}"))?,
-        );
+        ));
         {
             // Sanity check that our next item is "uploads".
             let uploads = parts
@@ -141,22 +143,55 @@ impl<'a> ResourceInfo<'a> {
 
         // `instance_name` is optional.
         if let Some(instance_name) = parts.next() {
-            output.instance_name = instance_name;
+            output.instance_name = Cow::Borrowed(instance_name);
         }
         Ok(output)
     }
 
+    /// Returns a new ResourceInfo with all fields owned.
+    pub fn to_owned(&self) -> ResourceInfo<'static> {
+        ResourceInfo {
+            instance_name: Cow::Owned(self.instance_name.to_string()),
+            uuid: self.uuid.as_ref().map(|uuid| Cow::Owned(uuid.to_string())),
+            compressor: self
+                .compressor
+                .as_ref()
+                .map(|compressor| Cow::Owned(compressor.to_string())),
+            digest_function: self
+                .digest_function
+                .as_ref()
+                .map(|digest_function| Cow::Owned(digest_function.to_string())),
+            hash: Cow::Owned(self.hash.to_string()),
+            size: Cow::Owned(self.size.to_string()),
+            expected_size: self.expected_size,
+            optional_metadata: self
+                .optional_metadata
+                .as_ref()
+                .map(|optional_metadata| Cow::Owned(optional_metadata.to_string())),
+        }
+    }
+
     pub fn to_string(&self, is_upload: bool) -> String {
         [
-            Some(self.instance_name),
+            Some(self.instance_name.as_ref()),
             is_upload.then_some("uploads"),
-            self.uuid,
-            Some(self.compressor.map_or("blobs", |_| "compressed-blobs")),
-            self.compressor,
-            self.digest_function,
-            Some(self.hash),
-            Some(self.size),
-            self.optional_metadata,
+            self.uuid.as_ref().map(|uuid| uuid.as_ref()),
+            Some(
+                self.compressor
+                    .as_ref()
+                    .map_or("blobs", |_| "compressed-blobs"),
+            ),
+            self.compressor
+                .as_ref()
+                .map(|compressor| compressor.as_ref()),
+            self.digest_function
+                .as_ref()
+                .map(|digest_function| digest_function.as_ref()),
+            Some(self.hash.as_ref()),
+            Some(self.size.as_ref()),
+            self.optional_metadata
+                .as_ref()
+                .map(|optional_metadata| optional_metadata.as_ref()),
         ]
         .into_iter()
         .flatten()
@@ -209,7 +244,7 @@ fn recursive_parse<'a>(
             State::Compressor => {
                 state = State::DigestFunction;
                 if COMPRESSORS.contains(&part) {
-                    output.compressor = Some(part);
+                    output.compressor = Some(Cow::Borrowed(part));
                     *bytes_processed += part.len() + SLASH_SIZE;
                     return Ok(state);
                 } else {
@@ -219,20 +254,20 @@ fn recursive_parse<'a>(
             State::DigestFunction => {
                 state = State::Hash;
                 if DIGEST_FUNCTIONS.contains(&part) {
-                    output.digest_function = Some(part);
+                    output.digest_function = Some(Cow::Borrowed(part));
                     *bytes_processed += part.len() + SLASH_SIZE;
                     return Ok(state);
                 }
                 continue;
             }
             State::Hash => {
-                output.hash = part;
+                output.hash = Cow::Borrowed(part);
                 *bytes_processed += part.len() + SLASH_SIZE;
                 // TODO(allada) Set the digest_function if it is not set based on the hash size.
                 return Ok(State::Size);
             }
             State::Size => {
-                output.size = part;
+                output.size = Cow::Borrowed(part);
                 output.expected_size = part.parse::<usize>().map_err(|_| {
                     make_input_err!(
                         "Digest size_bytes was not convertible to usize. Got: {}",
@@ -243,7 +278,7 @@ fn recursive_parse<'a>(
                 return Ok(State::OptionalMetadata);
             }
             State::OptionalMetadata => {
-                output.optional_metadata = Some(part);
+                output.optional_metadata = Some(Cow::Borrowed(part));
                 *bytes_processed += part.len() + SLASH_SIZE;
                 // If we get here, we are done parsing backwards and have successfully parsed
                 // everything beyond the "(compressed-)blobs" section.

--- a/nativelink-util/tests/resource_info_test.rs
+++ b/nativelink-util/tests/resource_info_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use nativelink_macro::nativelink_test;
 use nativelink_util::resource_info::ResourceInfo;
 
@@ -29,11 +31,14 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -45,8 +50,8 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -62,10 +67,13 @@ mod resource_info_tests {
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -78,7 +86,7 @@ mod resource_info_tests {
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -93,11 +101,14 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -109,8 +120,8 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -125,10 +136,13 @@ mod resource_info_tests {
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -140,7 +154,7 @@ mod resource_info_tests {
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -156,11 +170,14 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -172,7 +189,7 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "instance_name");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
@@ -192,7 +209,10 @@ mod resource_info_tests {
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -219,11 +239,14 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -235,7 +258,7 @@ mod resource_info_tests {
         let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
         assert_eq!(resource_info.instance_name, "");
         assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
@@ -255,7 +278,10 @@ mod resource_info_tests {
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
         Ok(())
     }
@@ -340,12 +366,15 @@ mod resource_info_tests {
             "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -357,9 +386,9 @@ mod resource_info_tests {
             "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -374,12 +403,15 @@ mod resource_info_tests {
             "instance_name/uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -390,9 +422,9 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -407,12 +439,15 @@ mod resource_info_tests {
             "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -423,9 +458,9 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -439,12 +474,15 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -455,9 +493,9 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some("blake3"));
+        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
         assert_eq!(resource_info.optional_metadata, None);
@@ -472,12 +510,15 @@ mod resource_info_tests {
             "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -488,8 +529,8 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
@@ -504,12 +545,15 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -520,7 +564,7 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
@@ -537,12 +581,15 @@ mod resource_info_tests {
             "uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -553,8 +600,8 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
-        assert_eq!(resource_info.compressor, Some("zstd"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
@@ -577,12 +624,15 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
         assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, Some("optional_metadata"));
+        assert_eq!(
+            resource_info.optional_metadata,
+            Some(Cow::Borrowed("optional_metadata"))
+        );
         assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
         Ok(())
     }
@@ -592,7 +642,7 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
@@ -607,7 +657,7 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "my/instance/name");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");
@@ -622,7 +672,7 @@ mod resource_info_tests {
         const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
         let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
         assert_eq!(resource_info.instance_name, "blobs");
-        assert_eq!(resource_info.uuid, Some("uuid"));
+        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
         assert_eq!(resource_info.compressor, None);
         assert_eq!(resource_info.digest_function, None);
         assert_eq!(resource_info.hash, "hash");

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -32,10 +32,11 @@ use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_util::action_messages::{ActionResult, ActionStage};
 use nativelink_util::common::fs;
-use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::digest_hasher::{DigestHasherFunc, ACTIVE_HASHER_FUNC};
 use nativelink_util::metrics_utils::{
     AsyncCounterWrapper, Collector, CollectorState, CounterWithTime, MetricsComponent, Registry,
 };
+use nativelink_util::origin_context::ActiveOriginContext;
 use nativelink_util::store_trait::Store;
 use nativelink_util::{spawn, tls_utils};
 use tokio::process;
@@ -43,7 +44,7 @@ use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::Streaming;
-use tracing::{event, instrument, Level};
+use tracing::{event, info_span, instrument, Level};
 
 use crate::running_actions_manager::{
     ExecutionConfiguration, Metrics as RunningActionManagerMetrics, RunningAction,
@@ -229,112 +230,128 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                         }
                         Update::StartAction(start_execute) => {
                             self.metrics.start_actions_received.inc();
-                            let add_future_channel = add_future_channel.clone();
-                            let mut grpc_client = self.grpc_client.clone();
-                            let maybe_instance_name = start_execute.execute_request.as_ref().map(|v| v.instance_name.clone());
+
+                            let execute_request = start_execute.execute_request.as_ref();
                             let salt = start_execute.salt;
-                            let worker_id = self.worker_id.clone();
-                            let action_digest = start_execute.execute_request.as_ref().and_then(|v| v.action_digest.clone());
-                            let try_hasher = start_execute.execute_request.as_ref()
+                            let maybe_instance_name = execute_request.map(|v| v.instance_name.clone());
+                            let action_digest = execute_request.and_then(|v| v.action_digest.clone());
+                            let digest_hasher = execute_request
                                 .ok_or(make_input_err!("Expected execute_request to be set"))
                                 .and_then(|v| DigestHasherFunc::try_from(v.digest_function))
-                                .err_tip(|| "In LocalWorkerImpl::new()");
-                            let running_actions_manager = self.running_actions_manager.clone();
-                            let worker_id_clone = worker_id.clone();
-                            let precondition_script_cfg = self.config.experimental_precondition_script.clone();
-                            let actions_in_transit = self.actions_in_transit.clone();
-                            let start_action_fut = self.metrics.clone().wrap(move |metrics| async move {
-                                metrics.preconditions.wrap(preconditions_met(precondition_script_cfg))
-                                .and_then(|_| running_actions_manager.create_and_add_action(worker_id_clone, start_execute))
-                                .map(|r| {
-                                    // Now that we either failed or registered our action, we can
-                                    // consider the action to no longer be in transit.
-                                    actions_in_transit.fetch_sub(1, Ordering::Release);
-                                    r
-                                })
-                                .and_then(|action| {
-                                    event!(
-                                        Level::INFO,
-                                        action_id = hex::encode(action.get_action_id()),
-                                        "Received request to run action"
-                                    );
-                                    action
-                                        .clone()
-                                        .prepare_action()
-                                        .and_then(RunningAction::execute)
-                                        .and_then(RunningAction::upload_results)
-                                        .and_then(RunningAction::get_finished_result)
-                                        // Note: We need ensure we run cleanup even if one of the other steps fail.
-                                        .then(|result| async move {
-                                            if let Err(e) = action.cleanup().await {
-                                                return Result::<ActionResult, Error>::Err(e).merge(result);
-                                            }
-                                            result
-                                        })
-                                }).await
-                            });
+                                .err_tip(|| "In LocalWorkerImpl::new()")?;
 
-                            let running_actions_manager = self.running_actions_manager.clone();
-                            let make_publish_future = move |res: Result<ActionResult, Error>| async move {
-                                let instance_name = maybe_instance_name
-                                    .err_tip(|| "`instance_name` could not be resolved; this is likely an internal error in local_worker.")?;
-                                match res {
-                                    Ok(mut action_result) => {
-                                        // Save in the action cache before notifying the scheduler that we've completed.
-                                        if let Some(digest_info) = action_digest.clone().and_then(|action_digest| action_digest.try_into().ok()) {
-                                            if let Err(err) = running_actions_manager.cache_action_result(digest_info, &mut action_result, try_hasher?).await {
-                                                event!(
-                                                    Level::ERROR,
-                                                    ?err,
-                                                    ?action_digest,
-                                                    "Error saving action in store",
-                                                );
+                            let start_action_fut = {
+                                let precondition_script_cfg = self.config.experimental_precondition_script.clone();
+                                let actions_in_transit = self.actions_in_transit.clone();
+                                let worker_id = self.worker_id.clone();
+                                let running_actions_manager = self.running_actions_manager.clone();
+                                self.metrics.clone().wrap(move |metrics| async move {
+                                    metrics.preconditions.wrap(preconditions_met(precondition_script_cfg))
+                                    .and_then(|_| running_actions_manager.create_and_add_action(worker_id, start_execute))
+                                    .map(move |r| {
+                                        // Now that we either failed or registered our action, we can
+                                        // consider the action to no longer be in transit.
+                                        actions_in_transit.fetch_sub(1, Ordering::Release);
+                                        r
+                                    })
+                                    .and_then(|action| {
+                                        event!(
+                                            Level::INFO,
+                                            action_id = hex::encode(action.get_action_id()),
+                                            "Received request to run action"
+                                        );
+                                        action
+                                            .clone()
+                                            .prepare_action()
+                                            .and_then(RunningAction::execute)
+                                            .and_then(RunningAction::upload_results)
+                                            .and_then(RunningAction::get_finished_result)
+                                            // Note: We need ensure we run cleanup even if one of the other steps fail.
+                                            .then(|result| async move {
+                                                if let Err(e) = action.cleanup().await {
+                                                    return Result::<ActionResult, Error>::Err(e).merge(result);
+                                                }
+                                                result
+                                            })
+                                    }).await
+                                })
+                            };
+
+                            let make_publish_future = {
+                                let mut grpc_client = self.grpc_client.clone();
+
+                                let worker_id = self.worker_id.clone();
+                                let running_actions_manager = self.running_actions_manager.clone();
+                                move |res: Result<ActionResult, Error>| async move {
+                                    let instance_name = maybe_instance_name
+                                        .err_tip(|| "`instance_name` could not be resolved; this is likely an internal error in local_worker.")?;
+                                    match res {
+                                        Ok(mut action_result) => {
+                                            // Save in the action cache before notifying the scheduler that we've completed.
+                                            if let Some(digest_info) = action_digest.clone().and_then(|action_digest| action_digest.try_into().ok()) {
+                                                if let Err(err) = running_actions_manager.cache_action_result(digest_info, &mut action_result, digest_hasher).await {
+                                                    event!(
+                                                        Level::ERROR,
+                                                        ?err,
+                                                        ?action_digest,
+                                                        "Error saving action in store",
+                                                    );
+                                                }
                                             }
-                                        }
-                                        let action_stage = ActionStage::Completed(action_result);
-                                        grpc_client.execution_response(
-                                            ExecuteResult{
+                                            let action_stage = ActionStage::Completed(action_result);
+                                            grpc_client.execution_response(
+                                                ExecuteResult{
+                                                    worker_id,
+                                                    instance_name,
+                                                    action_digest,
+                                                    salt,
+                                                    digest_function: digest_hasher.proto_digest_func().into(),
+                                                    result: Some(execute_result::Result::ExecuteResponse(action_stage.into())),
+                                                }
+                                            )
+                                            .await
+                                            .err_tip(|| "Error while calling execution_response")?;
+                                        },
+                                        Err(e) => {
+                                            grpc_client.execution_response(ExecuteResult{
                                                 worker_id,
                                                 instance_name,
                                                 action_digest,
                                                 salt,
-                                                result: Some(execute_result::Result::ExecuteResponse(action_stage.into())),
-                                            }
-                                        )
-                                        .await
-                                        .err_tip(|| "Error while calling execution_response")?;
-                                    },
-                                    Err(e) => {
-                                        grpc_client.execution_response(ExecuteResult{
-                                            worker_id,
-                                            instance_name,
-                                            action_digest,
-                                            salt,
-                                            result: Some(execute_result::Result::InternalError(e.into())),
-                                        }).await.err_tip(|| "Error calling execution_response with error")?;
-                                    },
+                                                digest_function: digest_hasher.proto_digest_func().into(),
+                                                result: Some(execute_result::Result::InternalError(e.into())),
+                                            }).await.err_tip(|| "Error calling execution_response with error")?;
+                                        },
+                                    }
+                                    Ok(())
                                 }
-                                Ok(())
                             };
 
                             self.actions_in_transit.fetch_add(1, Ordering::Release);
-                            futures.push(
-                                spawn!("worker_start_action", start_action_fut).map(move |res| {
-                                    let res = res.err_tip(|| "Failed to launch spawn")?;
-                                    if let Err(err) = &res {
-                                        event!(
-                                            Level::ERROR,
-                                            ?err,
-                                            "Error executing action",
-                                        );
-                                    }
-                                    add_future_channel
-                                        .send(make_publish_future(res).boxed())
-                                        .map_err(|_| make_err!(Code::Internal, "LocalWorker could not send future"))?;
-                                    Ok(())
-                                })
-                                .boxed()
-                            );
+                            let futures_ref = &futures;
+
+                            let add_future_channel = add_future_channel.clone();
+                            let mut ctx = ActiveOriginContext::fork().err_tip(|| "Expected ActiveOriginContext to be set in local_worker::run")?;
+                            ctx.set_value(&ACTIVE_HASHER_FUNC, Arc::new(digest_hasher));
+                            ctx.run(info_span!("worker_start_action_ctx"), move || {
+                                futures_ref.push(
+                                    spawn!("worker_start_action", start_action_fut).map(move |res| {
+                                        let res = res.err_tip(|| "Failed to launch spawn")?;
+                                        if let Err(err) = &res {
+                                            event!(
+                                                Level::ERROR,
+                                                ?err,
+                                                "Error executing action",
+                                            );
+                                        }
+                                        add_future_channel
+                                            .send(make_publish_future(res).boxed())
+                                            .map_err(|_| make_err!(Code::Internal, "LocalWorker could not send future"))?;
+                                        Ok(())
+                                    })
+                                    .boxed()
+                                );
+                            });
                         }
                     };
                 },

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1030,7 +1030,7 @@ impl RunningActionImpl {
             )
         };
         let cas_store = Pin::new(self.running_actions_manager.cas_store.as_ref());
-        let hasher = self.action_info.digest_function;
+        let hasher = self.action_info.unique_qualifier.digest_function;
         enum OutputType {
             None,
             File(FileInfo),

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -72,6 +72,7 @@ fn make_temp_path(data: &str) -> String {
 
 #[cfg(test)]
 mod local_worker_tests {
+    use nativelink_proto::build::bazel::remote::execution::v2::digest_function;
     use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::KillActionRequest;
     use pretty_assertions::assert_eq;
 
@@ -239,11 +240,11 @@ mod local_worker_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Blake3,
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Blake3,
         };
 
         {
@@ -325,11 +326,11 @@ mod local_worker_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         };
 
         {
@@ -406,6 +407,7 @@ mod local_worker_tests {
                 instance_name: INSTANCE_NAME.to_string(),
                 action_digest: Some(action_digest.into()),
                 salt: SALT,
+                digest_function: digest_function::Value::Sha256.into(),
                 result: Some(execute_result::Result::ExecuteResponse(
                     ActionStage::Completed(action_result).into()
                 )),
@@ -592,11 +594,11 @@ mod local_worker_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Sha256,
         };
 
         {
@@ -632,6 +634,7 @@ mod local_worker_tests {
                 instance_name: INSTANCE_NAME.to_string(),
                 action_digest: Some(action_digest.into()),
                 salt: SALT,
+                digest_function: digest_function::Value::Sha256.into(),
                 result: Some(execute_result::Result::InternalError(
                     make_err!(Code::ResourceExhausted, "{}", EXPECTED_MSG,).into()
                 )),
@@ -682,11 +685,11 @@ mod local_worker_tests {
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Blake3,
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
-            digest_function: DigestHasherFunc::Blake3,
         };
 
         {

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -502,6 +502,7 @@ mod running_actions_manager_tests {
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -618,6 +619,7 @@ mod running_actions_manager_tests {
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -921,6 +923,7 @@ mod running_actions_manager_tests {
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -1076,6 +1079,7 @@ mod running_actions_manager_tests {
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -1270,6 +1274,7 @@ mod running_actions_manager_tests {
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -1400,6 +1405,7 @@ mod running_actions_manager_tests {
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,
@@ -1546,6 +1552,7 @@ exit 0
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,
@@ -1713,6 +1720,7 @@ exit 0
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,
@@ -1854,6 +1862,7 @@ exit 1
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,
@@ -2372,6 +2381,7 @@ exit 1
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: 0,
@@ -2449,6 +2459,7 @@ exit 1
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: 0,
@@ -2526,6 +2537,7 @@ exit 1
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: 0,
@@ -2648,6 +2660,7 @@ exit 1
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: 0,
@@ -2767,6 +2780,7 @@ exit 1
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: 0,
@@ -2915,6 +2929,7 @@ exit 1
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         ..Default::default()
@@ -3002,6 +3017,7 @@ exit 1
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,
@@ -3135,6 +3151,7 @@ exit 1
                     StartExecute {
                         execute_request: Some(ExecuteRequest {
                             action_digest: Some(action_digest.into()),
+                            digest_function: ProtoDigestFunction::Sha256.into(),
                             ..Default::default()
                         }),
                         salt: SALT,
@@ -3308,6 +3325,7 @@ exit 1
                 StartExecute {
                     execute_request: Some(ExecuteRequest {
                         action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
                     salt: SALT,

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -730,7 +730,7 @@ async fn inner_main(
                                     });
                                 },
                                 result = &mut http_svc_fut => {
-                                    if let Err(err) = result.map_err(|err| {
+                                    if let Err(err) = result.or_else(|err| {
                                         use std::error::Error;
                                         if let Some(inner_err) = err.source() {
                                             if let Some(io_err) = inner_err.downcast_ref::<std::io::Error>() {

--- a/tools/create-worker.nix
+++ b/tools/create-worker.nix
@@ -95,7 +95,7 @@ in
       # Override the final image tag with the one from the base image. This way
       # the nativelink executable doesn't influence this tag and and changes to
       # its codebase don't invalidate existing toolchain containers.
-      tag = image.imageTag;
+      tag = null;
 
       config = {
         User = user;


### PR DESCRIPTION
The digest function the client requested is now properly implemented
in the OriginContext. This allows us to inspect what digest-function
the client requested from anywhere in the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/899)
<!-- Reviewable:end -->
