### PR TITLE
Convert RedisError into nativelink Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
  "nativelink-proto",
  "prost",
  "prost-types",
+ "redis",
  "tokio",
  "tonic 0.11.0",
 ]

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
         "@crates//:hex",
         "@crates//:prost",
         "@crates//:prost-types",
+        "@crates//:redis",
         "@crates//:tokio",
         "@crates//:tonic",
     ],

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -13,5 +13,6 @@ nativelink-proto = { path = "../nativelink-proto" }
 hex = "0.4.3"
 prost = "0.12.4"
 prost-types = "0.12.4"
+redis = "0.25.2"
 tokio = { version = "1.37.0" }
 tonic = { version = "0.11.0", features = ["gzip"] }

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -191,6 +191,12 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<redis::RedisError> for Error {
+    fn from(err: redis::RedisError) -> Self {
+        make_err!(Code::Internal, "{}", err.to_string())
+    }
+}
+
 impl From<Code> for Error {
     fn from(code: Code) -> Self {
         make_err!(code, "")

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -74,7 +74,7 @@ pub struct OperationFilter {
     pub unique_qualifier: Option<ActionInfoHashKey>,
 }
 
-type ActionStateResultStream = Pin<Box<dyn Stream<Item = Arc<dyn ActionStateResult>> + Send>>;
+pub type ActionStateResultStream = Pin<Box<dyn Stream<Item = Arc<dyn ActionStateResult>> + Send>>;
 
 #[async_trait]
 pub trait ClientStateManager {
@@ -108,7 +108,10 @@ pub trait WorkerStateManager {
 #[async_trait]
 pub trait MatchingEngineStateManager {
     /// Returns a stream of operations that match the filter.
-    fn filter_operations(&self, filter: OperationFilter) -> Result<ActionStateResultStream, Error>;
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error>;
 
     /// Update that state of an operation.
     async fn update_operation(


### PR DESCRIPTION
# Description
Adds the ability to convert a RedisError into a Nativelink Error. This will dramatically simplifies error handling when dealing with errors returned by the new redis backend for the scheduler.

## Type of change

Please delete options that aren't relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Compiler accepts conversion into nativelink_error::Error from RedisError::into

## Checklist
- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/959)
<!-- Reviewable:end -->
