### PR TITLE
Add subscribe API to Store API

### DIFF
--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -40,68 +40,69 @@ jobs:
            --verbose_failures \
            @local-remote-execution//examples:hello_lre"
 
-  remote:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [large-ubuntu-22.04]
-    name: Remote / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+  # TODO(nativelink#986) Re-enable once LRE is no longer flaky.
+  # remote:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [large-ubuntu-22.04]
+  #   name: Remote / ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   timeout-minutes: 45
+  #   steps:
+  #     - name: Checkout
+  #       uses: >- # v4.1.1
+  #         actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
+  #     - name: Install Nix
+  #       uses: >- # v10
+  #         DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
 
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+  #     - name: Cache Nix derivations
+  #       uses: >- # v4
+  #         DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
 
-      - name: Start Kubernetes cluster (Infra)
-        run: >
-          nix run .#native up
+  #     - name: Start Kubernetes cluster (Infra)
+  #       run: >
+  #         nix run .#native up
 
-      - name: Start Kubernetes cluster (Operations)
-        run: >
-          nix develop --impure --command
-          bash -c "./deployment-examples/kubernetes/01_operations.sh"
+  #     - name: Start Kubernetes cluster (Operations)
+  #       run: >
+  #         nix develop --impure --command
+  #         bash -c "./deployment-examples/kubernetes/01_operations.sh"
 
-      - name: Start Kubernetes cluster (Application)
-        run: >
-          nix develop --impure --command
-          bash -c "./deployment-examples/kubernetes/02_application.sh"
+  #     - name: Start Kubernetes cluster (Application)
+  #       run: >
+  #         nix develop --impure --command
+  #         bash -c "./deployment-examples/kubernetes/02_application.sh"
 
-      - name: Get gateway IPs
-        id: gateway-ips
-        run: |
-          echo "cache_ip=$(kubectl get gtw cache-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
-          echo "scheduler_ip=$(kubectl get gtw scheduler-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
+  #     - name: Get gateway IPs
+  #       id: gateway-ips
+  #       run: |
+  #         echo "cache_ip=$(kubectl get gtw cache-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
+  #         echo "scheduler_ip=$(kubectl get gtw scheduler-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
 
-      - name: Print cluster state
-        run: |
-          kubectl get svc -A
-          kubectl get pod -A
-          kubectl get svc -A
-          kubectl get deployments -A
-          kubectl describe gtw
-          echo "cas"
-          kubectl logs -l app=nativelink-cas
-          echo "scheduler"
-          kubectl logs -l app=nativelink-scheduler
-          echo "worker"
-          kubectl logs -l app=nativelink-worker
+  #     - name: Print cluster state
+  #       run: |
+  #         kubectl get svc -A
+  #         kubectl get pod -A
+  #         kubectl get svc -A
+  #         kubectl get deployments -A
+  #         kubectl describe gtw
+  #         echo "cas"
+  #         kubectl logs -l app=nativelink-cas
+  #         echo "scheduler"
+  #         kubectl logs -l app=nativelink-scheduler
+  #         echo "worker"
+  #         kubectl logs -l app=nativelink-worker
 
-      - name: Build hello_lre with LRE toolchain.
-        run: >
-          nix develop --impure --command
-          bash -c "bazel run \
-            --config=lre \
-            --remote_instance_name=main \
-            --remote_cache=grpc://$cache_ip \
-            --remote_executor=grpc://$scheduler_ip \
-            --verbose_failures \
-            @local-remote-execution//examples:hello_lre"
+  #     - name: Build hello_lre with LRE toolchain.
+  #       run: >
+  #         nix develop --impure --command
+  #         bash -c "bazel run \
+  #           --config=lre \
+  #           --remote_instance_name=main \
+  #           --remote_cache=grpc://$cache_ip \
+  #           --remote_executor=grpc://$scheduler_ip \
+  #           --verbose_failures \
+  #           @local-remote-execution//examples:hello_lre"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "nativelink-error",
  "nativelink-macro",
  "nativelink-proto",
