### PR TITLE
Fix pulumi ratelimiting build error

### DIFF
--- a/tools/nixpkgs_disable_ratehammering_pulumi_tests.diff
+++ b/tools/nixpkgs_disable_ratehammering_pulumi_tests.diff
@@ -1,17 +1,12 @@
 diff --git a/pkgs/tools/admin/pulumi/default.nix b/pkgs/tools/admin/pulumi/default.nix
-index d63bef2a0270..e85b4956b9ee 100644
+index d63bef2a0270..512ca00dec18 100644
 --- a/pkgs/tools/admin/pulumi/default.nix
 +++ b/pkgs/tools/admin/pulumi/default.nix
-@@ -103,6 +103,12 @@ buildGoModule rec {
-         # +aws
-         "TestPluginMapper_MappedNamesDifferFromPulumiName"
-         "TestProtect"
-+        # These potentially exceed GitHub's rate limits.
-+        "TestProviderVersionInputAndOption"
-+        "TestPulumiNewSetsTemplateTag"
-+        "TestProviderDeterministicPreview"
-+        "TestExpectedUnneededCreate"
-+        "TestMarshalDeployment"
-       ];
-     in
-     [ "-skip=^${lib.concatStringsSep "$|^" disabledTests}$" ];
+@@ -78,6 +78,7 @@ buildGoModule rec {
+     export PULUMI_HOME=$(mktemp -d)
+   '';
+
++  doCheck = false;
+   checkFlags =
+     let
+       disabledTests = [


### PR DESCRIPTION
On MacOS the pulumi testsuite hit the ratelimiting on github. Disable the pulumi tests with a patch on nixpkgs.

Commit 0eed7593b1a55ed9998569764080ea2c1b3406a4 didn't fix this issue.

# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

Tested with nix flake on MacOS.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/953)
<!-- Reviewable:end -->
