### PR TITLE
Fix nix build on MacOS

### DIFF
--- a/tools/nixpkgs_link_libunwind_and_libcxx.diff
+++ b/tools/nixpkgs_link_libunwind_and_libcxx.diff
@@ -41,9 +41,9 @@ index 4d2b160a23ff..d2b48b2de568 100644
 -      nixSupport.cc-ldflags = lib.optionals (!stdenv.targetPlatform.isWasm) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
 +      nixSupport.cc-ldflags = lib.optionals (!stdenv.targetPlatform.isWasm) [
 +        "-L${targetLlvmLibraries.libunwind}/lib"
-+        "-rpath=${targetLlvmLibraries.libunwind}/lib"
++        "-rpath ${targetLlvmLibraries.libunwind}/lib"
 +        "-L${targetLlvmLibraries.libcxx}/lib"
-+        "-rpath=${targetLlvmLibraries.libcxx}/lib"
++        "-rpath ${targetLlvmLibraries.libcxx}/lib"
 +      ];
      };
 


### PR DESCRIPTION
# Description

Any nix build will currently fail on MacOS due to the formatting of the linker arguments. This fixes it to re-enable nix builds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/919)
<!-- Reviewable:end -->