+ "nativelink-store",
  "parking_lot",
  "pin-project-lite",
  "pretty_assertions",

--- a/deployment-examples/chromium/01_operations.sh
+++ b/deployment-examples/chromium/01_operations.sh
@@ -34,6 +34,6 @@ monitor the PipelineRun logs.
 
 kubectl wait \
     --for=condition=Succeeded \
-    --timeout=30m \
+    --timeout=45m \
     pipelinerun \
         -l tekton.dev/pipeline=rebuild-nativelink

--- a/deployment-examples/kubernetes/01_operations.sh
+++ b/deployment-examples/kubernetes/01_operations.sh
@@ -32,6 +32,6 @@ monitor the PipelineRun logs.
 
 kubectl wait \
     --for=condition=Succeeded \
-    --timeout=30m \
+    --timeout=45m \
     pipelinerun \
         -l tekton.dev/pipeline=rebuild-nativelink

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
+        "apps.aarch64-linux.native"
         "aarch64-darwin"
       ];
       imports = [

--- a/local-remote-execution/README.md
+++ b/local-remote-execution/README.md
@@ -231,7 +231,7 @@ curl -v \
 # Wait for the pipelines to finish.
 sleep 1 && kubectl wait \
     --for=condition=Succeeded \
-    --timeout=30m \
+    --timeout=45m \
     pipelinerun \
         -l tekton.dev/pipeline=rebuild-nativelink
 

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -46,7 +46,6 @@ async fn verify_initial_connection_message(
     worker_id: WorkerId,
     rx: &mut mpsc::UnboundedReceiver<UpdateForWorker>,
 ) {
-    use pretty_assertions::assert_eq;
     // Worker should have been sent an execute command.
     let expected_msg_for_worker = UpdateForWorker {
         update: Some(update_for_worker::Update::ConnectionResult(

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -13,6 +13,7 @@ rust_library(
         "src/buf_channel.rs",
         "src/common.rs",
         "src/connection_manager.rs",
+        "src/default_store_key_subscribe.rs",
         "src/digest_hasher.rs",
         "src/evicting_map.rs",
         "src/fastcdc.rs",
@@ -68,6 +69,7 @@ rust_test_suite(
     timeout = "short",
     srcs = [
         "tests/buf_channel_test.rs",
+        "tests/default_store_key_subscribe_test.rs",
         "tests/evicting_map_test.rs",
         "tests/fastcdc_test.rs",
         "tests/fs_test.rs",
@@ -88,6 +90,7 @@ rust_test_suite(
         "//nativelink-config",
         "//nativelink-error",
         "//nativelink-proto",
+        "//nativelink-store",
         "@crates//:bytes",
         "@crates//:futures",
         "@crates//:hex",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -39,3 +39,4 @@ nativelink-macro = { path = "../nativelink-macro" }
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 mock_instant = "0.3.2"
+nativelink-store = { path = "../nativelink-store" }

--- a/nativelink-util/src/default_store_key_subscribe.rs
+++ b/nativelink-util/src/default_store_key_subscribe.rs
@@ -1,0 +1,164 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::Future;
+use nativelink_error::{make_err, Code, Error, ResultExt};
+use tokio::sync::watch;
+use tokio::time::sleep;
+use tonic::async_trait;
+
+use crate::background_spawn;
+use crate::buf_channel::{make_buf_channel_pair, DropCloserWriteHalf};
+use crate::common::DigestInfo;
+use crate::digest_hasher::{DigestHasher, DigestHasherFunc};
+use crate::store_trait::{StoreDriver, StoreKey, StoreSubscription, StoreSubscriptionItem};
+
+/// The default sleep time for checking changes in store keys.
+const DEFAULT_SLEEP_FOR_CHANGES: Duration = Duration::from_secs(10);
+
+struct DefaultStoreSubscription(watch::Receiver<Result<Arc<dyn StoreSubscriptionItem>, Error>>);
+
+#[async_trait]
+impl StoreSubscription for DefaultStoreSubscription {
+    fn peek(&self) -> Result<Arc<dyn StoreSubscriptionItem>, Error> {
+        self.0.borrow().clone()
+    }
+
+    async fn changed(&mut self) -> Result<Arc<dyn StoreSubscriptionItem>, Error> {
+        self.0.changed().await.map_err(|e| {
+            make_err!(
+                Code::Internal,
+                "Sender dropped in DefaultStoreSubscription::changed - {e:?}"
+            )
+        })?;
+        self.0.borrow().clone()
+    }
+}
+
+struct DefaultStoreSubscriptionItem<S: StoreDriver + ?Sized> {
+    store: Arc<S>,
+    key: StoreKey<'static>,
+}
+
+#[async_trait]
+impl<S: StoreDriver + ?Sized> StoreSubscriptionItem for DefaultStoreSubscriptionItem<S> {
+    async fn get_key(&self) -> Result<StoreKey, Error> {
+        Ok(self.key.borrow())
+    }
+
+    async fn get_part(
+        &self,
+        writer: &mut DropCloserWriteHalf,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<(), Error> {
+        Pin::new(self.store.as_ref())
+            .get_part(self.key.borrow(), writer, offset, length)
+            .await
+    }
+}
+
+/// Fetches all the data, hashes it and returns the hash of the data.
+async fn get_data_version_key<S: StoreDriver + ?Sized>(
+    store: Pin<&S>,
+    key: StoreKey<'_>,
+) -> Result<DigestInfo, Error> {
+    let mut hasher = DigestHasherFunc::Blake3.hasher();
+    let (mut writer, reader) = make_buf_channel_pair();
+    // Note: We wrap the future, so if the future is dropped, the writer will be dropped.
+    let read_fut = async move { store.get_part(key, &mut writer, 0, None).await };
+    let write_fut = async move {
+        let mut reader = reader;
+        loop {
+            let data = reader
+                .recv()
+                .await
+                .err_tip(|| "Failed to receive data in get_data_version_key")?;
+            hasher.update(&data);
+            if data.is_empty() {
+                break;
+            }
+        }
+        Result::<_, Error>::Ok(hasher.finalize_digest())
+    };
+    let (read_res, write_res) = futures::join!(read_fut, write_fut);
+    if read_res.is_err() {
+        return read_res.merge(write_res);
+    }
+    write_res
+}
+
+pub async fn default_store_key_subscribe_with_time<S, SleepFut>(
+    store: Arc<S>,
+    key: StoreKey<'_>,
+    sleep_fn: fn() -> SleepFut,
+) -> Box<dyn StoreSubscription>
+where
+    S: StoreDriver + ?Sized,
+    SleepFut: Future<Output = ()> + Send + 'static,
+{
+    let last_version_key = match get_data_version_key(Pin::new(store.as_ref()), key.borrow()).await
+    {
+        Ok(version_key) => version_key,
+        Err(e) => {
+            let (_, watch_rx) = watch::channel(Err(e));
+            return Box::new(DefaultStoreSubscription(watch_rx));
+        }
+    };
+
+    let (watch_tx, watch_rx) = watch::channel::<Result<Arc<dyn StoreSubscriptionItem>, Error>>(Ok(
+        Arc::new(DefaultStoreSubscriptionItem {
+            store: store.clone(),
+            key: key.borrow().into_owned(),
+        }),
+    ));
+    let key = key.borrow().into_owned();
+
+    background_spawn!("default_store_subscribe_spawn", async move {
+        let mut last_version_key = last_version_key;
+        loop {
+            tokio::select! {
+                _ = sleep_fn() => {
+                    match get_data_version_key(Pin::new(store.as_ref()), key.borrow()).await {
+                        Ok(next_version_key) => {
+                            if next_version_key != last_version_key {
+                                last_version_key = next_version_key;
+                                watch_tx.send_modify(|_| {});
+                            }
+                        },
+                        Err(e) => {
+                            let _ = watch_tx.send(Err(e)); // If error, it means receiver has been dropped.
+                            return;
+                        },
+                    }
+
+                },
+                _ = watch_tx.closed() => return, // The receiver has been dropped.
+            }
+        }
+    });
+    Box::new(DefaultStoreSubscription(watch_rx))
+}
+
+/// Default store key subscription implementation.
+pub(crate) async fn default_store_key_subscribe<S: StoreDriver + ?Sized>(
+    store: Arc<S>,
+    key: StoreKey<'_>,
+) -> Box<dyn StoreSubscription> {
+    default_store_key_subscribe_with_time(store, key, || sleep(DEFAULT_SLEEP_FOR_CHANGES)).await
+}

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -16,6 +16,7 @@ pub mod action_messages;
 pub mod buf_channel;
 pub mod common;
 pub mod connection_manager;
+pub mod default_store_key_subscribe;
 pub mod digest_hasher;
 pub mod evicting_map;
 pub mod fastcdc;

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -33,6 +33,7 @@ use tokio::time::timeout;
 
 use crate::buf_channel::{make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf};
 use crate::common::DigestInfo;
+use crate::default_store_key_subscribe::default_store_key_subscribe;
 use crate::digest_hasher::{default_digest_hasher_func, DigestHasher, DigestHasherFunc};
 use crate::fs::{self, idle_file_descriptor_timeout};
 use crate::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
@@ -142,6 +143,44 @@ pub enum StoreOptimizations {
 
     /// If the store will never serve downloads.
     NoopDownloads,
+
+    /// If the store is optimized for serving subscriptions to keys.
+    SubscribeChanges,
+}
+
+/// A key that has been subscribed to in the store. This can be used
+/// to wait for changes to the data for the key.
+#[async_trait]
+pub trait StoreSubscription {
+    /// Get the current store subscription item.
+    fn peek(&self) -> Result<Arc<dyn StoreSubscriptionItem>, Error>;
+
+    /// Wait for the data to change and return the new store subscription item.
+    /// Note: This will always have a value ready when struct is first created.
+    async fn changed(&mut self) -> Result<Arc<dyn StoreSubscriptionItem>, Error>;
+}
+
+/// An item that has been subscribed to in the store. Some stores may have
+/// the data already available when the data changes. This allows the store
+/// to store a reference to the data and return it when requested, otherwise
+/// the store can lazily retrieve the data when requested.
+#[async_trait]
+pub trait StoreSubscriptionItem: Send + Sync + Unpin {
+    /// Returns the key of the item being represented.
+    async fn get_key(&self) -> Result<StoreKey, Error>;
+
+    /// Same as `StoreLike::get_part`, but without the key.
+    async fn get_part(
+        &self,
+        writer: &mut DropCloserWriteHalf,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<(), Error>;
+
+    /// Same as `Store::get`, but without the key.
+    async fn get(&self, writer: &mut DropCloserWriteHalf) -> Result<(), Error> {
+        self.get_part(writer, 0, None).await
+    }
 }
 
 /// Holds something that can be converted into a key the
@@ -296,6 +335,21 @@ impl Store {
     #[inline]
     pub fn downcast_ref<U: StoreDriver>(&self, maybe_digest: Option<StoreKey<'_>>) -> Option<&U> {
         self.inner.inner_store(maybe_digest).as_any().downcast_ref()
+    }
+
+    /// Subscribe to a key in the store. The store will notify the subscriber
+    /// when the data for the key changes.
+    /// There is no guarantee that the store will notify the subscriber of all changes,
+    /// and there is no guarantee that the store will notify the subscriber of changes
+    /// in a timely manner.
+    /// Note: It can be quite expensive to subscribe to a key in stores that do not
+    /// have the optimization for this. One may check if a store has the optimization
+    /// by calling `optimized_for(StoreOptimizations::SubscribeChanges)`.
+    pub fn subscribe<'a>(
+        &self,
+        key: impl Into<StoreKey<'a>>,
+    ) -> impl Future<Output = Box<dyn StoreSubscription>> + 'a {
+        self.inner.clone().subscribe(key.into())
     }
 
     /// Register any metrics that this store wants to expose to the Prometheus.
@@ -484,7 +538,7 @@ pub trait StoreLike: Send + Sync + Sized + Unpin + 'static {
 
 #[async_trait]
 pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
-    /// See: `StoreLike::has()` for details.
+    /// See: [`StoreLike::has`] for details.
     #[inline]
     async fn has(self: Pin<&Self>, key: StoreKey<'_>) -> Result<Option<usize>, Error> {
         let mut result = [None];
@@ -492,7 +546,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(result[0])
     }
 
-    /// See: `StoreLike::has_many()` for details.
+    /// See: [`StoreLike::has_many`] for details.
     #[inline]
     async fn has_many(
         self: Pin<&Self>,
@@ -503,14 +557,14 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(results)
     }
 
-    /// See: `StoreLike::has_with_results()` for details.
+    /// See: [`StoreLike::has_with_results`] for details.
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
         results: &mut [Option<usize>],
     ) -> Result<(), Error>;
 
-    /// See: `StoreLike::update()` for details.
+    /// See: [`StoreLike::update`] for details.
     async fn update(
         self: Pin<&Self>,
         key: StoreKey<'_>,
@@ -518,12 +572,12 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error>;
 
-    /// See: `StoreLike::optimized_for()` for details.
+    /// See: [`StoreLike::optimized_for`] for details.
     fn optimized_for(&self, _optimization: StoreOptimizations) -> bool {
         false
     }
 
-    /// See: `StoreLike::update_with_whole_file()` for details.
+    /// See: [`StoreLike::update_with_whole_file`] for details.
     async fn update_with_whole_file(
         self: Pin<&Self>,
         key: StoreKey<'_>,
@@ -544,7 +598,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(Some(file))
     }
 
-    /// See: `StoreLike::update_oneshot()` for details.
+    /// See: [`StoreLike::update_oneshot`] for details.
     async fn update_oneshot(self: Pin<&Self>, key: StoreKey<'_>, data: Bytes) -> Result<(), Error> {
         // TODO(blaise.bruer) This is extremely inefficient, since we have exactly
         // what we need here. Maybe we could instead make a version of the stream
@@ -570,7 +624,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(())
     }
 
-    /// See: `StoreLike::get_part()` for details.
+    /// See: [`StoreLike::get_part`] for details.
     async fn get_part(
         self: Pin<&Self>,
         key: StoreKey<'_>,
@@ -579,7 +633,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         length: Option<usize>,
     ) -> Result<(), Error>;
 
-    /// See: `StoreLike::get()` for details.
+    /// See: [`StoreLike::get`] for details.
     #[inline]
     async fn get(
         self: Pin<&Self>,
@@ -589,7 +643,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         self.get_part(key, &mut writer, 0, None).await
     }
 
-    /// See: `StoreLike::get_part_unchunked()` for details.
+    /// See: [`StoreLike::get_part_unchunked`] for details.
     async fn get_part_unchunked(
         self: Pin<&Self>,
         key: StoreKey<'_>,
@@ -612,7 +666,12 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
             .merge(data_res.err_tip(|| "Failed to read stream to completion in get_part_unchunked"))
     }
 
-    /// See: `StoreLike::check_health()` for details.
+    /// See: [`Store::subscribe`] for details.
+    async fn subscribe(self: Arc<Self>, key: StoreKey<'_>) -> Box<dyn StoreSubscription> {
+        default_store_key_subscribe(self, key).await
+    }
+
+    /// See: [`StoreLike::check_health`] for details.
     async fn check_health(self: Pin<&Self>, namespace: Cow<'static, str>) -> HealthStatus {
         let digest_data_size = default_digest_size_health_check();
         let mut digest_data = vec![0u8; digest_data_size];
@@ -693,7 +752,7 @@ pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         HealthStatus::new_ok(self.get_ref(), "Successfully store health check".into())
     }
 
-    /// See: `StoreLike::inner_store()` for details.
+    /// See: [`Store::inner_store`] for details.
     fn inner_store(&self, _digest: Option<StoreKey<'_>>) -> &dyn StoreDriver;
 
     /// Returns an Any variation of whatever Self is.

--- a/nativelink-util/tests/default_store_key_subscribe_test.rs
+++ b/nativelink-util/tests/default_store_key_subscribe_test.rs
@@ -1,0 +1,95 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::task::Poll;
+
+use futures::poll;
+use nativelink_error::Code;
+use nativelink_macro::nativelink_test;
+use nativelink_store::memory_store::MemoryStore;
+use nativelink_util::buf_channel::make_buf_channel_pair;
+use nativelink_util::default_store_key_subscribe::default_store_key_subscribe_with_time;
+use nativelink_util::store_trait::StoreLike;
+use pretty_assertions::assert_eq;
+use tokio::task::yield_now;
+
+#[nativelink_test]
+async fn subscribe_get_key_test() -> Result<(), Box<dyn std::error::Error>> {
+    const KEY: &str = "foo";
+    let store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    store.update_oneshot(KEY, "bar".into()).await?;
+    let subscribe_receiver =
+        default_store_key_subscribe_with_time(store, KEY.into(), yield_now).await;
+    let subscription_item = subscribe_receiver.peek().unwrap();
+    assert_eq!(subscription_item.get_key().await, Ok(KEY.into()));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn subscribe_get_new_versions_test() -> Result<(), Box<dyn std::error::Error>> {
+    const KEY: &str = "foo";
+    const DATA1: &str = "bar";
+    const DATA2: &str = "baz";
+    let store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    store.update_oneshot(KEY, DATA1.into()).await?;
+    let mut subscribe_receiver =
+        default_store_key_subscribe_with_time(store.clone(), KEY.into(), yield_now).await;
+    {
+        // Test DATA1 ("bar") version.
+        let subscription_item = subscribe_receiver.peek().unwrap();
+        let (mut tx, mut rx) = make_buf_channel_pair();
+        let read_fut = subscription_item.get(&mut tx);
+        {
+            assert_eq!(poll!(read_fut), Poll::Ready(Ok(())));
+            assert_eq!(rx.recv().await, Ok(DATA1.into()));
+        }
+    }
+    {
+        // Change the data version.
+        let change_fut = subscribe_receiver.changed();
+        tokio::pin!(change_fut);
+        assert!(poll!(&mut change_fut).is_pending()); // Value should not have changed yet.
+        store.update_oneshot(KEY, DATA2.into()).await?;
+        change_fut.await.unwrap(); // Wait for the change (happens in another thread).
+    }
+    {
+        // Test DATA2 ("baz") version.
+        let subscription_item = subscribe_receiver.peek().unwrap();
+        let (mut tx, mut rx) = make_buf_channel_pair();
+        let read_fut = subscription_item.get(&mut tx);
+        {
+            assert_eq!(poll!(read_fut), Poll::Ready(Ok(())));
+            assert_eq!(rx.recv().await, Ok(DATA2.into()));
+        }
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn subscribe_not_found_key_test() -> Result<(), Box<dyn std::error::Error>> {
+    let store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let data = default_store_key_subscribe_with_time(store, "foo".into(), yield_now).await;
+    {
+        let subscription_err = data.peek().err().unwrap();
+        assert_eq!(subscription_err.code, Code::NotFound);
+    }
+    Ok(())
+}


### PR DESCRIPTION
This adds the basic subscribe to the Store API that allows users to subscribe to individual keys and listen for when they change. The default store subscribe implementation will poll every 10 seconds for changes. Future PRs will be landed to specialize specific stores to make it optimized for stores that support a more optimized way to subscribe (like redis or memory).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/924)
<!-- Reviewable:end -->
