### PR TITLE
Fix Cargo mismatch on MacOS build

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -103,6 +103,6 @@ jobs:
         uses: >- # v4
           DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
 
-      - name: Run build
-        run: >
-          nix build
+      - name: Test nix run
+        run: |
+           nix run -L .#nativelink-is-executable-test

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
 
         craneLib =
           if pkgs.stdenv.isDarwin
-          then crane.lib.${system}
+          then (crane.mkLib pkgs).overrideToolchain stable-rust.default
           else
             (crane.mkLib pkgs).overrideToolchain (stable-rust.default.override {
               targets = ["x86_64-unknown-linux-musl"];
@@ -138,6 +138,8 @@
         publish-ghcr = import ./tools/publish-ghcr.nix {inherit pkgs;};
 
         local-image-test = import ./tools/local-image-test.nix {inherit pkgs;};
+
+        nativelink-is-executable-test = import ./tools/nativelink-is-executable-test.nix {inherit pkgs nativelink;};
 
         generate-toolchains = import ./tools/generate-toolchains.nix {inherit pkgs;};
 
@@ -201,7 +203,7 @@
           };
         };
         packages = rec {
-          inherit publish-ghcr local-image-test nativelink nativelink-debug native-cli lre-cc;
+          inherit publish-ghcr local-image-test nativelink-is-executable-test nativelink nativelink-debug native-cli lre-cc;
           default = nativelink;
 
           rbe-autogen-lre-cc = rbe-autogen lre-cc;
@@ -276,6 +278,7 @@
 
               # Additional tools from within our development environment.
               local-image-test
+              nativelink-is-executable-test
               generate-toolchains
               customClang
               native-cli

--- a/tools/nativelink-is-executable-test.nix
+++ b/tools/nativelink-is-executable-test.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  nativelink,
+  ...
+}:
+pkgs.writeShellScriptBin "is-executable-test" ''
+  set -xuo pipefail
+
+  nativelink_output="$(${nativelink}/bin/nativelink 2>&1)"
+
+  print_error_output=$(cat <<EOF
+  error: the following required arguments were not provided:
+    <CONFIG_FILE>
+
+  Usage: nativelink <CONFIG_FILE>
+
+  For more information, try '--help'.
+  EOF)
+
+  if [ "$nativelink_output" = "$print_error_output" ]; then
+    echo "The output of nativelink matches the print_error output."
+  else
+    echo 'The output of nativelink does not match the print_error output:'
+    diff <(echo "$nativelink_output") <(echo "$print_error_output") >&2
+    exit 1
+  fi
+''


### PR DESCRIPTION
# Description

The flake.nix uses the default crane toolchain on darwin. Override the default crane toolchain and specify 
the target to use the correct rust toolchain.

Fixes #948

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Invoke nix build on MacOS

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/974)
<!-- Reviewable:end -->
