### PR TITLE
Use single quotes for char

### DIFF
--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -241,7 +241,7 @@ impl CasServer {
         let mut deque: VecDeque<DigestInfo> = VecDeque::new();
         let mut directories: Vec<Directory> = Vec::new();
         // `page_token` will return the `{hash_str}-{size_bytes}` of the current request's first directory digest.
-        let mut page_token_parts = request.page_token.split("-");
+        let mut page_token_parts = request.page_token.split('-');
         let page_token_digest = DigestInfo::try_new(
             page_token_parts
                 .next()


### PR DESCRIPTION
# Description
Nightly clippy reports a style issue when using double quotes around a
single char.

## Type of change
- [x] Lint

## Checklist
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/955)
<!-- Reviewable:end -->
