### PR TITLE
Enable hermetic Bazel sandboxing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,9 +16,6 @@
 startup --digest_function=blake3
 common --enable_platform_specific_config
 
-# TODO(aaronmondal): Remove this once we get the build working without it.
-common --noincompatible_sandbox_hermetic_tmp
-
 # Don't leak PATH and LD_LIBRARY_PATH into the build.
 build --incompatible_strict_action_env
 

--- a/flake.nix
+++ b/flake.nix
@@ -216,12 +216,17 @@
         };
         pre-commit.settings = {inherit hooks;};
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs =
+          nativeBuildInputs = let
+            bazel = pkgs.writeShellScriptBin "bazel" ''
+              unset TMPDIR TMP
+              exec ${pkgs.bazel_7}/bin/bazel "$@"
+            '';
+          in
             [
               # Development tooling goes here.
+              bazel
               stable-rust-native.default
               pkgs.pre-commit
-              pkgs.bazel_7
               pkgs.awscli2
               pkgs.skopeo
               pkgs.dive


### PR DESCRIPTION
The `--incompatible_sandbox_hermetic_tmp` flag doesn't work when `TMPDIR` or `TMP` are set to a location under `/tmp`. Nix shells set these environment variables to `/tmp/nix-shell.xxxxxx`, triggering mount errors. This change enables the flag by wrapping Bazel in the Nix shell with a script that unsets the `TMP` and `TMPDIR` environment variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/902)
<!-- Reviewable:end -->
