### PR TITLE
Redis State Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,11 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "rand",
+ "redis",
+ "redis-macros",
  "scopeguard",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -2564,6 +2568,8 @@ dependencies = [
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "ryu",
+ "serde",
+ "serde_json",
  "sha1_smol",
  "socket2",
  "tokio",
@@ -2571,6 +2577,29 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "redis-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b5407866b6626d251b18c878f043d37f43124680f26a806595a61714ab049a"
+dependencies = [
+ "redis",
+ "redis-macros-derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "redis-macros-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dfe1dc77e38e260bbd53e98d3aec64add3cdf5d773e38d344c63660196117f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -63,6 +63,7 @@ rust_test_suite(
         "tests/action_messages_test.rs",
         "tests/cache_lookup_scheduler_test.rs",
         "tests/property_modifier_scheduler_test.rs",
+        "tests/redis_operation_manager_test.rs",
         "tests/simple_scheduler_test.rs",
     ],
     compile_data = [

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -29,6 +29,10 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tonic = { version = "0.11.0", features = ["gzip", "tls"] }
 tracing = "0.1.40"
 bitflags = "2.5.0"
+redis = { version = "0.25.2", features = ["aio", "tokio", "json"] }
+serde = "1.0.203"
+redis-macros = "0.3.0"
+serde_json = "1.0.117"
 
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -19,6 +19,7 @@ pub mod grpc_scheduler;
 pub mod operation_state_manager;
 pub mod platform_property_manager;
 pub mod property_modifier_scheduler;
+pub mod redis_operation_state;
 pub mod scheduler_state;
 pub mod simple_scheduler;
 pub mod worker;

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -42,7 +42,7 @@ pub trait ActionStateResult: Send + Sync + 'static {
     // Provides the current state of the action.
     async fn as_state(&self) -> Result<Arc<ActionState>, Error>;
     // Subscribes to the state of the action, receiving updates as they are published.
-    async fn as_receiver(&self) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
+    async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error>;
     // Provide result as action info. This behavior will not be supported by all implementations.
     // TODO(adams): Expectation is this to experimental and removed in the future.
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error>;
@@ -103,7 +103,7 @@ pub trait ClientStateManager {
     async fn add_action(
         &mut self,
         action_info: ActionInfo,
-    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error>;
+    ) -> Result<Arc<dyn ActionStateResult>, Error>;
 
     /// Returns a stream of operations that match the filter.
     async fn filter_operations(

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -42,7 +42,7 @@ pub trait ActionStateResult: Send + Sync + 'static {
     // Provides the current state of the action.
     async fn as_state(&self) -> Result<Arc<ActionState>, Error>;
     // Subscribes to the state of the action, receiving updates as they are published.
-    async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error>;
+    async fn as_receiver(&self) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
     // Provide result as action info. This behavior will not be supported by all implementations.
     // TODO(adams): Expectation is this to experimental and removed in the future.
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error>;
@@ -103,7 +103,7 @@ pub trait ClientStateManager {
     async fn add_action(
         &mut self,
         action_info: ActionInfo,
-    ) -> Result<Arc<dyn ActionStateResult>, Error>;
+    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error>;
 
     /// Returns a stream of operations that match the filter.
     async fn filter_operations(

--- a/nativelink-scheduler/src/redis_operation_state.rs
+++ b/nativelink-scheduler/src/redis_operation_state.rs
@@ -12,170 +12,131 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::zip;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
-use futures::StreamExt;
+use futures::{join, StreamExt};
+use nativelink_store::redis_store::RedisStore;
+use nativelink_util::buf_channel::make_buf_channel_pair;
+use nativelink_util::background_spawn;
 use std::collections::HashMap;
 use tonic::async_trait;
 use nativelink_util::action_messages::{ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, OperationId, WorkerId};
-use redis::aio::{MultiplexedConnection, PubSub};
-use redis::{AsyncCommands, Client, Connection, Pipeline};
+use redis::aio::{ConnectionLike, ConnectionManager};
+use redis::{AsyncCommands, Pipeline};
 use nativelink_error::{make_input_err, Error};
 use tokio::sync::watch;
 use redis_macros::{FromRedisValue, ToRedisArgs};
 use serde::{Serialize, Deserialize};
 use crate::operation_state_manager::{ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager, OperationFilter, OperationStageFlags, WorkerStateManager};
+use nativelink_util::store_trait::{StoreDriver, StoreLike, StoreSubscription};
 
-pub struct RedisOperationState {
-    client: Client,
-    inner: RedisOperationImpl,
+
+fn match_optional_filter<T: PartialEq>(value_opt: Option<T>, filter_opt: Option<T>, cond: impl Fn(T, T) -> bool) -> bool {
+    let Some(filter) = filter_opt else { return true };
+    let Some(value) = value_opt else { return false; };
+    cond(filter, value)
 }
 
-impl RedisOperationState {
-    fn new(con: Client, inner: RedisOperationImpl) -> Self {
-        Self {
-            client: con,
-            inner
+pub fn matches_filter(operation: &RedisOperation, filter: &OperationFilter) -> bool {
+    if !parse_stage_flags(&filter.stages).contains(&operation.stage) && !(filter.stages == OperationStageFlags::Any) {
+        return false
+    }
+    match_optional_filter(Some(&operation.operation_id), filter.operation_id.as_ref(), |a, b| { a == b })
+        && match_optional_filter(operation.worker_id, filter.worker_id, |a, b| { a == b })
+        && match_optional_filter(Some(operation.unique_qualifier().digest), filter.action_digest, |a, b| { a == b })
+        && match_optional_filter(operation.completed_at, filter.completed_before, |a, b| { a < b })
+        && match_optional_filter(operation.last_client_update, filter.last_client_update_before, |a, b| { a < b })
+}
+
+pub struct RedisStateManager<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static = ConnectionManager> {
+    pub store: Arc<RedisStore<T>>
+}
+
+impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> RedisStateManager<T> {
+    pub fn new(store: Arc<RedisStore<T>>) -> Self {
+        Self { store }
+    }
+
+    async fn list<'a, V>(&self, prefix: &str, result_map: &mut HashMap<String, V>) -> Result<(), Error>
+    where
+    V: FromStr
+    {
+        let mut con = self.get_conn().await?;
+        let ids_iter = con.scan_match::<&str, String>(prefix).await?;
+        let keys = ids_iter.collect::<Vec<String>>().await;
+        let raw_values: Vec<String> = con.get(&keys).await?;
+
+        let value_res: Result<Vec<V>, Error> = raw_values.into_iter().map(|s| {
+            V::from_str(&s).map_err(|_| {
+                make_input_err!("list: Failed to convert value to type")
+            })
+        }).collect();
+        match value_res {
+            Ok(values) => {
+                let zipped = zip(keys.into_iter(), values.into_iter());
+                *result_map = HashMap::from_iter(zipped);
+                Ok(())
+            },
+            Err(e) => {
+                Err(e)
+            }
         }
     }
-}
 
-impl TryFrom<RedisOperationImpl> for ActionState {
-    type Error = Error;
-    fn try_from(value: RedisOperationImpl) -> Result<Self, Self::Error> {
-        Ok(ActionState {
-            id: value.operation_id.clone(),
-            stage: value.action_stage()?
-        })
-    }
-}
-
-impl RedisOperationState {
-    async fn subscribe<'a>(
-        &'a self,
-        client: &'a Client
-    ) -> Result<watch::Receiver<Arc<ActionState>>, nativelink_error::Error> {
-        let mut sub = client.get_async_pubsub().await?;
-        let sub_channel = format!("{}:*", &self.inner.operation_id.unique_qualifier.action_name());
-        // Subscribe to action name: any completed operation can return status
-        sub.subscribe(sub_channel).await.unwrap();
-        let mut stream = sub.into_on_message();
-        let action_state: ActionState = self.inner.clone().try_into()?;
-        // let arc_action_state: Arc<ActionState> = Arc::new();
-        // This hangs forever atm
-        let (tx, rx) = tokio::sync::watch::channel(Arc::new(action_state));
-        // Hand tuple of rx and future to pump the rx
-        // Note: nativelink spawn macro name field doesn't accept variables so for now we have to use this to avoid conflicts.
-        #[allow(clippy::disallowed_methods)]
-        tokio::spawn(async move {
-            let closed_fut = tx.closed();
-            tokio::pin!(closed_fut);
-            loop {
-                tokio::select! {
-                    msg = stream.next() => {
-                        println!("got message");
-                        let state: RedisOperationImpl = msg.unwrap().get_payload().unwrap();
-                        let finished = state.stage == OperationStage::Completed;
-                        let value: Arc<ActionState> = Arc::new(state.try_into().unwrap());
-                        if tx.send(value).is_err() {
-                            println!("Error sending value");
-                            return;
-                        }
-                        if finished {
-                            return;
-                        }
-                    }
-                    _  = &mut closed_fut => {
-                        println!("Future closed");
-                        return
-                    }
-                }
-
-            }
-        });
-        Ok(rx)
-    }
-}
-
-#[async_trait]
-impl ActionStateResult for RedisOperationState {
-    async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
-        Ok(Arc::new(self.inner.clone().try_into()?))
-    }
-    async fn as_receiver(&self) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
-        Ok(self.subscribe(&self.client).await?)
-    }
-    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
-        Ok(Arc::new(self.inner.info.clone()))
-    }
-}
-pub struct RedisStateManager  {
-    pub client: Client,
-}
-
-impl RedisStateManager {
-    pub fn new(url: String) -> Self {
-        Self { client: Client::open(url).unwrap() }
-    }
-
-    pub fn get_client(&self) -> Client {
-        self.client.clone()
-    }
-
-    async fn _get_async_pubsub(&self) -> Result<PubSub, Error> {
-        Ok(self.client.get_async_pubsub().await?)
-    }
-
-    async fn get_multiplex_connection(&self) -> Result<MultiplexedConnection, Error> {
-        Ok(self.client.get_multiplexed_tokio_connection().await?)
-    }
-
-    fn _get_connection(&self) -> Result<Connection, Error> {
-        Ok(self.client.get_connection()?)
+    pub async fn get_conn(&self) -> Result<T, Error> {
+        self.store.get_conn().await
     }
 
     async fn inner_add_action(
         &self,
         action_info: ActionInfo,
-    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error> {
+    ) -> Result<Arc<dyn ActionStateResult>, Error> {
         let operation_id = OperationId::new(action_info.unique_qualifier.clone());
-        let mut con = self.get_multiplex_connection().await?;
+        let mut con = self.get_conn().await?;
         let hash_key = operation_id.unique_qualifier.action_name().clone();
-        let action_key = format!("actions:{}", hash_key.clone());
-        let mut existing_operations: Vec<String> = con.smembers(&action_key).await?;
 
+        let action_key = format!("actions:{}", hash_key.clone());
+        // TODO: List API call to find existing actions.
+        let mut existing_operations: Vec<String> = Vec::new();
         let operation = match existing_operations.pop() {
             Some(existing_operation) => {
-                let operation: RedisOperationImpl = con.hget("operations:", &existing_operation).await?;
-                RedisOperationImpl::from_existing(operation.clone(), operation_id.clone())
+                let operation: RedisOperation = con.get(format!("operations:{}", &existing_operation)).await?;
+                RedisOperation::from_existing(operation.clone(), operation_id.clone())
             },
             None => {
-                RedisOperationImpl::new(action_info, operation_id.clone())
+                RedisOperation::new(action_info, operation_id.clone())
             }
         };
 
-        let mut pipe = Pipeline::new();
-        pipe
-            .hset("operations:", operation_id.to_string(), &operation)
-            .sadd(action_key, &operation_id.to_string())
-            .query_async(&mut con)
+        let operation_key = format!("operations:{}", operation_id).to_string();
+        let store = self.store.as_store_driver_pin();
+        store
+            .update_oneshot(operation_key.into(), operation.as_json().into())
             .await?;
-        let state = RedisOperationState::new(self.client.clone(), operation);
-        Ok(Box::new(Arc::new(state)))
+        store
+            .update_oneshot(action_key.into(), operation_id.to_string().into())
+            .await?;
+        let store_subscription = self.store.clone().subscribe(format!("operations:{}", operation_id).into()).await;
+        let state = RedisOperationState::new(operation, store_subscription);
+        Ok(Arc::new(state))
     }
 
     async fn inner_filter_operations(
         &self,
         filter: OperationFilter,
     ) -> Result<ActionStateResultStream, Error> {
-        let mut con = self.get_multiplex_connection().await?;
-        let existing_operations: HashMap<String, RedisOperationImpl> = con.hgetall("operations:").await?;
+        let mut existing_operations: HashMap<String, RedisOperation> = HashMap::new();
+        self.list("operations:*", &mut existing_operations).await?;
         let mut v: Vec<Arc<dyn ActionStateResult>> = Vec::new();
         for operation in existing_operations.values() {
             if matches_filter(operation, &filter) {
+
+                let store_subscription = self.store.clone().subscribe(format!("operations:{}", operation.operation_id).into()).await;
                 v.push(Arc::new(
                         RedisOperationState::new(
-                            self.client.clone(), operation.clone()
+                            operation.clone(), store_subscription
                         )
                     )
                 );
@@ -190,13 +151,18 @@ impl RedisStateManager {
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error> {
-        let mut con = self.get_multiplex_connection().await?;
-        let maybe_operation: Option<RedisOperationImpl> = con
-            .hget("operations:", operation_id.to_string())
-            .await?;
-        let Some(mut operation) = maybe_operation else {
+        let store = self.store.as_store_driver_pin();
+        let key = format!("operations:{}", operation_id);
+        let operation_bytes_res = &store.get_part_unchunked(
+            key.clone().into(),
+            0,
+            None
+        ).await;
+        let Ok(operation_bytes) = operation_bytes_res else {
             return Err(make_input_err!("Received request to update operation {operation_id}, but operation does not exist."))
         };
+        let mut operation: RedisOperation = RedisOperation::from_slice(&operation_bytes[..]);
+
         match action_stage {
             Ok(stage) => {
                 let (maybe_operation_stage, maybe_result) = match stage {
@@ -215,22 +181,125 @@ impl RedisStateManager {
             },
             Err(e) => { operation.last_error = Some(e); }
         }
-        Ok(con.hset("operations:", operation_id.to_string(), operation).await?)
+        store.update_oneshot(
+            key.into(),
+            operation.as_json().into()
+        ).await
     }
 
     async fn inner_remove_operation(&self, operation_id: OperationId) -> Result<(), Error> {
-        let mut con = self.get_multiplex_connection().await.unwrap();
-        let action_key = format!("actions:{}", operation_id.action_name());
+        let mut con = self.get_conn().await?;
         let mut pipe = Pipeline::new();
         Ok(pipe
-            .srem(action_key, operation_id.to_string())
-            .hdel("operations:", operation_id.to_string())
+            .del(format!("operations:{}", operation_id))
             .query_async(&mut con)
             .await?)
     }
 }
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[async_trait]
+impl ClientStateManager for RedisStateManager {
+    async fn add_action(
+        &mut self,
+        action_info: ActionInfo,
+    ) -> Result<Arc<dyn ActionStateResult>, Error> {
+        self.inner_add_action(action_info).await
+    }
+
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.inner_filter_operations(filter).await
+    }
+}
+
+#[async_trait]
+impl WorkerStateManager for RedisStateManager {
+    async fn update_operation(
+        &self,
+        operation_id: OperationId,
+        worker_id: WorkerId,
+        action_stage: Result<ActionStage, Error>,
+    ) -> Result<(), Error> {
+        self.inner_update_operation(operation_id, Some(worker_id), action_stage).await
+    }
+}
+
+#[async_trait]
+impl MatchingEngineStateManager for RedisStateManager {
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.inner_filter_operations(filter).await
+    }
+
+    async fn update_operation(
+        &self,
+        operation_id: OperationId,
+        worker_id: Option<WorkerId>,
+        action_stage: Result<ActionStage, Error>,
+    ) -> Result<(), Error> {
+        self.inner_update_operation(operation_id, worker_id, action_stage).await
+    }
+
+    async fn remove_operation(&self, operation_id: OperationId) -> Result<(), Error> {
+        self.inner_remove_operation(operation_id).await
+    }
+}
+
+pub struct RedisOperationState {
+    rx: watch::Receiver<Arc<ActionState>>,
+    inner: RedisOperation,
+}
+
+impl RedisOperationState {
+    fn new(inner: RedisOperation, mut subscription: Box<dyn StoreSubscription>) -> Self {
+        let (tx, rx) = watch::channel(inner.as_state().unwrap());
+
+        let _join_handle = background_spawn!("redis_subscription_watcher", async move {
+            loop {
+                let Ok(item) = subscription.changed().await else {
+                    return;
+                };
+                let (mut data_tx, mut data_rx) = make_buf_channel_pair();
+                // If get fails then we drop the tx.
+                let (res, data_res) = join!(async move { item.get(&mut data_tx).await }, data_rx.consume(None));
+                if let Err(_e) = res {
+                    todo!()
+                }
+                let Ok(data) = data_res else {
+                    todo!()
+                };
+                let slice = &data[..];
+                let state: Arc<ActionState> = RedisOperation::from_slice(slice).as_state().unwrap();
+                let _ = tx.send(state).map_err(|_| {
+                    todo!()
+                });
+
+            }
+        });
+        Self {
+            rx,
+            inner
+        }
+    }
+}
+
+#[async_trait]
+impl ActionStateResult for RedisOperationState {
+    async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
+        Ok(Arc::new(self.inner.clone().try_into()?))
+    }
+    async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error> {
+        Ok(&self.rx)
+    }
+    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
+        Ok(Arc::new(self.inner.info.clone()))
+    }
+}
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 enum OperationStage {
     CacheCheck,
     Queued,
@@ -266,8 +335,8 @@ fn parse_stage_flags(flags: &OperationStageFlags) -> Vec<OperationStage> {
 }
 
 
-#[derive(Serialize, Deserialize, Clone, ToRedisArgs, FromRedisValue)]
-pub struct RedisOperationImpl {
+#[derive(Serialize, Deserialize, Clone, Debug, ToRedisArgs, FromRedisValue)]
+pub struct RedisOperation {
     operation_id: OperationId,
     info: ActionInfo,
     worker_id: Option<WorkerId>,
@@ -279,7 +348,14 @@ pub struct RedisOperationImpl {
     completed_at: Option<SystemTime>
 }
 
-impl RedisOperationImpl {
+impl RedisOperation {
+    pub fn as_json(&self) -> String {
+        serde_json::json!(&self).to_string()
+    }
+    pub fn from_slice(s: &[u8]) -> Self {
+        serde_json::from_slice(s).unwrap()
+    }
+
     pub fn new(info: ActionInfo, operation_id: OperationId) -> Self {
         Self {
             operation_id,
@@ -294,7 +370,7 @@ impl RedisOperationImpl {
         }
     }
 
-    pub fn from_existing(existing: RedisOperationImpl, operation_id: OperationId) -> Self {
+    pub fn from_existing(existing: RedisOperation, operation_id: OperationId) -> Self {
         Self {
             operation_id,
             info: existing.info,
@@ -340,71 +416,21 @@ impl RedisOperationImpl {
     }
 }
 
-fn match_optional_filter<T: PartialEq>(value_opt: Option<T>, filter_opt: Option<T>, cond: impl Fn(T, T) -> bool) -> bool {
-    let Some(filter) = filter_opt else { return true };
-    let Some(value) = value_opt else { return false; };
-    cond(filter, value)
-}
-
-pub fn matches_filter(operation: &RedisOperationImpl, filter: &OperationFilter) -> bool {
-    if !parse_stage_flags(&filter.stages).contains(&operation.stage) && !(filter.stages == OperationStageFlags::Any) {
-        return false
-    }
-    match_optional_filter(Some(&operation.operation_id), filter.operation_id.as_ref(), |a, b| { a == b })
-        && match_optional_filter(operation.worker_id, filter.worker_id, |a, b| { a == b })
-        && match_optional_filter(Some(operation.unique_qualifier().digest), filter.action_digest, |a, b| { a == b })
-        && match_optional_filter(operation.completed_at, filter.completed_before, |a, b| { a < b })
-        && match_optional_filter(operation.last_client_update, filter.last_client_update_before, |a, b| { a < b })
-}
-
-#[async_trait]
-impl ClientStateManager for RedisStateManager {
-    async fn add_action(
-        &self,
-        action_info: ActionInfo,
-    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error> {
-        self.inner_add_action(action_info).await
-    }
-
-    async fn filter_operations(
-        &self,
-        filter: OperationFilter,
-    ) -> Result<ActionStateResultStream, Error> {
-        self.inner_filter_operations(filter).await
+impl FromStr for RedisOperation {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(|e| {
+            make_input_err!("Decode string to RedisOperation failed with error: {}", e.to_string())
+        })
     }
 }
 
-#[async_trait]
-impl WorkerStateManager for RedisStateManager {
-    async fn update_operation(
-        &self,
-        operation_id: OperationId,
-        worker_id: WorkerId,
-        action_stage: Result<ActionStage, Error>,
-    ) -> Result<(), Error> {
-        self.inner_update_operation(operation_id, Some(worker_id), action_stage).await
-    }
-}
-
-#[async_trait]
-impl MatchingEngineStateManager for RedisStateManager {
-    async fn filter_operations(
-        &self,
-        filter: OperationFilter,
-    ) -> Result<ActionStateResultStream, Error> {
-        self.inner_filter_operations(filter).await
-    }
-
-    async fn update_operation(
-        &self,
-        operation_id: OperationId,
-        worker_id: Option<WorkerId>,
-        action_stage: Result<ActionStage, Error>,
-    ) -> Result<(), Error> {
-        self.inner_update_operation(operation_id, worker_id, action_stage).await
-    }
-
-    async fn remove_operation(&self, operation_id: OperationId) -> Result<(), Error> {
-        self.inner_remove_operation(operation_id).await
+impl TryFrom<RedisOperation> for ActionState {
+    type Error = Error;
+    fn try_from(value: RedisOperation) -> Result<Self, Self::Error> {
+        Ok(ActionState {
+            id: value.operation_id.clone(),
+            stage: value.action_stage()?
+        })
     }
 }

--- a/nativelink-scheduler/src/redis_operation_state.rs
+++ b/nativelink-scheduler/src/redis_operation_state.rs
@@ -1,0 +1,410 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+use futures::StreamExt;
+use std::collections::HashMap;
+use tonic::async_trait;
+use nativelink_util::action_messages::{ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, OperationId, WorkerId};
+use redis::aio::{MultiplexedConnection, PubSub};
+use redis::{AsyncCommands, Client, Connection, Pipeline};
+use nativelink_error::{make_input_err, Error};
+use tokio::sync::watch;
+use redis_macros::{FromRedisValue, ToRedisArgs};
+use serde::{Serialize, Deserialize};
+use crate::operation_state_manager::{ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager, OperationFilter, OperationStageFlags, WorkerStateManager};
+
+pub struct RedisOperationState {
+    client: Client,
+    inner: RedisOperationImpl,
+}
+
+impl RedisOperationState {
+    fn new(con: Client, inner: RedisOperationImpl) -> Self {
+        Self {
+            client: con,
+            inner
+        }
+    }
+}
+
+impl TryFrom<RedisOperationImpl> for ActionState {
+    type Error = Error;
+    fn try_from(value: RedisOperationImpl) -> Result<Self, Self::Error> {
+        Ok(ActionState {
+            id: value.operation_id.clone(),
+            stage: value.action_stage()?
+        })
+    }
+}
+
+impl RedisOperationState {
+    async fn subscribe<'a>(
+        &'a self,
+        client: &'a Client
+    ) -> Result<watch::Receiver<Arc<ActionState>>, nativelink_error::Error> {
+        let mut sub = client.get_async_pubsub().await?;
+        let sub_channel = format!("{}:*", &self.inner.operation_id.unique_qualifier.action_name());
+        // Subscribe to action name: any completed operation can return status
+        sub.subscribe(sub_channel).await.unwrap();
+        let mut stream = sub.into_on_message();
+        let action_state: ActionState = self.inner.clone().try_into()?;
+        // let arc_action_state: Arc<ActionState> = Arc::new();
+        // This hangs forever atm
+        let (tx, rx) = tokio::sync::watch::channel(Arc::new(action_state));
+        // Hand tuple of rx and future to pump the rx
+        // Note: nativelink spawn macro name field doesn't accept variables so for now we have to use this to avoid conflicts.
+        #[allow(clippy::disallowed_methods)]
+        tokio::spawn(async move {
+            let closed_fut = tx.closed();
+            tokio::pin!(closed_fut);
+            loop {
+                tokio::select! {
+                    msg = stream.next() => {
+                        println!("got message");
+                        let state: RedisOperationImpl = msg.unwrap().get_payload().unwrap();
+                        let finished = state.stage == OperationStage::Completed;
+                        let value: Arc<ActionState> = Arc::new(state.try_into().unwrap());
+                        if tx.send(value).is_err() {
+                            println!("Error sending value");
+                            return;
+                        }
+                        if finished {
+                            return;
+                        }
+                    }
+                    _  = &mut closed_fut => {
+                        println!("Future closed");
+                        return
+                    }
+                }
+
+            }
+        });
+        Ok(rx)
+    }
+}
+
+#[async_trait]
+impl ActionStateResult for RedisOperationState {
+    async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
+        Ok(Arc::new(self.inner.clone().try_into()?))
+    }
+    async fn as_receiver(&self) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+        Ok(self.subscribe(&self.client).await?)
+    }
+    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
+        Ok(Arc::new(self.inner.info.clone()))
+    }
+}
+pub struct RedisStateManager  {
+    pub client: Client,
+}
+
+impl RedisStateManager {
+    pub fn new(url: String) -> Self {
+        Self { client: Client::open(url).unwrap() }
+    }
+
+    pub fn get_client(&self) -> Client {
+        self.client.clone()
+    }
+
+    async fn _get_async_pubsub(&self) -> Result<PubSub, Error> {
+        Ok(self.client.get_async_pubsub().await?)
+    }
+
+    async fn get_multiplex_connection(&self) -> Result<MultiplexedConnection, Error> {
+        Ok(self.client.get_multiplexed_tokio_connection().await?)
+    }
+
+    fn _get_connection(&self) -> Result<Connection, Error> {
+        Ok(self.client.get_connection()?)
+    }
+
+    async fn inner_add_action(
+        &self,
+        action_info: ActionInfo,
+    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error> {
+        let operation_id = OperationId::new(action_info.unique_qualifier.clone());
+        let mut con = self.get_multiplex_connection().await?;
+        let hash_key = operation_id.unique_qualifier.action_name().clone();
+        let action_key = format!("actions:{}", hash_key.clone());
+        let mut existing_operations: Vec<String> = con.smembers(&action_key).await?;
+
+        let operation = match existing_operations.pop() {
+            Some(existing_operation) => {
+                let operation: RedisOperationImpl = con.hget("operations:", &existing_operation).await?;
+                RedisOperationImpl::from_existing(operation.clone(), operation_id.clone())
+            },
+            None => {
+                RedisOperationImpl::new(action_info, operation_id.clone())
+            }
+        };
+
+        let mut pipe = Pipeline::new();
+        pipe
+            .hset("operations:", operation_id.to_string(), &operation)
+            .sadd(action_key, &operation_id.to_string())
+            .query_async(&mut con)
+            .await?;
+        let state = RedisOperationState::new(self.client.clone(), operation);
+        Ok(Box::new(Arc::new(state)))
+    }
+
+    async fn inner_filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        let mut con = self.get_multiplex_connection().await?;
+        let existing_operations: HashMap<String, RedisOperationImpl> = con.hgetall("operations:").await?;
+        let mut v: Vec<Arc<dyn ActionStateResult>> = Vec::new();
+        for operation in existing_operations.values() {
+            if matches_filter(operation, &filter) {
+                v.push(Arc::new(
+                        RedisOperationState::new(
+                            self.client.clone(), operation.clone()
+                        )
+                    )
+                );
+            }
+        }
+        Ok(Box::pin(futures::stream::iter(v)))
+    }
+
+    async fn inner_update_operation(
+        &self,
+        operation_id: OperationId,
+        worker_id: Option<WorkerId>,
+        action_stage: Result<ActionStage, Error>,
+    ) -> Result<(), Error> {
+        let mut con = self.get_multiplex_connection().await?;
+        let maybe_operation: Option<RedisOperationImpl> = con
+            .hget("operations:", operation_id.to_string())
+            .await?;
+        let Some(mut operation) = maybe_operation else {
+            return Err(make_input_err!("Received request to update operation {operation_id}, but operation does not exist."))
+        };
+        match action_stage {
+            Ok(stage) => {
+                let (maybe_operation_stage, maybe_result) = match stage {
+                    ActionStage::CompletedFromCache(_) => (None, None),
+                    ActionStage::Completed(result) => (Some(OperationStage::Completed), Some(result)),
+                    ActionStage::Queued => (Some(OperationStage::Completed), None),
+                    ActionStage::Unknown => (Some(OperationStage::Unknown), None),
+                    ActionStage::Executing => (Some(OperationStage::Executing), None),
+                    ActionStage::CacheCheck => (Some(OperationStage::CacheCheck), None),
+                };
+                if let Some(operation_stage) = maybe_operation_stage {
+                    operation.stage = operation_stage;
+                }
+                operation.result = maybe_result;
+                operation.worker_id = worker_id;
+            },
+            Err(e) => { operation.last_error = Some(e); }
+        }
+        Ok(con.hset("operations:", operation_id.to_string(), operation).await?)
+    }
+
+    async fn inner_remove_operation(&self, operation_id: OperationId) -> Result<(), Error> {
+        let mut con = self.get_multiplex_connection().await.unwrap();
+        let action_key = format!("actions:{}", operation_id.action_name());
+        let mut pipe = Pipeline::new();
+        Ok(pipe
+            .srem(action_key, operation_id.to_string())
+            .hdel("operations:", operation_id.to_string())
+            .query_async(&mut con)
+            .await?)
+    }
+}
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Clone)]
+enum OperationStage {
+    CacheCheck,
+    Queued,
+    Executing,
+    Completed,
+    Unknown,
+}
+
+fn parse_stage_flags(flags: &OperationStageFlags) -> Vec<OperationStage> {
+    if flags.contains(OperationStageFlags::Any) {
+        return Vec::from([
+            OperationStage::CacheCheck,
+            OperationStage::Queued,
+            OperationStage::Executing,
+            OperationStage::Completed,
+            OperationStage::Unknown,
+        ]);
+    }
+    let mut stage_vec = Vec::new();
+    if flags.contains(OperationStageFlags::CacheCheck) {
+        stage_vec.push(OperationStage::CacheCheck)
+    }
+    if flags.contains(OperationStageFlags::Executing) {
+        stage_vec.push(OperationStage::Executing)
+    }
+    if flags.contains(OperationStageFlags::Completed) {
+        stage_vec.push(OperationStage::Completed)
+    }
+    if flags.contains(OperationStageFlags::Queued) {
+        stage_vec.push(OperationStage::Queued)
+    }
+    stage_vec
+}
+
+
+#[derive(Serialize, Deserialize, Clone, ToRedisArgs, FromRedisValue)]
+pub struct RedisOperationImpl {
+    operation_id: OperationId,
+    info: ActionInfo,
+    worker_id: Option<WorkerId>,
+    result: Option<ActionResult>,
+    stage: OperationStage,
+    last_worker_update: Option<SystemTime>,
+    last_client_update: Option<SystemTime>,
+    last_error: Option<Error>,
+    completed_at: Option<SystemTime>
+}
+
+impl RedisOperationImpl {
+    pub fn new(info: ActionInfo, operation_id: OperationId) -> Self {
+        Self {
+            operation_id,
+            info,
+            worker_id: None,
+            result: None,
+            stage: OperationStage::CacheCheck,
+            last_worker_update: None,
+            last_client_update: None,
+            last_error: None,
+            completed_at: None
+        }
+    }
+
+    pub fn from_existing(existing: RedisOperationImpl, operation_id: OperationId) -> Self {
+        Self {
+            operation_id,
+            info: existing.info,
+            worker_id: existing.worker_id,
+            result: existing.result,
+            stage: existing.stage,
+            last_worker_update: existing.last_worker_update,
+            last_client_update: existing.last_client_update,
+            last_error: existing.last_error,
+            completed_at: existing.completed_at
+        }
+    }
+
+    pub fn as_state(&self) -> Result<Arc<ActionState>, Error> {
+        let action_state = ActionState {
+            stage: self.action_stage()?,
+            id: self.operation_id.clone()
+        };
+        Ok(Arc::new(action_state))
+    }
+
+    pub fn action_stage(&self) -> Result<ActionStage, Error> {
+        match self.stage {
+            OperationStage::CacheCheck => Ok(ActionStage::CacheCheck),
+            OperationStage::Queued => Ok(ActionStage::Queued),
+            OperationStage::Executing => Ok(ActionStage::Executing),
+            OperationStage::Unknown => Ok(ActionStage::Unknown),
+            OperationStage::Completed => {
+                let Some(result) = &self.result else {
+                    return Err(
+                        make_input_err!(
+                            "Operation {} was marked as completed but has no result",
+                            self.operation_id.to_string()
+                        )
+                    )
+                };
+                Ok(ActionStage::Completed(result.clone()))
+            }
+        }
+    }
+    fn unique_qualifier(&self) -> &ActionInfoHashKey {
+        &self.operation_id.unique_qualifier
+    }
+}
+
+fn match_optional_filter<T: PartialEq>(value_opt: Option<T>, filter_opt: Option<T>, cond: impl Fn(T, T) -> bool) -> bool {
+    let Some(filter) = filter_opt else { return true };
+    let Some(value) = value_opt else { return false; };
+    cond(filter, value)
+}
+
+pub fn matches_filter(operation: &RedisOperationImpl, filter: &OperationFilter) -> bool {
+    if !parse_stage_flags(&filter.stages).contains(&operation.stage) && !(filter.stages == OperationStageFlags::Any) {
+        return false
+    }
+    match_optional_filter(Some(&operation.operation_id), filter.operation_id.as_ref(), |a, b| { a == b })
+        && match_optional_filter(operation.worker_id, filter.worker_id, |a, b| { a == b })
+        && match_optional_filter(Some(operation.unique_qualifier().digest), filter.action_digest, |a, b| { a == b })
+        && match_optional_filter(operation.completed_at, filter.completed_before, |a, b| { a < b })
+        && match_optional_filter(operation.last_client_update, filter.last_client_update_before, |a, b| { a < b })
+}
+
+#[async_trait]
+impl ClientStateManager for RedisStateManager {
+    async fn add_action(
+        &self,
+        action_info: ActionInfo,
+    ) -> Result<Box<Arc<dyn ActionStateResult>>, Error> {
+        self.inner_add_action(action_info).await
+    }
+
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.inner_filter_operations(filter).await
+    }
+}
+
+#[async_trait]
+impl WorkerStateManager for RedisStateManager {
+    async fn update_operation(
+        &self,
+        operation_id: OperationId,
+        worker_id: WorkerId,
+        action_stage: Result<ActionStage, Error>,
+    ) -> Result<(), Error> {
+        self.inner_update_operation(operation_id, Some(worker_id), action_stage).await
+    }
+}
+
+#[async_trait]
+impl MatchingEngineStateManager for RedisStateManager {
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.inner_filter_operations(filter).await
+    }
+
+    async fn update_operation(
+        &self,
+        operation_id: OperationId,
+        worker_id: Option<WorkerId>,
+        action_stage: Result<ActionStage, Error>,
+    ) -> Result<(), Error> {
+        self.inner_update_operation(operation_id, worker_id, action_stage).await
+    }
+
+    async fn remove_operation(&self, operation_id: OperationId) -> Result<(), Error> {
+        self.inner_remove_operation(operation_id).await
+    }
+}

--- a/nativelink-scheduler/tests/redis_state_manager_test.rs
+++ b/nativelink-scheduler/tests/redis_state_manager_test.rs
@@ -1,0 +1,186 @@
+// Copyright 2023 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_scheduler::operation_state_manager::{
+    ClientStateManager, MatchingEngineStateManager, OperationFilter, OperationStageFlags,
+};
+use nativelink_scheduler::redis_operation_state::RedisStateManager;
+use nativelink_util::action_messages::{ActionInfo, ActionStage, WorkerId};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::platform_properties::PlatformProperties;
+
+mod utils {
+    pub(crate) mod scheduler_utils;
+}
+use utils::scheduler_utils::make_base_action_info;
+
+fn create_action_info(
+    action_digest: DigestInfo,
+    platform_properties: PlatformProperties,
+    insert_timestamp: SystemTime,
+) -> ActionInfo {
+    let mut action_info = make_base_action_info(insert_timestamp);
+    action_info.platform_properties = platform_properties;
+    action_info.unique_qualifier.digest = action_digest;
+    action_info
+}
+
+fn create_default_filter() -> OperationFilter {
+    OperationFilter {
+        stages: OperationStageFlags::Any,
+        operation_id: None,
+        worker_id: None,
+        action_digest: None,
+        worker_update_before: None,
+        completed_before: None,
+        last_client_update_before: None,
+        unique_qualifier: None,
+        order_by: None,
+    }
+}
+
+#[cfg(test)]
+mod redis_state_manager_tests {
+    use futures::StreamExt;
+    use pretty_assertions::assert_eq;
+
+    use super::*; // Must be declared in every module.
+
+    const WORKER_TIMEOUT_S: u64 = 100;
+
+    #[nativelink_test]
+    async fn basic_add_operation_test() -> Result<(), Error> {
+        let state_manager = RedisStateManager::new("redis://localhost/".to_string());
+        let client = state_manager.get_client();
+        let mut con = client.get_multiplexed_async_connection().await?;
+        let cmd = redis::cmd("FLUSHDB");
+        cmd.query_async(&mut con).await?;
+        let action_info = create_action_info(
+            DigestInfo::new([99u8; 32], 512),
+            PlatformProperties::default(),
+            SystemTime::now(),
+        );
+        let id = &state_manager
+            .add_action(action_info)
+            .await?
+            .as_state()
+            .await
+            .unwrap()
+            .id;
+        let mut filter = create_default_filter();
+        filter.operation_id = Some(id.clone());
+        let mut stream =
+            <RedisStateManager as ClientStateManager>::filter_operations(&state_manager, filter)
+                .await?;
+        assert_eq!(stream.next().await.is_some(), true);
+        Ok(())
+    }
+
+    #[nativelink_test]
+    async fn basic_remove_operation_test() -> Result<(), Error> {
+        let state_manager = RedisStateManager::new("redis://localhost/".to_string());
+        let client = state_manager.get_client();
+        let mut con = client.get_multiplexed_async_connection().await?;
+        let cmd = redis::cmd("FLUSHDB");
+        cmd.query_async(&mut con).await?;
+        let action_info = create_action_info(
+            DigestInfo::new([99u8; 32], 512),
+            PlatformProperties::default(),
+            SystemTime::now(),
+        );
+        let id = &state_manager
+            .add_action(action_info)
+            .await?
+            .as_state()
+            .await
+            .unwrap()
+            .id;
+        let mut filter = create_default_filter();
+        filter.operation_id = Some(id.clone());
+        let mut stream =
+            <RedisStateManager as ClientStateManager>::filter_operations(&state_manager, filter)
+                .await?;
+        let mut res = stream.next().await;
+        while let Some(action_state_result) = res {
+            let operation_id = &action_state_result.as_state().await.unwrap().id;
+            state_manager.remove_operation(operation_id.clone()).await?;
+            res = stream.next().await;
+        }
+        Ok(())
+    }
+
+    #[nativelink_test]
+    async fn basic_update_operation_test() -> Result<(), Error> {
+        let worker_id = WorkerId(uuid::Uuid::new_v4());
+        let state_manager = RedisStateManager::new("redis://localhost/".to_string());
+        let client = state_manager.get_client();
+        let mut con = client.get_multiplexed_async_connection().await?;
+        let action_info = create_action_info(
+            DigestInfo::new([99u8; 32], 512),
+            PlatformProperties::default(),
+            SystemTime::now(),
+        );
+        let action = state_manager.add_action(action_info.clone()).await?;
+        let operation_id = &action.as_state().await.unwrap().id;
+        <RedisStateManager as MatchingEngineStateManager>::update_operation(
+            &state_manager,
+            operation_id.clone(),
+            Some(worker_id),
+            Ok(ActionStage::Executing),
+        )
+        .await?;
+        let mut filter = create_default_filter();
+        filter.worker_id = Some(worker_id);
+        filter.operation_id = Some(operation_id.clone());
+        filter.stages = OperationStageFlags::Executing;
+        let mut stream =
+            <RedisStateManager as ClientStateManager>::filter_operations(&state_manager, filter)
+                .await?;
+        assert_eq!(stream.next().await.is_some(), true);
+        Ok(())
+    }
+
+    #[nativelink_test]
+    async fn basic_filter_operation_test() -> Result<(), Error> {
+        let worker_id = WorkerId(uuid::Uuid::new_v4());
+        let state_manager = RedisStateManager::new("redis://localhost/".to_string());
+        let action_info = create_action_info(
+            DigestInfo::new([99u8; 32], 512),
+            PlatformProperties::default(),
+            SystemTime::now(),
+        );
+        let action = state_manager.add_action(action_info).await?;
+        let operation_id = &action.as_state().await.unwrap().id;
+        <RedisStateManager as MatchingEngineStateManager>::update_operation(
+            &state_manager,
+            operation_id.clone(),
+            Some(worker_id),
+            Ok(ActionStage::Executing),
+        )
+        .await?;
+        let mut filter = create_default_filter();
+        filter.worker_id = Some(worker_id);
+        filter.operation_id = Some(operation_id.clone());
+        filter.stages = OperationStageFlags::Executing;
+        let mut stream =
+            <RedisStateManager as ClientStateManager>::filter_operations(&state_manager, filter)
+                .await?;
+        assert_eq!(stream.next().await.is_some(), true);
+        Ok(())
+    }
+}

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -116,7 +116,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync> RedisStore<T> {
         }
     }
 
-    async fn get_conn(&self) -> Result<T, Error> {
+    pub async fn get_conn(&self) -> Result<T, Error> {
         let result = match self.lazy_conn.get().as_ref() {
             LazyConnection::Connection(conn_result) => return conn_result.clone(),
             LazyConnection::Future(fut) => fut.clone().await,

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -151,7 +151,7 @@ pub enum StoreOptimizations {
 /// A key that has been subscribed to in the store. This can be used
 /// to wait for changes to the data for the key.
 #[async_trait]
-pub trait StoreSubscription {
+pub trait StoreSubscription: Send + Sync + Unpin {
     /// Get the current store subscription item.
     fn peek(&self) -> Result<Arc<dyn StoreSubscriptionItem>, Error>;
 


### PR DESCRIPTION
- **Add serialize and deserialize to structs**
- **Add OperationStateManager for redis**

# Description
Basic Implementation of WorkerStateManager, ClientStateManager, and MatchingEngineStateManager for RedisStateManager. Adds Serialize and Deserialize to all structs required for storing in redis as json.

One of the following must be merged for this to work:
1. Serialize and Deserialize added to structs (done in a commit on this PR)
2. #941 must be merged and types here can be changed. #941 would enable storage of non-json values in Redis

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
TDB

## Checklist

- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/962)
<!-- Reviewable:end -->
