### PR TITLE
Refactor Store Api into client side and driver side

### DIFF
--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -30,7 +29,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::background_spawn;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::{Store, StoreLike};
 use parking_lot::{Mutex, MutexGuard};
 use scopeguard::guard;
 use tokio::select;
@@ -50,7 +49,7 @@ type CheckActions = HashMap<ActionInfoHashKey, Arc<watch::Sender<Arc<ActionState
 pub struct CacheLookupScheduler {
     /// A reference to the AC to find existing actions in.
     /// To prevent unintended issues, this store should probably be a CompletenessCheckingStore.
-    ac_store: Arc<dyn Store>,
+    ac_store: Store,
     /// The "real" scheduler to use to perform actions if they were not found
     /// in the action cache.
     action_scheduler: Arc<dyn ActionScheduler>,
@@ -59,14 +58,13 @@ pub struct CacheLookupScheduler {
 }
 
 async fn get_action_from_store(
-    ac_store: Pin<&dyn Store>,
+    ac_store: &Store,
     action_digest: DigestInfo,
     instance_name: String,
     digest_function: DigestHasherFunc,
 ) -> Option<ProtoActionResult> {
     // If we are a GrpcStore we shortcut here, as this is a special store.
-    let any_store = ac_store.inner_store(Some(action_digest)).as_any();
-    if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
+    if let Some(grpc_store) = ac_store.downcast_ref::<GrpcStore>(Some(action_digest)) {
         let action_result_request = GetActionResultRequest {
             instance_name,
             action_digest: Some(action_digest.into()),
@@ -103,10 +101,7 @@ fn subscribe_to_existing_action(
 }
 
 impl CacheLookupScheduler {
-    pub fn new(
-        ac_store: Arc<dyn Store>,
-        action_scheduler: Arc<dyn ActionScheduler>,
-    ) -> Result<Self, Error> {
+    pub fn new(ac_store: Store, action_scheduler: Arc<dyn ActionScheduler>) -> Result<Self, Error> {
         Ok(Self {
             ac_store,
             action_scheduler,
@@ -170,17 +165,14 @@ impl ActionScheduler for CacheLookupScheduler {
             let action_digest = current_state.action_digest();
             let instance_name = action_info.instance_name().clone();
             if let Some(action_result) = get_action_from_store(
-                Pin::new(ac_store.as_ref()),
+                &ac_store,
                 *action_digest,
                 instance_name,
                 current_state.id.unique_qualifier.digest_function,
             )
             .await
             {
-                match Pin::new(ac_store.clone().as_ref())
-                    .has(*action_digest)
-                    .await
-                {
+                match ac_store.has(*action_digest).await {
                     Ok(Some(_)) => {
                         Arc::make_mut(&mut current_state).stage =
                             ActionStage::CompletedFromCache(action_result);

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
@@ -35,7 +34,7 @@ use nativelink_util::action_messages::{
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::{Store, StoreLike};
 use prost::Message;
 use tokio::sync::watch;
 use tokio::{self};
@@ -44,15 +43,15 @@ use utils::scheduler_utils::{make_base_action_info, INSTANCE_NAME};
 
 struct TestContext {
     mock_scheduler: Arc<MockActionScheduler>,
-    ac_store: Arc<dyn Store>,
+    ac_store: Store,
     cache_scheduler: CacheLookupScheduler,
 }
 
 fn make_cache_scheduler() -> Result<TestContext, Error> {
     let mock_scheduler = Arc::new(MockActionScheduler::new());
-    let ac_store = Arc::new(MemoryStore::new(
+    let ac_store = Store::new(Arc::new(MemoryStore::new(
         &nativelink_config::stores::MemoryStore::default(),
-    ));
+    )));
     let cache_scheduler = CacheLookupScheduler::new(ac_store.clone(), mock_scheduler.clone())?;
     Ok(TestContext {
         mock_scheduler,
@@ -93,8 +92,8 @@ mod cache_lookup_scheduler_tests {
         let context = make_cache_scheduler()?;
         let action_info = make_base_action_info(UNIX_EPOCH);
         let action_result = ProtoActionResult::from(ActionResult::default());
-        let store_pin = Pin::new(context.ac_store.as_ref());
-        store_pin
+        context
+            .ac_store
             .update_oneshot(*action_info.digest(), action_result.encode_to_vec().into())
             .await?;
         let (_forward_watch_channel_tx, forward_watch_channel_rx) =

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::poll;
@@ -27,6 +26,7 @@ use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::common::{encode_stream_proto, DigestInfo};
 use nativelink_util::spawn;
+use nativelink_util::store_trait::StoreLike;
 use nativelink_util::task::JoinHandleDropGuard;
 use prometheus_client::registry::Registry;
 use tokio::task::yield_now;
@@ -86,9 +86,7 @@ pub mod write_tests {
     pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         // Setup stream.
         let (mut tx, join_handle) = {
@@ -181,9 +179,7 @@ pub mod write_tests {
     pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         async fn setup_stream(
             bs_server: ByteStreamServer,
@@ -277,9 +273,7 @@ pub mod write_tests {
     pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         async fn setup_stream(
             bs_server: ByteStreamServer,
@@ -379,9 +373,7 @@ pub mod write_tests {
     pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         async fn setup_stream(
             bs_server: ByteStreamServer,
@@ -485,9 +477,7 @@ pub mod write_tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         // Setup stream.
         let (mut tx, mut write_fut) = {
@@ -658,8 +648,7 @@ pub mod write_tests {
     pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         async fn setup_stream(
             bs_server: ByteStreamServer,
@@ -854,9 +843,7 @@ pub mod read_tests {
     {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         const VALUE1: &str = "12456789abcdefghijk";
 
@@ -890,9 +877,7 @@ pub mod read_tests {
     pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn std::error::Error>> {
         let store_manager = make_store_manager().await?;
         let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store_owned = store_manager.get_store("main_cas").unwrap();
-
-        let store = Pin::new(store_owned.as_ref());
+        let store = store_manager.get_store("main_cas").unwrap();
 
         const DATA_SIZE: usize = 10_000_000;
         let mut raw_data = vec![41u8; DATA_SIZE];

--- a/nativelink-store/src/ac_utils.rs
+++ b/nativelink-store/src/ac_utils.rs
@@ -24,7 +24,7 @@ use futures::TryFutureExt;
 use nativelink_error::{Code, Error, ResultExt};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasher;
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::StoreLike;
 use prost::Message;
 
 // NOTE(blaise.bruer) From some local testing it looks like action cache items are rarely greater than
@@ -38,7 +38,7 @@ const MAX_ACTION_MSG_SIZE: usize = 10 << 20; // 10mb.
 
 /// Attempts to fetch the digest contents from a store into the associated proto.
 pub async fn get_and_decode_digest<T: Message + Default>(
-    store: Pin<&dyn Store>,
+    store: &impl StoreLike,
     digest: &DigestInfo,
 ) -> Result<T, Error> {
     get_size_and_decode_digest(store, digest)
@@ -47,8 +47,8 @@ pub async fn get_and_decode_digest<T: Message + Default>(
 }
 
 /// Attempts to fetch the digest contents from a store into the associated proto.
-pub async fn get_size_and_decode_digest<T: Message + Default>(
-    store: Pin<&dyn Store>,
+pub async fn get_size_and_decode_digest<'a, T: Message + Default>(
+    store: &impl StoreLike,
     digest: &DigestInfo,
 ) -> Result<(T, usize), Error> {
     let mut store_data_resp = store
@@ -91,7 +91,7 @@ pub fn message_to_digest(
 /// Takes a proto message and will serialize it and upload it to the provided store.
 pub async fn serialize_and_upload_message<'a, T: Message>(
     message: &'a T,
-    cas_store: Pin<&'a dyn Store>,
+    cas_store: Pin<&'a impl StoreLike>,
     hasher: &mut impl DigestHasher,
 ) -> Result<DigestInfo, Error> {
     let mut buffer = BytesMut::with_capacity(message.encoded_len());

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -29,7 +29,7 @@ use nativelink_util::health_utils::{default_health_status_indicator, HealthStatu
 use nativelink_util::metrics_utils::{
     Collector, CollectorState, CounterWithTime, MetricsComponent, Registry,
 };
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tracing::{event, Level};
@@ -62,7 +62,7 @@ fn get_digests_and_output_dirs(
 /// that need to be checked and pass them into `handle_digest_infos_fn`
 /// as they are found.
 async fn check_output_directories(
-    cas_store: Pin<&dyn Store>,
+    cas_store: &Store,
     output_directories: Vec<ProtoOutputDirectory>,
     handle_digest_infos_fn: &impl Fn(Vec<DigestInfo>),
 ) -> Result<(), Error> {
@@ -106,15 +106,15 @@ async fn check_output_directories(
 }
 
 pub struct CompletenessCheckingStore {
-    cas_store: Arc<dyn Store>,
-    ac_store: Arc<dyn Store>,
+    cas_store: Store,
+    ac_store: Store,
 
     incomplete_entries_counter: CounterWithTime,
     complete_entries_counter: CounterWithTime,
 }
 
 impl CompletenessCheckingStore {
-    pub fn new(ac_store: Arc<dyn Store>, cas_store: Arc<dyn Store>) -> Self {
+    pub fn new(ac_store: Store, cas_store: Store) -> Self {
         CompletenessCheckingStore {
             cas_store,
             ac_store,
@@ -132,8 +132,6 @@ impl CompletenessCheckingStore {
         action_result_digests: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error> {
-        let ac_store = Pin::new(self.ac_store.as_ref());
-        let cas_store = Pin::new(self.cas_store.as_ref());
         // Holds shared state between the different futures.
         // This is how get around lifetime issues.
         struct State<'a> {
@@ -164,7 +162,8 @@ impl CompletenessCheckingStore {
                 async move {
                     // Note: We don't err_tip here because often have NotFound here which is ok.
                     let (action_result, size) =
-                        get_size_and_decode_digest::<ProtoActionResult>(ac_store, digest).await?;
+                        get_size_and_decode_digest::<ProtoActionResult>(&self.ac_store, digest)
+                            .await?;
 
                     let (mut digest_infos, output_directories) =
                         get_digests_and_output_dirs(action_result)?;
@@ -197,15 +196,19 @@ impl CompletenessCheckingStore {
                         return Ok(());
                     }
 
-                    check_output_directories(cas_store, output_directories, &move |digest_infos| {
-                        let mut state = state_mux.lock();
-                        let rep_len = digest_infos.len();
-                        state.digests_to_check.extend(digest_infos);
-                        state
-                            .digests_to_check_idxs
-                            .extend(iter::repeat(i).take(rep_len));
-                        state.notify.notify_one();
-                    })
+                    check_output_directories(
+                        &self.cas_store,
+                        output_directories,
+                        &move |digest_infos| {
+                            let mut state = state_mux.lock();
+                            let rep_len = digest_infos.len();
+                            state.digests_to_check.extend(digest_infos);
+                            state
+                                .digests_to_check_idxs
+                                .extend(iter::repeat(i).take(rep_len));
+                            state.notify.notify_one();
+                        },
+                    )
                     .await?;
 
                     Result::<(), Error>::Ok(())
@@ -262,7 +265,7 @@ impl CompletenessCheckingStore {
                 // Recycle our results vector to avoid needless allocations.
                 has_results.clear();
                 has_results.resize(digests.len(), None);
-                cas_store
+                self.cas_store
                     .has_with_results(&digests, &mut has_results[..])
                     .await
                     .err_tip(|| {
@@ -331,7 +334,7 @@ impl CompletenessCheckingStore {
 }
 
 #[async_trait]
-impl Store for CompletenessCheckingStore {
+impl StoreDriver for CompletenessCheckingStore {
     async fn has_with_results(
         self: Pin<&Self>,
         action_result_digests: &[DigestInfo],
@@ -347,12 +350,10 @@ impl Store for CompletenessCheckingStore {
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
-        Pin::new(self.ac_store.as_ref())
-            .update(digest, reader, size_info)
-            .await
+        self.ac_store.update(digest, reader, size_info).await
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -362,23 +363,17 @@ impl Store for CompletenessCheckingStore {
         let results = &mut [None];
         self.inner_has_with_results(&[digest], results)
             .await
-            .err_tip(|| "when calling CompletenessCheckingStore::get_part_ref")?;
+            .err_tip(|| "when calling CompletenessCheckingStore::get_part")?;
         if results[0].is_none() {
             return Err(make_err!(
                 Code::NotFound,
-                "Digest found, but not all parts were found in CompletenessCheckingStore::get_part_ref"
+                "Digest found, but not all parts were found in CompletenessCheckingStore::get_part"
             ));
         }
-        Pin::new(self.ac_store.as_ref())
-            .get_part_ref(digest, writer, offset, length)
-            .await
+        self.ac_store.get_part(digest, writer, offset, length).await
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 
@@ -392,10 +387,8 @@ impl Store for CompletenessCheckingStore {
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         self.cas_store
-            .clone()
             .register_metrics(registry.sub_registry_with_prefix("cas_store"));
         self.ac_store
-            .clone()
             .register_metrics(registry.sub_registry_with_prefix("ac_store"));
         registry.register_collector(Box::new(Collector::new(&self)));
     }

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -31,7 +31,7 @@ use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::Registry;
 use nativelink_util::spawn;
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 use serde::{Deserialize, Serialize};
 
 use crate::cas_utils::is_zero_digest;
@@ -211,7 +211,7 @@ impl UploadState {
 /// result in the entire contents being read from the inner store but will
 /// only send the contents requested.
 pub struct CompressionStore {
-    inner_store: Arc<dyn Store>,
+    inner_store: Store,
     config: nativelink_config::stores::Lz4Config,
     bincode_options: BincodeOptions,
 }
@@ -219,7 +219,7 @@ pub struct CompressionStore {
 impl CompressionStore {
     pub fn new(
         compression_config: nativelink_config::stores::CompressionStore,
-        inner_store: Arc<dyn Store>,
+        inner_store: Store,
     ) -> Result<Self, Error> {
         let lz4_config = match compression_config.compression_algorithm {
             nativelink_config::stores::CompressionAlgorithm::lz4(mut lz4_config) => {
@@ -241,15 +241,13 @@ impl CompressionStore {
 }
 
 #[async_trait]
-impl Store for CompressionStore {
+impl StoreDriver for CompressionStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error> {
-        Pin::new(self.inner_store.as_ref())
-            .has_with_results(digests, results)
-            .await
+        self.inner_store.has_with_results(digests, results).await
     }
 
     async fn update(
@@ -264,7 +262,7 @@ impl Store for CompressionStore {
 
         let inner_store = self.inner_store.clone();
         let update_fut = spawn!("compression_store_update_spawn", async move {
-            Pin::new(inner_store.as_ref())
+            inner_store
                 .update(
                     digest,
                     rx,
@@ -388,7 +386,7 @@ impl Store for CompressionStore {
         write_result.merge(update_result)
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -398,7 +396,7 @@ impl Store for CompressionStore {
         if is_zero_digest(&digest) {
             writer
                 .send_eof()
-                .err_tip(|| "Failed to send zero EOF in filesystem store get_part_ref")?;
+                .err_tip(|| "Failed to send zero EOF in filesystem store get_part")?;
             return Ok(());
         }
 
@@ -407,7 +405,7 @@ impl Store for CompressionStore {
 
         let inner_store = self.inner_store.clone();
         let get_part_fut = spawn!("compression_store_get_part_spawn", async move {
-            Pin::new(inner_store.as_ref())
+            inner_store
                 .get_part(digest, tx, 0, None)
                 .await
                 .err_tip(|| "Inner store get in compression store failed")
@@ -613,11 +611,7 @@ impl Store for CompressionStore {
         Ok(())
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 
@@ -631,9 +625,7 @@ impl Store for CompressionStore {
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         let inner_store_registry = registry.sub_registry_with_prefix("inner_store");
-        self.inner_store
-            .clone()
-            .register_metrics(inner_store_registry);
+        self.inner_store.register_metrics(inner_store_registry);
     }
 }
 

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -25,7 +25,7 @@ use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::fastcdc::FastCDC;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::FramedRead;
 use tokio_util::io::StreamReader;
@@ -44,8 +44,8 @@ pub struct DedupIndex {
 }
 
 pub struct DedupStore {
-    index_store: Arc<dyn Store>,
-    content_store: Arc<dyn Store>,
+    index_store: Store,
+    content_store: Store,
     fast_cdc_decoder: FastCDC,
     max_concurrent_fetch_per_get: usize,
     bincode_options: WithOtherIntEncoding<DefaultOptions, FixintEncoding>,
@@ -54,8 +54,8 @@ pub struct DedupStore {
 impl DedupStore {
     pub fn new(
         config: &nativelink_config::stores::DedupStore,
-        index_store: Arc<dyn Store>,
-        content_store: Arc<dyn Store>,
+        index_store: Store,
+        content_store: Store,
     ) -> Self {
         let min_size = if config.min_size == 0 {
             DEFAULT_MIN_SIZE
@@ -86,16 +86,12 @@ impl DedupStore {
         }
     }
 
-    fn pin_index_store(&self) -> Pin<&dyn Store> {
-        Pin::new(self.index_store.as_ref())
-    }
-
     async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
         // First we need to load the index that contains where the individual parts actually
         // can be fetched from.
         let index_entries = {
             let maybe_data = self
-                .pin_index_store()
+                .index_store
                 .get_part_unchunked(digest, 0, None)
                 .await
                 .err_tip(|| "Failed to read index store in dedup store");
@@ -130,10 +126,7 @@ impl DedupStore {
             .map(|index_entry| DigestInfo::new(index_entry.packed_hash, index_entry.size_bytes))
             .collect();
         let mut sum = 0;
-        for size in Pin::new(self.content_store.as_ref())
-            .has_many(&digests)
-            .await?
-        {
+        for size in self.content_store.has_many(&digests).await? {
             let Some(size) = size else {
                 // A part is missing so return None meaning not-found.
                 // This will abort all in-flight queries related to this request.
@@ -146,7 +139,7 @@ impl DedupStore {
 }
 
 #[async_trait]
-impl Store for DedupStore {
+impl StoreDriver for DedupStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
@@ -178,13 +171,13 @@ impl Store for DedupStore {
     ) -> Result<(), Error> {
         let mut bytes_reader = StreamReader::new(reader);
         let frame_reader = FramedRead::new(&mut bytes_reader, self.fast_cdc_decoder.clone());
-        let content_store_pin = Pin::new(self.content_store.as_ref());
         let index_entries = frame_reader
             .map(|r| r.err_tip(|| "Failed to decode frame from fast_cdc"))
             .map_ok(|frame| async move {
                 let hash = blake3::hash(&frame[..]).into();
                 let index_entry = DigestInfo::new(hash, frame.len() as i64);
-                if content_store_pin
+                if self
+                    .content_store
                     .has(index_entry)
                     .await
                     .err_tip(|| "Failed to call .has() in DedupStore::update()")?
@@ -193,7 +186,7 @@ impl Store for DedupStore {
                     // If our store has this digest, we don't need to upload it.
                     return Result::<_, Error>::Ok(index_entry);
                 }
-                content_store_pin
+                self.content_store
                     .update_oneshot(index_entry, frame)
                     .await
                     .err_tip(|| "Failed to update content store in dedup_store")?;
@@ -216,7 +209,7 @@ impl Store for DedupStore {
                 )
             })?;
 
-        self.pin_index_store()
+        self.index_store
             .update_oneshot(digest, serialized_index.into())
             .await
             .err_tip(|| "Failed to insert our index entry to index_store in dedup_store")?;
@@ -224,7 +217,7 @@ impl Store for DedupStore {
         Ok(())
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -242,7 +235,7 @@ impl Store for DedupStore {
         // can be fetched from.
         let index_entries = {
             let data = self
-                .pin_index_store()
+                .index_store
                 .get_part_unchunked(digest, 0, None)
                 .await
                 .err_tip(|| "Failed to read index store in dedup store")?;
@@ -296,17 +289,14 @@ impl Store for DedupStore {
         // Note: We will buffer our data here up to:
         // `config.max_size * config.max_concurrent_fetch_per_get` per `get_part()` request.
         let mut entries_stream = stream::iter(entries)
-            .map(move |index_entry| {
-                let content_store = self.content_store.clone();
+            .map(move |index_entry| async move {
+                let data = self
+                    .content_store
+                    .get_part_unchunked(index_entry, 0, None)
+                    .await
+                    .err_tip(|| "Failed to get_part in content_store in dedup_store")?;
 
-                async move {
-                    let data = Pin::new(content_store.as_ref())
-                        .get_part_unchunked(index_entry, 0, None)
-                        .await
-                        .err_tip(|| "Failed to get_part in content_store in dedup_store")?;
-
-                    Result::<_, Error>::Ok(data)
-                }
+                Result::<_, Error>::Ok(data)
             })
             .buffered(self.max_concurrent_fetch_per_get);
 
@@ -343,11 +333,7 @@ impl Store for DedupStore {
         Ok(())
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::BorrowMut;
 use std::cmp::{max, min};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use futures::{join, FutureExt};
@@ -29,7 +30,7 @@ use nativelink_util::fs;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::{CollectorState, MetricsComponent, Registry};
 use nativelink_util::store_trait::{
-    slow_update_store_with_file, Store, StoreOptimizations, UploadSizeInfo,
+    slow_update_store_with_file, Store, StoreDriver, StoreLike, StoreOptimizations, UploadSizeInfo,
 };
 
 // TODO(blaise.bruer) This store needs to be evaluated for more efficient memory usage,
@@ -40,40 +41,45 @@ use nativelink_util::store_trait::{
 // "BufferedStore" that could be placed on the "slow" store that would hang up early
 // if data is in the buffer.
 pub struct FastSlowStore {
-    fast_store: Arc<dyn Store>,
-    slow_store: Arc<dyn Store>,
-
+    fast_store: Store,
+    slow_store: Store,
+    weak_self: Weak<Self>,
     metrics: FastSlowStoreMetrics,
 }
 
 impl FastSlowStore {
     pub fn new(
         _config: &nativelink_config::stores::FastSlowStore,
-        fast_store: Arc<dyn Store>,
-        slow_store: Arc<dyn Store>,
-    ) -> Self {
-        Self {
+        fast_store: Store,
+        slow_store: Store,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
             fast_store,
             slow_store,
+            weak_self: weak_self.clone(),
             metrics: FastSlowStoreMetrics::default(),
-        }
+        })
     }
 
-    pub fn fast_store(&self) -> &Arc<dyn Store> {
+    pub fn fast_store(&self) -> &Store {
         &self.fast_store
     }
 
-    pub fn slow_store(&self) -> &Arc<dyn Store> {
+    pub fn slow_store(&self) -> &Store {
         &self.slow_store
+    }
+
+    pub fn get_arc(&self) -> Option<Arc<Self>> {
+        self.weak_self.upgrade()
     }
 
     /// Ensure our fast store is populated. This should be kept as a low
     /// cost function. Since the data itself is shared and not copied it should be fairly
     /// low cost to just discard the data, but does cost a few mutex locks while
     /// streaming.
-    pub async fn populate_fast_store(self: Pin<&Self>, digest: DigestInfo) -> Result<(), Error> {
+    pub async fn populate_fast_store(&self, digest: DigestInfo) -> Result<(), Error> {
         let maybe_size_info = self
-            .pin_fast_store()
+            .fast_store
             .has(digest)
             .await
             .err_tip(|| "While querying in populate_fast_store")?;
@@ -88,16 +94,8 @@ impl FastSlowStore {
             while !rx.recv().await?.is_empty() {}
             Ok(())
         };
-        let (drain_res, get_res) = join!(drain_fut, self.get(digest, tx));
+        let (drain_res, get_res) = join!(drain_fut, StoreDriver::get(Pin::new(self), digest, tx));
         get_res.err_tip(|| "Failed to populate()").merge(drain_res)
-    }
-
-    fn pin_fast_store(&self) -> Pin<&dyn Store> {
-        Pin::new(self.fast_store.as_ref())
-    }
-
-    fn pin_slow_store(&self) -> Pin<&dyn Store> {
-        Pin::new(self.slow_store.as_ref())
     }
 
     /// Returns the range of bytes that should be sent given a slice bounds
@@ -125,7 +123,7 @@ impl FastSlowStore {
 }
 
 #[async_trait]
-impl Store for FastSlowStore {
+impl StoreDriver for FastSlowStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
@@ -135,18 +133,13 @@ impl Store for FastSlowStore {
         // so only check the fast store in such case.
         let slow_store = self.slow_store.inner_store(None);
         if slow_store.optimized_for(StoreOptimizations::NoopDownloads) {
-            return self
-                .pin_fast_store()
-                .has_with_results(digests, results)
-                .await;
+            return self.fast_store.has_with_results(digests, results).await;
         }
         // Only check the slow store because if it's not there, then something
         // down stream might be unable to get it.  This should not affect
         // workers as they only use get() and a CAS can use an
         // ExistenceCacheStore to avoid the bottleneck.
-        self.pin_slow_store()
-            .has_with_results(digests, results)
-            .await
+        self.slow_store.has_with_results(digests, results).await
     }
 
     async fn update(
@@ -159,17 +152,11 @@ impl Store for FastSlowStore {
         // and just use the store that is not a noop store.
         let slow_store = self.slow_store.inner_store(Some(digest));
         if slow_store.optimized_for(StoreOptimizations::NoopUpdates) {
-            return self
-                .pin_fast_store()
-                .update(digest, reader, size_info)
-                .await;
+            return self.fast_store.update(digest, reader, size_info).await;
         }
         let fast_store = self.fast_store.inner_store(Some(digest));
         if fast_store.optimized_for(StoreOptimizations::NoopUpdates) {
-            return self
-                .pin_slow_store()
-                .update(digest, reader, size_info)
-                .await;
+            return self.slow_store.update(digest, reader, size_info).await;
         }
 
         let (mut fast_tx, fast_rx) = make_buf_channel_pair();
@@ -212,8 +199,8 @@ impl Store for FastSlowStore {
             }
         };
 
-        let fast_store_fut = self.pin_fast_store().update(digest, fast_rx, size_info);
-        let slow_store_fut = self.pin_slow_store().update(digest, slow_rx, size_info);
+        let fast_store_fut = self.fast_store.update(digest, fast_rx, size_info);
+        let slow_store_fut = self.slow_store.update(digest, slow_rx, size_info);
 
         let (data_stream_res, fast_res, slow_res) =
             join!(data_stream_fut, fast_store_fut, slow_store_fut);
@@ -235,26 +222,48 @@ impl Store for FastSlowStore {
         mut file: fs::ResumeableFileSlot,
         upload_size: UploadSizeInfo,
     ) -> Result<Option<fs::ResumeableFileSlot>, Error> {
-        let fast_store = self.fast_store.inner_store(Some(digest));
-        let slow_store = self.slow_store.inner_store(Some(digest));
-        if fast_store.optimized_for(StoreOptimizations::FileUpdates) {
-            if !slow_store.optimized_for(StoreOptimizations::NoopUpdates) {
-                slow_update_store_with_file(Pin::new(slow_store), digest, &mut file, upload_size)
-                    .await
-                    .err_tip(|| "In FastSlowStore::update_with_whole_file slow_store")?;
+        if self
+            .fast_store
+            .optimized_for(StoreOptimizations::FileUpdates)
+        {
+            if !self
+                .slow_store
+                .optimized_for(StoreOptimizations::NoopUpdates)
+            {
+                slow_update_store_with_file(
+                    self.slow_store.as_store_driver_pin(),
+                    digest,
+                    &mut file,
+                    upload_size,
+                )
+                .await
+                .err_tip(|| "In FastSlowStore::update_with_whole_file slow_store")?;
             }
-            return Pin::new(fast_store)
+            return self
+                .fast_store
                 .update_with_whole_file(digest, file, upload_size)
                 .await;
         }
 
-        if slow_store.optimized_for(StoreOptimizations::FileUpdates) {
-            if !fast_store.optimized_for(StoreOptimizations::NoopUpdates) {
-                slow_update_store_with_file(Pin::new(fast_store), digest, &mut file, upload_size)
-                    .await
-                    .err_tip(|| "In FastSlowStore::update_with_whole_file fast_store")?;
+        if self
+            .slow_store
+            .optimized_for(StoreOptimizations::FileUpdates)
+        {
+            if !self
+                .fast_store
+                .optimized_for(StoreOptimizations::NoopUpdates)
+            {
+                slow_update_store_with_file(
+                    self.fast_store.as_store_driver_pin(),
+                    digest,
+                    &mut file,
+                    upload_size,
+                )
+                .await
+                .err_tip(|| "In FastSlowStore::update_with_whole_file fast_store")?;
             }
-            return Pin::new(slow_store)
+            return self
+                .slow_store
                 .update_with_whole_file(digest, file, upload_size)
                 .await;
         }
@@ -265,7 +274,7 @@ impl Store for FastSlowStore {
         Ok(Some(file))
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -274,14 +283,12 @@ impl Store for FastSlowStore {
     ) -> Result<(), Error> {
         // TODO(blaise.bruer) Investigate if we should maybe ignore errors here instead of
         // forwarding the up.
-        let fast_store = self.pin_fast_store();
-        let slow_store = self.pin_slow_store();
-        if fast_store.has(digest).await?.is_some() {
+        if self.fast_store.has(digest).await?.is_some() {
             self.metrics
                 .fast_store_hit_count
                 .fetch_add(1, Ordering::Acquire);
-            fast_store
-                .get_part_ref(digest, writer, offset, length)
+            self.fast_store
+                .get_part(digest, writer.borrow_mut(), offset, length)
                 .await?;
             self.metrics
                 .fast_store_downloaded_bytes
@@ -289,7 +296,8 @@ impl Store for FastSlowStore {
             return Ok(());
         }
 
-        let sz = slow_store
+        let sz = self
+            .slow_store
             .has(digest)
             .await
             .err_tip(|| "Failed to run has() on slow store")?
@@ -343,8 +351,10 @@ impl Store for FastSlowStore {
             }
         };
 
-        let slow_store_fut = slow_store.get(digest, slow_tx);
-        let fast_store_fut = fast_store.update(digest, fast_rx, UploadSizeInfo::ExactSize(sz));
+        let slow_store_fut = self.slow_store.get(digest, slow_tx);
+        let fast_store_fut = self
+            .fast_store
+            .update(digest, fast_rx, UploadSizeInfo::ExactSize(sz));
 
         let (data_stream_res, slow_res, fast_res) =
             join!(data_stream_fut, slow_store_fut, fast_store_fut);
@@ -362,11 +372,7 @@ impl Store for FastSlowStore {
         }
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 
@@ -380,13 +386,9 @@ impl Store for FastSlowStore {
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         let fast_store_registry = registry.sub_registry_with_prefix("fast");
-        self.fast_store
-            .clone()
-            .register_metrics(fast_store_registry);
+        self.fast_store.register_metrics(fast_store_registry);
         let slow_store_registry = registry.sub_registry_with_prefix("slow");
-        self.slow_store
-            .clone()
-            .register_metrics(slow_store_registry);
+        self.slow_store.register_metrics(slow_store_registry);
     }
 }
 

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -45,7 +45,7 @@ use nativelink_util::proto_stream_utils::{
 };
 use nativelink_util::resource_info::ResourceInfo;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{StoreDriver, UploadSizeInfo};
 use nativelink_util::{default_health_status_indicator, tls_utils};
 use parking_lot::Mutex;
 use prost::Message;
@@ -501,7 +501,7 @@ impl GrpcStore {
 }
 
 #[async_trait]
-impl Store for GrpcStore {
+impl StoreDriver for GrpcStore {
     // NOTE: This function can only be safely used on CAS stores. AC stores may return a size that
     // is incorrect.
     async fn has_with_results(
@@ -640,7 +640,7 @@ impl Store for GrpcStore {
         Ok(())
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -735,11 +735,7 @@ impl Store for GrpcStore {
             .await
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -20,7 +20,7 @@ use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
-use nativelink_util::store_trait::{Store, StoreOptimizations, UploadSizeInfo};
+use nativelink_util::store_trait::{StoreDriver, StoreOptimizations, UploadSizeInfo};
 
 #[derive(Default)]
 pub struct NoopStore;
@@ -32,7 +32,7 @@ impl NoopStore {
 }
 
 #[async_trait]
-impl Store for NoopStore {
+impl StoreDriver for NoopStore {
     async fn has_with_results(
         self: Pin<&Self>,
         _digests: &[DigestInfo],
@@ -59,7 +59,7 @@ impl Store for NoopStore {
             || optimization == StoreOptimizations::NoopDownloads
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         _digest: DigestInfo,
         _writer: &mut DropCloserWriteHalf,
@@ -69,11 +69,7 @@ impl Store for NoopStore {
         Err(make_err!(Code::NotFound, "Not found in noop store"))
     }
 
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store {
-        self
-    }
-
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver {
         self
     }
 

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -21,13 +21,13 @@ use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 use tracing::{event, Level};
 
 use crate::store_manager::StoreManager;
 
 #[repr(C, align(8))]
-struct AlignedStoreCell(UnsafeCell<Option<Arc<dyn Store>>>);
+struct AlignedStoreCell(UnsafeCell<Option<Store>>);
 
 struct StoreReference {
     cell: AlignedStoreCell,
@@ -65,7 +65,7 @@ impl RefStore {
     // 2. It should only happen on platforms that are < 64 bit address space
     // 3. It is likely that the internals of how Option work protect us anyway.
     #[inline]
-    fn get_store(&self) -> Result<&Arc<dyn Store>, Error> {
+    fn get_store(&self) -> Result<&Store, Error> {
         let ref_store = self.ref_store.cell.0.get();
         unsafe {
             if let Some(ref store) = *ref_store {
@@ -87,7 +87,7 @@ impl RefStore {
             .err_tip(|| "Store manager is gone")?;
         if let Some(store) = store_manager.get_store(&self.ref_store_name) {
             unsafe {
-                *ref_store = Some(store.clone());
+                *ref_store = Some(store);
                 return Ok((*ref_store).as_ref().unwrap());
             }
         }
@@ -99,16 +99,13 @@ impl RefStore {
 }
 
 #[async_trait]
-impl Store for RefStore {
+impl StoreDriver for RefStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error> {
-        let store = self.get_store()?;
-        Pin::new(store.as_ref())
-            .has_with_results(digests, results)
-            .await
+        self.get_store()?.has_with_results(digests, results).await
     }
 
     async fn update(
@@ -117,43 +114,24 @@ impl Store for RefStore {
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
-        let store = self.get_store()?;
-        Pin::new(store.as_ref())
-            .update(digest, reader, size_info)
-            .await
+        self.get_store()?.update(digest, reader, size_info).await
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
         offset: usize,
         length: Option<usize>,
     ) -> Result<(), Error> {
-        let store = self.get_store()?;
-        Pin::new(store.as_ref())
-            .get_part_ref(digest, writer, offset, length)
+        self.get_store()?
+            .get_part(digest, writer, offset, length)
             .await
     }
 
-    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn Store {
+    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn StoreDriver {
         match self.get_store() {
             Ok(store) => store.inner_store(digest),
-            Err(err) => {
-                event!(
-                    Level::ERROR,
-                    ?digest,
-                    ?err,
-                    "Failed to get store for digest",
-                );
-                self
-            }
-        }
-    }
-
-    fn inner_store_arc(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
-        match self.get_store() {
-            Ok(store) => store.clone().inner_store_arc(digest),
             Err(err) => {
                 event!(
                     Level::ERROR,

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -23,18 +23,18 @@ use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::Registry;
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 
 pub struct ShardStore {
     // The weights will always be in ascending order a specific store is choosen based on the
     // the hash of the digest hash that is nearest-binary searched using the u32 as the index.
-    weights_and_stores: Vec<(u32, Arc<dyn Store>)>,
+    weights_and_stores: Vec<(u32, Store)>,
 }
 
 impl ShardStore {
     pub fn new(
         config: &nativelink_config::stores::ShardStore,
-        stores: Vec<Arc<dyn Store>>,
+        stores: Vec<Store>,
     ) -> Result<Self, Error> {
         error_if!(
             config.stores.len() != stores.len(),
@@ -107,14 +107,14 @@ impl ShardStore {
             .unwrap_or_else(|index| index)
     }
 
-    fn get_store(&self, digest: &DigestInfo) -> Pin<&dyn Store> {
+    fn get_store(&self, digest: &DigestInfo) -> &Store {
         let index = self.get_store_index(digest);
-        Pin::new(self.weights_and_stores[index].1.as_ref())
+        &self.weights_and_stores[index].1
     }
 }
 
 #[async_trait]
-impl Store for ShardStore {
+impl StoreDriver for ShardStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
@@ -123,7 +123,7 @@ impl Store for ShardStore {
         if digests.len() == 1 {
             // Hot path: It is very common to lookup only one digest.
             let store_idx = self.get_store_index(&digests[0]);
-            let store = Pin::new(self.weights_and_stores[store_idx].1.as_ref());
+            let store = &self.weights_and_stores[store_idx].1;
             return store
                 .has_with_results(digests, results)
                 .await
@@ -151,7 +151,7 @@ impl Store for ShardStore {
             .into_iter()
             .enumerate()
             .map(|(store_idx, (digest_idxs, digests))| async move {
-                let store = Pin::new(self.weights_and_stores[store_idx].1.as_ref());
+                let store = &self.weights_and_stores[store_idx].1;
                 let mut inner_results = vec![None; digests.len()];
                 store
                     .has_with_results(&digests, &mut inner_results)
@@ -183,7 +183,7 @@ impl Store for ShardStore {
             .err_tip(|| "In ShardStore::update()")
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -192,9 +192,17 @@ impl Store for ShardStore {
     ) -> Result<(), Error> {
         let store = self.get_store(&digest);
         store
-            .get_part_ref(digest, writer, offset, length)
+            .get_part(digest, writer, offset, length)
             .await
-            .err_tip(|| "In ShardStore::get_part_ref()")
+            .err_tip(|| "In ShardStore::get_part()")
+    }
+
+    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn StoreDriver {
+        let Some(digest) = digest else {
+            return self;
+        };
+        let index = self.get_store_index(&digest);
+        self.weights_and_stores[index].1.inner_store(Some(digest))
     }
 
     fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
@@ -203,25 +211,6 @@ impl Store for ShardStore {
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
         self
-    }
-
-    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn Store {
-        let Some(digest) = digest else {
-            return self;
-        };
-        let index = self.get_store_index(&digest);
-        self.weights_and_stores[index].1.inner_store(Some(digest))
-    }
-
-    fn inner_store_arc(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
-        let Some(digest) = digest else {
-            return self;
-        };
-        let index = self.get_store_index(&digest);
-        self.weights_and_stores[index]
-            .1
-            .clone()
-            .inner_store_arc(Some(digest))
     }
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -21,20 +21,20 @@ use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::metrics_utils::{Collector, CollectorState, MetricsComponent, Registry};
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreDriver, StoreLike, UploadSizeInfo};
 use tokio::join;
 
 pub struct SizePartitioningStore {
     partition_size: i64,
-    lower_store: Arc<dyn Store>,
-    upper_store: Arc<dyn Store>,
+    lower_store: Store,
+    upper_store: Store,
 }
 
 impl SizePartitioningStore {
     pub fn new(
         config: &nativelink_config::stores::SizePartitioningStore,
-        lower_store: Arc<dyn Store>,
-        upper_store: Arc<dyn Store>,
+        lower_store: Store,
+        upper_store: Store,
     ) -> Self {
         SizePartitioningStore {
             partition_size: config.size as i64,
@@ -45,7 +45,7 @@ impl SizePartitioningStore {
 }
 
 #[async_trait]
-impl Store for SizePartitioningStore {
+impl StoreDriver for SizePartitioningStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
@@ -56,8 +56,8 @@ impl Store for SizePartitioningStore {
             .cloned()
             .partition(|digest| digest.size_bytes < self.partition_size);
         let (lower_results, upper_results) = join!(
-            Pin::new(self.lower_store.as_ref()).has_many(&lower_digests),
-            Pin::new(self.upper_store.as_ref()).has_many(&upper_digests),
+            self.lower_store.has_many(&lower_digests),
+            self.upper_store.has_many(&upper_digests),
         );
         let mut lower_results = match lower_results {
             Ok(lower_results) => lower_results.into_iter(),
@@ -90,16 +90,12 @@ impl Store for SizePartitioningStore {
         size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
         if digest.size_bytes < self.partition_size {
-            return Pin::new(self.lower_store.as_ref())
-                .update(digest, reader, size_info)
-                .await;
+            return self.lower_store.update(digest, reader, size_info).await;
         }
-        Pin::new(self.upper_store.as_ref())
-            .update(digest, reader, size_info)
-            .await
+        self.upper_store.update(digest, reader, size_info).await
     }
 
-    async fn get_part_ref(
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -107,16 +103,17 @@ impl Store for SizePartitioningStore {
         length: Option<usize>,
     ) -> Result<(), Error> {
         if digest.size_bytes < self.partition_size {
-            return Pin::new(self.lower_store.as_ref())
-                .get_part_ref(digest, writer, offset, length)
+            return self
+                .lower_store
+                .get_part(digest, writer, offset, length)
                 .await;
         }
-        Pin::new(self.upper_store.as_ref())
-            .get_part_ref(digest, writer, offset, length)
+        self.upper_store
+            .get_part(digest, writer, offset, length)
             .await
     }
 
-    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn Store {
+    fn inner_store(&self, digest: Option<DigestInfo>) -> &'_ dyn StoreDriver {
         let Some(digest) = digest else {
             return self;
         };
@@ -124,16 +121,6 @@ impl Store for SizePartitioningStore {
             return self.lower_store.inner_store(Some(digest));
         }
         self.upper_store.inner_store(Some(digest))
-    }
-
-    fn inner_store_arc(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
-        let Some(digest) = digest else {
-            return self;
-        };
-        if digest.size_bytes < self.partition_size {
-            return self.lower_store.clone().inner_store_arc(Some(digest));
-        }
-        self.upper_store.clone().inner_store_arc(Some(digest))
     }
 
     fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
@@ -146,13 +133,9 @@ impl Store for SizePartitioningStore {
 
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         let lower_store_registry = registry.sub_registry_with_prefix("lower_store");
-        self.lower_store
-            .clone()
-            .register_metrics(lower_store_registry);
+        self.lower_store.register_metrics(lower_store_registry);
         let upper_store_registry = registry.sub_registry_with_prefix("upper_store");
-        self.upper_store
-            .clone()
-            .register_metrics(upper_store_registry);
+        self.upper_store.register_metrics(upper_store_registry);
         registry.register_collector(Box::new(Collector::new(&self)));
     }
 }

--- a/nativelink-store/src/store_manager.rs
+++ b/nativelink-store/src/store_manager.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use nativelink_util::store_trait::Store;
 
 pub struct StoreManager {
-    stores: RwLock<HashMap<String, Arc<dyn Store>>>,
+    stores: RwLock<HashMap<String, Store>>,
 }
 
 impl StoreManager {
@@ -28,7 +28,7 @@ impl StoreManager {
         }
     }
 
-    pub fn add_store(&self, name: &str, store: Arc<dyn Store>) {
+    pub fn add_store(&self, name: &str, store: Store) {
         let mut stores = self
             .stores
             .write()
@@ -36,7 +36,7 @@ impl StoreManager {
         stores.insert(name.to_string(), store);
     }
 
-    pub fn get_store(&self, name: &str) -> Option<Arc<dyn Store>> {
+    pub fn get_store(&self, name: &str) -> Option<Store> {
         let stores = self
             .stores
             .read()

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -30,7 +30,7 @@ use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::spawn;
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
@@ -75,7 +75,7 @@ mod compression_store_tests {
 
     #[nativelink_test]
     async fn simple_smoke_test() -> Result<(), Error> {
-        let store_owned = CompressionStore::new(
+        let store = CompressionStore::new(
             nativelink_config::stores::CompressionStore {
                 backend: nativelink_config::stores::StoreConfig::memory(
                     nativelink_config::stores::MemoryStore::default(),
@@ -86,12 +86,11 @@ mod compression_store_tests {
                     },
                 ),
             },
-            Arc::new(MemoryStore::new(
+            Store::new(Arc::new(MemoryStore::new(
                 &nativelink_config::stores::MemoryStore::default(),
-            )),
+            ))),
         )
         .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
 
         const RAW_INPUT: &str = "123";
         let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
@@ -124,9 +123,9 @@ mod compression_store_tests {
                     },
                 ),
             },
-            Arc::new(MemoryStore::new(
+            Store::new(Arc::new(MemoryStore::new(
                 &nativelink_config::stores::MemoryStore::default(),
-            )),
+            ))),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(&store_owned);
@@ -182,9 +181,9 @@ mod compression_store_tests {
                     },
                 ),
             },
-            Arc::new(MemoryStore::new(
+            Store::new(Arc::new(MemoryStore::new(
                 &nativelink_config::stores::MemoryStore::default(),
-            )),
+            ))),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(&store_owned);
@@ -221,7 +220,7 @@ mod compression_store_tests {
                     },
                 ),
             },
-            inner_store.clone(),
+            Store::new(inner_store.clone()),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(&store_owned);
@@ -279,7 +278,7 @@ mod compression_store_tests {
                     },
                 ),
             },
-            inner_store.clone(),
+            Store::new(inner_store.clone()),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(&store_owned);
@@ -368,7 +367,7 @@ mod compression_store_tests {
                     },
                 ),
             },
-            inner_store.clone(),
+            Store::new(inner_store.clone()),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(&store_owned);
@@ -520,7 +519,7 @@ mod compression_store_tests {
                     },
                 ),
             },
-            inner_store.clone(),
+            Store::new(inner_store.clone()),
         )
         .err_tip(|| "Failed to create compression store")?;
         let store = Pin::new(Arc::new(store_owned));
@@ -530,9 +529,9 @@ mod compression_store_tests {
         let _drop_guard = spawn!("get_part_is_zero_digest", async move {
             let _ = store
                 .as_ref()
-                .get_part_ref(digest, &mut writer, 0, None)
+                .get_part(digest, &mut writer, 0, None)
                 .await
-                .err_tip(|| "Failed to get_part_ref");
+                .err_tip(|| "Failed to get_part");
         });
 
         let file_data = reader

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -18,7 +18,6 @@ use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::DerefMut;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -40,7 +39,7 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::evicting_map::LenEntry;
 use nativelink_util::origin_context::ContextAwareFuture;
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
 use nativelink_util::{background_spawn, spawn};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -266,7 +265,7 @@ mod filesystem_store_tests {
         let content_path = make_temp_path("content_path");
         let temp_path = make_temp_path("temp_path");
         {
-            let store = Box::pin(
+            let store = Store::new(
                 FilesystemStore::<FileEntryImpl>::new(
                     &nativelink_config::stores::FilesystemStore {
                         content_path: content_path.clone(),
@@ -280,10 +279,10 @@ mod filesystem_store_tests {
             );
 
             // Insert dummy value into store.
-            store.as_ref().update_oneshot(digest, VALUE1.into()).await?;
+            store.update_oneshot(digest, VALUE1.into()).await?;
 
             assert_eq!(
-                store.as_ref().has(digest).await,
+                store.has(digest).await,
                 Ok(Some(VALUE1.len())),
                 "Expected filesystem store to have hash: {}",
                 HASH1
@@ -303,7 +302,7 @@ mod filesystem_store_tests {
                 .await?,
             );
 
-            let content = store.as_ref().get_part_unchunked(digest, 0, None).await?;
+            let content = store.get_part_unchunked(digest, 0, None).await?;
             assert_eq!(content, VALUE1.as_bytes());
         }
 
@@ -340,10 +339,7 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        store
-            .as_ref()
-            .update_oneshot(digest1, VALUE1.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE1.into()).await?;
 
         let expected_file_name = OsString::from(format!(
             "{}/{}-{}",
@@ -362,10 +358,7 @@ mod filesystem_store_tests {
         }
 
         // Replace content.
-        store
-            .as_ref()
-            .update_oneshot(digest1, VALUE2.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE2.into()).await?;
 
         {
             // Check to ensure our file now has new content.
@@ -432,23 +425,15 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        let store_pin = Pin::new(store.as_ref());
         // Insert data into store.
-        store_pin
-            .as_ref()
-            .update_oneshot(digest1, VALUE1.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE1.into()).await?;
 
         let (writer, mut reader) = make_buf_channel_pair();
         let store_clone = store.clone();
         let digest1_clone = digest1;
         background_spawn!(
             "file_continues_to_stream_on_content_replace_test_store_get",
-            async move {
-                Pin::new(store_clone.as_ref())
-                    .get(digest1_clone, writer)
-                    .await
-            },
+            async move { store_clone.get(digest1_clone, writer).await },
         );
 
         {
@@ -465,10 +450,7 @@ mod filesystem_store_tests {
         }
 
         // Replace content.
-        store_pin
-            .as_ref()
-            .update_oneshot(digest1, VALUE2.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE2.into()).await?;
 
         // Ensure we let any background tasks finish.
         tokio::task::yield_now().await;
@@ -566,19 +548,15 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        let store_pin = Pin::new(store.as_ref());
         // Insert data into store.
-        store_pin
-            .as_ref()
-            .update_oneshot(digest1, VALUE1.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE1.into()).await?;
 
         let mut reader = {
             let (writer, reader) = make_buf_channel_pair();
             let store_clone = store.clone();
             background_spawn!(
                 "file_gets_cleans_up_on_cache_eviction_store_get",
-                async move { Pin::new(store_clone.as_ref()).get(digest1, writer).await },
+                async move { store_clone.get(digest1, writer).await },
             );
             reader
         };
@@ -587,10 +565,7 @@ mod filesystem_store_tests {
         assert!(reader.peek().await.is_ok(), "Could not peek into reader");
 
         // Insert new content. This will evict the old item.
-        store_pin
-            .as_ref()
-            .update_oneshot(digest2, VALUE2.into())
-            .await?;
+        store.update_oneshot(digest2, VALUE2.into()).await?;
 
         // Ensure we let any background tasks finish.
         tokio::task::yield_now().await;
@@ -664,10 +639,7 @@ mod filesystem_store_tests {
             .await?,
         );
         // Insert data into store.
-        store
-            .as_ref()
-            .update_oneshot(digest1, VALUE1.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE1.into()).await?;
 
         let file_entry = store.get_file_entry_for_digest(&digest1).await?;
         file_entry
@@ -685,7 +657,7 @@ mod filesystem_store_tests {
             .await?;
 
         // Now touch digest1.
-        let data = store.as_ref().get_part_unchunked(digest1, 0, None).await?;
+        let data = store.get_part_unchunked(digest1, 0, None).await?;
         assert_eq!(data, VALUE1.as_bytes());
 
         file_entry
@@ -769,10 +741,7 @@ mod filesystem_store_tests {
             .await?,
         );
         // Insert data into store.
-        store
-            .as_ref()
-            .update_oneshot(digest1, VALUE1.into())
-            .await?;
+        store.update_oneshot(digest1, VALUE1.into()).await?;
 
         let file_entry = store.get_file_entry_for_digest(&digest1).await?;
         file_entry
@@ -790,7 +759,7 @@ mod filesystem_store_tests {
             .await?;
 
         // Now touch digest1.
-        let data = store.as_ref().get_part_unchunked(digest1, 0, None).await?;
+        let data = store.get_part_unchunked(digest1, 0, None).await?;
         assert_eq!(data, VALUE1.as_bytes());
 
         file_entry
@@ -822,7 +791,7 @@ mod filesystem_store_tests {
             .await?,
         );
         // Insert data into store.
-        store.as_ref().update_oneshot(digest, VALUE1.into()).await?;
+        store.update_oneshot(digest, VALUE1.into()).await?;
         let file_entry = store.get_file_entry_for_digest(&digest).await?;
         {
             // The file contents should equal our initial data.
@@ -837,7 +806,7 @@ mod filesystem_store_tests {
         }
 
         // Now replace the data.
-        store.as_ref().update_oneshot(digest, VALUE2.into()).await?;
+        store.update_oneshot(digest, VALUE2.into()).await?;
 
         {
             // The file contents still equal our old data.
@@ -894,13 +863,9 @@ mod filesystem_store_tests {
         );
         // Insert data into store.
         store
-            .as_ref()
             .update_oneshot(small_digest, SMALL_VALUE.into())
             .await?;
-        store
-            .as_ref()
-            .update_oneshot(big_digest, BIG_VALUE.into())
-            .await?;
+        store.update_oneshot(big_digest, BIG_VALUE.into()).await?;
 
         {
             // Our first digest should have been unrefed exactly once.
@@ -948,7 +913,7 @@ mod filesystem_store_tests {
         );
 
         let (mut tx, rx) = make_buf_channel_pair();
-        let update_fut = Arc::new(async_lock::Mutex::new(store.as_ref().update(
+        let update_fut = Arc::new(async_lock::Mutex::new(store.update(
             digest,
             rx,
             UploadSizeInfo::MaxSize(100),
@@ -1050,7 +1015,7 @@ mod filesystem_store_tests {
 
         // Finally ensure that our entry is not in the store.
         assert_eq!(
-            store.as_ref().has(digest).await?,
+            store.has(digest).await?,
             None,
             "Entry should not be in store"
         );
@@ -1079,10 +1044,7 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        let store_pin = Pin::new(store.as_ref());
-
-        store_pin
-            .as_ref()
+        store
             .update_oneshot(digest, large_value.clone().into())
             .await?;
 
@@ -1091,9 +1053,7 @@ mod filesystem_store_tests {
         let digest_clone = digest;
 
         let _drop_guard = spawn!("get_part_timeout_test_get", async move {
-            Pin::new(store_clone.as_ref())
-                .get(digest_clone, writer)
-                .await
+            store_clone.get(digest_clone, writer).await
         });
 
         let file_data = reader
@@ -1137,11 +1097,11 @@ mod filesystem_store_tests {
         let store_clone = store.clone();
         let (mut writer, mut reader) = make_buf_channel_pair();
 
-        let _drop_guard = spawn!("get_part_is_zero_digest_get_part_ref", async move {
-            let _ = Pin::new(store_clone.as_ref())
-                .get_part_ref(digest, &mut writer, 0, None)
+        let _drop_guard = spawn!("get_part_is_zero_digest_get_part", async move {
+            let _ = store_clone
+                .get_part(digest, &mut writer, 0, None)
                 .await
-                .err_tip(|| "Failed to get_part_ref");
+                .err_tip(|| "Failed to get_part");
         });
 
         let file_data = reader
@@ -1181,10 +1141,10 @@ mod filesystem_store_tests {
 
         let digests = vec![digest];
         let mut results = vec![None];
-        let _ = Pin::new(store.as_ref())
+        let _ = store
             .has_with_results(&digests, &mut results)
             .await
-            .err_tip(|| "Failed to get_part_ref");
+            .err_tip(|| "Failed to get_part");
         assert_eq!(results, vec!(Some(0)));
 
         async fn wait_for_empty_content_file<
@@ -1265,7 +1225,7 @@ mod filesystem_store_tests {
 
         // Populate our first store entry.
         let first_file_entry = {
-            store.as_ref().update_oneshot(digest, VALUE1.into()).await?;
+            store.update_oneshot(digest, VALUE1.into()).await?;
             store.get_file_entry_for_digest(&digest).await?
         };
 
@@ -1276,7 +1236,7 @@ mod filesystem_store_tests {
         // 4. Then drop the lock.
         {
             let rename_pause_request_lock = RENAME_REQUEST_PAUSE_MUX.lock().await;
-            let mut update_fut = store.as_ref().update_oneshot(digest, VALUE2.into()).boxed();
+            let mut update_fut = store.update_oneshot(digest, VALUE2.into()).boxed();
 
             loop {
                 // Try to advance our update future.
@@ -1341,7 +1301,7 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        store.as_ref().update_oneshot(digest, VALUE1.into()).await?;
+        store.update_oneshot(digest, VALUE1.into()).await?;
 
         let stored_file_path = OsString::from(format!(
             "{}/{}-{}",
@@ -1352,7 +1312,6 @@ mod filesystem_store_tests {
         std::fs::remove_file(stored_file_path)?;
 
         let digest_result = store
-            .as_ref()
             .has(digest)
             .await
             .err_tip(|| "Failed to execute has")?;
@@ -1392,24 +1351,12 @@ mod filesystem_store_tests {
             .await?,
         );
 
-        store
-            .as_ref()
-            .update_oneshot(digest_1kb, value_1kb.into())
-            .await?;
-        let short_entry = store
-            .as_ref()
-            .get_file_entry_for_digest(&digest_1kb)
-            .await?;
+        store.update_oneshot(digest_1kb, value_1kb.into()).await?;
+        let short_entry = store.get_file_entry_for_digest(&digest_1kb).await?;
         assert_eq!(short_entry.size_on_disk(), 4 * 1024);
 
-        store
-            .as_ref()
-            .update_oneshot(digest_5kb, value_5kb.into())
-            .await?;
-        let long_entry = store
-            .as_ref()
-            .get_file_entry_for_digest(&digest_5kb)
-            .await?;
+        store.update_oneshot(digest_5kb, value_5kb.into()).await?;
+        let long_entry = store.get_file_entry_for_digest(&digest_5kb).await?;
         assert_eq!(long_entry.size_on_disk(), 8 * 1024);
         Ok(())
     }
@@ -1446,10 +1393,7 @@ mod filesystem_store_tests {
             })
             .await?,
         );
-        store
-            .as_ref()
-            .update_oneshot(digest, value.clone().into())
-            .await?;
+        store.update_oneshot(digest, value.clone().into()).await?;
 
         let mut file = fs::create_file(OsString::from(format!("{temp_path}/dummy_file"))).await?;
         {
@@ -1460,7 +1404,6 @@ mod filesystem_store_tests {
         }
 
         store
-            .as_ref()
             .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
             .await?;
         Ok(())
@@ -1487,7 +1430,7 @@ mod filesystem_store_tests {
 
         let digest = DigestInfo::try_new(HASH1, value.len())?;
 
-        let store = Box::pin(FastSlowStore::new(
+        let store = FastSlowStore::new(
             // Note: The config is not needed for this test, so use dummy data.
             &nativelink_config::stores::FastSlowStore {
                 fast: nativelink_config::stores::StoreConfig::memory(
@@ -1497,7 +1440,7 @@ mod filesystem_store_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
             },
-            Arc::new(
+            Store::new(
                 FilesystemStore::<FileEntryImpl>::new(
                     &nativelink_config::stores::FilesystemStore {
                         content_path: make_temp_path("content_path"),
@@ -1508,7 +1451,7 @@ mod filesystem_store_tests {
                 )
                 .await?,
             ),
-            Arc::new(
+            Store::new(
                 FilesystemStore::<FileEntryImpl>::new(
                     &nativelink_config::stores::FilesystemStore {
                         content_path: make_temp_path("content_path1"),
@@ -1519,11 +1462,8 @@ mod filesystem_store_tests {
                 )
                 .await?,
             ),
-        ));
-        store
-            .as_ref()
-            .update_oneshot(digest, value.clone().into())
-            .await?;
+        );
+        store.update_oneshot(digest, value.clone().into()).await?;
 
         let temp_path = make_temp_path("temp_path2");
         fs::create_dir_all(&temp_path).await?;
@@ -1536,7 +1476,6 @@ mod filesystem_store_tests {
         }
 
         store
-            .as_ref()
             .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
             .await?;
         Ok(())
@@ -1581,7 +1520,6 @@ mod filesystem_store_tests {
             .ino();
 
         let result = store
-            .as_ref()
             .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
             .await?;
         assert!(

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -23,7 +23,7 @@ use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::spawn;
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::StoreLike;
 use sha2::{Digest, Sha256};
 
 const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
@@ -44,8 +44,7 @@ mod memory_store_tests {
     async fn insert_one_item_then_update() -> Result<(), Error> {
         const VALUE1: &str = "13";
         const VALUE2: &str = "23";
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-        let store = Pin::new(&store_owned);
+        let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
 
         // Insert dummy value into store.
         store
@@ -258,9 +257,9 @@ mod memory_store_tests {
 
         let _drop_guard = spawn!("get_part_is_zero_digest", async move {
             let _ = Pin::new(store_clone.as_ref())
-                .get_part_ref(digest, &mut writer, 0, None)
+                .get_part(digest, &mut writer, 0, None)
                 .await
-                .err_tip(|| "Failed to get_part_ref");
+                .err_tip(|| "Failed to get_part");
         });
 
         let file_data = reader
@@ -290,7 +289,7 @@ mod memory_store_tests {
             .as_ref()
             .has_with_results(&digests, &mut results)
             .await
-            .err_tip(|| "Failed to get_part_ref");
+            .err_tip(|| "Failed to get_part");
         assert_eq!(results, vec!(Some(0)));
 
         Ok(())

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -200,7 +200,7 @@ macro_rules! default_health_status_indicator {
                 &self,
                 namespace: std::borrow::Cow<'static, str>,
             ) -> nativelink_util::health_utils::HealthStatus {
-                Store::check_health(Pin::new(self), namespace).await
+                StoreDriver::check_health(Pin::new(self), namespace).await
             }
         }
     };

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+use std::borrow::{BorrowMut, Cow};
 use std::collections::hash_map::DefaultHasher as StdHasher;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::pin::Pin;
+use std::ptr::addr_eq;
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::future::{select, Either};
-use futures::{join, try_join, FutureExt};
+use futures::{join, try_join, Future, FutureExt};
 use nativelink_error::{error_if, make_err, Code, Error, ResultExt};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
@@ -74,7 +75,7 @@ pub enum UploadSizeInfo {
 /// Utility to send all the data to the store from a file.
 // Note: This is not inlined because some code may want to bypass any underlying
 // optimizations that may be present in the inner store.
-pub async fn slow_update_store_with_file<S: Store + ?Sized>(
+pub async fn slow_update_store_with_file<S: StoreDriver + ?Sized>(
     store: Pin<&S>,
     digest: DigestInfo,
     file: &mut fs::ResumeableFileSlot,
@@ -128,11 +129,6 @@ pub async fn slow_update_store_with_file<S: Store + ?Sized>(
     }
 }
 
-// TODO(allada) When 1.76.0 stabalizes more we can use `core::ptr::addr_eq` instead.
-fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
-    std::ptr::eq(p as *const (), q as *const ())
-}
-
 /// Optimizations that stores may want to expose to the callers.
 /// This is useful for specific cases when the store can optimize the processing
 /// of the data being processed.
@@ -148,11 +144,224 @@ pub enum StoreOptimizations {
     NoopDownloads,
 }
 
-#[async_trait]
-pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct Store {
+    inner: Arc<dyn StoreDriver>,
+}
+
+impl Store {
+    pub fn new(inner: Arc<dyn StoreDriver>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Store {
+    /// Returns the immediate inner store driver.
+    /// Note: This does not recursively try to resolve underlying store drivers
+    /// like `.inner_store()` does.
+    #[inline]
+    pub fn into_inner(self) -> Arc<dyn StoreDriver> {
+        self.inner
+    }
+
+    /// Gets the underlying store for the given digest.
+    /// A caller might want to use this to obtain a reference to the "real" underlying store
+    /// (if applicable) and check if it implements some special traits that allow optimizations.
+    /// Note: If the store performs complex operations on the data, it should return itself.
+    #[inline]
+    pub fn inner_store(&self, digest: Option<DigestInfo>) -> &dyn StoreDriver {
+        self.inner.inner_store(digest)
+    }
+
+    /// Tries to cast the underlying store to the given type.
+    #[inline]
+    pub fn downcast_ref<U: StoreDriver>(&self, maybe_digest: Option<DigestInfo>) -> Option<&U> {
+        self.inner.inner_store(maybe_digest).as_any().downcast_ref()
+    }
+
+    /// Register any metrics that this store wants to expose to the Prometheus.
+    #[inline]
+    pub fn register_metrics(&self, registry: &mut Registry) {
+        self.inner.clone().register_metrics(registry)
+    }
+
+    /// Register health checks used to monitor the store.
+    #[inline]
+    pub fn register_health(&self, registry: &mut HealthRegistryBuilder) {
+        self.inner.clone().register_health(registry)
+    }
+}
+
+impl StoreLike for Store {
+    #[inline]
+    fn as_store_driver(&self) -> &'_ dyn StoreDriver {
+        self.inner.as_ref()
+    }
+
+    fn as_pin(&self) -> Pin<&Self> {
+        Pin::new(self)
+    }
+}
+
+impl<T> StoreLike for T
+where
+    T: StoreDriver + Sized,
+{
+    #[inline]
+    fn as_store_driver(&self) -> &'_ dyn StoreDriver {
+        self
+    }
+
+    fn as_pin(&self) -> Pin<&Self> {
+        Pin::new(self)
+    }
+}
+
+pub trait StoreLike: Send + Sync + Sized {
+    /// Returns the immediate inner store driver.
+    fn as_store_driver(&self) -> &'_ dyn StoreDriver;
+
+    /// Utility function to return a pinned reference to self.
+    fn as_pin(&self) -> Pin<&Self>;
+
+    /// Utility function to return a pinned reference to the store driver.
+    #[inline]
+    fn as_store_driver_pin(&self) -> Pin<&'_ dyn StoreDriver> {
+        Pin::new(self.as_store_driver())
+    }
+
     /// Look up a digest in the store and return None if it does not exist in
     /// the store, or Some(size) if it does.
     /// Note: On an AC store the size will be incorrect and should not be used!
+    #[inline]
+    fn has(&self, digest: DigestInfo) -> impl Future<Output = Result<Option<usize>, Error>> + '_ {
+        self.as_store_driver_pin().has(digest)
+    }
+
+    /// Look up a list of digests in the store and return a result for each in
+    /// the same order as input.  The result will either be None if it does not
+    /// exist in the store, or Some(size) if it does.
+    /// Note: On an AC store the size will be incorrect and should not be used!
+    #[inline]
+    fn has_many<'b>(
+        &'b self,
+        digests: &'b [DigestInfo],
+    ) -> impl Future<Output = Result<Vec<Option<usize>>, Error>> + Send + 'b {
+        self.as_store_driver_pin().has_many(digests)
+    }
+
+    /// The implementation of the above has and has_many functions.  See their
+    /// documentation for details.
+    #[inline]
+    fn has_with_results<'b>(
+        &'b self,
+        digests: &'b [DigestInfo],
+        results: &'b mut [Option<usize>],
+    ) -> impl Future<Output = Result<(), Error>> + Send + 'b {
+        self.as_store_driver_pin()
+            .has_with_results(digests, results)
+    }
+
+    /// Sends the data to the store.
+    #[inline]
+    fn update(
+        &self,
+        digest: DigestInfo,
+        reader: DropCloserReadHalf,
+        upload_size: UploadSizeInfo,
+    ) -> impl Future<Output = Result<(), Error>> + Send + '_ {
+        self.as_store_driver_pin()
+            .update(digest, reader, upload_size)
+    }
+
+    /// Any optimizations the store might want to expose to the callers.
+    /// By default, no optimizations are exposed.
+    #[inline]
+    fn optimized_for(&self, optimization: StoreOptimizations) -> bool {
+        self.as_store_driver_pin().optimized_for(optimization)
+    }
+
+    /// Specialized version of `.update()` which takes a `ResumeableFileSlot`.
+    /// This is useful if the underlying store can optimize the upload process
+    /// when it knows the data is coming from a file.
+    #[inline]
+    fn update_with_whole_file(
+        &self,
+        digest: DigestInfo,
+        file: fs::ResumeableFileSlot,
+        upload_size: UploadSizeInfo,
+    ) -> impl Future<Output = Result<Option<fs::ResumeableFileSlot>, Error>> + Send + '_ {
+        self.as_store_driver_pin()
+            .update_with_whole_file(digest, file, upload_size)
+    }
+
+    /// Utility to send all the data to the store when you have all the bytes.
+    #[inline]
+    fn update_oneshot(
+        &self,
+        digest: DigestInfo,
+        data: Bytes,
+    ) -> impl Future<Output = Result<(), Error>> + Send + '_ {
+        self.as_store_driver_pin().update_oneshot(digest, data)
+    }
+
+    /// Retreives part of the data from the store and writes it to the given writer.
+    #[inline]
+    fn get_part<'b>(
+        &'b self,
+        digest: DigestInfo,
+        mut writer: impl BorrowMut<DropCloserWriteHalf> + Send + 'b,
+        offset: usize,
+        length: Option<usize>,
+    ) -> impl Future<Output = Result<(), Error>> + Send + 'b {
+        // Note: We need to capture `writer` just in case the caller
+        // expects the drop() method to be called on it when the future
+        // is done due to the complex interaction between the DropCloserWriteHalf
+        // and the DropCloserReadHalf during drop().
+        async move {
+            self.as_store_driver_pin()
+                .get_part(digest, writer.borrow_mut(), offset, length)
+                .await
+        }
+    }
+
+    /// Utility that works the same as `.get_part()`, but writes all the data.
+    #[inline]
+    fn get(
+        &self,
+        digest: DigestInfo,
+        writer: DropCloserWriteHalf,
+    ) -> impl Future<Output = Result<(), Error>> + Send + '_ {
+        self.as_store_driver_pin().get(digest, writer)
+    }
+
+    /// Utility that will return all the bytes at once instead of in a streaming manner.
+    #[inline]
+    fn get_part_unchunked(
+        &self,
+        digest: DigestInfo,
+        offset: usize,
+        length: Option<usize>,
+    ) -> impl Future<Output = Result<Bytes, Error>> + Send + '_ {
+        self.as_store_driver_pin()
+            .get_part_unchunked(digest, offset, length)
+    }
+
+    /// Default implementation of the health check. Some stores may want to override this
+    /// in situations where the default implementation is not sufficient.
+    #[inline]
+    fn check_health(
+        &self,
+        namespace: Cow<'static, str>,
+    ) -> impl Future<Output = HealthStatus> + Send + '_ {
+        self.as_store_driver_pin().check_health(namespace)
+    }
+}
+
+#[async_trait]
+pub trait StoreDriver: Sync + Send + Unpin + HealthStatusIndicator + 'static {
+    /// See: `StoreLike::has()` for details.
     #[inline]
     async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
         let mut result = [None];
@@ -160,10 +369,7 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(result[0])
     }
 
-    /// Look up a list of digests in the store and return a result for each in
-    /// the same order as input.  The result will either be None if it does not
-    /// exist in the store, or Some(size) if it does.
-    /// Note: On an AC store the size will be incorrect and should not be used!
+    /// See: `StoreLike::has_many()` for details.
     #[inline]
     async fn has_many(
         self: Pin<&Self>,
@@ -174,14 +380,14 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(results)
     }
 
-    /// The implementation of the above has and has_many functions.  See their
-    /// documentation for details.
+    /// See: `StoreLike::has_with_results()` for details.
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error>;
 
+    /// See: `StoreLike::update()` for details.
     async fn update(
         self: Pin<&Self>,
         digest: DigestInfo,
@@ -189,15 +395,12 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error>;
 
-    /// Any optimizations the store might want to expose to the callers.
-    /// By default, no optimizations are exposed.
+    /// See: `StoreLike::optimized_for()` for details.
     fn optimized_for(&self, _optimization: StoreOptimizations) -> bool {
         false
     }
 
-    /// Specialized version of `.update()` which takes a `ResumeableFileSlot`.
-    /// This is useful if the underlying store can optimize the upload process
-    /// when it knows the data is coming from a file.
+    /// See: `StoreLike::update_with_whole_file()` for details.
     async fn update_with_whole_file(
         self: Pin<&Self>,
         digest: DigestInfo,
@@ -218,7 +421,7 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(Some(file))
     }
 
-    // Utility to send all the data to the store when you have all the bytes.
+    /// See: `StoreLike::update_oneshot()` for details.
     async fn update_oneshot(
         self: Pin<&Self>,
         digest: DigestInfo,
@@ -248,8 +451,8 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         Ok(())
     }
 
-    /// Retreives part of the data from the store and writes it to the given writer.
-    async fn get_part_ref(
+    /// See: `StoreLike::get_part()` for details.
+    async fn get_part(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -257,49 +460,17 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         length: Option<usize>,
     ) -> Result<(), Error>;
 
-    /// Same as `get_part_ref`, but takes ownership of the writer. This is preferred
-    /// when the writer is definitly not going to be needed after the function returns.
-    /// This is useful because the read half of the writer will block until the writer
-    /// is dropped or EOF is sent. If the writer was passed as a reference, and the
-    /// reader was being waited with the `.get_part()`, it could deadlock if the writer
-    /// is not dropped or EOF sent. `.get_part_ref()` should be used when the writer
-    /// might be used after the function returns.
-    #[inline]
-    async fn get_part(
-        self: Pin<&Self>,
-        digest: DigestInfo,
-        mut writer: DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
-    ) -> Result<(), Error> {
-        self.get_part_ref(digest, &mut writer, offset, length).await
-    }
-
-    /// Utility that works the same as ``.get_part()`, but writes all the data.
+    /// See: `StoreLike::get()` for details.
     #[inline]
     async fn get(
         self: Pin<&Self>,
         digest: DigestInfo,
-        writer: DropCloserWriteHalf,
+        mut writer: DropCloserWriteHalf,
     ) -> Result<(), Error> {
-        self.get_part(digest, writer, 0, None).await
+        self.get_part(digest, &mut writer, 0, None).await
     }
 
-    /// Utility for when `self` is an `Arc` to make the code easier to write.
-    #[inline]
-    async fn get_part_arc(
-        self: Arc<Self>,
-        digest: DigestInfo,
-        writer: DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
-    ) -> Result<(), Error> {
-        Pin::new(self.as_ref())
-            .get_part(digest, writer, offset, length)
-            .await
-    }
-
-    // Utility that will return all the bytes at once instead of in a streaming manner.
+    /// See: `StoreLike::get_part_unchunked()` for details.
     async fn get_part_unchunked(
         self: Pin<&Self>,
         digest: DigestInfo,
@@ -309,19 +480,20 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         // TODO(blaise.bruer) This is extremely inefficient, since we have exactly
         // what we need here. Maybe we could instead make a version of the stream
         // that can take objects already fully in memory instead?
-        let (tx, mut rx) = make_buf_channel_pair();
+        let (mut tx, mut rx) = make_buf_channel_pair();
 
         let (data_res, get_part_res) = join!(
             rx.consume(length),
-            self.get_part(digest, tx, offset, length),
+            // We use a closure here to ensure that the `tx` is dropped when the
+            // future is done.
+            async move { self.get_part(digest, &mut tx, offset, length).await },
         );
         get_part_res
             .err_tip(|| "Failed to get_part in get_part_unchunked")
             .merge(data_res.err_tip(|| "Failed to read stream to completion in get_part_unchunked"))
     }
 
-    // Default implementation of the health check. Some stores may want to override this
-    // in situations where the default implementation is not sufficient.
+    /// See: `StoreLike::check_health()` for details.
     async fn check_health(self: Pin<&Self>, namespace: Cow<'static, str>) -> HealthStatus {
         let digest_data_size = default_digest_size_health_check();
         let mut digest_data = vec![0u8; digest_data_size];
@@ -399,12 +571,8 @@ pub trait Store: Sync + Send + Unpin + HealthStatusIndicator + 'static {
         HealthStatus::new_ok(self.get_ref(), "Successfully store health check".into())
     }
 
-    /// Gets the underlying store for the given digest.
-    /// A caller might want to use this to obtain a reference to the "real" underlying store
-    /// (if applicable) and check if it implements some special traits that allow optimizations.
-    /// Note: If the store performs complex operations on the data, it should return itself.
-    fn inner_store(&self, _digest: Option<DigestInfo>) -> &'_ dyn Store;
-    fn inner_store_arc(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store>;
+    /// See: `StoreLike::inner_store()` for details.
+    fn inner_store(&self, _digest: Option<DigestInfo>) -> &dyn StoreDriver;
 
     /// Returns an Any variation of whatever Self is.
     fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static);

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -64,7 +64,7 @@ use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::metrics_utils::{
     AsyncCounterWrapper, CollectorState, CounterWithTime, MetricsComponent,
 };
-use nativelink_util::store_trait::{Store, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
 use nativelink_util::{background_spawn, spawn, spawn_blocking};
 use parking_lot::Mutex;
 use prost::Message;
@@ -121,7 +121,7 @@ struct SideChannelInfo {
 // of the future. So we need to force this function to return a dynamic future instead.
 // see: https://github.com/rust-lang/rust/issues/78649
 pub fn download_to_directory<'a>(
-    cas_store: Pin<&'a FastSlowStore>,
+    cas_store: &'a FastSlowStore,
     filesystem_store: Pin<&'a FilesystemStore>,
     digest: &'a DigestInfo,
     current_directory: &'a str,
@@ -256,7 +256,7 @@ fn is_executable(metadata: &std::fs::Metadata, _full_path: &impl AsRef<Path>) ->
 }
 
 async fn upload_file(
-    cas_store: Pin<&dyn Store>,
+    cas_store: Pin<&impl StoreLike>,
     full_path: impl AsRef<Path> + Debug,
     hasher: DigestHasherFunc,
     metadata: std::fs::Metadata,
@@ -364,7 +364,7 @@ async fn upload_symlink(
 }
 
 fn upload_directory<'a, P: AsRef<Path> + Debug + Send + Sync + Clone + 'a>(
-    cas_store: Pin<&'a dyn Store>,
+    cas_store: Pin<&'a impl StoreLike>,
     full_dir_path: P,
     full_work_directory: &'a str,
     hasher: DigestHasherFunc,
@@ -664,10 +664,9 @@ impl RunningActionImpl {
         }
         let command = {
             // Download and build out our input files/folders. Also fetch and decode our Command.
-            let cas_store_pin = Pin::new(self.running_actions_manager.cas_store.as_ref());
             let command_fut = self.metrics().get_proto_command_from_store.wrap(async {
                 get_and_decode_digest::<ProtoCommand>(
-                    cas_store_pin,
+                    self.running_actions_manager.cas_store.as_ref(),
                     &self.action_info.command_digest,
                 )
                 .await
@@ -683,7 +682,7 @@ impl RunningActionImpl {
                 self.metrics()
                     .download_to_directory
                     .wrap(download_to_directory(
-                        cas_store_pin,
+                        &self.running_actions_manager.cas_store,
                         filesystem_store_pin,
                         &self.action_info.input_root_digest,
                         &self.work_directory,
@@ -1029,7 +1028,7 @@ impl RunningActionImpl {
                 state.execution_metadata.clone(),
             )
         };
-        let cas_store = Pin::new(self.running_actions_manager.cas_store.as_ref());
+        let cas_store = self.running_actions_manager.cas_store.as_ref();
         let hasher = self.action_info.unique_qualifier.digest_function;
         enum OutputType {
             None,
@@ -1073,7 +1072,7 @@ impl RunningActionImpl {
 
                     if metadata.is_file() {
                         return Ok(OutputType::File(
-                            upload_file(cas_store, &full_path, hasher, metadata)
+                            upload_file(cas_store.as_pin(), &full_path, hasher, metadata)
                                 .await
                                 .map(|mut file_info| {
                                     file_info.name_or_path = NameOrPath::Path(entry);
@@ -1086,7 +1085,7 @@ impl RunningActionImpl {
                 };
                 if metadata.is_dir() {
                     Ok(OutputType::Directory(
-                        upload_directory(cas_store, &full_path, work_directory, hasher)
+                        upload_directory(cas_store.as_pin(), &full_path, work_directory, hasher)
                             .and_then(|(root_dir, children)| async move {
                                 let tree = ProtoTree {
                                     root: Some(root_dir),
@@ -1094,7 +1093,7 @@ impl RunningActionImpl {
                                 };
                                 let tree_digest = serialize_and_upload_message(
                                     &tree,
-                                    cas_store,
+                                    cas_store.as_pin(),
                                     &mut hasher.hasher(),
                                 )
                                 .await
@@ -1389,8 +1388,8 @@ pub struct ExecutionConfiguration {
 struct UploadActionResults {
     upload_ac_results_strategy: UploadCacheResultsStrategy,
     upload_historical_results_strategy: UploadCacheResultsStrategy,
-    ac_store: Option<Arc<dyn Store>>,
-    historical_store: Arc<dyn Store>,
+    ac_store: Option<Store>,
+    historical_store: Store,
     success_message_template: Template,
     failure_message_template: Template,
 }
@@ -1398,8 +1397,8 @@ struct UploadActionResults {
 impl UploadActionResults {
     fn new(
         config: &UploadActionResultConfig,
-        ac_store: Option<Arc<dyn Store>>,
-        historical_store: Arc<dyn Store>,
+        ac_store: Option<Store>,
+        historical_store: Store,
     ) -> Result<Self, Error> {
         let upload_historical_results_strategy = config
             .upload_historical_results_strategy
@@ -1489,12 +1488,11 @@ impl UploadActionResults {
         action_result: ProtoActionResult,
         hasher: DigestHasherFunc,
     ) -> Result<(), Error> {
-        let Some(ac_store) = self.ac_store.as_deref() else {
+        let Some(ac_store) = self.ac_store.as_ref() else {
             return Ok(());
         };
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = ac_store.inner_store(Some(action_digest)).as_any();
-        if let Some(grpc_store) = any_store.downcast_ref::<GrpcStore>() {
+        if let Some(grpc_store) = ac_store.downcast_ref::<GrpcStore>(Some(action_digest)) {
             let update_action_request = UpdateActionResultRequest {
                 // This is populated by `update_action_result`.
                 instance_name: String::new(),
@@ -1515,7 +1513,7 @@ impl UploadActionResults {
             .encode(&mut store_data)
             .err_tip(|| "Encoding ActionResult for caching")?;
 
-        Pin::new(ac_store)
+        ac_store
             .update_oneshot(action_digest, store_data.split().freeze())
             .await
             .err_tip(|| "Caching ActionResult")
@@ -1533,7 +1531,7 @@ impl UploadActionResults {
                 action_digest: Some(action_digest.into()),
                 execute_response: Some(execute_response.clone()),
             },
-            Pin::new(self.historical_store.as_ref()),
+            self.historical_store.as_pin(),
             &mut hasher.hasher(),
         )
         .await
@@ -1625,8 +1623,8 @@ pub struct RunningActionsManagerArgs<'a> {
     pub root_action_directory: String,
     pub execution_configuration: ExecutionConfiguration,
     pub cas_store: Arc<FastSlowStore>,
-    pub ac_store: Option<Arc<dyn Store>>,
-    pub historical_store: Arc<dyn Store>,
+    pub ac_store: Option<Store>,
+    pub historical_store: Store,
     pub upload_action_result_config: &'a UploadActionResultConfig,
     pub max_action_timeout: Duration,
     pub timeout_handled_externally: bool,
@@ -1656,17 +1654,15 @@ impl RunningActionsManagerImpl {
         callbacks: Callbacks,
     ) -> Result<Self, Error> {
         // Sadly because of some limitations of how Any works we need to clone more times than optimal.
-        let any_store = args
+        let filesystem_store = args
             .cas_store
             .fast_store()
-            .clone()
-            .inner_store_arc(None)
-            .as_any_arc();
-        let filesystem_store = any_store.downcast::<FilesystemStore>().map_err(|_| {
-            make_input_err!(
+            .downcast_ref::<FilesystemStore>(None)
+            .err_tip(|| {
                 "Expected FilesystemStore store for .fast_store() in RunningActionsManagerImpl"
-            )
-        })?;
+            })?
+            .get_arc()
+            .err_tip(|| "FilesystemStore's internal Arc was lost")?;
         let (action_done_tx, _) = watch::channel(());
         Ok(Self {
             root_action_directory: args.root_action_directory,
@@ -1727,10 +1723,9 @@ impl RunningActionsManagerImpl {
                 .err_tip(|| "Expected action_digest to exist on StartExecute")?
                 .try_into()?;
             let load_start_timestamp = (self.callbacks.now_fn)();
-            let action =
-                get_and_decode_digest::<Action>(Pin::new(self.cas_store.as_ref()), &action_digest)
-                    .await
-                    .err_tip(|| "During start_action")?;
+            let action = get_and_decode_digest::<Action>(self.cas_store.as_ref(), &action_digest)
+                .await
+                .err_tip(|| "During start_action")?;
             let action_info = ActionInfo::try_from_action_and_execute_request_with_salt(
                 execute_request,
                 action,

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -32,11 +32,12 @@ mod utils {
 use nativelink_config::cas_server::{LocalWorkerConfig, WorkerProperty};
 use nativelink_error::{make_err, make_input_err, Code, Error};
 use nativelink_macro::nativelink_test;
+use nativelink_proto::build::bazel::remote::execution::v2::digest_function;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    execute_result, ConnectionResult, ExecuteResult, StartExecute, SupportedProperties,
-    UpdateForWorker,
+    execute_result, ConnectionResult, ExecuteResult, KillActionRequest, StartExecute,
+    SupportedProperties, UpdateForWorker,
 };
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::filesystem_store::FilesystemStore;
@@ -47,6 +48,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::{encode_stream_proto, fs, DigestInfo};
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
+use nativelink_util::store_trait::Store;
 use nativelink_worker::local_worker::new_local_worker;
 use prost::Message;
 use rand::{thread_rng, Rng};
@@ -72,8 +74,6 @@ fn make_temp_path(data: &str) -> String {
 
 #[cfg(test)]
 mod local_worker_tests {
-    use nativelink_proto::build::bazel::remote::execution::v2::digest_function;
-    use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::KillActionRequest;
     use pretty_assertions::assert_eq;
 
     use super::*; // Must be declared in every module.
@@ -420,7 +420,7 @@ mod local_worker_tests {
     #[nativelink_test]
     async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn std::error::Error>>
     {
-        let cas_store = Arc::new(FastSlowStore::new(
+        let cas_store = Store::new(FastSlowStore::new(
             &nativelink_config::stores::FastSlowStore {
                 // Note: These are not needed for this test, so we put dummy memory stores here.
                 fast: nativelink_config::stores::StoreConfig::memory(
@@ -430,7 +430,7 @@ mod local_worker_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
             },
-            Arc::new(
+            Store::new(
                 <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
                     content_path: make_temp_path("content_path"),
                     temp_path: make_temp_path("temp_path"),
@@ -438,13 +438,13 @@ mod local_worker_tests {
                 })
                 .await?,
             ),
-            Arc::new(MemoryStore::new(
+            Store::new(Arc::new(MemoryStore::new(
                 &nativelink_config::stores::MemoryStore::default(),
-            )),
+            ))),
         ));
-        let ac_store = Arc::new(MemoryStore::new(
+        let ac_store = Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
+        )));
         let work_directory = make_temp_path("foo");
         new_local_worker(
             Arc::new(LocalWorkerConfig {
@@ -468,7 +468,7 @@ mod local_worker_tests {
     #[nativelink_test]
     async fn new_local_worker_removes_work_directory_before_start_test(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let cas_store = Arc::new(FastSlowStore::new(
+        let cas_store = Store::new(FastSlowStore::new(
             &nativelink_config::stores::FastSlowStore {
                 // Note: These are not needed for this test, so we put dummy memory stores here.
                 fast: nativelink_config::stores::StoreConfig::memory(
@@ -478,7 +478,7 @@ mod local_worker_tests {
                     nativelink_config::stores::MemoryStore::default(),
                 ),
             },
-            Arc::new(
+            Store::new(
                 <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
                     content_path: make_temp_path("content_path"),
                     temp_path: make_temp_path("temp_path"),
@@ -486,13 +486,13 @@ mod local_worker_tests {
                 })
                 .await?,
             ),
-            Arc::new(MemoryStore::new(
+            Store::new(Arc::new(MemoryStore::new(
                 &nativelink_config::stores::MemoryStore::default(),
-            )),
+            ))),
         ));
-        let ac_store = Arc::new(MemoryStore::new(
+        let ac_store = Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
+        )));
         let work_directory = make_temp_path("foo");
         fs::create_dir_all(format!("{}/{}", work_directory, "another_dir")).await?;
         let mut file =


### PR DESCRIPTION
Refactors the Store api into the driver (backend) implementation and a client Store/StoreLike api. Store & StoreLike have their sizes known at compile-time. This enables us to add templates to the client-side to make it easier to work with, for example, we no longer need to Pin the store and we'll be able to add things like `digest: impl Into<DigestInfo>` to make the callers life much easier.

towards: #934

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/935)
<!-- Reviewable:end -->
