### PR TITLE
Fix operations scripts evaluating to quickly

### DIFF
--- a/deployment-examples/chromium/01_operations.sh
+++ b/deployment-examples/chromium/01_operations.sh
@@ -22,7 +22,19 @@ curl -v \
     -d '{"flakeOutput": "./src_root#nativelink-worker-siso-chromium"}' \
     http://${EVENTLISTENER}:8080
 
-# Wait for the pipelines to finish.
+until kubectl get pipelinerun \
+        -l tekton.dev/pipeline=rebuild-nativelink | grep -q 'NAME'; do
+    echo "Waiting for PipelineRuns to start..."
+    sleep 0.1
+done
+
+printf 'Waiting for PipelineRuns to finish...
+
+You may cancel this script now and use `tkn pr ls` and `tkn pr logs -f` to
+monitor the PipelineRun logs.
+
+'
+
 kubectl wait \
     --for=condition=Succeeded \
     --timeout=30m \

--- a/deployment-examples/kubernetes/01_operations.sh
+++ b/deployment-examples/kubernetes/01_operations.sh
@@ -20,7 +20,19 @@ curl -v \
     -d '{"flakeOutput": "./src_root#nativelink-worker-lre-cc"}' \
     http://${EVENTLISTENER}:8080
 
-# Wait for the pipelines to finish.
+until kubectl get pipelinerun \
+        -l tekton.dev/pipeline=rebuild-nativelink | grep -q 'NAME'; do
+    echo "Waiting for PipelineRuns to start..."
+    sleep 0.1
+done
+
+printf 'Waiting for PipelineRuns to finish...
+
+You may cancel this script now and use `tkn pr ls` and `tkn pr logs -f` to
+monitor the PipelineRun logs.
+
+'
+
 kubectl wait \
     --for=condition=Succeeded \
     --timeout=30m \


### PR DESCRIPTION
The `curl` commands we send to Tekton can take longer to evaluate than it takes for bash to continue to the `kubectl wait` section.

In CI it's most likely not an issue if the `kubectl wait` fails since the `02_*` scripts will retry (and wait) until the pipelines succeed.

However, for manual invocations and examples it can be confusion if these scripts print error messages about non-existing pipelines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/906)
<!-- Reviewable:end -->
