### PR TITLE
Include UUID in ActionState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "tonic 0.11.0",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3481,6 +3482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
         DEBIAN_FRONTEND=noninteractive \
         apt-get install --no-install-recommends -y \
             npm=8.5.1~ds-1 \
-            git=1:2.34.1-1ubuntu1.10 \
+            git=1:2.34.1-1ubuntu1.11 \
             gcc=4:11.2.0-1ubuntu1 \
             g++=4:11.2.0-1ubuntu1 \
             python3=3.10.6-1~22.04 \
@@ -38,7 +38,7 @@ RUN apt-get update \
         DEBIAN_FRONTEND=noninteractive \
         apt-get install --no-install-recommends -y \
             npm=6.14.4+ds-1ubuntu2 \
-            git=1:2.25.1-1ubuntu3.11 \
+            git=1:2.25.1-1ubuntu3.12 \
             gcc=4:9.3.0-1ubuntu2 \
             g++=4:9.3.0-1ubuntu2 \
             python3=3.8.2-0ubuntu2 \

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -28,6 +28,7 @@ use nativelink_config::schedulers::WorkerAllocationStrategy;
 use nativelink_error::{error_if, make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ExecutionMetadata,
+    OperationId,
 };
 use nativelink_util::metrics_utils::{
     AsyncCounterWrapper, Collector, CollectorState, CounterWithTime, FuncCounterWrapper,
@@ -182,22 +183,29 @@ struct CompletedAction {
 
 impl Hash for CompletedAction {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ActionInfoHashKey::hash(&self.state.unique_qualifier, state);
+        OperationId::hash(&self.state.id, state);
     }
 }
 
 impl PartialEq for CompletedAction {
     fn eq(&self, other: &Self) -> bool {
-        ActionInfoHashKey::eq(&self.state.unique_qualifier, &other.state.unique_qualifier)
+        OperationId::eq(&self.state.id, &other.state.id)
     }
 }
 
 impl Eq for CompletedAction {}
 
+impl Borrow<OperationId> for CompletedAction {
+    #[inline]
+    fn borrow(&self) -> &OperationId {
+        &self.state.id
+    }
+}
+
 impl Borrow<ActionInfoHashKey> for CompletedAction {
     #[inline]
     fn borrow(&self) -> &ActionInfoHashKey {
-        &self.state.unique_qualifier
+        &self.state.id.unique_qualifier
     }
 }
 
@@ -291,9 +299,10 @@ impl SimpleSchedulerImpl {
         self.metrics.add_action_new_action_created.inc();
         // Action needs to be added to queue or is not cacheable.
         let action_info = Arc::new(action_info);
+        let id = OperationId::new(action_info.unique_qualifier.clone());
 
         let current_state = Arc::new(ActionState {
-            unique_qualifier: action_info.unique_qualifier.clone(),
+            id,
             stage: ActionStage::Queued,
         });
 

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -23,6 +23,7 @@ use nativelink_proto::google::longrunning::{operation, Operation};
 use nativelink_proto::google::rpc::Status;
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ExecutionMetadata,
+    OperationId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -44,13 +45,15 @@ mod action_messages_tests {
 
     #[nativelink_test]
     async fn action_state_any_url_test() -> Result<(), Error> {
+        let unique_qualifier = ActionInfoHashKey {
+            instance_name: "foo_instance".to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::new([1u8; 32], 5),
+            salt: 0,
+        };
+        let id = OperationId::new(unique_qualifier);
         let action_state = ActionState {
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: "foo_instance".to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: DigestInfo::new([1u8; 32], 5),
-                salt: 0,
-            },
+            id,
             // Result is only populated if has_action_result.
             stage: ActionStage::Completed(ActionResult::default()),
         };

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -30,7 +30,9 @@ use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::cache_lookup_scheduler::CacheLookupScheduler;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_store::memory_store::MemoryStore;
-use nativelink_util::action_messages::{ActionInfoHashKey, ActionResult, ActionStage, ActionState};
+use nativelink_util::action_messages::{
+    ActionInfoHashKey, ActionResult, ActionStage, ActionState, OperationId,
+};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::Store;
@@ -97,7 +99,7 @@ mod cache_lookup_scheduler_tests {
             .await?;
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let mut skip_cache_action = action_info.clone();

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -28,7 +28,7 @@ use nativelink_macro::nativelink_test;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
-use nativelink_util::action_messages::{ActionInfoHashKey, ActionStage, ActionState};
+use nativelink_util::action_messages::{ActionInfoHashKey, ActionStage, ActionState, OperationId};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::platform_properties::PlatformPropertyValue;
 use tokio::sync::watch;
@@ -74,7 +74,7 @@ mod property_modifier_scheduler_tests {
         let action_info = make_base_action_info(UNIX_EPOCH);
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
@@ -114,7 +114,7 @@ mod property_modifier_scheduler_tests {
             .insert(name.clone(), PlatformPropertyValue::Unknown(original_value));
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
@@ -151,7 +151,7 @@ mod property_modifier_scheduler_tests {
         let action_info = make_base_action_info(UNIX_EPOCH);
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
@@ -188,7 +188,7 @@ mod property_modifier_scheduler_tests {
         let action_info = make_base_action_info(UNIX_EPOCH);
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
@@ -223,7 +223,7 @@ mod property_modifier_scheduler_tests {
             .insert(name, PlatformPropertyValue::Unknown(value));
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =
             watch::channel(Arc::new(ActionState {
-                unique_qualifier: action_info.unique_qualifier.clone(),
+                id: OperationId::new(action_info.unique_qualifier.clone()),
                 stage: ActionStage::Queued,
             }));
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -59,6 +59,7 @@ rust_library(
         "@crates//:tonic",
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
+        "@crates//:uuid",
     ],
 )
 

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -31,6 +31,7 @@ tokio-util = { version = "0.7.11" }
 tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+uuid = { version = "1.8.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -14,7 +14,6 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -33,16 +32,118 @@ use nativelink_proto::google::rpc::Status;
 use prost::bytes::Bytes;
 use prost::Message;
 use prost_types::Any;
+use uuid::Uuid;
 
 use crate::common::{DigestInfo, HashMapExt, VecExt};
-use crate::digest_hasher::{default_digest_hasher_func, DigestHasherFunc, ACTIVE_HASHER_FUNC};
+use crate::digest_hasher::DigestHasherFunc;
 use crate::metrics_utils::{CollectorState, MetricsComponent};
-use crate::origin_context::ActiveOriginContext;
 use crate::platform_properties::PlatformProperties;
 
 /// Default priority remote execution jobs will get when not provided.
 pub const DEFAULT_EXECUTION_PRIORITY: i32 = 0;
 
+pub type WorkerTimestamp = u64;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct OperationId {
+    pub unique_qualifier: ActionInfoHashKey,
+    pub id: Uuid,
+}
+
+// TODO: Eventually we should make this it's own hash rather than delegate to ActionInfoHashKey.
+impl Hash for OperationId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        ActionInfoHashKey::hash(&self.unique_qualifier, state)
+    }
+}
+
+impl OperationId {
+    pub fn new(unique_qualifier: ActionInfoHashKey) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            unique_qualifier,
+        }
+    }
+
+    /// Utility function used to make a unique hash of the digest including the salt.
+    pub fn get_hash(&self) -> [u8; 32] {
+        self.unique_qualifier.get_hash()
+    }
+
+    /// Returns the salt used for cache busting/hashing.
+    #[inline]
+    pub fn action_name(&self) -> String {
+        self.unique_qualifier.action_name()
+    }
+}
+
+impl TryFrom<&str> for OperationId {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Error> {
+        let (unique_qualifier, id) = value
+            .split_once(':')
+            .err_tip(|| "Invalid Id string - {value}")?;
+        Ok(Self {
+            unique_qualifier: ActionInfoHashKey::try_from(unique_qualifier)?,
+            id: Uuid::parse_str(id).map_err(|e| make_input_err!("Failed to parse {e} as uuid"))?,
+        })
+    }
+}
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "{}:{}",
+            self.unique_qualifier.action_name(),
+            self.id
+        ))
+    }
+}
+
+impl std::fmt::Debug for OperationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "{}:{}",
+            self.unique_qualifier.action_name(),
+            self.id
+        ))
+    }
+}
+
+/// Unique id of worker.
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+pub struct WorkerId(pub Uuid);
+
+impl std::fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut buf = Uuid::encode_buffer();
+        let worker_id_str = self.0.hyphenated().encode_lower(&mut buf);
+        f.write_fmt(format_args!("{worker_id_str}"))
+    }
+}
+
+impl std::fmt::Debug for WorkerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut buf = Uuid::encode_buffer();
+        let worker_id_str = self.0.hyphenated().encode_lower(&mut buf);
+        f.write_fmt(format_args!("{worker_id_str}"))
+    }
+}
+
+impl TryFrom<String> for WorkerId {
+    type Error = Error;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match Uuid::parse_str(&s) {
+            Err(e) => Err(make_input_err!(
+                "Failed to convert string to WorkerId : {} : {:?}",
+                s,
+                e
+            )),
+            Ok(my_uuid) => Ok(WorkerId(my_uuid)),
+        }
+    }
+}
 /// This is a utility struct used to make it easier to match `ActionInfos` in a
 /// `HashMap` without needing to construct an entire `ActionInfo`.
 /// Since the hashing only needs the digest and salt we can just alias them here
