### PR TITLE
Refactor simple scheduler method signatures to async

### DIFF
--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -124,7 +124,8 @@ pub mod connect_worker_tests {
 
         let worker_exists = test_context
             .scheduler
-            .contains_worker_for_test(&test_context.worker_id);
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
         assert!(worker_exists, "Expected worker to exist in worker map");
 
         Ok(())
@@ -151,7 +152,8 @@ pub mod keep_alive_tests {
                 .await?;
             let worker_exists = test_context
                 .scheduler
-                .contains_worker_for_test(&test_context.worker_id);
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
             assert!(worker_exists, "Expected worker to exist in worker map");
         }
         {
@@ -163,7 +165,8 @@ pub mod keep_alive_tests {
                 .await?;
             let worker_exists = test_context
                 .scheduler
-                .contains_worker_for_test(&test_context.worker_id);
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
             assert!(!worker_exists, "Expected worker to not exist in map");
         }
 
@@ -195,7 +198,8 @@ pub mod keep_alive_tests {
                 .await?;
             let worker_exists = test_context
                 .scheduler
-                .contains_worker_for_test(&test_context.worker_id);
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
             assert!(worker_exists, "Expected worker to exist in worker map");
         }
         {
@@ -217,7 +221,8 @@ pub mod keep_alive_tests {
                 .await?;
             let worker_exists = test_context
                 .scheduler
-                .contains_worker_for_test(&test_context.worker_id);
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
             assert!(worker_exists, "Expected worker to exist in map");
         }
 
@@ -234,6 +239,7 @@ pub mod keep_alive_tests {
         test_context
             .scheduler
             .send_keep_alive_to_worker_for_test(&test_context.worker_id)
+            .await
             .err_tip(|| "Could not send keep alive to worker")?;
 
         {
@@ -269,7 +275,8 @@ pub mod going_away_tests {
 
         let worker_exists = test_context
             .scheduler
-            .contains_worker_for_test(&test_context.worker_id);
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
         assert!(worker_exists, "Expected worker to exist in worker map");
 
         test_context
@@ -279,7 +286,8 @@ pub mod going_away_tests {
 
         let worker_exists = test_context
             .scheduler
-            .contains_worker_for_test(&test_context.worker_id);
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
         assert!(
             !worker_exists,
             "Expected worker to be removed from worker map"


### PR DESCRIPTION
# Description

Being able to hold a lock over async code requires the use of `async_lock` over `parking_lot`, migrating `Mutex` & `MutexGuard` to that package. In addition updating function signatures to `async` for better fitting of API updates for new scheduler.

Fixes # (https://github.com/TraceMachina/nativelink/issues/979)

## Type of change

- [x] Refactor (non-breaking change which no functionality added)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/971)
<!-- Reviewable:end -->
