### PR TITLE
Register metrics on PropertyModifierScheduler

### DIFF
--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use nativelink_config::schedulers::{PropertyModification, PropertyType};
 use nativelink_error::{Error, ResultExt};
 use nativelink_util::action_messages::{ActionInfo, ActionInfoHashKey, ActionState};
+use nativelink_util::metrics_utils::Registry;
 use parking_lot::Mutex;
 use tokio::sync::watch;
 
@@ -122,5 +123,11 @@ impl ActionScheduler for PropertyModifierScheduler {
 
     async fn clean_recently_completed_actions(&self) {
         self.scheduler.clean_recently_completed_actions().await
+    }
+
+    // Register metrics for the underlying ActionScheduler.
+    fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
+        let scheduler_registry = registry.sub_registry_with_prefix("property_modifier");
+        self.scheduler.clone().register_metrics(scheduler_registry);
     }
 }


### PR DESCRIPTION
# Description
Fixes metrics being lost due to the underlying ActionScheduler not having it's metrics passed through the PropertyModifierScheduler. This should fix any scaling issues related to queued actions metrics not being available.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
  not work as expected)

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/954)
<!-- Reviewable:end -->