@@ -974,12 +1075,6 @@ impl TryFrom<Operation> for ActionState {
         )
         .err_tip(|| "Could not decode metadata in upstream operation")?;
 
-        let action_digest = metadata
-            .action_digest
-            .err_tip(|| "No action digest in upstream operation metadata")?
-            .try_into()
-            .err_tip(|| "Could not convert Digest to DigestInfo")?;
-
         let stage = match execution_stage::Value::try_from(metadata.stage).err_tip(|| {
             format!(
                 "Could not convert {} to execution_stage::Value",
@@ -1011,28 +1106,11 @@ impl TryFrom<Operation> for ActionState {
             }
         };
 
-        let unique_qualifier = if let Ok(v) = operation.name.as_str().try_into() {
-            v
-        } else {
-            // This branch might happen in a case where we are forwarding an operation from
-            // one remote execution system to another that does not use our operation name
-            // format (ie: very unlikely, but possible).
-            let mut hasher = DefaultHasher::new();
-            operation.name.hash(&mut hasher);
-            ActionInfoHashKey {
-                instance_name: "UNKNOWN_INSTANCE_NAME_INOPERATION_CONVERSION".to_string(),
-                digest_function: ActiveOriginContext::get_value(&ACTIVE_HASHER_FUNC)
-                    .err_tip(|| "In TryFrom<Operation> for ActionState")?
-                    .map_or_else(default_digest_hasher_func, |v| *v),
-                digest: action_digest,
-                salt: hasher.finish(),
-            }
-        };
-
-        Ok(Self {
-            unique_qualifier,
-            stage,
-        })
+        // NOTE: This will error if we are forwarding an operation from
+        // one remote execution system to another that does not use our operation name
+        // format (ie: very unlikely, but possible).
+        let id = OperationId::try_from(operation.name.as_str())?;
+        Ok(Self { id, stage })
     }
 }
 
