### PR TITLE
Update old tag version in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 2. Install NativeLink with Cargo.
 ```bash
-cargo install --git https://github.com/TraceMachina/nativelink --tag v0.3.0
+cargo install --git https://github.com/TraceMachina/nativelink --tag v0.4.0
 ```
 
 ### ⚙️ Configure and 🦾 Start NativeLink


### PR DESCRIPTION
# Description

Currently, in `README.md`, the tag version is still `v0.3.0` even though we already upgraded it to `v0.4.0` recently.

https://github.com/TraceMachina/nativelink/blob/75105df746c626da76f74e412764e6755296a8ab/README.md?plain=1#L33

Fixes #922 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/923)
<!-- Reviewable:end -->
