### PR TITLE
bump serde to more current version

### DIFF
--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 byte-unit = "5.1.4"
 humantime = "2.1.0"
-serde = { version = "1.0.198", features = ["derive"] }
+serde = { version = "1.0.203", features = ["derive"] }
 serde_json5 = "0.1.0"
 shellexpand = "3.1.0"


### PR DESCRIPTION
# Description

Upon rebasing https://github.com/TraceMachina/nativelink/pull/891, I realized that I accidentally dropped the Serde version. This PR restores it (unless that breaks something). 

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/966)
<!-- Reviewable:end -->
