### PR TITLE
Increase pre-commit timeout in CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   pre-commit-checks:
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: >- # v4.1.1


### PR DESCRIPTION
The original setting of 5 minutes was a bit too flaky. Increase it to 10 minutes so that cache misses don't break the job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/956)
<!-- Reviewable:end -->