@@ -1041,13 +1119,17 @@ impl TryFrom<Operation> for ActionState {
 #[derive(PartialEq, Debug, Clone)]
 pub struct ActionState {
     pub stage: ActionStage,
-    pub unique_qualifier: ActionInfoHashKey,
+    pub id: OperationId,
 }
 
 impl ActionState {
     #[inline]
+    pub fn unique_qualifier(&self) -> &ActionInfoHashKey {
+        &self.id.unique_qualifier
+    }
+    #[inline]
     pub fn action_digest(&self) -> &DigestInfo {
-        &self.unique_qualifier.digest
+        &self.id.unique_qualifier.digest
     }
 }
 
@@ -1060,6 +1142,7 @@ impl MetricsComponent for ActionState {
 impl From<ActionState> for Operation {
     fn from(val: ActionState) -> Self {
         let stage = Into::<execution_stage::Value>::into(&val.stage) as i32;
+        let name = val.id.to_string();
 
         let result = if val.stage.has_action_result() {
             let execute_response: ExecuteResponse = val.stage.into();
@@ -1067,10 +1150,11 @@ impl From<ActionState> for Operation {
         } else {
             None
         };
+        let digest = Some(val.id.unique_qualifier.digest.into());
 
         let metadata = ExecuteOperationMetadata {
             stage,
-            action_digest: Some((&val.unique_qualifier.digest).into()),
+            action_digest: digest,
             // TODO(blaise.bruer) We should support stderr/stdout streaming.
             stdout_stream_name: String::default(),
             stderr_stream_name: String::default(),
@@ -1078,7 +1162,7 @@ impl From<ActionState> for Operation {
         };
 
         Self {
-            name: val.unique_qualifier.action_name(),
+            name,
             metadata: Some(to_any(&metadata)),
             done: result.is_some(),
             result,


### PR DESCRIPTION
# Description

Changes the field used for identifying which action an ActionState corresponds to include a uuid as well as the ActionInfoHashKey. All existing functionality is kept the same by making use of the nested ActionInfoHashKey contained within the Id. These changes will provide the basis for all usage of Id in followup changes to the scheduler.  This breaks compatibility for forwarding an operation from one remote execution system to another that does not use our operation name format (ie: very unlikely, but possible).


Please delete options that aren't relevant.
- [x] Refactor
- [x] Breaking Change 
## How Has This Been Tested?

All existing tests have been modified to remain functionally equivalent.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/927)
<!-- Reviewable:end -->
