### PR TITLE
Remove extraneous `mod` statements from tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ version = "0.4.0"
 dependencies = [
  "byte-unit",
  "humantime",
+ "pretty_assertions",
  "serde",
  "serde_json5",
  "shellexpand",

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -35,6 +35,7 @@ rust_test_suite(
         "//nativelink-error",
         "@crates//:byte-unit",
         "@crates//:humantime",
+        "@crates//:pretty_assertions",
         "@crates//:serde",
         "@crates//:serde_json5",
     ],

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -9,3 +9,6 @@ humantime = "2.1.0"
 serde = { version = "1.0.198", features = ["derive"] }
 serde_json5 = "0.1.0"
 shellexpand = "3.1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/nativelink-config/tests/deserialization_test.rs
+++ b/nativelink-config/tests/deserialization_test.rs
@@ -15,6 +15,7 @@
 use nativelink_config::serde_utils::{
     convert_data_size_with_shellexpand, convert_duration_with_shellexpand,
 };
+use pretty_assertions::assert_eq;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -29,43 +30,38 @@ struct DataSizeEntity {
     data_size: usize,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_duration_human_readable_deserialize() {
-        let example = r#"
+#[test]
+fn test_duration_human_readable_deserialize() {
+    let example = r#"
             {"duration": "1m 10s"}
         "#;
-        let deserialized: DurationEntity = serde_json5::from_str(example).unwrap();
-        assert_eq!(deserialized.duration, 70);
-    }
+    let deserialized: DurationEntity = serde_json5::from_str(example).unwrap();
+    assert_eq!(deserialized.duration, 70);
+}
 
-    #[test]
-    fn test_duration_usize_deserialize() {
-        let example = r#"
+#[test]
+fn test_duration_usize_deserialize() {
+    let example = r#"
             {"duration": 10}
         "#;
-        let deserialized: DurationEntity = serde_json5::from_str(example).unwrap();
-        assert_eq!(deserialized.duration, 10);
-    }
+    let deserialized: DurationEntity = serde_json5::from_str(example).unwrap();
+    assert_eq!(deserialized.duration, 10);
+}
 
-    #[test]
-    fn test_data_size_unit_deserialize() {
-        let example = r#"
+#[test]
+fn test_data_size_unit_deserialize() {
+    let example = r#"
             {"data_size": "1KiB"}
         "#;
-        let deserialized: DataSizeEntity = serde_json5::from_str(example).unwrap();
-        assert_eq!(deserialized.data_size, 1024);
-    }
+    let deserialized: DataSizeEntity = serde_json5::from_str(example).unwrap();
+    assert_eq!(deserialized.data_size, 1024);
+}
 
-    #[test]
-    fn test_data_size_usize_deserialize() {
-        let example = r#"
+#[test]
+fn test_data_size_usize_deserialize() {
+    let example = r#"
             {"data_size": 10}
         "#;
-        let deserialized: DataSizeEntity = serde_json5::from_str(example).unwrap();
-        assert_eq!(deserialized.data_size, 10);
-    }
+    let deserialized: DataSizeEntity = serde_json5::from_str(example).unwrap();
+    assert_eq!(deserialized.data_size, 10);
 }

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -28,6 +28,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
+use pretty_assertions::assert_eq;
 
 const NOW_TIME: u64 = 10000;
 
@@ -37,185 +38,178 @@ fn make_system_time(add_time: u64) -> SystemTime {
         .unwrap()
 }
 
-#[cfg(test)]
-mod action_messages_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn action_state_any_url_test() -> Result<(), Error> {
+    let unique_qualifier = ActionInfoHashKey {
+        instance_name: "foo_instance".to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::new([1u8; 32], 5),
+        salt: 0,
+    };
+    let id = OperationId::new(unique_qualifier);
+    let action_state = ActionState {
+        id,
+        // Result is only populated if has_action_result.
+        stage: ActionStage::Completed(ActionResult::default()),
+    };
+    let operation: Operation = action_state.clone().into();
 
-    use super::*; // Must be declared in every module.
+    match &operation.result {
+        Some(operation::Result::Response(any)) => assert_eq!(
+            any.type_url,
+            "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteResponse"
+        ),
+        other => panic!("Expected Some(Result(Any)), got: {other:?}"),
+    }
 
-    #[nativelink_test]
-    async fn action_state_any_url_test() -> Result<(), Error> {
-        let unique_qualifier = ActionInfoHashKey {
-            instance_name: "foo_instance".to_string(),
+    let action_state_round_trip: ActionState = operation.try_into()?;
+    assert_eq!(action_state, action_state_round_trip);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn execute_response_status_message_is_some_on_success_test() -> Result<(), Error> {
+    let execute_response: ExecuteResponse = ActionStage::Completed(ActionResult {
+        output_files: vec![],
+        output_folders: vec![],
+        output_file_symlinks: vec![],
+        output_directory_symlinks: vec![],
+        exit_code: 0,
+        stdout_digest: DigestInfo::new([2u8; 32], 5),
+        stderr_digest: DigestInfo::new([3u8; 32], 5),
+        execution_metadata: ExecutionMetadata {
+            worker: "foo_worker_id".to_string(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: SystemTime::UNIX_EPOCH,
+            worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+            execution_start_timestamp: SystemTime::UNIX_EPOCH,
+            execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    })
+    .into();
+
+    // This was once discovered to be None, which is why this test exists.
+    assert_eq!(execute_response.status, Some(Status::default()));
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn highest_priority_action_first() -> Result<(), Error> {
+    const INSTANCE_NAME: &str = "foobar_instance_name";
+
+    let high_priority_action = Arc::new(ActionInfo {
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 1000,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([1u8; 32], 5),
+            digest: DigestInfo::new([0u8; 32], 0),
             salt: 0,
-        };
-        let id = OperationId::new(unique_qualifier);
-        let action_state = ActionState {
-            id,
-            // Result is only populated if has_action_result.
-            stage: ActionStage::Completed(ActionResult::default()),
-        };
-        let operation: Operation = action_state.clone().into();
+        },
+        skip_cache_lookup: true,
+    });
+    let lowest_priority_action = Arc::new(ActionInfo {
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::new([1u8; 32], 0),
+            salt: 0,
+        },
+        skip_cache_lookup: true,
+    });
+    let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
+    action_set.insert(lowest_priority_action.clone());
+    action_set.insert(high_priority_action.clone());
 
-        match &operation.result {
-            Some(operation::Result::Response(any)) => assert_eq!(
-                any.type_url,
-                "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteResponse"
-            ),
-            other => panic!("Expected Some(Result(Any)), got: {other:?}"),
-        }
+    assert_eq!(
+        vec![high_priority_action, lowest_priority_action],
+        action_set
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<Arc<ActionInfo>>>()
+    );
 
-        let action_state_round_trip: ActionState = operation.try_into()?;
-        assert_eq!(action_state, action_state_round_trip);
+    Ok(())
+}
 
-        Ok(())
-    }
+#[nativelink_test]
+async fn equal_priority_earliest_first() -> Result<(), Error> {
+    const INSTANCE_NAME: &str = "foobar_instance_name";
 
-    #[nativelink_test]
-    async fn execute_response_status_message_is_some_on_success_test() -> Result<(), Error> {
-        let execute_response: ExecuteResponse = ActionStage::Completed(ActionResult {
-            output_files: vec![],
-            output_folders: vec![],
-            output_file_symlinks: vec![],
-            output_directory_symlinks: vec![],
-            exit_code: 0,
-            stdout_digest: DigestInfo::new([2u8; 32], 5),
-            stderr_digest: DigestInfo::new([3u8; 32], 5),
-            execution_metadata: ExecutionMetadata {
-                worker: "foo_worker_id".to_string(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: SystemTime::UNIX_EPOCH,
-                worker_completed_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
-                execution_start_timestamp: SystemTime::UNIX_EPOCH,
-                execution_completed_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
-        })
-        .into();
+    let first_action = Arc::new(ActionInfo {
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::new([0u8; 32], 0),
+            salt: 0,
+        },
+        skip_cache_lookup: true,
+    });
+    let current_action = Arc::new(ActionInfo {
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: make_system_time(0),
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::new([1u8; 32], 0),
+            salt: 0,
+        },
+        skip_cache_lookup: true,
+    });
+    let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
+    action_set.insert(current_action.clone());
+    action_set.insert(first_action.clone());
 
-        // This was once discovered to be None, which is why this test exists.
-        assert_eq!(execute_response.status, Some(Status::default()));
+    assert_eq!(
+        vec![first_action, current_action],
+        action_set
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<Arc<ActionInfo>>>()
+    );
 
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn highest_priority_action_first() -> Result<(), Error> {
-        const INSTANCE_NAME: &str = "foobar_instance_name";
-
-        let high_priority_action = Arc::new(ActionInfo {
-            command_digest: DigestInfo::new([0u8; 32], 0),
-            input_root_digest: DigestInfo::new([0u8; 32], 0),
-            timeout: Duration::MAX,
-            platform_properties: PlatformProperties {
-                properties: HashMap::new(),
-            },
-            priority: 1000,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: DigestInfo::new([0u8; 32], 0),
-                salt: 0,
-            },
-            skip_cache_lookup: true,
-        });
-        let lowest_priority_action = Arc::new(ActionInfo {
-            command_digest: DigestInfo::new([0u8; 32], 0),
-            input_root_digest: DigestInfo::new([0u8; 32], 0),
-            timeout: Duration::MAX,
-            platform_properties: PlatformProperties {
-                properties: HashMap::new(),
-            },
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: DigestInfo::new([1u8; 32], 0),
-                salt: 0,
-            },
-            skip_cache_lookup: true,
-        });
-        let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
-        action_set.insert(lowest_priority_action.clone());
-        action_set.insert(high_priority_action.clone());
-
-        assert_eq!(
-            vec![high_priority_action, lowest_priority_action],
-            action_set
-                .iter()
-                .rev()
-                .cloned()
-                .collect::<Vec<Arc<ActionInfo>>>()
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn equal_priority_earliest_first() -> Result<(), Error> {
-        const INSTANCE_NAME: &str = "foobar_instance_name";
-
-        let first_action = Arc::new(ActionInfo {
-            command_digest: DigestInfo::new([0u8; 32], 0),
-            input_root_digest: DigestInfo::new([0u8; 32], 0),
-            timeout: Duration::MAX,
-            platform_properties: PlatformProperties {
-                properties: HashMap::new(),
-            },
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: DigestInfo::new([0u8; 32], 0),
-                salt: 0,
-            },
-            skip_cache_lookup: true,
-        });
-        let current_action = Arc::new(ActionInfo {
-            command_digest: DigestInfo::new([0u8; 32], 0),
-            input_root_digest: DigestInfo::new([0u8; 32], 0),
-            timeout: Duration::MAX,
-            platform_properties: PlatformProperties {
-                properties: HashMap::new(),
-            },
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: make_system_time(0),
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: DigestInfo::new([1u8; 32], 0),
-                salt: 0,
-            },
-            skip_cache_lookup: true,
-        });
-        let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
-        action_set.insert(current_action.clone());
-        action_set.insert(first_action.clone());
-
-        assert_eq!(
-            vec![first_action, current_action],
-            action_set
-                .iter()
-                .rev()
-                .cloned()
-                .collect::<Vec<Arc<ActionInfo>>>()
-        );
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -35,6 +35,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::{Store, StoreLike};
+use pretty_assertions::assert_eq;
 use prost::Message;
 use tokio::sync::watch;
 use tokio::{self};
@@ -60,73 +61,66 @@ fn make_cache_scheduler() -> Result<TestContext, Error> {
     })
 }
 
-#[cfg(test)]
-mod cache_lookup_scheduler_tests {
-    use pretty_assertions::assert_eq;
-
-    use super::*; // Must be declared in every module.
-
-    #[nativelink_test]
-    async fn platform_property_manager_call_passed() -> Result<(), Error> {
-        let context = make_cache_scheduler()?;
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
-        let instance_name = INSTANCE_NAME.to_string();
-        let (actual_manager, actual_instance_name) = join!(
-            context
-                .cache_scheduler
-                .get_platform_property_manager(&instance_name),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager.clone())),
-        );
-        assert_eq!(
-            Arc::as_ptr(&platform_property_manager),
-            Arc::as_ptr(&actual_manager?)
-        );
-        assert_eq!(instance_name, actual_instance_name);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn add_action_handles_skip_cache() -> Result<(), Error> {
-        let context = make_cache_scheduler()?;
-        let action_info = make_base_action_info(UNIX_EPOCH);
-        let action_result = ProtoActionResult::from(ActionResult::default());
+#[nativelink_test]
+async fn platform_property_manager_call_passed() -> Result<(), Error> {
+    let context = make_cache_scheduler()?;
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
+    let instance_name = INSTANCE_NAME.to_string();
+    let (actual_manager, actual_instance_name) = join!(
         context
-            .ac_store
-            .update_oneshot(*action_info.digest(), action_result.encode_to_vec().into())
-            .await?;
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let mut skip_cache_action = action_info.clone();
-        skip_cache_action.skip_cache_lookup = true;
-        let _ = join!(
-            context.cache_scheduler.add_action(skip_cache_action),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx))
-        );
-        Ok(())
-    }
+            .cache_scheduler
+            .get_platform_property_manager(&instance_name),
+        context
+            .mock_scheduler
+            .expect_get_platform_property_manager(Ok(platform_property_manager.clone())),
+    );
+    assert_eq!(
+        Arc::as_ptr(&platform_property_manager),
+        Arc::as_ptr(&actual_manager?)
+    );
+    assert_eq!(instance_name, actual_instance_name);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn find_existing_action_call_passed() -> Result<(), Error> {
-        let context = make_cache_scheduler()?;
-        let action_name = ActionInfoHashKey {
-            instance_name: "instance".to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([8; 32], 1),
-            salt: 1000,
-        };
-        let (actual_result, actual_action_name) = join!(
-            context.cache_scheduler.find_existing_action(&action_name),
-            context.mock_scheduler.expect_find_existing_action(None),
-        );
-        assert_eq!(true, actual_result.is_none());
-        assert_eq!(action_name, actual_action_name);
-        Ok(())
-    }
+#[nativelink_test]
+async fn add_action_handles_skip_cache() -> Result<(), Error> {
+    let context = make_cache_scheduler()?;
+    let action_info = make_base_action_info(UNIX_EPOCH);
+    let action_result = ProtoActionResult::from(ActionResult::default());
+    context
+        .ac_store
+        .update_oneshot(*action_info.digest(), action_result.encode_to_vec().into())
+        .await?;
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let mut skip_cache_action = action_info.clone();
+    skip_cache_action.skip_cache_lookup = true;
+    let _ = join!(
+        context.cache_scheduler.add_action(skip_cache_action),
+        context
+            .mock_scheduler
+            .expect_add_action(Ok(forward_watch_channel_rx))
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn find_existing_action_call_passed() -> Result<(), Error> {
+    let context = make_cache_scheduler()?;
+    let action_name = ActionInfoHashKey {
+        instance_name: "instance".to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::new([8; 32], 1),
+        salt: 1000,
+    };
+    let (actual_result, actual_action_name) = join!(
+        context.cache_scheduler.find_existing_action(&action_name),
+        context.mock_scheduler.expect_find_existing_action(None),
+    );
+    assert_eq!(true, actual_result.is_none());
+    assert_eq!(action_name, actual_action_name);
+    Ok(())
 }

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -30,7 +30,9 @@ use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
 use nativelink_util::action_messages::{ActionInfoHashKey, ActionStage, ActionState, OperationId};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformPropertyValue;
+use pretty_assertions::assert_eq;
 use tokio::sync::watch;
 use utils::mock_scheduler::MockActionScheduler;
 use utils::scheduler_utils::{make_base_action_info, INSTANCE_NAME};
@@ -55,254 +57,246 @@ fn make_modifier_scheduler(modifications: Vec<PropertyModification>) -> TestCont
     }
 }
 
-#[cfg(test)]
-mod property_modifier_scheduler_tests {
-    use nativelink_util::digest_hasher::DigestHasherFunc;
-    use pretty_assertions::assert_eq;
-
-    use super::*; // Must be declared in every module.
-
-    #[nativelink_test]
-    async fn add_action_adds_property() -> Result<(), Error> {
-        let name = "name".to_string();
-        let value = "value".to_string();
-        let context =
-            make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
-                name: name.clone(),
-                value: value.clone(),
-            })]);
-        let action_info = make_base_action_info(UNIX_EPOCH);
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-            name.clone(),
-            PropertyType::exact,
-        )])));
-        let (_, _, action_info) = join!(
-            context.modifier_scheduler.add_action(action_info),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager)),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx)),
-        );
-        assert_eq!(
-            HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
-            action_info.platform_properties.properties
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn add_action_overwrites_property() -> Result<(), Error> {
-        let name = "name".to_string();
-        let original_value = "value".to_string();
-        let replaced_value = "replaced".to_string();
-        let context =
-            make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
-                name: name.clone(),
-                value: replaced_value.clone(),
-            })]);
-        let mut action_info = make_base_action_info(UNIX_EPOCH);
-        action_info
-            .platform_properties
-            .properties
-            .insert(name.clone(), PlatformPropertyValue::Unknown(original_value));
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-            name.clone(),
-            PropertyType::exact,
-        )])));
-        let (_, _, action_info) = join!(
-            context.modifier_scheduler.add_action(action_info),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager)),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx)),
-        );
-        assert_eq!(
-            HashMap::from([(name, PlatformPropertyValue::Exact(replaced_value))]),
-            action_info.platform_properties.properties
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn add_action_property_added_after_remove() -> Result<(), Error> {
-        let name = "name".to_string();
-        let value = "value".to_string();
-        let context = make_modifier_scheduler(vec![
-            PropertyModification::remove(name.clone()),
-            PropertyModification::add(PlatformPropertyAddition {
-                name: name.clone(),
-                value: value.clone(),
-            }),
-        ]);
-        let action_info = make_base_action_info(UNIX_EPOCH);
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-            name.clone(),
-            PropertyType::exact,
-        )])));
-        let (_, _, action_info) = join!(
-            context.modifier_scheduler.add_action(action_info),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager)),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx)),
-        );
-        assert_eq!(
-            HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
-            action_info.platform_properties.properties
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn add_action_property_remove_after_add() -> Result<(), Error> {
-        let name = "name".to_string();
-        let value = "value".to_string();
-        let context = make_modifier_scheduler(vec![
-            PropertyModification::add(PlatformPropertyAddition {
-                name: name.clone(),
-                value: value.clone(),
-            }),
-            PropertyModification::remove(name.clone()),
-        ]);
-        let action_info = make_base_action_info(UNIX_EPOCH);
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-            name,
-            PropertyType::exact,
-        )])));
-        let (_, _, action_info) = join!(
-            context.modifier_scheduler.add_action(action_info),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager)),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx)),
-        );
-        assert_eq!(
-            HashMap::from([]),
-            action_info.platform_properties.properties
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn add_action_property_remove() -> Result<(), Error> {
-        let name = "name".to_string();
-        let value = "value".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
-        let mut action_info = make_base_action_info(UNIX_EPOCH);
-        action_info
-            .platform_properties
-            .properties
-            .insert(name, PlatformPropertyValue::Unknown(value));
-        let (_forward_watch_channel_tx, forward_watch_channel_rx) =
-            watch::channel(Arc::new(ActionState {
-                id: OperationId::new(action_info.unique_qualifier.clone()),
-                stage: ActionStage::Queued,
-            }));
-        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
-        let (_, _, action_info) = join!(
-            context.modifier_scheduler.add_action(action_info),
-            context
-                .mock_scheduler
-                .expect_get_platform_property_manager(Ok(platform_property_manager)),
-            context
-                .mock_scheduler
-                .expect_add_action(Ok(forward_watch_channel_rx)),
-        );
-        assert_eq!(
-            HashMap::from([]),
-            action_info.platform_properties.properties
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn find_existing_action_call_passed() -> Result<(), Error> {
-        let context = make_modifier_scheduler(vec![]);
-        let action_name = ActionInfoHashKey {
-            instance_name: "instance".to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([8; 32], 1),
-            salt: 1000,
-        };
-        let (actual_result, actual_action_name) = join!(
-            context
-                .modifier_scheduler
-                .find_existing_action(&action_name),
-            context.mock_scheduler.expect_find_existing_action(None),
-        );
-        assert_eq!(true, actual_result.is_none());
-        assert_eq!(action_name, actual_action_name);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
-        let name = "name".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
-        let scheduler_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
-        let get_property_manager_fut = context
+#[nativelink_test]
+async fn add_action_adds_property() -> Result<(), Error> {
+    let name = "name".to_string();
+    let value = "value".to_string();
+    let context =
+        make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
+            name: name.clone(),
+            value: value.clone(),
+        })]);
+    let action_info = make_base_action_info(UNIX_EPOCH);
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
+        name.clone(),
+        PropertyType::exact,
+    )])));
+    let (_, _, action_info) = join!(
+        context.modifier_scheduler.add_action(action_info),
+        context
             .mock_scheduler
-            .expect_get_platform_property_manager(Ok(scheduler_property_manager));
-        let property_manager_fut = context
-            .modifier_scheduler
-            .get_platform_property_manager(INSTANCE_NAME);
-        let (actual_instance_name, property_manager) =
-            join!(get_property_manager_fut, property_manager_fut);
-        assert_eq!(
-            HashMap::<_, _>::from_iter([(name, PropertyType::priority)]),
-            *property_manager?.get_known_properties()
-        );
-        assert_eq!(actual_instance_name, INSTANCE_NAME);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
-        let name = "name".to_string();
-        let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
-        let scheduler_property_manager =
-            Arc::new(PlatformPropertyManager::new(HashMap::<_, _>::from_iter([
-                (name.clone(), PropertyType::exact),
-            ])));
-        let get_property_manager_fut = context
+            .expect_get_platform_property_manager(Ok(platform_property_manager)),
+        context
             .mock_scheduler
-            .expect_get_platform_property_manager(Ok(scheduler_property_manager));
-        let property_manager_fut = context
+            .expect_add_action(Ok(forward_watch_channel_rx)),
+    );
+    assert_eq!(
+        HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
+        action_info.platform_properties.properties
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn add_action_overwrites_property() -> Result<(), Error> {
+    let name = "name".to_string();
+    let original_value = "value".to_string();
+    let replaced_value = "replaced".to_string();
+    let context =
+        make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
+            name: name.clone(),
+            value: replaced_value.clone(),
+        })]);
+    let mut action_info = make_base_action_info(UNIX_EPOCH);
+    action_info
+        .platform_properties
+        .properties
+        .insert(name.clone(), PlatformPropertyValue::Unknown(original_value));
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
+        name.clone(),
+        PropertyType::exact,
+    )])));
+    let (_, _, action_info) = join!(
+        context.modifier_scheduler.add_action(action_info),
+        context
+            .mock_scheduler
+            .expect_get_platform_property_manager(Ok(platform_property_manager)),
+        context
+            .mock_scheduler
+            .expect_add_action(Ok(forward_watch_channel_rx)),
+    );
+    assert_eq!(
+        HashMap::from([(name, PlatformPropertyValue::Exact(replaced_value))]),
+        action_info.platform_properties.properties
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn add_action_property_added_after_remove() -> Result<(), Error> {
+    let name = "name".to_string();
+    let value = "value".to_string();
+    let context = make_modifier_scheduler(vec![
+        PropertyModification::remove(name.clone()),
+        PropertyModification::add(PlatformPropertyAddition {
+            name: name.clone(),
+            value: value.clone(),
+        }),
+    ]);
+    let action_info = make_base_action_info(UNIX_EPOCH);
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
+        name.clone(),
+        PropertyType::exact,
+    )])));
+    let (_, _, action_info) = join!(
+        context.modifier_scheduler.add_action(action_info),
+        context
+            .mock_scheduler
+            .expect_get_platform_property_manager(Ok(platform_property_manager)),
+        context
+            .mock_scheduler
+            .expect_add_action(Ok(forward_watch_channel_rx)),
+    );
+    assert_eq!(
+        HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
+        action_info.platform_properties.properties
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn add_action_property_remove_after_add() -> Result<(), Error> {
+    let name = "name".to_string();
+    let value = "value".to_string();
+    let context = make_modifier_scheduler(vec![
+        PropertyModification::add(PlatformPropertyAddition {
+            name: name.clone(),
+            value: value.clone(),
+        }),
+        PropertyModification::remove(name.clone()),
+    ]);
+    let action_info = make_base_action_info(UNIX_EPOCH);
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
+        name,
+        PropertyType::exact,
+    )])));
+    let (_, _, action_info) = join!(
+        context.modifier_scheduler.add_action(action_info),
+        context
+            .mock_scheduler
+            .expect_get_platform_property_manager(Ok(platform_property_manager)),
+        context
+            .mock_scheduler
+            .expect_add_action(Ok(forward_watch_channel_rx)),
+    );
+    assert_eq!(
+        HashMap::from([]),
+        action_info.platform_properties.properties
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn add_action_property_remove() -> Result<(), Error> {
+    let name = "name".to_string();
+    let value = "value".to_string();
+    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let mut action_info = make_base_action_info(UNIX_EPOCH);
+    action_info
+        .platform_properties
+        .properties
+        .insert(name, PlatformPropertyValue::Unknown(value));
+    let (_forward_watch_channel_tx, forward_watch_channel_rx) =
+        watch::channel(Arc::new(ActionState {
+            id: OperationId::new(action_info.unique_qualifier.clone()),
+            stage: ActionStage::Queued,
+        }));
+    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
+    let (_, _, action_info) = join!(
+        context.modifier_scheduler.add_action(action_info),
+        context
+            .mock_scheduler
+            .expect_get_platform_property_manager(Ok(platform_property_manager)),
+        context
+            .mock_scheduler
+            .expect_add_action(Ok(forward_watch_channel_rx)),
+    );
+    assert_eq!(
+        HashMap::from([]),
+        action_info.platform_properties.properties
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn find_existing_action_call_passed() -> Result<(), Error> {
+    let context = make_modifier_scheduler(vec![]);
+    let action_name = ActionInfoHashKey {
+        instance_name: "instance".to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::new([8; 32], 1),
+        salt: 1000,
+    };
+    let (actual_result, actual_action_name) = join!(
+        context
             .modifier_scheduler
-            .get_platform_property_manager(INSTANCE_NAME);
-        let (_, property_manager) = join!(get_property_manager_fut, property_manager_fut);
-        assert_eq!(
-            HashMap::<_, _>::from_iter([(name, PropertyType::exact)]),
-            *property_manager?.get_known_properties()
-        );
-        Ok(())
-    }
+            .find_existing_action(&action_name),
+        context.mock_scheduler.expect_find_existing_action(None),
+    );
+    assert_eq!(true, actual_result.is_none());
+    assert_eq!(action_name, actual_action_name);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
+    let name = "name".to_string();
+    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let scheduler_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
+    let get_property_manager_fut = context
+        .mock_scheduler
+        .expect_get_platform_property_manager(Ok(scheduler_property_manager));
+    let property_manager_fut = context
+        .modifier_scheduler
+        .get_platform_property_manager(INSTANCE_NAME);
+    let (actual_instance_name, property_manager) =
+        join!(get_property_manager_fut, property_manager_fut);
+    assert_eq!(
+        HashMap::<_, _>::from_iter([(name, PropertyType::priority)]),
+        *property_manager?.get_known_properties()
+    );
+    assert_eq!(actual_instance_name, INSTANCE_NAME);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
+    let name = "name".to_string();
+    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let scheduler_property_manager =
+        Arc::new(PlatformPropertyManager::new(HashMap::<_, _>::from_iter([
+            (name.clone(), PropertyType::exact),
+        ])));
+    let get_property_manager_fut = context
+        .mock_scheduler
+        .expect_get_platform_property_manager(Ok(scheduler_property_manager));
+    let property_manager_fut = context
+        .modifier_scheduler
+        .get_platform_property_manager(INSTANCE_NAME);
+    let (_, property_manager) = join!(get_property_manager_fut, property_manager_fut);
+    assert_eq!(
+        HashMap::<_, _>::from_iter([(name, PropertyType::exact)]),
+        *property_manager?.get_known_properties()
+    );
+    Ok(())
 }

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -19,25 +19,28 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
-use nativelink_scheduler::action_scheduler::ActionScheduler;
-use nativelink_util::action_messages::{
-    ActionInfoHashKey, ActionResult, ActionStage, ActionState, DirectoryInfo, ExecutionMetadata,
-    FileInfo, NameOrPath, OperationId, SymlinkInfo, INTERNAL_ERROR_EXIT_CODE,
-};
-use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
-mod utils {
-    pub(crate) mod scheduler_utils;
-}
 use nativelink_proto::build::bazel::remote::execution::v2::{digest_function, ExecuteRequest};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
     update_for_worker, ConnectionResult, StartExecute, UpdateForWorker,
 };
+use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::simple_scheduler::SimpleScheduler;
 use nativelink_scheduler::worker::{Worker, WorkerId};
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
+use nativelink_util::action_messages::{
+    ActionInfoHashKey, ActionResult, ActionStage, ActionState, DirectoryInfo, ExecutionMetadata,
+    FileInfo, NameOrPath, OperationId, SymlinkInfo, INTERNAL_ERROR_EXIT_CODE,
+};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
+use pretty_assertions::assert_eq;
 use tokio::sync::{mpsc, watch};
 use utils::scheduler_utils::{make_base_action_info, INSTANCE_NAME};
+
+mod utils {
+    pub(crate) mod scheduler_utils;
+}
 
 async fn verify_initial_connection_message(
     worker_id: WorkerId,
@@ -94,618 +97,32 @@ async fn setup_action(
     result
 }
 
-#[cfg(test)]
-mod scheduler_tests {
-    use nativelink_util::digest_hasher::DigestHasherFunc;
-    use pretty_assertions::assert_eq;
+const WORKER_TIMEOUT_S: u64 = 100;
 
-    use super::*; // Must be declared in every module.
+#[nativelink_test]
+async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
-    const WORKER_TIMEOUT_S: u64 = 100;
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
 
-    #[nativelink_test]
-    async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
 
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Worker should have been sent an execute command.
-            let expected_msg_for_worker = UpdateForWorker {
-                update: Some(update_for_worker::Update::StartAction(StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        instance_name: INSTANCE_NAME.to_string(),
-                        skip_cache_lookup: true,
-                        action_digest: Some(action_digest.into()),
-                        digest_function: digest_function::Value::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(insert_timestamp.into()),
-                })),
-            };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
-            assert_eq!(msg_for_worker, expected_msg_for_worker);
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Executing,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn find_executing_action() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        // Drop our receiver and look up a new one.
-        let unique_qualifier = client_rx.borrow().id.unique_qualifier.clone();
-        drop(client_rx);
-        let mut client_rx = scheduler
-            .find_existing_action(&unique_qualifier)
-            .await
-            .err_tip(|| "Action not found")?;
-
-        {
-            // Worker should have been sent an execute command.
-            let expected_msg_for_worker = UpdateForWorker {
-                update: Some(update_for_worker::Update::StartAction(StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        instance_name: INSTANCE_NAME.to_string(),
-                        skip_cache_lookup: true,
-                        action_digest: Some(action_digest.into()),
-                        digest_function: digest_function::Value::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(insert_timestamp.into()),
-                })),
-            };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
-            assert_eq!(msg_for_worker, expected_msg_for_worker);
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Executing,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Error> {
-        const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
-        const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler {
-                worker_timeout_s: WORKER_TIMEOUT_S,
-                ..Default::default()
-            },
-            || async move {},
-        );
-        let action_digest1 = DigestInfo::new([99u8; 32], 512);
-        let action_digest2 = DigestInfo::new([88u8; 32], 512);
-
-        let mut rx_from_worker1 =
-            setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
-        let insert_timestamp1 = make_system_time(1);
-        let mut client_rx1 = setup_action(
-            &scheduler,
-            action_digest1,
-            PlatformProperties::default(),
-            insert_timestamp1,
-        )
-        .await?;
-        let insert_timestamp2 = make_system_time(2);
-        let mut client_rx2 = setup_action(
-            &scheduler,
-            action_digest2,
-            PlatformProperties::default(),
-            insert_timestamp2,
-        )
-        .await?;
-
-        let unique_qualifier = ActionInfoHashKey {
-            instance_name: "".to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::zero_digest(),
-            salt: 0,
-        };
-
-        let id = OperationId::new(unique_qualifier);
-        let mut expected_action_state1 = ActionState {
-            // Name is a random string, so we ignore it and just make it the same.
-            id: id.clone(),
-            stage: ActionStage::Executing,
-        };
-        let mut expected_action_state2 = ActionState {
-            // Name is a random string, so we ignore it and just make it the same.
-            id,
-            stage: ActionStage::Executing,
-        };
-
-        let execution_request_for_worker1 = UpdateForWorker {
-            update: Some(update_for_worker::Update::StartAction(StartExecute {
-                execute_request: Some(ExecuteRequest {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    skip_cache_lookup: true,
-                    action_digest: Some(action_digest1.into()),
-                    digest_function: digest_function::Value::Sha256.into(),
-                    ..Default::default()
-                }),
-                salt: 0,
-                queued_timestamp: Some(insert_timestamp1.into()),
-            })),
-        };
-        {
-            // Worker1 should now see execution request.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker1);
-        }
-        let execution_request_for_worker2 = UpdateForWorker {
-            update: Some(update_for_worker::Update::StartAction(StartExecute {
-                execute_request: Some(ExecuteRequest {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    skip_cache_lookup: true,
-                    action_digest: Some(action_digest2.into()),
-                    digest_function: digest_function::Value::Sha256.into(),
-                    ..Default::default()
-                }),
-                salt: 0,
-                queued_timestamp: Some(insert_timestamp2.into()),
-            })),
-        };
-        {
-            // Worker1 should now see second execution request.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker2);
-        }
-
-        // Add a second worker that can take jobs if the first dies.
-        let mut rx_from_worker2 =
-            setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
-
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx1.borrow_and_update();
-            // We now know the name of the action so populate it.
-            expected_action_state1.id = action_state.id.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state1);
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx2.borrow_and_update();
-            // We now know the name of the action so populate it.
-            expected_action_state2.id = action_state.id.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state2);
-        }
-
-        // Now remove worker.
-        scheduler.remove_worker(WORKER_ID1).await;
-        tokio::task::yield_now().await; // Allow task<->worker matcher to run.
-
-        {
-            // Worker1 should have received a disconnect message.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
-            assert_eq!(
-                msg_for_worker,
-                UpdateForWorker {
-                    update: Some(update_for_worker::Update::Disconnect(()))
-                }
-            );
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx1.borrow_and_update();
-            expected_action_state1.stage = ActionStage::Executing;
-            assert_eq!(action_state.as_ref(), &expected_action_state1);
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx2.borrow_and_update();
-            expected_action_state2.stage = ActionStage::Executing;
-            assert_eq!(action_state.as_ref(), &expected_action_state2);
-        }
-        {
-            // Worker2 should now see execution request.
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker1);
-        }
-        {
-            // Worker2 should now see execution request.
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker2);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        // Set the worker draining.
-        scheduler.set_drain_worker(WORKER_ID, true).await?;
-        tokio::task::yield_now().await;
-
-        let action_digest = DigestInfo::new([88u8; 32], 512);
-        let insert_timestamp = make_system_time(14);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Client should get notification saying it's been queued.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Queued,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        // Set the worker not draining.
-        scheduler.set_drain_worker(WORKER_ID, false).await?;
-        tokio::task::yield_now().await;
-
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Executing,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), Error> {
-        const WORKER_ID1: WorkerId = WorkerId(0x0010_0001);
-        const WORKER_ID2: WorkerId = WorkerId(0x0010_0002);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-        let mut platform_properties = PlatformProperties::default();
-        platform_properties.properties.insert(
-            "prop".to_string(),
-            PlatformPropertyValue::Exact("1".to_string()),
-        );
-        let mut worker_properties = platform_properties.clone();
-        worker_properties.properties.insert(
-            "prop".to_string(),
-            PlatformPropertyValue::Exact("2".to_string()),
-        );
-
-        let mut rx_from_worker1 =
-            setup_new_worker(&scheduler, WORKER_ID1, platform_properties.clone()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            worker_properties.clone(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Client should get notification saying it's been queued.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Queued,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        let mut rx_from_worker2 =
-            setup_new_worker(&scheduler, WORKER_ID2, worker_properties).await?;
-        {
-            // Worker should have been sent an execute command.
-            let expected_msg_for_worker = UpdateForWorker {
-                update: Some(update_for_worker::Update::StartAction(StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        instance_name: INSTANCE_NAME.to_string(),
-                        skip_cache_lookup: true,
-                        action_digest: Some(action_digest.into()),
-                        digest_function: digest_function::Value::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(insert_timestamp.into()),
-                })),
-            };
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
-            assert_eq!(msg_for_worker, expected_msg_for_worker);
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Executing,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        // Our first worker should have no updates over this test.
-        assert_eq!(
-            rx_from_worker1.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x0010_0009);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let unique_qualifier = ActionInfoHashKey {
-            instance_name: "".to_string(),
-            digest: DigestInfo::zero_digest(),
-            digest_function: DigestHasherFunc::Sha256,
-            salt: 0,
-        };
-        let id = OperationId::new(unique_qualifier);
-        let mut expected_action_state = ActionState {
-            id,
-            stage: ActionStage::Queued,
-        };
-
-        let insert_timestamp1 = make_system_time(1);
-        let insert_timestamp2 = make_system_time(2);
-        let mut client1_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp1,
-        )
-        .await?;
-        let mut client2_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp2,
-        )
-        .await?;
-
-        {
-            // Clients should get notification saying it's been queued.
-            let action_state1 = client1_rx.borrow_and_update();
-            let action_state2 = client2_rx.borrow_and_update();
-            // Name is random so we set force it to be the same.
-            expected_action_state.id = action_state1.id.clone();
-            assert_eq!(action_state1.as_ref(), &expected_action_state);
-            assert_eq!(action_state2.as_ref(), &expected_action_state);
-        }
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-
-        {
-            // Worker should have been sent an execute command.
-            let expected_msg_for_worker = UpdateForWorker {
-                update: Some(update_for_worker::Update::StartAction(StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        instance_name: INSTANCE_NAME.to_string(),
-                        skip_cache_lookup: true,
-                        action_digest: Some(action_digest.into()),
-                        digest_function: digest_function::Value::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(insert_timestamp1.into()),
-                })),
-            };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
-            assert_eq!(msg_for_worker, expected_msg_for_worker);
-        }
-
-        // Action should now be executing.
-        expected_action_state.stage = ActionStage::Executing;
-        {
-            // Both client1 and client2 should be receiving the same updates.
-            // Most importantly the `name` (which is random) will be the same.
-            assert_eq!(
-                client1_rx.borrow_and_update().as_ref(),
-                &expected_action_state
-            );
-            assert_eq!(
-                client2_rx.borrow_and_update().as_ref(),
-                &expected_action_state
-            );
-        }
-
-        {
-            // Now if another action is requested it should also join with executing action.
-            let insert_timestamp3 = make_system_time(2);
-            let mut client3_rx = setup_action(
-                &scheduler,
-                action_digest,
-                PlatformProperties::default(),
-                insert_timestamp3,
-            )
-            .await?;
-            assert_eq!(
-                client3_rx.borrow_and_update().as_ref(),
-                &expected_action_state
-            );
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x0010_0010);
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-
-        // Now act like the worker disconnected.
-        drop(rx_from_worker);
-
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-        {
-            // Client should get notification saying it's being queued not executed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Queued,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
-        const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
-        const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler {
-                worker_timeout_s: WORKER_TIMEOUT_S,
-                ..Default::default()
-            },
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        // Note: This needs to stay in scope or a disconnect will trigger.
-        let mut rx_from_worker1 =
-            setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        // Note: This needs to stay in scope or a disconnect will trigger.
-        let mut rx_from_worker2 =
-            setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
-
-        let unique_qualifier = ActionInfoHashKey {
-            instance_name: "".to_string(),
-            digest: DigestInfo::zero_digest(),
-            digest_function: DigestHasherFunc::Sha256,
-            salt: 0,
-        };
-        let id = OperationId::new(unique_qualifier);
-        let mut expected_action_state = ActionState {
-            id,
-            stage: ActionStage::Executing,
-        };
-
-        let execution_request_for_worker = UpdateForWorker {
+    {
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
             update: Some(update_for_worker::Update::StartAction(StartExecute {
                 execute_request: Some(ExecuteRequest {
                     instance_name: INSTANCE_NAME.to_string(),
@@ -718,706 +135,1049 @@ mod scheduler_tests {
                 queued_timestamp: Some(insert_timestamp.into()),
             })),
         };
-
-        {
-            // Worker1 should now see execution request.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker);
-        }
-
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            // We now know the name of the action so populate it.
-            expected_action_state.id = action_state.id.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        // Keep worker 2 alive.
-        scheduler
-            .worker_keep_alive_received(&WORKER_ID2, NOW_TIME + WORKER_TIMEOUT_S)
-            .await?;
-        // This should remove worker 1 (the one executing our job).
-        scheduler
-            .remove_timedout_workers(NOW_TIME + WORKER_TIMEOUT_S)
-            .await?;
-        tokio::task::yield_now().await; // Allow task<->worker matcher to run.
-
-        {
-            // Worker1 should have received a disconnect message.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
-            assert_eq!(
-                msg_for_worker,
-                UpdateForWorker {
-                    update: Some(update_for_worker::Update::Disconnect(()))
-                }
-            );
-        }
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            expected_action_state.stage = ActionStage::Executing;
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-        {
-            // Worker2 should now see execution request.
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
-            assert_eq!(msg_for_worker, execution_request_for_worker);
-        }
-
-        Ok(())
+        let msg_for_worker = rx_from_worker.recv().await.unwrap();
+        assert_eq!(msg_for_worker, expected_msg_for_worker);
     }
-
-    #[nativelink_test]
-    async fn update_action_sends_completed_result_to_client_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        let action_info_hash_key = ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: action_digest,
-            salt: 0,
-        };
-        let action_result = ActionResult {
-            output_files: vec![FileInfo {
-                name_or_path: NameOrPath::Name("hello".to_string()),
-                digest: DigestInfo::new([5u8; 32], 18),
-                is_executable: true,
-            }],
-            output_folders: vec![DirectoryInfo {
-                path: "123".to_string(),
-                tree_digest: DigestInfo::new([9u8; 32], 100),
-            }],
-            output_file_symlinks: vec![SymlinkInfo {
-                name_or_path: NameOrPath::Name("foo".to_string()),
-                target: "bar".to_string(),
-            }],
-            output_directory_symlinks: vec![SymlinkInfo {
-                name_or_path: NameOrPath::Name("foo2".to_string()),
-                target: "bar2".to_string(),
-            }],
-            exit_code: 0,
-            stdout_digest: DigestInfo::new([6u8; 32], 19),
-            stderr_digest: DigestInfo::new([7u8; 32], 20),
-            execution_metadata: ExecutionMetadata {
-                worker: WORKER_ID.to_string(),
-                queued_timestamp: make_system_time(5),
-                worker_start_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-                input_fetch_start_timestamp: make_system_time(8),
-                input_fetch_completed_timestamp: make_system_time(9),
-                execution_start_timestamp: make_system_time(10),
-                execution_completed_timestamp: make_system_time(11),
-                output_upload_start_timestamp: make_system_time(12),
-                output_upload_completed_timestamp: make_system_time(13),
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
-        };
-        scheduler
-            .update_action(
-                &WORKER_ID,
-                &action_info_hash_key,
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await?;
-
-        {
-            // Client should get notification saying it has been completed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Completed(action_result),
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-        {
-            // Update info for the action should now be closed (notification happens through Err).
-            let result = client_rx.changed().await;
-            assert!(
-                result.is_err(),
-                "Expected result to be an error : {result:?}"
-            );
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn update_action_sends_completed_result_after_disconnect() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        // Drop our receiver and don't reconnect until completed.
-        let unique_qualifier = client_rx.borrow().id.unique_qualifier.clone();
-        drop(client_rx);
-
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-        }
-
-        let action_info_hash_key = ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: action_digest,
-            salt: 0,
-        };
-        let action_result = ActionResult {
-            output_files: vec![FileInfo {
-                name_or_path: NameOrPath::Name("hello".to_string()),
-                digest: DigestInfo::new([5u8; 32], 18),
-                is_executable: true,
-            }],
-            output_folders: vec![DirectoryInfo {
-                path: "123".to_string(),
-                tree_digest: DigestInfo::new([9u8; 32], 100),
-            }],
-            output_file_symlinks: vec![SymlinkInfo {
-                name_or_path: NameOrPath::Name("foo".to_string()),
-                target: "bar".to_string(),
-            }],
-            output_directory_symlinks: vec![SymlinkInfo {
-                name_or_path: NameOrPath::Name("foo2".to_string()),
-                target: "bar2".to_string(),
-            }],
-            exit_code: 0,
-            stdout_digest: DigestInfo::new([6u8; 32], 19),
-            stderr_digest: DigestInfo::new([7u8; 32], 20),
-            execution_metadata: ExecutionMetadata {
-                worker: WORKER_ID.to_string(),
-                queued_timestamp: make_system_time(5),
-                worker_start_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-                input_fetch_start_timestamp: make_system_time(8),
-                input_fetch_completed_timestamp: make_system_time(9),
-                execution_start_timestamp: make_system_time(10),
-                execution_completed_timestamp: make_system_time(11),
-                output_upload_start_timestamp: make_system_time(12),
-                output_upload_completed_timestamp: make_system_time(13),
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
-        };
-        scheduler
-            .update_action(
-                &WORKER_ID,
-                &action_info_hash_key,
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await?;
-
-        // Now look up a channel after the action has completed.
-        let mut client_rx = scheduler
-            .find_existing_action(&unique_qualifier)
-            .await
-            .err_tip(|| "Action not found")?;
-        {
-            // Client should get notification saying it has been completed.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Completed(action_result),
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
-        const GOOD_WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-        const ROGUE_WORKER_ID: WorkerId = WorkerId(0x0009_8765_4321);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, GOOD_WORKER_ID, PlatformProperties::default()).await?;
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        let action_info_hash_key = ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: action_digest,
-            salt: 0,
-        };
-        let action_result = ActionResult {
-            output_files: Vec::default(),
-            output_folders: Vec::default(),
-            output_file_symlinks: Vec::default(),
-            output_directory_symlinks: Vec::default(),
-            exit_code: 0,
-            stdout_digest: DigestInfo::new([6u8; 32], 19),
-            stderr_digest: DigestInfo::new([7u8; 32], 20),
-            execution_metadata: ExecutionMetadata {
-                worker: GOOD_WORKER_ID.to_string(),
-                queued_timestamp: make_system_time(5),
-                worker_start_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-                input_fetch_start_timestamp: make_system_time(8),
-                input_fetch_completed_timestamp: make_system_time(9),
-                execution_start_timestamp: make_system_time(10),
-                execution_completed_timestamp: make_system_time(11),
-                output_upload_start_timestamp: make_system_time(12),
-                output_upload_completed_timestamp: make_system_time(13),
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
-        };
-        let update_action_result = scheduler
-            .update_action(
-                &ROGUE_WORKER_ID,
-                &action_info_hash_key,
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await;
-
-        {
-            const EXPECTED_ERR: &str =
-                "Got a result from a worker that should not be running the action";
-            // Our request should have sent an error back.
-            assert!(
-                update_action_result.is_err(),
-                "Expected error, got: {:?}",
-                &update_action_result
-            );
-            let err = update_action_result.unwrap_err();
-            assert!(
-                err.to_string().contains(EXPECTED_ERR),
-                "Error should contain '{EXPECTED_ERR}', got: {err:?}",
-            );
-        }
-        {
-            // Ensure client did not get notified.
-            assert_eq!(
-                client_rx.has_changed().unwrap(),
-                false,
-                "Client should not have been notified of event"
-            );
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x0010_000f);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let unique_qualifier = ActionInfoHashKey {
-            instance_name: "".to_string(),
-            digest: DigestInfo::zero_digest(),
-            digest_function: DigestHasherFunc::Sha256,
-            salt: 0,
-        };
-        let id = OperationId::new(unique_qualifier);
-        let mut expected_action_state = ActionState {
-            id,
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
             stage: ActionStage::Executing,
         };
-
-        let insert_timestamp = make_system_time(1);
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            insert_timestamp,
-        )
-        .await?;
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-
-        {
-            // Worker should have been sent an execute command.
-            let expected_msg_for_worker = UpdateForWorker {
-                update: Some(update_for_worker::Update::StartAction(StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        instance_name: INSTANCE_NAME.to_string(),
-                        skip_cache_lookup: true,
-                        action_digest: Some(action_digest.into()),
-                        digest_function: digest_function::Value::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(insert_timestamp.into()),
-                })),
-            };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
-            assert_eq!(msg_for_worker, expected_msg_for_worker);
-        }
-
-        {
-            // Client should get notification saying it's being executed.
-            let action_state = client_rx.borrow_and_update();
-            // We now know the name of the action so populate it.
-            expected_action_state.id = action_state.id.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        let action_result = ActionResult {
-            output_files: Vec::default(),
-            output_folders: Vec::default(),
-            output_directory_symlinks: Vec::default(),
-            output_file_symlinks: Vec::default(),
-            exit_code: Default::default(),
-            stdout_digest: DigestInfo::new([1u8; 32], 512),
-            stderr_digest: DigestInfo::new([2u8; 32], 512),
-            execution_metadata: ExecutionMetadata {
-                worker: String::new(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: SystemTime::UNIX_EPOCH,
-                worker_completed_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
-                execution_start_timestamp: SystemTime::UNIX_EPOCH,
-                execution_completed_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
-        };
-
-        scheduler
-            .update_action(
-                &WORKER_ID,
-                &ActionInfoHashKey {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    digest_function: DigestHasherFunc::Sha256,
-                    digest: action_digest,
-                    salt: 0,
-                },
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await?;
-
-        {
-            // Action should now be executing.
-            expected_action_state.stage = ActionStage::Completed(action_result.clone());
-            assert_eq!(
-                client_rx.borrow_and_update().as_ref(),
-                &expected_action_state
-            );
-        }
-
-        // Now we need to ensure that if we schedule another execution of the same job it doesn't
-        // fail.
-
-        {
-            let insert_timestamp = make_system_time(1);
-            let mut client_rx = setup_action(
-                &scheduler,
-                action_digest,
-                PlatformProperties::default(),
-                insert_timestamp,
-            )
-            .await?;
-            // We didn't disconnect our worker, so it will have scheduled it to the worker.
-            expected_action_state.stage = ActionStage::Executing;
-            let action_state = client_rx.borrow_and_update();
-            // The name of the action changed (since it's a new action), so update it.
-            expected_action_state.id = action_state.id.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
+        assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
-    /// This tests to ensure that platform property restrictions allow jobs to continue to run after
-    /// a job finished on a specific worker (eg: restore platform properties).
-    #[nativelink_test]
-    async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> Result<(), Error>
+    Ok(())
+}
+
+#[nativelink_test]
+async fn find_executing_action() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    // Drop our receiver and look up a new one.
+    let unique_qualifier = client_rx.borrow().id.unique_qualifier.clone();
+    drop(client_rx);
+    let mut client_rx = scheduler
+        .find_existing_action(&unique_qualifier)
+        .await
+        .err_tip(|| "Action not found")?;
+
     {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest1 = DigestInfo::new([11u8; 32], 512);
-        let action_digest2 = DigestInfo::new([99u8; 32], 512);
-
-        let mut properties = HashMap::new();
-        properties.insert("prop1".to_string(), PlatformPropertyValue::Minimum(1));
-        let platform_properties = PlatformProperties { properties };
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, platform_properties.clone()).await?;
-        let insert_timestamp1 = make_system_time(1);
-        let mut client1_rx = setup_action(
-            &scheduler,
-            action_digest1,
-            platform_properties.clone(),
-            insert_timestamp1,
-        )
-        .await?;
-        let insert_timestamp2 = make_system_time(1);
-        let mut client2_rx = setup_action(
-            &scheduler,
-            action_digest2,
-            platform_properties,
-            insert_timestamp2,
-        )
-        .await?;
-
-        match rx_from_worker.recv().await.unwrap().update {
-            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-            v => panic!("Expected StartAction, got : {v:?}"),
-        }
-        {
-            // First client should be in an Executing state.
-            assert_eq!(client1_rx.borrow_and_update().stage, ActionStage::Executing);
-            // Second client should be in a queued state.
-            assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Queued);
-        }
-
-        let action_result = ActionResult {
-            output_files: Vec::default(),
-            output_folders: Vec::default(),
-            output_file_symlinks: Vec::default(),
-            output_directory_symlinks: Vec::default(),
-            exit_code: 0,
-            stdout_digest: DigestInfo::new([6u8; 32], 19),
-            stderr_digest: DigestInfo::new([7u8; 32], 20),
-            execution_metadata: ExecutionMetadata {
-                worker: WORKER_ID.to_string(),
-                queued_timestamp: make_system_time(5),
-                worker_start_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-                input_fetch_start_timestamp: make_system_time(8),
-                input_fetch_completed_timestamp: make_system_time(9),
-                execution_start_timestamp: make_system_time(10),
-                execution_completed_timestamp: make_system_time(11),
-                output_upload_start_timestamp: make_system_time(12),
-                output_upload_completed_timestamp: make_system_time(13),
-            },
-            server_logs: HashMap::default(),
-            error: None,
-            message: String::new(),
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
+            update: Some(update_for_worker::Update::StartAction(StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    instance_name: INSTANCE_NAME.to_string(),
+                    skip_cache_lookup: true,
+                    action_digest: Some(action_digest.into()),
+                    digest_function: digest_function::Value::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(insert_timestamp.into()),
+            })),
         };
-
-        // Tell scheduler our first task is completed.
-        scheduler
-            .update_action(
-                &WORKER_ID,
-                &ActionInfoHashKey {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    digest_function: DigestHasherFunc::Sha256,
-                    digest: action_digest1,
-                    salt: 0,
-                },
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await?;
-
-        // Ensure client did not get notified.
-        assert!(
-            client1_rx.changed().await.is_ok(),
-            "Client should have been notified of event"
-        );
-
-        {
-            // First action should now be completed.
-            let action_state = client1_rx.borrow_and_update();
-            let mut expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Completed(action_result.clone()),
-            };
-            // We now know the name of the action so populate it.
-            expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        // At this stage it should have added back any platform_properties and the next
-        // task should be executing on the same worker.
-
-        {
-            // Our second client should now executing.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        // Tell scheduler our second task is completed.
-        scheduler
-            .update_action(
-                &WORKER_ID,
-                &ActionInfoHashKey {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    digest_function: DigestHasherFunc::Sha256,
-                    digest: action_digest2,
-                    salt: 0,
-                },
-                ActionStage::Completed(action_result.clone()),
-            )
-            .await?;
-
-        {
-            // Our second client should be notified it completed.
-            let action_state = client2_rx.borrow_and_update();
-            let mut expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Completed(action_result.clone()),
-            };
-            // We now know the name of the action so populate it.
-            expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
+        let msg_for_worker = rx_from_worker.recv().await.unwrap();
+        assert_eq!(msg_for_worker, expected_msg_for_worker);
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Executing,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
-    /// This tests that actions are performed in the order they were queued.
-    #[nativelink_test]
-    async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+    Ok(())
+}
 
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
+#[nativelink_test]
+async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Error> {
+    const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
+    const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler {
+            worker_timeout_s: WORKER_TIMEOUT_S,
+            ..Default::default()
+        },
+        || async move {},
+    );
+    let action_digest1 = DigestInfo::new([99u8; 32], 512);
+    let action_digest2 = DigestInfo::new([88u8; 32], 512);
+
+    let mut rx_from_worker1 =
+        setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
+    let insert_timestamp1 = make_system_time(1);
+    let mut client_rx1 = setup_action(
+        &scheduler,
+        action_digest1,
+        PlatformProperties::default(),
+        insert_timestamp1,
+    )
+    .await?;
+    let insert_timestamp2 = make_system_time(2);
+    let mut client_rx2 = setup_action(
+        &scheduler,
+        action_digest2,
+        PlatformProperties::default(),
+        insert_timestamp2,
+    )
+    .await?;
+
+    let unique_qualifier = ActionInfoHashKey {
+        instance_name: "".to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::zero_digest(),
+        salt: 0,
+    };
+
+    let id = OperationId::new(unique_qualifier);
+    let mut expected_action_state1 = ActionState {
+        // Name is a random string, so we ignore it and just make it the same.
+        id: id.clone(),
+        stage: ActionStage::Executing,
+    };
+    let mut expected_action_state2 = ActionState {
+        // Name is a random string, so we ignore it and just make it the same.
+        id,
+        stage: ActionStage::Executing,
+    };
+
+    let execution_request_for_worker1 = UpdateForWorker {
+        update: Some(update_for_worker::Update::StartAction(StartExecute {
+            execute_request: Some(ExecuteRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                skip_cache_lookup: true,
+                action_digest: Some(action_digest1.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+                ..Default::default()
+            }),
+            salt: 0,
+            queued_timestamp: Some(insert_timestamp1.into()),
+        })),
+    };
+    {
+        // Worker1 should now see execution request.
+        let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker1);
+    }
+    let execution_request_for_worker2 = UpdateForWorker {
+        update: Some(update_for_worker::Update::StartAction(StartExecute {
+            execute_request: Some(ExecuteRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                skip_cache_lookup: true,
+                action_digest: Some(action_digest2.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+                ..Default::default()
+            }),
+            salt: 0,
+            queued_timestamp: Some(insert_timestamp2.into()),
+        })),
+    };
+    {
+        // Worker1 should now see second execution request.
+        let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker2);
+    }
+
+    // Add a second worker that can take jobs if the first dies.
+    let mut rx_from_worker2 =
+        setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
+
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx1.borrow_and_update();
+        // We now know the name of the action so populate it.
+        expected_action_state1.id = action_state.id.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state1);
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx2.borrow_and_update();
+        // We now know the name of the action so populate it.
+        expected_action_state2.id = action_state.id.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state2);
+    }
+
+    // Now remove worker.
+    scheduler.remove_worker(WORKER_ID1).await;
+    tokio::task::yield_now().await; // Allow task<->worker matcher to run.
+
+    {
+        // Worker1 should have received a disconnect message.
+        let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+        assert_eq!(
+            msg_for_worker,
+            UpdateForWorker {
+                update: Some(update_for_worker::Update::Disconnect(()))
+            }
         );
-        let action_digest1 = DigestInfo::new([11u8; 32], 512);
-        let action_digest2 = DigestInfo::new([99u8; 32], 512);
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx1.borrow_and_update();
+        expected_action_state1.stage = ActionStage::Executing;
+        assert_eq!(action_state.as_ref(), &expected_action_state1);
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx2.borrow_and_update();
+        expected_action_state2.stage = ActionStage::Executing;
+        assert_eq!(action_state.as_ref(), &expected_action_state2);
+    }
+    {
+        // Worker2 should now see execution request.
+        let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker1);
+    }
+    {
+        // Worker2 should now see execution request.
+        let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker2);
+    }
 
-        // Use property to restrict the worker to a single action at a time.
-        let mut properties = HashMap::new();
-        properties.insert("prop1".to_string(), PlatformPropertyValue::Minimum(1));
-        let platform_properties = PlatformProperties { properties };
-        // This is queued after the next one (even though it's placed in the map
-        // first), so it should execute second.
-        let insert_timestamp2 = make_system_time(2);
-        let mut client2_rx = setup_action(
-            &scheduler,
-            action_digest2,
-            platform_properties.clone(),
-            insert_timestamp2,
-        )
-        .await?;
-        let insert_timestamp1 = make_system_time(1);
-        let mut client1_rx = setup_action(
-            &scheduler,
-            action_digest1,
-            platform_properties.clone(),
-            insert_timestamp1,
-        )
-        .await?;
+    Ok(())
+}
 
-        // Add the worker after the queue has been set up.
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, platform_properties).await?;
+#[nativelink_test]
+async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
         match rx_from_worker.recv().await.unwrap().update {
             Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
             v => panic!("Expected StartAction, got : {v:?}"),
         }
-        {
-            // First client should be in an Executing state.
-            assert_eq!(client1_rx.borrow_and_update().stage, ActionStage::Executing);
-            // Second client should be in a queued state.
-            assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Queued);
-        }
-
-        Ok(())
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
     }
 
-    #[nativelink_test]
-    async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> {
-        const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+    // Set the worker draining.
+    scheduler.set_drain_worker(WORKER_ID, true).await?;
+    tokio::task::yield_now().await;
 
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler {
-                max_job_retries: 2,
-                ..Default::default()
-            },
-            || async move {},
+    let action_digest = DigestInfo::new([88u8; 32], 512);
+    let insert_timestamp = make_system_time(14);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Client should get notification saying it's been queued.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Queued,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    // Set the worker not draining.
+    scheduler.set_drain_worker(WORKER_ID, false).await?;
+    tokio::task::yield_now().await;
+
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Executing,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), Error> {
+    const WORKER_ID1: WorkerId = WorkerId(0x0010_0001);
+    const WORKER_ID2: WorkerId = WorkerId(0x0010_0002);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+    let mut platform_properties = PlatformProperties::default();
+    platform_properties.properties.insert(
+        "prop".to_string(),
+        PlatformPropertyValue::Exact("1".to_string()),
+    );
+    let mut worker_properties = platform_properties.clone();
+    worker_properties.properties.insert(
+        "prop".to_string(),
+        PlatformPropertyValue::Exact("2".to_string()),
+    );
+
+    let mut rx_from_worker1 =
+        setup_new_worker(&scheduler, WORKER_ID1, platform_properties.clone()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        worker_properties.clone(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Client should get notification saying it's been queued.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Queued,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    let mut rx_from_worker2 = setup_new_worker(&scheduler, WORKER_ID2, worker_properties).await?;
+    {
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
+            update: Some(update_for_worker::Update::StartAction(StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    instance_name: INSTANCE_NAME.to_string(),
+                    skip_cache_lookup: true,
+                    action_digest: Some(action_digest.into()),
+                    digest_function: digest_function::Value::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(insert_timestamp.into()),
+            })),
+        };
+        let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+        assert_eq!(msg_for_worker, expected_msg_for_worker);
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Executing,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    // Our first worker should have no updates over this test.
+    assert_eq!(
+        rx_from_worker1.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x0010_0009);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let unique_qualifier = ActionInfoHashKey {
+        instance_name: "".to_string(),
+        digest: DigestInfo::zero_digest(),
+        digest_function: DigestHasherFunc::Sha256,
+        salt: 0,
+    };
+    let id = OperationId::new(unique_qualifier);
+    let mut expected_action_state = ActionState {
+        id,
+        stage: ActionStage::Queued,
+    };
+
+    let insert_timestamp1 = make_system_time(1);
+    let insert_timestamp2 = make_system_time(2);
+    let mut client1_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp1,
+    )
+    .await?;
+    let mut client2_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp2,
+    )
+    .await?;
+
+    {
+        // Clients should get notification saying it's been queued.
+        let action_state1 = client1_rx.borrow_and_update();
+        let action_state2 = client2_rx.borrow_and_update();
+        // Name is random so we set force it to be the same.
+        expected_action_state.id = action_state1.id.clone();
+        assert_eq!(action_state1.as_ref(), &expected_action_state);
+        assert_eq!(action_state2.as_ref(), &expected_action_state);
+    }
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+
+    {
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
+            update: Some(update_for_worker::Update::StartAction(StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    instance_name: INSTANCE_NAME.to_string(),
+                    skip_cache_lookup: true,
+                    action_digest: Some(action_digest.into()),
+                    digest_function: digest_function::Value::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(insert_timestamp1.into()),
+            })),
+        };
+        let msg_for_worker = rx_from_worker.recv().await.unwrap();
+        assert_eq!(msg_for_worker, expected_msg_for_worker);
+    }
+
+    // Action should now be executing.
+    expected_action_state.stage = ActionStage::Executing;
+    {
+        // Both client1 and client2 should be receiving the same updates.
+        // Most importantly the `name` (which is random) will be the same.
+        assert_eq!(
+            client1_rx.borrow_and_update().as_ref(),
+            &expected_action_state
         );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
+        assert_eq!(
+            client2_rx.borrow_and_update().as_ref(),
+            &expected_action_state
+        );
+    }
 
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    {
+        // Now if another action is requested it should also join with executing action.
+        let insert_timestamp3 = make_system_time(2);
+        let mut client3_rx = setup_action(
+            &scheduler,
+            action_digest,
+            PlatformProperties::default(),
+            insert_timestamp3,
+        )
+        .await?;
+        assert_eq!(
+            client3_rx.borrow_and_update().as_ref(),
+            &expected_action_state
+        );
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x0010_0010);
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+
+    // Now act like the worker disconnected.
+    drop(rx_from_worker);
+
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+    {
+        // Client should get notification saying it's being queued not executed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Queued,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
+    const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
+    const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler {
+            worker_timeout_s: WORKER_TIMEOUT_S,
+            ..Default::default()
+        },
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    // Note: This needs to stay in scope or a disconnect will trigger.
+    let mut rx_from_worker1 =
+        setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    // Note: This needs to stay in scope or a disconnect will trigger.
+    let mut rx_from_worker2 =
+        setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
+
+    let unique_qualifier = ActionInfoHashKey {
+        instance_name: "".to_string(),
+        digest: DigestInfo::zero_digest(),
+        digest_function: DigestHasherFunc::Sha256,
+        salt: 0,
+    };
+    let id = OperationId::new(unique_qualifier);
+    let mut expected_action_state = ActionState {
+        id,
+        stage: ActionStage::Executing,
+    };
+
+    let execution_request_for_worker = UpdateForWorker {
+        update: Some(update_for_worker::Update::StartAction(StartExecute {
+            execute_request: Some(ExecuteRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                skip_cache_lookup: true,
+                action_digest: Some(action_digest.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+                ..Default::default()
+            }),
+            salt: 0,
+            queued_timestamp: Some(insert_timestamp.into()),
+        })),
+    };
+
+    {
+        // Worker1 should now see execution request.
+        let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker);
+    }
+
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        // We now know the name of the action so populate it.
+        expected_action_state.id = action_state.id.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    // Keep worker 2 alive.
+    scheduler
+        .worker_keep_alive_received(&WORKER_ID2, NOW_TIME + WORKER_TIMEOUT_S)
+        .await?;
+    // This should remove worker 1 (the one executing our job).
+    scheduler
+        .remove_timedout_workers(NOW_TIME + WORKER_TIMEOUT_S)
+        .await?;
+    tokio::task::yield_now().await; // Allow task<->worker matcher to run.
+
+    {
+        // Worker1 should have received a disconnect message.
+        let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+        assert_eq!(
+            msg_for_worker,
+            UpdateForWorker {
+                update: Some(update_for_worker::Update::Disconnect(()))
+            }
+        );
+    }
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        expected_action_state.stage = ActionStage::Executing;
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+    {
+        // Worker2 should now see execution request.
+        let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+        assert_eq!(msg_for_worker, execution_request_for_worker);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_action_sends_completed_result_to_client_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    let action_info_hash_key = ActionInfoHashKey {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: action_digest,
+        salt: 0,
+    };
+    let action_result = ActionResult {
+        output_files: vec![FileInfo {
+            name_or_path: NameOrPath::Name("hello".to_string()),
+            digest: DigestInfo::new([5u8; 32], 18),
+            is_executable: true,
+        }],
+        output_folders: vec![DirectoryInfo {
+            path: "123".to_string(),
+            tree_digest: DigestInfo::new([9u8; 32], 100),
+        }],
+        output_file_symlinks: vec![SymlinkInfo {
+            name_or_path: NameOrPath::Name("foo".to_string()),
+            target: "bar".to_string(),
+        }],
+        output_directory_symlinks: vec![SymlinkInfo {
+            name_or_path: NameOrPath::Name("foo2".to_string()),
+            target: "bar2".to_string(),
+        }],
+        exit_code: 0,
+        stdout_digest: DigestInfo::new([6u8; 32], 19),
+        stderr_digest: DigestInfo::new([7u8; 32], 20),
+        execution_metadata: ExecutionMetadata {
+            worker: WORKER_ID.to_string(),
+            queued_timestamp: make_system_time(5),
+            worker_start_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+            input_fetch_start_timestamp: make_system_time(8),
+            input_fetch_completed_timestamp: make_system_time(9),
+            execution_start_timestamp: make_system_time(10),
+            execution_completed_timestamp: make_system_time(11),
+            output_upload_start_timestamp: make_system_time(12),
+            output_upload_completed_timestamp: make_system_time(13),
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    };
+    scheduler
+        .update_action(
+            &WORKER_ID,
+            &action_info_hash_key,
+            ActionStage::Completed(action_result.clone()),
+        )
+        .await?;
+
+    {
+        // Client should get notification saying it has been completed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Completed(action_result),
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+    {
+        // Update info for the action should now be closed (notification happens through Err).
+        let result = client_rx.changed().await;
+        assert!(
+            result.is_err(),
+            "Expected result to be an error : {result:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_action_sends_completed_result_after_disconnect() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    // Drop our receiver and don't reconnect until completed.
+    let unique_qualifier = client_rx.borrow().id.unique_qualifier.clone();
+    drop(client_rx);
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+    }
+
+    let action_info_hash_key = ActionInfoHashKey {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: action_digest,
+        salt: 0,
+    };
+    let action_result = ActionResult {
+        output_files: vec![FileInfo {
+            name_or_path: NameOrPath::Name("hello".to_string()),
+            digest: DigestInfo::new([5u8; 32], 18),
+            is_executable: true,
+        }],
+        output_folders: vec![DirectoryInfo {
+            path: "123".to_string(),
+            tree_digest: DigestInfo::new([9u8; 32], 100),
+        }],
+        output_file_symlinks: vec![SymlinkInfo {
+            name_or_path: NameOrPath::Name("foo".to_string()),
+            target: "bar".to_string(),
+        }],
+        output_directory_symlinks: vec![SymlinkInfo {
+            name_or_path: NameOrPath::Name("foo2".to_string()),
+            target: "bar2".to_string(),
+        }],
+        exit_code: 0,
+        stdout_digest: DigestInfo::new([6u8; 32], 19),
+        stderr_digest: DigestInfo::new([7u8; 32], 20),
+        execution_metadata: ExecutionMetadata {
+            worker: WORKER_ID.to_string(),
+            queued_timestamp: make_system_time(5),
+            worker_start_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+            input_fetch_start_timestamp: make_system_time(8),
+            input_fetch_completed_timestamp: make_system_time(9),
+            execution_start_timestamp: make_system_time(10),
+            execution_completed_timestamp: make_system_time(11),
+            output_upload_start_timestamp: make_system_time(12),
+            output_upload_completed_timestamp: make_system_time(13),
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    };
+    scheduler
+        .update_action(
+            &WORKER_ID,
+            &action_info_hash_key,
+            ActionStage::Completed(action_result.clone()),
+        )
+        .await?;
+
+    // Now look up a channel after the action has completed.
+    let mut client_rx = scheduler
+        .find_existing_action(&unique_qualifier)
+        .await
+        .err_tip(|| "Action not found")?;
+    {
+        // Client should get notification saying it has been completed.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Completed(action_result),
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
+    const GOOD_WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+    const ROGUE_WORKER_ID: WorkerId = WorkerId(0x0009_8765_4321);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, GOOD_WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    let action_info_hash_key = ActionInfoHashKey {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: action_digest,
+        salt: 0,
+    };
+    let action_result = ActionResult {
+        output_files: Vec::default(),
+        output_folders: Vec::default(),
+        output_file_symlinks: Vec::default(),
+        output_directory_symlinks: Vec::default(),
+        exit_code: 0,
+        stdout_digest: DigestInfo::new([6u8; 32], 19),
+        stderr_digest: DigestInfo::new([7u8; 32], 20),
+        execution_metadata: ExecutionMetadata {
+            worker: GOOD_WORKER_ID.to_string(),
+            queued_timestamp: make_system_time(5),
+            worker_start_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+            input_fetch_start_timestamp: make_system_time(8),
+            input_fetch_completed_timestamp: make_system_time(9),
+            execution_start_timestamp: make_system_time(10),
+            execution_completed_timestamp: make_system_time(11),
+            output_upload_start_timestamp: make_system_time(12),
+            output_upload_completed_timestamp: make_system_time(13),
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    };
+    let update_action_result = scheduler
+        .update_action(
+            &ROGUE_WORKER_ID,
+            &action_info_hash_key,
+            ActionStage::Completed(action_result.clone()),
+        )
+        .await;
+
+    {
+        const EXPECTED_ERR: &str =
+            "Got a result from a worker that should not be running the action";
+        // Our request should have sent an error back.
+        assert!(
+            update_action_result.is_err(),
+            "Expected error, got: {:?}",
+            &update_action_result
+        );
+        let err = update_action_result.unwrap_err();
+        assert!(
+            err.to_string().contains(EXPECTED_ERR),
+            "Error should contain '{EXPECTED_ERR}', got: {err:?}",
+        );
+    }
+    {
+        // Ensure client did not get notified.
+        assert_eq!(
+            client_rx.has_changed().unwrap(),
+            false,
+            "Client should not have been notified of event"
+        );
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x0010_000f);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let unique_qualifier = ActionInfoHashKey {
+        instance_name: "".to_string(),
+        digest: DigestInfo::zero_digest(),
+        digest_function: DigestHasherFunc::Sha256,
+        salt: 0,
+    };
+    let id = OperationId::new(unique_qualifier);
+    let mut expected_action_state = ActionState {
+        id,
+        stage: ActionStage::Executing,
+    };
+
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+
+    {
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
+            update: Some(update_for_worker::Update::StartAction(StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    instance_name: INSTANCE_NAME.to_string(),
+                    skip_cache_lookup: true,
+                    action_digest: Some(action_digest.into()),
+                    digest_function: digest_function::Value::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(insert_timestamp.into()),
+            })),
+        };
+        let msg_for_worker = rx_from_worker.recv().await.unwrap();
+        assert_eq!(msg_for_worker, expected_msg_for_worker);
+    }
+
+    {
+        // Client should get notification saying it's being executed.
+        let action_state = client_rx.borrow_and_update();
+        // We now know the name of the action so populate it.
+        expected_action_state.id = action_state.id.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    let action_result = ActionResult {
+        output_files: Vec::default(),
+        output_folders: Vec::default(),
+        output_directory_symlinks: Vec::default(),
+        output_file_symlinks: Vec::default(),
+        exit_code: Default::default(),
+        stdout_digest: DigestInfo::new([1u8; 32], 512),
+        stderr_digest: DigestInfo::new([2u8; 32], 512),
+        execution_metadata: ExecutionMetadata {
+            worker: String::new(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: SystemTime::UNIX_EPOCH,
+            worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+            execution_start_timestamp: SystemTime::UNIX_EPOCH,
+            execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    };
+
+    scheduler
+        .update_action(
+            &WORKER_ID,
+            &ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
+                digest: action_digest,
+                salt: 0,
+            },
+            ActionStage::Completed(action_result.clone()),
+        )
+        .await?;
+
+    {
+        // Action should now be executing.
+        expected_action_state.stage = ActionStage::Completed(action_result.clone());
+        assert_eq!(
+            client_rx.borrow_and_update().as_ref(),
+            &expected_action_state
+        );
+    }
+
+    // Now we need to ensure that if we schedule another execution of the same job it doesn't
+    // fail.
+
+    {
         let insert_timestamp = make_system_time(1);
         let mut client_rx = setup_action(
             &scheduler,
@@ -1426,200 +1186,432 @@ mod scheduler_tests {
             insert_timestamp,
         )
         .await?;
-
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        let action_info_hash_key = ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: action_digest,
-            salt: 0,
-        };
-        scheduler
-            .update_action_with_internal_error(
-                &WORKER_ID,
-                &action_info_hash_key,
-                make_err!(Code::Internal, "Some error"),
-            )
-            .await;
-
-        {
-            // Client should get notification saying it has been queued again.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Queued,
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        // Now connect a new worker and it should pickup the action.
-        let mut rx_from_worker =
-            setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        let err = make_err!(Code::Internal, "Some error");
-        // Send internal error from worker again.
-        scheduler
-            .update_action_with_internal_error(&WORKER_ID, &action_info_hash_key, err.clone())
-            .await;
-
-        {
-            // Client should get notification saying it has been queued again.
-            let action_state = client_rx.borrow_and_update();
-            let expected_action_state = ActionState {
-                // Name is a random string, so we ignore it and just make it the same.
-                id: action_state.id.clone(),
-                stage: ActionStage::Completed(ActionResult {
-                    output_files: Vec::default(),
-                    output_folders: Vec::default(),
-                    output_file_symlinks: Vec::default(),
-                    output_directory_symlinks: Vec::default(),
-                    exit_code: INTERNAL_ERROR_EXIT_CODE,
-                    stdout_digest: DigestInfo::zero_digest(),
-                    stderr_digest: DigestInfo::zero_digest(),
-                    execution_metadata: ExecutionMetadata {
-                        worker: WORKER_ID.to_string(),
-                        queued_timestamp: SystemTime::UNIX_EPOCH,
-                        worker_start_timestamp: SystemTime::UNIX_EPOCH,
-                        worker_completed_timestamp: SystemTime::UNIX_EPOCH,
-                        input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
-                        input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
-                        execution_start_timestamp: SystemTime::UNIX_EPOCH,
-                        execution_completed_timestamp: SystemTime::UNIX_EPOCH,
-                        output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
-                        output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
-                    },
-                    server_logs: HashMap::default(),
-                    error: Some(err.merge(make_err!(
-                        Code::Internal,
-                        "Job cancelled because it attempted to execute too many times and failed"
-                    ))),
-                    message: String::new(),
-                }),
-            };
-            assert_eq!(action_state.as_ref(), &expected_action_state);
-        }
-
-        Ok(())
+        // We didn't disconnect our worker, so it will have scheduled it to the worker.
+        expected_action_state.stage = ActionStage::Executing;
+        let action_state = client_rx.borrow_and_update();
+        // The name of the action changed (since it's a new action), so update it.
+        expected_action_state.id = action_state.id.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
-    #[nativelink_test]
-    async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
-        struct DropChecker {
-            dropped: Arc<AtomicBool>,
-        }
-        impl Drop for DropChecker {
-            fn drop(&mut self) {
-                self.dropped.store(true, Ordering::Relaxed);
-            }
-        }
+    Ok(())
+}
 
-        let dropped = Arc::new(AtomicBool::new(false));
-        let drop_checker = Arc::new(DropChecker {
-            dropped: dropped.clone(),
-        });
+/// This tests to ensure that platform property restrictions allow jobs to continue to run after
+/// a job finished on a specific worker (eg: restore platform properties).
+#[nativelink_test]
+async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
 
-        // Since the inner spawn owns this callback, we can use the callback to know if the
-        // inner spawn was dropped because our callback would be dropped, which dropps our
-        // DropChecker.
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            move || {
-                // This will ensure dropping happens if this function is ever dropped.
-                let _drop_checker = drop_checker.clone();
-                async move {}
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest1 = DigestInfo::new([11u8; 32], 512);
+    let action_digest2 = DigestInfo::new([99u8; 32], 512);
+
+    let mut properties = HashMap::new();
+    properties.insert("prop1".to_string(), PlatformPropertyValue::Minimum(1));
+    let platform_properties = PlatformProperties { properties };
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, platform_properties.clone()).await?;
+    let insert_timestamp1 = make_system_time(1);
+    let mut client1_rx = setup_action(
+        &scheduler,
+        action_digest1,
+        platform_properties.clone(),
+        insert_timestamp1,
+    )
+    .await?;
+    let insert_timestamp2 = make_system_time(1);
+    let mut client2_rx = setup_action(
+        &scheduler,
+        action_digest2,
+        platform_properties,
+        insert_timestamp2,
+    )
+    .await?;
+
+    match rx_from_worker.recv().await.unwrap().update {
+        Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+        v => panic!("Expected StartAction, got : {v:?}"),
+    }
+    {
+        // First client should be in an Executing state.
+        assert_eq!(client1_rx.borrow_and_update().stage, ActionStage::Executing);
+        // Second client should be in a queued state.
+        assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Queued);
+    }
+
+    let action_result = ActionResult {
+        output_files: Vec::default(),
+        output_folders: Vec::default(),
+        output_file_symlinks: Vec::default(),
+        output_directory_symlinks: Vec::default(),
+        exit_code: 0,
+        stdout_digest: DigestInfo::new([6u8; 32], 19),
+        stderr_digest: DigestInfo::new([7u8; 32], 20),
+        execution_metadata: ExecutionMetadata {
+            worker: WORKER_ID.to_string(),
+            queued_timestamp: make_system_time(5),
+            worker_start_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+            input_fetch_start_timestamp: make_system_time(8),
+            input_fetch_completed_timestamp: make_system_time(9),
+            execution_start_timestamp: make_system_time(10),
+            execution_completed_timestamp: make_system_time(11),
+            output_upload_start_timestamp: make_system_time(12),
+            output_upload_completed_timestamp: make_system_time(13),
+        },
+        server_logs: HashMap::default(),
+        error: None,
+        message: String::new(),
+    };
+
+    // Tell scheduler our first task is completed.
+    scheduler
+        .update_action(
+            &WORKER_ID,
+            &ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
+                digest: action_digest1,
+                salt: 0,
             },
-        );
-        assert_eq!(dropped.load(Ordering::Relaxed), false);
-
-        drop(scheduler);
-        tokio::task::yield_now().await; // The drop may happen in a different task.
-
-        // Ensure our callback was dropped.
-        assert_eq!(dropped.load(Ordering::Relaxed), true);
-
-        Ok(())
-    }
-
-    /// Regression test for: https://github.com/TraceMachina/nativelink/issues/257.
-    #[nativelink_test]
-    async fn ensure_task_or_worker_change_notification_received_test() -> Result<(), Error> {
-        const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
-        const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
-
-        let scheduler = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
-            || async move {},
-        );
-        let action_digest = DigestInfo::new([99u8; 32], 512);
-
-        let mut rx_from_worker1 =
-            setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
-        let mut client_rx = setup_action(
-            &scheduler,
-            action_digest,
-            PlatformProperties::default(),
-            make_system_time(1),
+            ActionStage::Completed(action_result.clone()),
         )
         .await?;
 
-        let mut rx_from_worker2 =
-            setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
+    // Ensure client did not get notified.
+    assert!(
+        client1_rx.changed().await.is_ok(),
+        "Client should have been notified of event"
+    );
 
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            match rx_from_worker1.recv().await.unwrap().update {
-                Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
-                v => panic!("Expected StartAction, got : {v:?}"),
-            }
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        scheduler
-            .update_action_with_internal_error(
-                &WORKER_ID1,
-                &ActionInfoHashKey {
-                    instance_name: INSTANCE_NAME.to_string(),
-                    digest_function: DigestHasherFunc::Sha256,
-                    digest: action_digest,
-                    salt: 0,
-                },
-                make_err!(Code::NotFound, "Some error"),
-            )
-            .await;
-
-        tokio::task::yield_now().await; // Allow task<->worker matcher to run.
-
-        // Now connect a new worker and it should pickup the action.
-        {
-            // Other tests check full data. We only care if we got StartAction.
-            rx_from_worker2
-                .recv()
-                .await
-                .err_tip(|| "worker went away")?;
-            // Other tests check full data. We only care if client thinks we are Executing.
-            assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
-        }
-
-        Ok(())
+    {
+        // First action should now be completed.
+        let action_state = client1_rx.borrow_and_update();
+        let mut expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Completed(action_result.clone()),
+        };
+        // We now know the name of the action so populate it.
+        expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state);
     }
+
+    // At this stage it should have added back any platform_properties and the next
+    // task should be executing on the same worker.
+
+    {
+        // Our second client should now executing.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    // Tell scheduler our second task is completed.
+    scheduler
+        .update_action(
+            &WORKER_ID,
+            &ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
+                digest: action_digest2,
+                salt: 0,
+            },
+            ActionStage::Completed(action_result.clone()),
+        )
+        .await?;
+
+    {
+        // Our second client should be notified it completed.
+        let action_state = client2_rx.borrow_and_update();
+        let mut expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Completed(action_result.clone()),
+        };
+        // We now know the name of the action so populate it.
+        expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    Ok(())
+}
+
+/// This tests that actions are performed in the order they were queued.
+#[nativelink_test]
+async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest1 = DigestInfo::new([11u8; 32], 512);
+    let action_digest2 = DigestInfo::new([99u8; 32], 512);
+
+    // Use property to restrict the worker to a single action at a time.
+    let mut properties = HashMap::new();
+    properties.insert("prop1".to_string(), PlatformPropertyValue::Minimum(1));
+    let platform_properties = PlatformProperties { properties };
+    // This is queued after the next one (even though it's placed in the map
+    // first), so it should execute second.
+    let insert_timestamp2 = make_system_time(2);
+    let mut client2_rx = setup_action(
+        &scheduler,
+        action_digest2,
+        platform_properties.clone(),
+        insert_timestamp2,
+    )
+    .await?;
+    let insert_timestamp1 = make_system_time(1);
+    let mut client1_rx = setup_action(
+        &scheduler,
+        action_digest1,
+        platform_properties.clone(),
+        insert_timestamp1,
+    )
+    .await?;
+
+    // Add the worker after the queue has been set up.
+    let mut rx_from_worker = setup_new_worker(&scheduler, WORKER_ID, platform_properties).await?;
+
+    match rx_from_worker.recv().await.unwrap().update {
+        Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+        v => panic!("Expected StartAction, got : {v:?}"),
+    }
+    {
+        // First client should be in an Executing state.
+        assert_eq!(client1_rx.borrow_and_update().stage, ActionStage::Executing);
+        // Second client should be in a queued state.
+        assert_eq!(client2_rx.borrow_and_update().stage, ActionStage::Queued);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> {
+    const WORKER_ID: WorkerId = WorkerId(0x1234_5678_9111);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler {
+            max_job_retries: 2,
+            ..Default::default()
+        },
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        insert_timestamp,
+    )
+    .await?;
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    let action_info_hash_key = ActionInfoHashKey {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: action_digest,
+        salt: 0,
+    };
+    scheduler
+        .update_action_with_internal_error(
+            &WORKER_ID,
+            &action_info_hash_key,
+            make_err!(Code::Internal, "Some error"),
+        )
+        .await;
+
+    {
+        // Client should get notification saying it has been queued again.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Queued,
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    // Now connect a new worker and it should pickup the action.
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, WORKER_ID, PlatformProperties::default()).await?;
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    let err = make_err!(Code::Internal, "Some error");
+    // Send internal error from worker again.
+    scheduler
+        .update_action_with_internal_error(&WORKER_ID, &action_info_hash_key, err.clone())
+        .await;
+
+    {
+        // Client should get notification saying it has been queued again.
+        let action_state = client_rx.borrow_and_update();
+        let expected_action_state = ActionState {
+            // Name is a random string, so we ignore it and just make it the same.
+            id: action_state.id.clone(),
+            stage: ActionStage::Completed(ActionResult {
+                output_files: Vec::default(),
+                output_folders: Vec::default(),
+                output_file_symlinks: Vec::default(),
+                output_directory_symlinks: Vec::default(),
+                exit_code: INTERNAL_ERROR_EXIT_CODE,
+                stdout_digest: DigestInfo::zero_digest(),
+                stderr_digest: DigestInfo::zero_digest(),
+                execution_metadata: ExecutionMetadata {
+                    worker: WORKER_ID.to_string(),
+                    queued_timestamp: SystemTime::UNIX_EPOCH,
+                    worker_start_timestamp: SystemTime::UNIX_EPOCH,
+                    worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+                    input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+                    input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+                    execution_start_timestamp: SystemTime::UNIX_EPOCH,
+                    execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+                    output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+                    output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+                },
+                server_logs: HashMap::default(),
+                error: Some(err.merge(make_err!(
+                    Code::Internal,
+                    "Job cancelled because it attempted to execute too many times and failed"
+                ))),
+                message: String::new(),
+            }),
+        };
+        assert_eq!(action_state.as_ref(), &expected_action_state);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
+    struct DropChecker {
+        dropped: Arc<AtomicBool>,
+    }
+    impl Drop for DropChecker {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Relaxed);
+        }
+    }
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    let drop_checker = Arc::new(DropChecker {
+        dropped: dropped.clone(),
+    });
+
+    // Since the inner spawn owns this callback, we can use the callback to know if the
+    // inner spawn was dropped because our callback would be dropped, which dropps our
+    // DropChecker.
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        move || {
+            // This will ensure dropping happens if this function is ever dropped.
+            let _drop_checker = drop_checker.clone();
+            async move {}
+        },
+    );
+    assert_eq!(dropped.load(Ordering::Relaxed), false);
+
+    drop(scheduler);
+    tokio::task::yield_now().await; // The drop may happen in a different task.
+
+    // Ensure our callback was dropped.
+    assert_eq!(dropped.load(Ordering::Relaxed), true);
+
+    Ok(())
+}
+
+/// Regression test for: https://github.com/TraceMachina/nativelink/issues/257.
+#[nativelink_test]
+async fn ensure_task_or_worker_change_notification_received_test() -> Result<(), Error> {
+    const WORKER_ID1: WorkerId = WorkerId(0x0011_1111);
+    const WORKER_ID2: WorkerId = WorkerId(0x0022_2222);
+
+    let scheduler = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler::default(),
+        || async move {},
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let mut rx_from_worker1 =
+        setup_new_worker(&scheduler, WORKER_ID1, PlatformProperties::default()).await?;
+    let mut client_rx = setup_action(
+        &scheduler,
+        action_digest,
+        PlatformProperties::default(),
+        make_system_time(1),
+    )
+    .await?;
+
+    let mut rx_from_worker2 =
+        setup_new_worker(&scheduler, WORKER_ID2, PlatformProperties::default()).await?;
+
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        match rx_from_worker1.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => { /* Success */ }
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    scheduler
+        .update_action_with_internal_error(
+            &WORKER_ID1,
+            &ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
+                digest_function: DigestHasherFunc::Sha256,
+                digest: action_digest,
+                salt: 0,
+            },
+            make_err!(Code::NotFound, "Some error"),
+        )
+        .await;
+
+    tokio::task::yield_now().await; // Allow task<->worker matcher to run.
+
+    // Now connect a new worker and it should pickup the action.
+    {
+        // Other tests check full data. We only care if we got StartAction.
+        rx_from_worker2
+            .recv()
+            .await
+            .err_tip(|| "worker went away")?;
+        // Other tests check full data. We only care if client thinks we are Executing.
+        assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
+    }
+
+    Ok(())
 }

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -38,6 +38,7 @@ use nativelink_store::store_manager::StoreManager;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::encode_stream_proto;
 use nativelink_util::store_trait::{Store, StoreKey, StoreLike};
+use pretty_assertions::assert_eq;
 use prometheus_client::registry::Registry;
 use prost::Message;
 use prost_types::Timestamp;
@@ -80,254 +81,241 @@ fn get_bep_store(store_manager: &StoreManager) -> Result<Store, Error> {
         .err_tip(|| format!("While retrieving bep_store {BEP_STORE_NAME}"))
 }
 
-#[cfg(test)]
-mod tbep_server {
-    use pretty_assertions::assert_eq;
+/// Asserts that a gRPC request for a [`PublishLifecycleEventRequest`] is correctly dumped into a [`Store`]
+#[nativelink_test]
+async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bep_server = make_bep_server(&store_manager)?;
+    let bep_store = get_bep_store(&store_manager)?;
 
-    use super::*;
+    let stream_id = StreamId {
+        build_id: "some-build-id".to_string(),
+        invocation_id: "some-invocation-id".to_string(),
+        component: BuildComponent::Controller as i32,
+    };
+    let store_key = StoreKey::Str(Cow::Owned(format!(
+        "{}-{}-{}",
+        stream_id.build_id, stream_id.invocation_id, stream_id.component
+    )));
 
-    /// Asserts that a gRPC request for a [`PublishLifecycleEventRequest`] is correctly dumped into a [`Store`]
-    #[nativelink_test]
-    async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bep_server = make_bep_server(&store_manager)?;
-        let bep_store = get_bep_store(&store_manager)?;
+    let request = PublishLifecycleEventRequest {
+        service_level: ServiceLevel::Interactive as i32,
+        build_event: Some(OrderedBuildEvent {
+            stream_id: Some(stream_id),
+            sequence_number: 1,
+            event: Some(BuildEvent {
+                event_time: Some(Timestamp::date(1999, 1, 6)?),
+                event: Some(Event::ConsoleOutput(ConsoleOutput {
+                    r#type: ConsoleOutputStream::Stdout as i32,
+                    output: Some(Output::TextOutput(
+                        "Here's some text that's been printed to stdout".to_string(),
+                    )),
+                })),
+            }),
+        }),
+        stream_timeout: None,
+        notification_keywords: vec!["testing".to_string(), "console".to_string()],
+        project_id: "some-project-id".to_string(),
+        check_preceding_lifecycle_events_present: false,
+    };
 
+    bep_server
+        .publish_lifecycle_event(Request::new(request.clone()))
+        .await
+        .err_tip(|| "While invoking publish_lifecycle_event")?;
+
+    let (mut writer, mut reader) = make_buf_channel_pair();
+
+    bep_store
+        .get_part(store_key, &mut writer, 0, None)
+        .await
+        .err_tip(|| "While retrieving lifecycle_event_request from store")?;
+
+    let bytes = reader
+        .recv()
+        .await
+        .err_tip(|| "While receiving bytes from reader")?;
+
+    let decoded_request = PublishLifecycleEventRequest::decode(bytes)
+        .err_tip(|| "While decoding request from bytes")?;
+
+    assert_eq!(request, decoded_request);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bep_server = make_bep_server(&store_manager)?;
+    let bep_store = get_bep_store(&store_manager)?;
+
+    let (mut request_tx, mut response_stream) = async {
+        // Set up the request and response streams.
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<PublishBuildToolEventStreamRequest, _>::default();
+        let stream = Streaming::new_request(codec.decoder(), body, None, None);
+        let stream = bep_server
+            .publish_build_tool_event_stream(Request::new(stream))
+            .await
+            .err_tip(|| "While invoking publish_build_tool_event_stream")?
+            .into_inner();
+
+        Ok::<_, Box<dyn std::error::Error>>((tx, stream))
+    }
+    .await?;
+
+    let (requests, store_key) = {
+        // Construct some requests to send off and a store key to retrieve them with.
         let stream_id = StreamId {
             build_id: "some-build-id".to_string(),
             invocation_id: "some-invocation-id".to_string(),
             component: BuildComponent::Controller as i32,
         };
-        let store_key = StoreKey::Str(Cow::Owned(format!(
-            "{}-{}-{}",
-            stream_id.build_id, stream_id.invocation_id, stream_id.component
-        )));
+        let project_id = "some-project-id".to_string();
 
-        let request = PublishLifecycleEventRequest {
-            service_level: ServiceLevel::Interactive as i32,
-            build_event: Some(OrderedBuildEvent {
-                stream_id: Some(stream_id),
-                sequence_number: 1,
-                event: Some(BuildEvent {
-                    event_time: Some(Timestamp::date(1999, 1, 6)?),
-                    event: Some(Event::ConsoleOutput(ConsoleOutput {
-                        r#type: ConsoleOutputStream::Stdout as i32,
-                        output: Some(Output::TextOutput(
-                            "Here's some text that's been printed to stdout".to_string(),
-                        )),
-                    })),
+        let requests = [
+            PublishBuildToolEventStreamRequest {
+                ordered_build_event: Some(OrderedBuildEvent {
+                    stream_id: Some(stream_id.clone()),
+                    sequence_number: 1,
+                    event: Some(BuildEvent {
+                        event_time: Some(Timestamp::date(1999, 1, 4)?),
+                        event: Some(Event::BuildEnqueued(BuildEnqueued { details: None })),
+                    }),
                 }),
-            }),
-            stream_timeout: None,
-            notification_keywords: vec!["testing".to_string(), "console".to_string()],
-            project_id: "some-project-id".to_string(),
-            check_preceding_lifecycle_events_present: false,
-        };
-
-        bep_server
-            .publish_lifecycle_event(Request::new(request.clone()))
-            .await
-            .err_tip(|| "While invoking publish_lifecycle_event")?;
-
-        let (mut writer, mut reader) = make_buf_channel_pair();
-
-        bep_store
-            .get_part(store_key, &mut writer, 0, None)
-            .await
-            .err_tip(|| "While retrieving lifecycle_event_request from store")?;
-
-        let bytes = reader
-            .recv()
-            .await
-            .err_tip(|| "While receiving bytes from reader")?;
-
-        let decoded_request = PublishLifecycleEventRequest::decode(bytes)
-            .err_tip(|| "While decoding request from bytes")?;
-
-        assert_eq!(request, decoded_request);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bep_server = make_bep_server(&store_manager)?;
-        let bep_store = get_bep_store(&store_manager)?;
-
-        let (mut request_tx, mut response_stream) = async {
-            // Set up the request and response streams.
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<PublishBuildToolEventStreamRequest, _>::default();
-            let stream = Streaming::new_request(codec.decoder(), body, None, None);
-            let stream = bep_server
-                .publish_build_tool_event_stream(Request::new(stream))
-                .await
-                .err_tip(|| "While invoking publish_build_tool_event_stream")?
-                .into_inner();
-
-            Ok::<_, Box<dyn std::error::Error>>((tx, stream))
-        }
-        .await?;
-
-        let (requests, store_key) = {
-            // Construct some requests to send off and a store key to retrieve them with.
-            let stream_id = StreamId {
-                build_id: "some-build-id".to_string(),
-                invocation_id: "some-invocation-id".to_string(),
-                component: BuildComponent::Controller as i32,
-            };
-            let project_id = "some-project-id".to_string();
-
-            let requests = [
-                PublishBuildToolEventStreamRequest {
-                    ordered_build_event: Some(OrderedBuildEvent {
-                        stream_id: Some(stream_id.clone()),
-                        sequence_number: 1,
-                        event: Some(BuildEvent {
-                            event_time: Some(Timestamp::date(1999, 1, 4)?),
-                            event: Some(Event::BuildEnqueued(BuildEnqueued { details: None })),
-                        }),
+                notification_keywords: vec!["testing".to_string(), "build-enqueued".to_string()],
+                project_id: project_id.clone(),
+                check_preceding_lifecycle_events_present: false,
+            },
+            PublishBuildToolEventStreamRequest {
+                ordered_build_event: Some(OrderedBuildEvent {
+                    stream_id: Some(stream_id.clone()),
+                    sequence_number: 2,
+                    event: Some(BuildEvent {
+                        event_time: Some(Timestamp::date(1999, 1, 5)?),
+                        event: Some(Event::InvocationAttemptStarted(InvocationAttemptStarted {
+                            attempt_number: 1,
+                            details: None,
+                        })),
                     }),
-                    notification_keywords: vec![
-                        "testing".to_string(),
-                        "build-enqueued".to_string(),
-                    ],
-                    project_id: project_id.clone(),
-                    check_preceding_lifecycle_events_present: false,
-                },
-                PublishBuildToolEventStreamRequest {
-                    ordered_build_event: Some(OrderedBuildEvent {
-                        stream_id: Some(stream_id.clone()),
-                        sequence_number: 2,
-                        event: Some(BuildEvent {
-                            event_time: Some(Timestamp::date(1999, 1, 5)?),
-                            event: Some(Event::InvocationAttemptStarted(
-                                InvocationAttemptStarted {
-                                    attempt_number: 1,
-                                    details: None,
-                                },
+                }),
+                notification_keywords: vec!["testing".to_string()],
+                project_id: project_id.clone(),
+                check_preceding_lifecycle_events_present: false,
+            },
+            PublishBuildToolEventStreamRequest {
+                ordered_build_event: Some(OrderedBuildEvent {
+                    stream_id: Some(stream_id.clone()),
+                    sequence_number: 3,
+                    event: Some(BuildEvent {
+                        event_time: Some(Timestamp::date(1999, 1, 6)?),
+                        event: Some(Event::ConsoleOutput(ConsoleOutput {
+                            r#type: ConsoleOutputStream::Stdout as i32,
+                            output: Some(Output::TextOutput(
+                                "This is taking a while...".to_string(),
                             )),
-                        }),
+                        })),
                     }),
-                    notification_keywords: vec!["testing".to_string()],
-                    project_id: project_id.clone(),
-                    check_preceding_lifecycle_events_present: false,
-                },
-                PublishBuildToolEventStreamRequest {
-                    ordered_build_event: Some(OrderedBuildEvent {
-                        stream_id: Some(stream_id.clone()),
-                        sequence_number: 3,
-                        event: Some(BuildEvent {
-                            event_time: Some(Timestamp::date(1999, 1, 6)?),
-                            event: Some(Event::ConsoleOutput(ConsoleOutput {
-                                r#type: ConsoleOutputStream::Stdout as i32,
-                                output: Some(Output::TextOutput(
-                                    "This is taking a while...".to_string(),
-                                )),
-                            })),
-                        }),
-                    }),
-                    notification_keywords: vec!["testing".to_string()],
-                    project_id: project_id.clone(),
-                    check_preceding_lifecycle_events_present: false,
-                },
-                PublishBuildToolEventStreamRequest {
-                    ordered_build_event: Some(OrderedBuildEvent {
-                        stream_id: Some(stream_id.clone()),
-                        sequence_number: 4,
-                        event: Some(BuildEvent {
-                            event_time: Some(Timestamp::date(1999, 1, 7)?),
-                            event: Some(Event::InvocationAttemptFinished(
-                                InvocationAttemptFinished {
-                                    invocation_status: Some(BuildStatus {
-                                        result: build_status::Result::InvocationDeadlineExceeded
-                                            as i32,
-                                        final_invocation_id: String::default(),
-                                        build_tool_exit_code: Some(1),
-                                        error_message: "You missed my birthday!".to_string(),
-                                        details: None,
-                                    }),
-                                    details: None,
-                                },
-                            )),
-                        }),
-                    }),
-                    notification_keywords: vec!["testing".to_string()],
-                    project_id: "some-project-id".to_string(),
-                    check_preceding_lifecycle_events_present: false,
-                },
-                PublishBuildToolEventStreamRequest {
-                    ordered_build_event: Some(OrderedBuildEvent {
-                        stream_id: Some(stream_id.clone()),
-                        sequence_number: 5,
-                        event: Some(BuildEvent {
-                            event_time: Some(Timestamp::date(1999, 1, 8)?),
-                            event: Some(Event::BuildFinished(BuildFinished {
-                                status: Some(BuildStatus {
+                }),
+                notification_keywords: vec!["testing".to_string()],
+                project_id: project_id.clone(),
+                check_preceding_lifecycle_events_present: false,
+            },
+            PublishBuildToolEventStreamRequest {
+                ordered_build_event: Some(OrderedBuildEvent {
+                    stream_id: Some(stream_id.clone()),
+                    sequence_number: 4,
+                    event: Some(BuildEvent {
+                        event_time: Some(Timestamp::date(1999, 1, 7)?),
+                        event: Some(Event::InvocationAttemptFinished(
+                            InvocationAttemptFinished {
+                                invocation_status: Some(BuildStatus {
                                     result: build_status::Result::InvocationDeadlineExceeded as i32,
                                     final_invocation_id: String::default(),
                                     build_tool_exit_code: Some(1),
-                                    error_message: "Missed her birthday...".to_string(),
+                                    error_message: "You missed my birthday!".to_string(),
                                     details: None,
                                 }),
                                 details: None,
-                            })),
-                        }),
+                            },
+                        )),
                     }),
-                    notification_keywords: vec!["testing".to_string()],
-                    project_id: project_id.clone(),
-                    check_preceding_lifecycle_events_present: false,
-                },
-            ];
+                }),
+                notification_keywords: vec!["testing".to_string()],
+                project_id: "some-project-id".to_string(),
+                check_preceding_lifecycle_events_present: false,
+            },
+            PublishBuildToolEventStreamRequest {
+                ordered_build_event: Some(OrderedBuildEvent {
+                    stream_id: Some(stream_id.clone()),
+                    sequence_number: 5,
+                    event: Some(BuildEvent {
+                        event_time: Some(Timestamp::date(1999, 1, 8)?),
+                        event: Some(Event::BuildFinished(BuildFinished {
+                            status: Some(BuildStatus {
+                                result: build_status::Result::InvocationDeadlineExceeded as i32,
+                                final_invocation_id: String::default(),
+                                build_tool_exit_code: Some(1),
+                                error_message: "Missed her birthday...".to_string(),
+                                details: None,
+                            }),
+                            details: None,
+                        })),
+                    }),
+                }),
+                notification_keywords: vec!["testing".to_string()],
+                project_id: project_id.clone(),
+                check_preceding_lifecycle_events_present: false,
+            },
+        ];
 
-            (
-                requests,
-                StoreKey::Str(Cow::Owned(format!(
-                    "{}-{}-{}",
-                    stream_id.build_id, stream_id.invocation_id, stream_id.component
-                ))),
-            )
-        };
+        (
+            requests,
+            StoreKey::Str(Cow::Owned(format!(
+                "{}-{}-{}",
+                stream_id.build_id, stream_id.invocation_id, stream_id.component
+            ))),
+        )
+    };
 
-        {
-            // Send off the requests and validate the responses.
-            for (sequence_number, request) in requests.iter().enumerate().map(|(i, req)| {
-                // Sequence numbers are 1-indexed, while `.enumerate()` indexes from 0.
-                (i as i64 + 1, req)
-            }) {
-                let encoded_request = encode_stream_proto(request)?;
-                request_tx.send_data(encoded_request).await?;
+    {
+        // Send off the requests and validate the responses.
+        for (sequence_number, request) in requests.iter().enumerate().map(|(i, req)| {
+            // Sequence numbers are 1-indexed, while `.enumerate()` indexes from 0.
+            (i as i64 + 1, req)
+        }) {
+            let encoded_request = encode_stream_proto(request)?;
+            request_tx.send_data(encoded_request).await?;
 
-                let response = response_stream
-                    .next()
-                    .await
-                    .err_tip(|| "Response stream closed unexpectedly")?
-                    .err_tip(|| "While awaiting next PublishBuildToolEventStreamResponse")?;
+            let response = response_stream
+                .next()
+                .await
+                .err_tip(|| "Response stream closed unexpectedly")?
+                .err_tip(|| "While awaiting next PublishBuildToolEventStreamResponse")?;
 
-                // First, check if the response matches what we expect.
-                assert_eq!(response.sequence_number, sequence_number);
-                assert_eq!(
-                    response.stream_id,
-                    request
-                        .ordered_build_event
-                        .as_ref()
-                        .and_then(|evt| evt.stream_id.clone())
-                );
+            // First, check if the response matches what we expect.
+            assert_eq!(response.sequence_number, sequence_number);
+            assert_eq!(
+                response.stream_id,
+                request
+                    .ordered_build_event
+                    .as_ref()
+                    .and_then(|evt| evt.stream_id.clone())
+            );
 
-                // Second, check if the message was forwarded correctly.
-                let (mut writer, mut reader) = make_buf_channel_pair();
-                bep_store
-                    .get_part(store_key.borrow(), &mut writer, 0, None)
-                    .await?;
-                let encoded_request = reader.recv().await?;
+            // Second, check if the message was forwarded correctly.
+            let (mut writer, mut reader) = make_buf_channel_pair();
+            bep_store
+                .get_part(store_key.borrow(), &mut writer, 0, None)
+                .await?;
+            let encoded_request = reader.recv().await?;
 
-                let decoded_request = PublishBuildToolEventStreamRequest::decode(encoded_request)?;
+            let decoded_request = PublishBuildToolEventStreamRequest::decode(encoded_request)?;
 
-                assert_eq!(*request, decoded_request);
-            }
-
-            Ok(())
+            assert_eq!(*request, decoded_request);
         }
+
+        Ok(())
     }
 }

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -20,7 +20,10 @@ use hyper::body::Sender;
 use maplit::hashmap;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
-use nativelink_proto::google::bytestream::WriteResponse;
+use nativelink_proto::google::bytestream::byte_stream_server::ByteStream;
+use nativelink_proto::google::bytestream::{
+    QueryWriteStatusRequest, QueryWriteStatusResponse, ReadRequest, WriteRequest, WriteResponse,
+};
 use nativelink_service::bytestream_server::ByteStreamServer;
 use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
@@ -28,9 +31,13 @@ use nativelink_util::common::{encode_stream_proto, DigestInfo};
 use nativelink_util::spawn;
 use nativelink_util::store_trait::StoreLike;
 use nativelink_util::task::JoinHandleDropGuard;
+use pretty_assertions::assert_eq;
 use prometheus_client::registry::Registry;
 use tokio::task::yield_now;
-use tonic::{Request, Response};
+use tokio_stream::StreamExt;
+use tonic::codec::{Codec, CompressionEncoding, ProstCodec};
+use tonic::transport::Body;
+use tonic::{Request, Response, Streaming};
 
 const INSTANCE_NAME: &str = "foo_instance_name";
 const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
@@ -65,926 +72,36 @@ fn make_bytestream_server(store_manager: &StoreManager) -> Result<ByteStreamServ
     )
 }
 
-#[cfg(test)]
-pub mod write_tests {
-    use nativelink_proto::google::bytestream::{
-        byte_stream_server::ByteStream, // Needed to call .write().
-        WriteRequest,
+#[nativelink_test]
+pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    // Setup stream.
+    let (mut tx, join_handle) = {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!(
+            "chunked_stream_receives_all_data_write_stream",
+            async move {
+                let response_future = bs_server.write(Request::new(stream));
+                response_future.await
+            },
+        );
+        (tx, join_handle)
     };
-    use pretty_assertions::assert_eq; // Must be declared in every module.
-    use tonic::{
-        codec::Codec, // Needed for .decoder().
-        codec::CompressionEncoding,
-        codec::ProstCodec,
-        transport::Body,
-        Streaming,
-    };
-
-    use super::*;
-
-    #[nativelink_test]
-    pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        // Setup stream.
-        let (mut tx, join_handle) = {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!(
-                "chunked_stream_receives_all_data_write_stream",
-                async move {
-                    let response_future = bs_server.write(Request::new(stream));
-                    response_future.await
-                },
-            );
-            (tx, join_handle)
-        };
-        // Send data.
-        let raw_data = {
-            let raw_data = "12456789abcdefghijk".as_bytes();
-            // Chunk our data into two chunks to simulate something a client
-            // might do.
-            const BYTE_SPLIT_OFFSET: usize = 8;
-
-            let resource_name = format!(
-                "{}/uploads/{}/blobs/{}/{}",
-                INSTANCE_NAME,
-                "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-                HASH1,
-                raw_data.len()
-            );
-            let mut write_request = WriteRequest {
-                resource_name,
-                write_offset: 0,
-                finish_write: false,
-                data: vec![].into(),
-            };
-            // Write first chunk of data.
-            write_request.write_offset = 0;
-            write_request.data = raw_data[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-
-            // Write empty set of data (clients are allowed to do this.
-            write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
-            write_request.data = vec![].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-
-            // Write final bit of data.
-            write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
-            write_request.data = raw_data[BYTE_SPLIT_OFFSET..].into();
-            write_request.finish_write = true;
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-
-            raw_data
-        };
-        // Check results of server.
-        {
-            // One for spawn() future and one for result.
-            let server_result = join_handle.await??;
-            let committed_size = usize::try_from(server_result.into_inner().committed_size)
-                .or(Err("Cant convert i64 to usize"))?;
-            assert_eq!(committed_size, raw_data.len());
-
-            // Now lets check our store to ensure it was written with proper data.
-            assert!(
-                store
-                    .has(DigestInfo::try_new(HASH1, raw_data.len())?)
-                    .await?
-                    .is_some(),
-                "Not found in store",
-            );
-            let store_data = store
-                .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None)
-                .await?;
-            assert_eq!(
-                std::str::from_utf8(&store_data),
-                std::str::from_utf8(raw_data),
-                "Expected store to have been updated to new value"
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("resume_write_success_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        const WRITE_DATA: &str = "12456789abcdefghijk";
-
-        // Chunk our data into two chunks to simulate something a client
-        // might do.
-        const BYTE_SPLIT_OFFSET: usize = 8;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            WRITE_DATA.len()
-        );
-        let mut write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: false,
-            data: vec![].into(),
-        };
-        {
-            // Write first chunk of data.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        let bs_server = {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, bs_server) = join_handle.await?;
-            assert_eq!(result.is_err(), true, "Expected error to be returned");
-            bs_server
-        };
-        // Now reconnect.
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        {
-            // Write the remainder of our data.
-            write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
-            write_request.finish_write = true;
-            write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, _bs_server) = join_handle.await?;
-            result?;
-        }
-        {
-            // Check to make sure our store recorded the data properly.
-            let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
-            assert_eq!(
-                store.get_part_unchunked(digest, 0, None).await?,
-                WRITE_DATA,
-                "Data written to store did not match expected data",
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("restart_write_success_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        const WRITE_DATA: &str = "12456789abcdefghijk";
-
-        // Chunk our data into two chunks to simulate something a client
-        // might do.
-        const BYTE_SPLIT_OFFSET: usize = 8;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            WRITE_DATA.len()
-        );
-        let mut write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: false,
-            data: vec![].into(),
-        };
-        {
-            // Write first chunk of data.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        let bs_server = {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, bs_server) = join_handle.await?;
-            assert_eq!(result.is_err(), true, "Expected error to be returned");
-            bs_server
-        };
-        // Now reconnect.
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        {
-            // Write first chunk of data again.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Write the remainder of our data.
-            write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
-            write_request.finish_write = true;
-            write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, _bs_server) = join_handle.await?;
-            assert!(result.is_ok(), "Expected success to be returned");
-        }
-        {
-            // Check to make sure our store recorded the data properly.
-            let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
-            assert_eq!(
-                store.get_part_unchunked(digest, 0, None).await?,
-                WRITE_DATA,
-                "Data written to store did not match expected data",
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!(
-                "restart_mid_stream_write_success_write_stream",
-                async move {
-                    let response_future = bs_server.write(Request::new(stream));
-                    (response_future.await, bs_server)
-                },
-            );
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        const WRITE_DATA: &str = "12456789abcdefghijk";
-
-        // Chunk our data into two chunks to simulate something a client
-        // might do.
-        const BYTE_SPLIT_OFFSET: usize = 8;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            WRITE_DATA.len()
-        );
-        let mut write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: false,
-            data: vec![].into(),
-        };
-        {
-            // Write first chunk of data.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        let bs_server = {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, bs_server) = join_handle.await?;
-            assert_eq!(result.is_err(), true, "Expected error to be returned");
-            bs_server
-        };
-        // Now reconnect.
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        {
-            // Write some of the first chunk of data again.
-            write_request.write_offset = 2;
-            write_request.data = WRITE_DATA[2..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Write the remainder of our data.
-            write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
-            write_request.finish_write = true;
-            write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Now disconnect our stream.
-            drop(tx);
-            let (result, _bs_server) = join_handle.await?;
-            assert!(result.is_ok(), "Expected success to be returned");
-        }
-        {
-            // Check to make sure our store recorded the data properly.
-            let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
-            assert_eq!(
-                store.get_part_unchunked(digest, 0, None).await?,
-                WRITE_DATA,
-                "Data written to store did not match expected data",
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn ensure_write_is_not_done_until_write_request_is_set(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        // Setup stream.
-        let (mut tx, mut write_fut) = {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            (tx, bs_server.write(Request::new(stream)))
-        };
-        const WRITE_DATA: &str = "12456789abcdefghijk";
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            WRITE_DATA.len()
-        );
-        let mut write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: false,
-            data: vec![].into(),
-        };
-        {
-            // Write our data.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        // Note: We have to pull multiple times because there are multiple futures
-        // joined onto this one future and we need to ensure we run the state machine as
-        // far as possible.
-        for _ in 0..100 {
-            assert!(
-                poll!(&mut write_fut).is_pending(),
-                "Expected the future to not be completed yet"
-            );
-        }
-        {
-            // Write our EOF.
-            write_request.write_offset = WRITE_DATA.len() as i64;
-            write_request.finish_write = true;
-            write_request.data.clear();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        let mut result = None;
-        for _ in 0..100 {
-            if let Poll::Ready(r) = poll!(&mut write_fut) {
-                result = Some(r);
-                break;
-            }
-        }
-        {
-            // Check our results.
-            assert_eq!(
-                result
-                    .err_tip(|| "bs_server.write never returned a value")?
-                    .err_tip(|| "bs_server.write returned an error")?
-                    .into_inner(),
-                WriteResponse {
-                    committed_size: WRITE_DATA.len() as i64
-                },
-                "Expected Responses to match"
-            );
-        }
-        {
-            // Check to make sure our store recorded the data properly.
-            let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
-            assert_eq!(
-                store.get_part_unchunked(digest, 0, None).await?,
-                WRITE_DATA,
-                "Data written to store did not match expected data",
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn out_of_order_data_fails() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("out_of_order_data_fails_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-        const WRITE_DATA: &str = "12456789abcdefghijk";
-
-        // Chunk our data into two chunks to simulate something a client
-        // might do.
-        const BYTE_SPLIT_OFFSET: usize = 8;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            WRITE_DATA.len()
-        );
-        let mut write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: false,
-            data: vec![].into(),
-        };
-        {
-            // Write first chunk of data.
-            write_request.write_offset = 0;
-            write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        {
-            // Write data it already has.
-            write_request.write_offset = (BYTE_SPLIT_OFFSET - 1) as i64;
-            write_request.data = WRITE_DATA[(BYTE_SPLIT_OFFSET - 1)..].into();
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-        }
-        assert!(
-            join_handle.await?.0.is_err(),
-            "Expected error to be returned"
-        );
-        {
-            // Make sure stream was closed.
-            write_request.write_offset = (BYTE_SPLIT_OFFSET - 1) as i64;
-            write_request.data = WRITE_DATA[(BYTE_SPLIT_OFFSET - 1)..].into();
-            assert!(
-                tx.send_data(encode_stream_proto(&write_request)?)
-                    .await
-                    .is_err(),
-                "Expected error to be returned"
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("upload_zero_byte_chunk_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            0
-        );
-        let write_request = WriteRequest {
-            resource_name,
-            write_offset: 0,
-            finish_write: true,
-            data: vec![].into(),
-        };
-
-        {
-            // Write our zero byte data.
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-            // Wait for stream to finish.
-            join_handle.await?.0?;
-        }
-        {
-            // Check to make sure our store recorded the data properly.
-            let data = store
-                .get_part_unchunked(DigestInfo::try_new(HASH1, 0)?, 0, None)
-                .await?;
-            assert_eq!(data, "", "Expected data to exist and be empty");
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("disallow_negative_write_offset_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            0
-        );
-        let write_request = WriteRequest {
-            resource_name,
-            write_offset: -1,
-            finish_write: true,
-            data: vec![].into(),
-        };
-
-        {
-            // Write our zero byte data.
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-            // Expect the write command to fail.
-            assert!(join_handle.await?.0.is_err());
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn out_of_sequence_write() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-
-        async fn setup_stream(
-            bs_server: ByteStreamServer,
-        ) -> Result<
-            (
-                Sender,
-                JoinHandleDropGuard<(
-                    Result<Response<WriteResponse>, tonic::Status>,
-                    ByteStreamServer,
-                )>,
-            ),
-            Error,
-        > {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let join_handle = spawn!("out_of_sequence_write_write_stream", async move {
-                let response_future = bs_server.write(Request::new(stream));
-                (response_future.await, bs_server)
-            });
-            Ok((tx, join_handle))
-        }
-        let (mut tx, join_handle) = setup_stream(bs_server).await?;
-
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}",
-            INSTANCE_NAME,
-            "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
-            HASH1,
-            100
-        );
-        let write_request = WriteRequest {
-            resource_name,
-            write_offset: 10,
-            finish_write: false,
-            data: "TEST".into(),
-        };
-
-        {
-            // Write our zero byte data.
-            tx.send_data(encode_stream_proto(&write_request)?).await?;
-            // Expect the write command to fail.
-            assert!(join_handle.await?.0.is_err());
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-pub mod read_tests {
-    use nativelink_proto::google::bytestream::{
-        byte_stream_server::ByteStream, // Needed to call .read().
-        ReadRequest,
-    };
-    use pretty_assertions::assert_eq; // Must be declared in every module.
-    use tokio_stream::StreamExt;
-
-    use super::*;
-
-    #[nativelink_test]
-    pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn std::error::Error>>
-    {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        const VALUE1: &str = "12456789abcdefghijk";
-
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        store.update_oneshot(digest, VALUE1.into()).await?;
-
-        let read_request = ReadRequest {
-            resource_name: format!("{}/blobs/{}/{}", INSTANCE_NAME, HASH1, VALUE1.len()),
-            read_offset: 0,
-            read_limit: VALUE1.len() as i64,
-        };
-        let mut read_stream = bs_server
-            .read(Request::new(read_request))
-            .await?
-            .into_inner();
-        {
-            let mut roundtrip_data = Vec::with_capacity(VALUE1.len());
-            while let Some(result_read_response) = read_stream.next().await {
-                roundtrip_data.append(&mut result_read_response?.data.to_vec());
-            }
-            assert_eq!(
-                roundtrip_data,
-                VALUE1.as_bytes(),
-                "Expected response to match what is in store"
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = make_bytestream_server(store_manager.as_ref())?;
-        let store = store_manager.get_store("main_cas").unwrap();
-
-        const DATA_SIZE: usize = 10_000_000;
-        let mut raw_data = vec![41u8; DATA_SIZE];
-        // Change just a few bits to ensure we don't get same packet
-        // over and over.
-        raw_data[5] = 42u8;
-        raw_data[DATA_SIZE - 2] = 43u8;
-
-        let data_len = raw_data.len();
-        let digest = DigestInfo::try_new(HASH1, data_len)?;
-        store
-            .update_oneshot(digest, raw_data.clone().into())
-            .await?;
-
-        let read_request = ReadRequest {
-            resource_name: format!("{}/blobs/{}/{}", INSTANCE_NAME, HASH1, raw_data.len()),
-            read_offset: 0,
-            read_limit: raw_data.len() as i64,
-        };
-        let mut read_stream = bs_server
-            .read(Request::new(read_request))
-            .await?
-            .into_inner();
-        {
-            let mut roundtrip_data = Vec::with_capacity(raw_data.len());
-            assert!(
-                !raw_data.is_empty(),
-                "Expected at least one byte to be sent"
-            );
-            while let Some(result_read_response) = read_stream.next().await {
-                roundtrip_data.append(&mut result_read_response?.data.to_vec());
-            }
-            assert_eq!(
-                roundtrip_data, raw_data,
-                "Expected response to match what is in store"
-            );
-        }
-        Ok(())
-    }
-
-    /// A bug was found in early development where we could deadlock when reading a stream if the
-    /// store backend resulted in an error. This was because we were not shutting down the stream
-    /// when on the backend store error which caused the AsyncReader to block forever because the
-    /// stream was never shutdown.
-    #[nativelink_test]
-    pub async fn read_with_not_found_does_not_deadlock() -> Result<(), Error> {
-        let store_manager = make_store_manager()
-            .await
-            .err_tip(|| "Couldn't get store manager")?;
-        let mut read_stream = {
-            let bs_server =
-                make_bytestream_server(store_manager.as_ref()).err_tip(|| "Couldn't make store")?;
-            let read_request = ReadRequest {
-                resource_name: format!(
-                    "{}/blobs/{}/{}",
-                    INSTANCE_NAME,
-                    HASH1,
-                    55, // Dummy value
-                ),
-                read_offset: 0,
-                read_limit: 55,
-            };
-            // This should fail because there's no data in the store yet.
-            bs_server
-                .read(Request::new(read_request))
-                .await
-                .err_tip(|| "Couldn't send read")?
-                .into_inner()
-        };
-        // We need to give a chance for the other spawns to do some work before we poll.
-        yield_now().await;
-        {
-            let result_fut = read_stream.next();
-
-            let result = result_fut.await.err_tip(|| "Expected result to be ready")?;
-            let expected_err_str = concat!(
-                "status: NotFound, message: \"Key Digest(DigestInfo { size_bytes: 55, hash: \\\"0123456789abcdef000000000000000000000000000000000123456789abcdef\\\" }) not found\", details: [], metadata: MetadataMap { headers: {} }",
-            );
-            assert_eq!(
-                Error::from(result.unwrap_err()),
-                make_err!(Code::NotFound, "{}", expected_err_str),
-                "Expected error data to match"
-            );
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-pub mod query_tests {
-    use nativelink_proto::google::bytestream::byte_stream_server::ByteStream;
-    use nativelink_proto::google::bytestream::{
-        QueryWriteStatusRequest, QueryWriteStatusResponse, WriteRequest,
-    };
-    use pretty_assertions::assert_eq; // Must be declared in every module.
-    use tonic::codec::{Codec, CompressionEncoding, ProstCodec};
-    use tonic::transport::Body;
-    use tonic::Streaming;
-
-    use super::*;
-
-    #[nativelink_test]
-    pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
-        let store_manager = make_store_manager().await?;
-        let bs_server = Arc::new(make_bytestream_server(store_manager.as_ref())?);
-
+    // Send data.
+    let raw_data = {
         let raw_data = "12456789abcdefghijk".as_bytes();
+        // Chunk our data into two chunks to simulate something a client
+        // might do.
+        const BYTE_SPLIT_OFFSET: usize = 8;
+
         let resource_name = format!(
             "{}/uploads/{}/blobs/{}/{}",
             INSTANCE_NAME,
@@ -992,98 +109,903 @@ pub mod query_tests {
             HASH1,
             raw_data.len()
         );
-
-        {
-            let response = bs_server
-                .query_write_status(Request::new(QueryWriteStatusRequest {
-                    resource_name: resource_name.clone(),
-                }))
-                .await;
-            assert_eq!(response.is_err(), true);
-            let expected_err = make_err!(
-                Code::NotFound,
-                "{}{}",
-                "status: NotFound, message: \"not found : Failed on query_write_status() ",
-                "command\", details: [], metadata: MetadataMap { headers: {} }"
-            );
-            assert_eq!(Into::<Error>::into(response.unwrap_err()), expected_err);
-        }
-
-        // Setup stream.
-        let (mut tx, join_handle) = {
-            let (tx, body) = Body::channel();
-            let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
-            // Note: This is an undocumented function.
-            let stream = Streaming::new_request(
-                codec.decoder(),
-                body,
-                Some(CompressionEncoding::Gzip),
-                None,
-            );
-
-            let bs_server_clone = bs_server.clone();
-            let join_handle = spawn!("query_write_status_smoke_test_write_stream", async move {
-                let response_future = bs_server_clone.write(Request::new(stream));
-                response_future.await
-            });
-            (tx, join_handle)
-        };
-
-        const BYTE_SPLIT_OFFSET: usize = 8;
-
         let mut write_request = WriteRequest {
-            resource_name: resource_name.clone(),
+            resource_name,
             write_offset: 0,
             finish_write: false,
             data: vec![].into(),
         };
-
         // Write first chunk of data.
         write_request.write_offset = 0;
         write_request.data = raw_data[..BYTE_SPLIT_OFFSET].into();
         tx.send_data(encode_stream_proto(&write_request)?).await?;
 
-        {
-            // Check to see if our request is active.
-            tokio::task::yield_now().await;
-            let data = bs_server
-                .query_write_status(Request::new(QueryWriteStatusRequest {
-                    resource_name: resource_name.clone(),
-                }))
-                .await?;
-            assert_eq!(
-                data.into_inner(),
-                QueryWriteStatusResponse {
-                    committed_size: write_request.data.len() as i64,
-                    complete: false,
-                }
-            );
-        }
+        // Write empty set of data (clients are allowed to do this.
+        write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
+        write_request.data = vec![].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
 
-        // Finish writing our data.
+        // Write final bit of data.
         write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
         write_request.data = raw_data[BYTE_SPLIT_OFFSET..].into();
         write_request.finish_write = true;
         tx.send_data(encode_stream_proto(&write_request)?).await?;
 
-        {
-            // Now that it's done uploading, ensure it returns a success when requested again.
-            tokio::task::yield_now().await;
-            let data = bs_server
-                .query_write_status(Request::new(QueryWriteStatusRequest { resource_name }))
-                .await?;
-            assert_eq!(
-                data.into_inner(),
-                QueryWriteStatusResponse {
-                    committed_size: raw_data.len() as i64,
-                    complete: true,
-                }
-            );
-        }
-        join_handle
-            .await
-            .err_tip(|| "Failed to join")?
-            .err_tip(|| "Failed write")?;
-        Ok(())
+        raw_data
+    };
+    // Check results of server.
+    {
+        // One for spawn() future and one for result.
+        let server_result = join_handle.await??;
+        let committed_size = usize::try_from(server_result.into_inner().committed_size)
+            .or(Err("Cant convert i64 to usize"))?;
+        assert_eq!(committed_size, raw_data.len());
+
+        // Now lets check our store to ensure it was written with proper data.
+        assert!(
+            store
+                .has(DigestInfo::try_new(HASH1, raw_data.len())?)
+                .await?
+                .is_some(),
+            "Not found in store",
+        );
+        let store_data = store
+            .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None)
+            .await?;
+        assert_eq!(
+            std::str::from_utf8(&store_data),
+            std::str::from_utf8(raw_data),
+            "Expected store to have been updated to new value"
+        );
     }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("resume_write_success_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    const WRITE_DATA: &str = "12456789abcdefghijk";
+
+    // Chunk our data into two chunks to simulate something a client
+    // might do.
+    const BYTE_SPLIT_OFFSET: usize = 8;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        WRITE_DATA.len()
+    );
+    let mut write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+    {
+        // Write first chunk of data.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    let bs_server = {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, bs_server) = join_handle.await?;
+        assert_eq!(result.is_err(), true, "Expected error to be returned");
+        bs_server
+    };
+    // Now reconnect.
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    {
+        // Write the remainder of our data.
+        write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
+        write_request.finish_write = true;
+        write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, _bs_server) = join_handle.await?;
+        result?;
+    }
+    {
+        // Check to make sure our store recorded the data properly.
+        let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
+        assert_eq!(
+            store.get_part_unchunked(digest, 0, None).await?,
+            WRITE_DATA,
+            "Data written to store did not match expected data",
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("restart_write_success_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    const WRITE_DATA: &str = "12456789abcdefghijk";
+
+    // Chunk our data into two chunks to simulate something a client
+    // might do.
+    const BYTE_SPLIT_OFFSET: usize = 8;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        WRITE_DATA.len()
+    );
+    let mut write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+    {
+        // Write first chunk of data.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    let bs_server = {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, bs_server) = join_handle.await?;
+        assert_eq!(result.is_err(), true, "Expected error to be returned");
+        bs_server
+    };
+    // Now reconnect.
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    {
+        // Write first chunk of data again.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Write the remainder of our data.
+        write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
+        write_request.finish_write = true;
+        write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, _bs_server) = join_handle.await?;
+        assert!(result.is_ok(), "Expected success to be returned");
+    }
+    {
+        // Check to make sure our store recorded the data properly.
+        let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
+        assert_eq!(
+            store.get_part_unchunked(digest, 0, None).await?,
+            WRITE_DATA,
+            "Data written to store did not match expected data",
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!(
+            "restart_mid_stream_write_success_write_stream",
+            async move {
+                let response_future = bs_server.write(Request::new(stream));
+                (response_future.await, bs_server)
+            },
+        );
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    const WRITE_DATA: &str = "12456789abcdefghijk";
+
+    // Chunk our data into two chunks to simulate something a client
+    // might do.
+    const BYTE_SPLIT_OFFSET: usize = 8;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        WRITE_DATA.len()
+    );
+    let mut write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+    {
+        // Write first chunk of data.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    let bs_server = {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, bs_server) = join_handle.await?;
+        assert_eq!(result.is_err(), true, "Expected error to be returned");
+        bs_server
+    };
+    // Now reconnect.
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    {
+        // Write some of the first chunk of data again.
+        write_request.write_offset = 2;
+        write_request.data = WRITE_DATA[2..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Write the remainder of our data.
+        write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
+        write_request.finish_write = true;
+        write_request.data = WRITE_DATA[BYTE_SPLIT_OFFSET..].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Now disconnect our stream.
+        drop(tx);
+        let (result, _bs_server) = join_handle.await?;
+        assert!(result.is_ok(), "Expected success to be returned");
+    }
+    {
+        // Check to make sure our store recorded the data properly.
+        let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
+        assert_eq!(
+            store.get_part_unchunked(digest, 0, None).await?,
+            WRITE_DATA,
+            "Data written to store did not match expected data",
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn ensure_write_is_not_done_until_write_request_is_set(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    // Setup stream.
+    let (mut tx, mut write_fut) = {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        (tx, bs_server.write(Request::new(stream)))
+    };
+    const WRITE_DATA: &str = "12456789abcdefghijk";
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        WRITE_DATA.len()
+    );
+    let mut write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+    {
+        // Write our data.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    // Note: We have to pull multiple times because there are multiple futures
+    // joined onto this one future and we need to ensure we run the state machine as
+    // far as possible.
+    for _ in 0..100 {
+        assert!(
+            poll!(&mut write_fut).is_pending(),
+            "Expected the future to not be completed yet"
+        );
+    }
+    {
+        // Write our EOF.
+        write_request.write_offset = WRITE_DATA.len() as i64;
+        write_request.finish_write = true;
+        write_request.data.clear();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    let mut result = None;
+    for _ in 0..100 {
+        if let Poll::Ready(r) = poll!(&mut write_fut) {
+            result = Some(r);
+            break;
+        }
+    }
+    {
+        // Check our results.
+        assert_eq!(
+            result
+                .err_tip(|| "bs_server.write never returned a value")?
+                .err_tip(|| "bs_server.write returned an error")?
+                .into_inner(),
+            WriteResponse {
+                committed_size: WRITE_DATA.len() as i64
+            },
+            "Expected Responses to match"
+        );
+    }
+    {
+        // Check to make sure our store recorded the data properly.
+        let digest = DigestInfo::try_new(HASH1, WRITE_DATA.len())?;
+        assert_eq!(
+            store.get_part_unchunked(digest, 0, None).await?,
+            WRITE_DATA,
+            "Data written to store did not match expected data",
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn out_of_order_data_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("out_of_order_data_fails_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+    const WRITE_DATA: &str = "12456789abcdefghijk";
+
+    // Chunk our data into two chunks to simulate something a client
+    // might do.
+    const BYTE_SPLIT_OFFSET: usize = 8;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        WRITE_DATA.len()
+    );
+    let mut write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+    {
+        // Write first chunk of data.
+        write_request.write_offset = 0;
+        write_request.data = WRITE_DATA[..BYTE_SPLIT_OFFSET].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    {
+        // Write data it already has.
+        write_request.write_offset = (BYTE_SPLIT_OFFSET - 1) as i64;
+        write_request.data = WRITE_DATA[(BYTE_SPLIT_OFFSET - 1)..].into();
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+    }
+    assert!(
+        join_handle.await?.0.is_err(),
+        "Expected error to be returned"
+    );
+    {
+        // Make sure stream was closed.
+        write_request.write_offset = (BYTE_SPLIT_OFFSET - 1) as i64;
+        write_request.data = WRITE_DATA[(BYTE_SPLIT_OFFSET - 1)..].into();
+        assert!(
+            tx.send_data(encode_stream_proto(&write_request)?)
+                .await
+                .is_err(),
+            "Expected error to be returned"
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("upload_zero_byte_chunk_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        0
+    );
+    let write_request = WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: true,
+        data: vec![].into(),
+    };
+
+    {
+        // Write our zero byte data.
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+        // Wait for stream to finish.
+        join_handle.await?.0?;
+    }
+    {
+        // Check to make sure our store recorded the data properly.
+        let data = store
+            .get_part_unchunked(DigestInfo::try_new(HASH1, 0)?, 0, None)
+            .await?;
+        assert_eq!(data, "", "Expected data to exist and be empty");
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("disallow_negative_write_offset_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        0
+    );
+    let write_request = WriteRequest {
+        resource_name,
+        write_offset: -1,
+        finish_write: true,
+        data: vec![].into(),
+    };
+
+    {
+        // Write our zero byte data.
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+        // Expect the write command to fail.
+        assert!(join_handle.await?.0.is_err());
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn out_of_sequence_write() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+
+    async fn setup_stream(
+        bs_server: ByteStreamServer,
+    ) -> Result<
+        (
+            Sender,
+            JoinHandleDropGuard<(
+                Result<Response<WriteResponse>, tonic::Status>,
+                ByteStreamServer,
+            )>,
+        ),
+        Error,
+    > {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let join_handle = spawn!("out_of_sequence_write_write_stream", async move {
+            let response_future = bs_server.write(Request::new(stream));
+            (response_future.await, bs_server)
+        });
+        Ok((tx, join_handle))
+    }
+    let (mut tx, join_handle) = setup_stream(bs_server).await?;
+
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        100
+    );
+    let write_request = WriteRequest {
+        resource_name,
+        write_offset: 10,
+        finish_write: false,
+        data: "TEST".into(),
+    };
+
+    {
+        // Write our zero byte data.
+        tx.send_data(encode_stream_proto(&write_request)?).await?;
+        // Expect the write command to fail.
+        assert!(join_handle.await?.0.is_err());
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    const VALUE1: &str = "12456789abcdefghijk";
+
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    store.update_oneshot(digest, VALUE1.into()).await?;
+
+    let read_request = ReadRequest {
+        resource_name: format!("{}/blobs/{}/{}", INSTANCE_NAME, HASH1, VALUE1.len()),
+        read_offset: 0,
+        read_limit: VALUE1.len() as i64,
+    };
+    let mut read_stream = bs_server
+        .read(Request::new(read_request))
+        .await?
+        .into_inner();
+    {
+        let mut roundtrip_data = Vec::with_capacity(VALUE1.len());
+        while let Some(result_read_response) = read_stream.next().await {
+            roundtrip_data.append(&mut result_read_response?.data.to_vec());
+        }
+        assert_eq!(
+            roundtrip_data,
+            VALUE1.as_bytes(),
+            "Expected response to match what is in store"
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = make_bytestream_server(store_manager.as_ref())?;
+    let store = store_manager.get_store("main_cas").unwrap();
+
+    const DATA_SIZE: usize = 10_000_000;
+    let mut raw_data = vec![41u8; DATA_SIZE];
+    // Change just a few bits to ensure we don't get same packet
+    // over and over.
+    raw_data[5] = 42u8;
+    raw_data[DATA_SIZE - 2] = 43u8;
+
+    let data_len = raw_data.len();
+    let digest = DigestInfo::try_new(HASH1, data_len)?;
+    store
+        .update_oneshot(digest, raw_data.clone().into())
+        .await?;
+
+    let read_request = ReadRequest {
+        resource_name: format!("{}/blobs/{}/{}", INSTANCE_NAME, HASH1, raw_data.len()),
+        read_offset: 0,
+        read_limit: raw_data.len() as i64,
+    };
+    let mut read_stream = bs_server
+        .read(Request::new(read_request))
+        .await?
+        .into_inner();
+    {
+        let mut roundtrip_data = Vec::with_capacity(raw_data.len());
+        assert!(
+            !raw_data.is_empty(),
+            "Expected at least one byte to be sent"
+        );
+        while let Some(result_read_response) = read_stream.next().await {
+            roundtrip_data.append(&mut result_read_response?.data.to_vec());
+        }
+        assert_eq!(
+            roundtrip_data, raw_data,
+            "Expected response to match what is in store"
+        );
+    }
+    Ok(())
+}
+
+/// A bug was found in early development where we could deadlock when reading a stream if the
+/// store backend resulted in an error. This was because we were not shutting down the stream
+/// when on the backend store error which caused the AsyncReader to block forever because the
+/// stream was never shutdown.
+#[nativelink_test]
+pub async fn read_with_not_found_does_not_deadlock() -> Result<(), Error> {
+    let store_manager = make_store_manager()
+        .await
+        .err_tip(|| "Couldn't get store manager")?;
+    let mut read_stream = {
+        let bs_server =
+            make_bytestream_server(store_manager.as_ref()).err_tip(|| "Couldn't make store")?;
+        let read_request = ReadRequest {
+            resource_name: format!(
+                "{}/blobs/{}/{}",
+                INSTANCE_NAME,
+                HASH1,
+                55, // Dummy value
+            ),
+            read_offset: 0,
+            read_limit: 55,
+        };
+        // This should fail because there's no data in the store yet.
+        bs_server
+            .read(Request::new(read_request))
+            .await
+            .err_tip(|| "Couldn't send read")?
+            .into_inner()
+    };
+    // We need to give a chance for the other spawns to do some work before we poll.
+    yield_now().await;
+    {
+        let result_fut = read_stream.next();
+
+        let result = result_fut.await.err_tip(|| "Expected result to be ready")?;
+        let expected_err_str = concat!(
+                "status: NotFound, message: \"Key Digest(DigestInfo { size_bytes: 55, hash: \\\"0123456789abcdef000000000000000000000000000000000123456789abcdef\\\" }) not found\", details: [], metadata: MetadataMap { headers: {} }",
+            );
+        assert_eq!(
+            Error::from(result.unwrap_err()),
+            make_err!(Code::NotFound, "{}", expected_err_str),
+            "Expected error data to match"
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let bs_server = Arc::new(make_bytestream_server(store_manager.as_ref())?);
+
+    let raw_data = "12456789abcdefghijk".as_bytes();
+    let resource_name = format!(
+        "{}/uploads/{}/blobs/{}/{}",
+        INSTANCE_NAME,
+        "4dcec57e-1389-4ab5-b188-4a59f22ceb4b", // Randomly generated.
+        HASH1,
+        raw_data.len()
+    );
+
+    {
+        let response = bs_server
+            .query_write_status(Request::new(QueryWriteStatusRequest {
+                resource_name: resource_name.clone(),
+            }))
+            .await;
+        assert_eq!(response.is_err(), true);
+        let expected_err = make_err!(
+            Code::NotFound,
+            "{}{}",
+            "status: NotFound, message: \"not found : Failed on query_write_status() ",
+            "command\", details: [], metadata: MetadataMap { headers: {} }"
+        );
+        assert_eq!(Into::<Error>::into(response.unwrap_err()), expected_err);
+    }
+
+    // Setup stream.
+    let (mut tx, join_handle) = {
+        let (tx, body) = Body::channel();
+        let mut codec = ProstCodec::<WriteRequest, WriteRequest>::default();
+        // Note: This is an undocumented function.
+        let stream =
+            Streaming::new_request(codec.decoder(), body, Some(CompressionEncoding::Gzip), None);
+
+        let bs_server_clone = bs_server.clone();
+        let join_handle = spawn!("query_write_status_smoke_test_write_stream", async move {
+            let response_future = bs_server_clone.write(Request::new(stream));
+            response_future.await
+        });
+        (tx, join_handle)
+    };
+
+    const BYTE_SPLIT_OFFSET: usize = 8;
+
+    let mut write_request = WriteRequest {
+        resource_name: resource_name.clone(),
+        write_offset: 0,
+        finish_write: false,
+        data: vec![].into(),
+    };
+
+    // Write first chunk of data.
+    write_request.write_offset = 0;
+    write_request.data = raw_data[..BYTE_SPLIT_OFFSET].into();
+    tx.send_data(encode_stream_proto(&write_request)?).await?;
+
+    {
+        // Check to see if our request is active.
+        tokio::task::yield_now().await;
+        let data = bs_server
+            .query_write_status(Request::new(QueryWriteStatusRequest {
+                resource_name: resource_name.clone(),
+            }))
+            .await?;
+        assert_eq!(
+            data.into_inner(),
+            QueryWriteStatusResponse {
+                committed_size: write_request.data.len() as i64,
+                complete: false,
+            }
+        );
+    }
+
+    // Finish writing our data.
+    write_request.write_offset = BYTE_SPLIT_OFFSET as i64;
+    write_request.data = raw_data[BYTE_SPLIT_OFFSET..].into();
+    write_request.finish_write = true;
+    tx.send_data(encode_stream_proto(&write_request)?).await?;
+
+    {
+        // Now that it's done uploading, ensure it returns a success when requested again.
+        tokio::task::yield_now().await;
+        let data = bs_server
+            .query_write_status(Request::new(QueryWriteStatusRequest { resource_name }))
+            .await?;
+        assert_eq!(
+            data.into_inner(),
+            QueryWriteStatusResponse {
+                committed_size: raw_data.len() as i64,
+                complete: true,
+            }
+        );
+    }
+    join_handle
+        .await
+        .err_tip(|| "Failed to join")?
+        .err_tip(|| "Failed write")?;
+    Ok(())
 }

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -37,6 +37,7 @@ use nativelink_util::action_messages::{ActionInfo, ActionInfoHashKey, ActionStag
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
+use pretty_assertions::assert_eq;
 use tokio_stream::StreamExt;
 use tonic::Request;
 
@@ -113,335 +114,308 @@ async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestCont
     })
 }
 
-#[cfg(test)]
-pub mod connect_worker_tests {
-    use super::*;
+#[nativelink_test]
+pub async fn connect_worker_adds_worker_to_scheduler_test() -> Result<(), Box<dyn std::error::Error>>
+{
+    let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
-    #[nativelink_test]
-    pub async fn connect_worker_adds_worker_to_scheduler_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
+    let worker_exists = test_context
+        .scheduler
+        .contains_worker_for_test(&test_context.worker_id)
+        .await;
+    assert!(worker_exists, "Expected worker to exist in worker map");
 
-        let worker_exists = test_context
-            .scheduler
-            .contains_worker_for_test(&test_context.worker_id)
-            .await;
-        assert!(worker_exists, "Expected worker to exist in worker map");
-
-        Ok(())
-    }
+    Ok(())
 }
 
-#[cfg(test)]
-pub mod keep_alive_tests {
-    use pretty_assertions::assert_eq; // Must be declared in every module.
+#[nativelink_test]
+pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::Error>> {
+    let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
-    use super::*;
-
-    #[nativelink_test]
-    pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::Error>> {
-        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
-
-        let mut now_timestamp = BASE_NOW_S;
-        {
-            // Now change time to 1 second before timeout and ensure the worker is still in the pool.
-            now_timestamp += BASE_WORKER_TIMEOUT_S - 1;
-            test_context
-                .scheduler
-                .remove_timedout_workers(now_timestamp)
-                .await?;
-            let worker_exists = test_context
-                .scheduler
-                .contains_worker_for_test(&test_context.worker_id)
-                .await;
-            assert!(worker_exists, "Expected worker to exist in worker map");
-        }
-        {
-            // Now add 1 second and our worker should have been evicted due to timeout.
-            now_timestamp += 1;
-            test_context
-                .scheduler
-                .remove_timedout_workers(now_timestamp)
-                .await?;
-            let worker_exists = test_context
-                .scheduler
-                .contains_worker_for_test(&test_context.worker_id)
-                .await;
-            assert!(!worker_exists, "Expected worker to not exist in map");
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn server_does_not_timeout_if_keep_alive_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let now_timestamp = Arc::new(Mutex::new(BASE_NOW_S));
-        let now_timestamp_clone = now_timestamp.clone();
-        let add_and_return_timestamp = move |add_amount: u64| -> u64 {
-            let mut locked_now_timestamp = now_timestamp.lock().unwrap();
-            *locked_now_timestamp += add_amount;
-            *locked_now_timestamp
-        };
-
-        let test_context = setup_api_server(
-            BASE_WORKER_TIMEOUT_S,
-            Box::new(move || Ok(Duration::from_secs(*now_timestamp_clone.lock().unwrap()))),
-        )
-        .await?;
-        {
-            // Now change time to 1 second before timeout and ensure the worker is still in the pool.
-            let timestamp = add_and_return_timestamp(BASE_WORKER_TIMEOUT_S - 1);
-            test_context
-                .scheduler
-                .remove_timedout_workers(timestamp)
-                .await?;
-            let worker_exists = test_context
-                .scheduler
-                .contains_worker_for_test(&test_context.worker_id)
-                .await;
-            assert!(worker_exists, "Expected worker to exist in worker map");
-        }
-        {
-            // Now send keep alive.
-            test_context
-                .worker_api_server
-                .keep_alive(Request::new(KeepAliveRequest {
-                    worker_id: test_context.worker_id.to_string(),
-                }))
-                .await
-                .err_tip(|| "Error sending keep alive")?;
-        }
-        {
-            // Now add 1 second and our worker should still exist in our map.
-            let timestamp = add_and_return_timestamp(1);
-            test_context
-                .scheduler
-                .remove_timedout_workers(timestamp)
-                .await?;
-            let worker_exists = test_context
-                .scheduler
-                .contains_worker_for_test(&test_context.worker_id)
-                .await;
-            assert!(worker_exists, "Expected worker to exist in map");
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std::error::Error>>
+    let mut now_timestamp = BASE_NOW_S;
     {
-        let mut test_context =
-            setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
-
-        // Send keep alive to client.
+        // Now change time to 1 second before timeout and ensure the worker is still in the pool.
+        now_timestamp += BASE_WORKER_TIMEOUT_S - 1;
         test_context
             .scheduler
-            .send_keep_alive_to_worker_for_test(&test_context.worker_id)
-            .await
-            .err_tip(|| "Could not send keep alive to worker")?;
-
-        {
-            // Read stream and ensure it was a keep alive message.
-            let maybe_message = test_context.connection_worker_stream.next().await;
-            assert!(
-                maybe_message.is_some(),
-                "Expected next message in stream to exist"
-            );
-            let update_message = maybe_message
-                .unwrap()
-                .err_tip(|| "Expected success result")?
-                .update
-                .err_tip(|| "Expected update field to be populated")?;
-            assert_eq!(
-                update_message,
-                update_for_worker::Update::KeepAlive(()),
-                "Expected KeepAlive message"
-            );
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-pub mod going_away_tests {
-    use super::*;
-
-    #[nativelink_test]
-    pub async fn going_away_removes_worker_test() -> Result<(), Box<dyn std::error::Error>> {
-        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
-
+            .remove_timedout_workers(now_timestamp)
+            .await?;
         let worker_exists = test_context
             .scheduler
             .contains_worker_for_test(&test_context.worker_id)
             .await;
         assert!(worker_exists, "Expected worker to exist in worker map");
-
+    }
+    {
+        // Now add 1 second and our worker should have been evicted due to timeout.
+        now_timestamp += 1;
         test_context
             .scheduler
-            .remove_worker(test_context.worker_id)
-            .await;
-
+            .remove_timedout_workers(now_timestamp)
+            .await?;
         let worker_exists = test_context
             .scheduler
             .contains_worker_for_test(&test_context.worker_id)
             .await;
-        assert!(
-            !worker_exists,
-            "Expected worker to be removed from worker map"
-        );
-
-        Ok(())
+        assert!(!worker_exists, "Expected worker to not exist in map");
     }
+
+    Ok(())
 }
 
-#[cfg(test)]
-pub mod execution_response_tests {
-    use pretty_assertions::assert_eq; // Must be declared in every module.
+#[nativelink_test]
+pub async fn server_does_not_timeout_if_keep_alive_test() -> Result<(), Box<dyn std::error::Error>>
+{
+    let now_timestamp = Arc::new(Mutex::new(BASE_NOW_S));
+    let now_timestamp_clone = now_timestamp.clone();
+    let add_and_return_timestamp = move |add_amount: u64| -> u64 {
+        let mut locked_now_timestamp = now_timestamp.lock().unwrap();
+        *locked_now_timestamp += add_amount;
+        *locked_now_timestamp
+    };
 
-    use super::*;
-
-    fn make_system_time(time: u64) -> SystemTime {
-        UNIX_EPOCH.checked_add(Duration::from_secs(time)).unwrap()
+    let test_context = setup_api_server(
+        BASE_WORKER_TIMEOUT_S,
+        Box::new(move || Ok(Duration::from_secs(*now_timestamp_clone.lock().unwrap()))),
+    )
+    .await?;
+    {
+        // Now change time to 1 second before timeout and ensure the worker is still in the pool.
+        let timestamp = add_and_return_timestamp(BASE_WORKER_TIMEOUT_S - 1);
+        test_context
+            .scheduler
+            .remove_timedout_workers(timestamp)
+            .await?;
+        let worker_exists = test_context
+            .scheduler
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
+        assert!(worker_exists, "Expected worker to exist in worker map");
     }
-
-    #[nativelink_test]
-    pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error::Error>> {
-        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
-
-        const SALT: u64 = 5;
-        let action_digest = DigestInfo::new([7u8; 32], 123);
-        let instance_name = "instance_name".to_string();
-
-        let action_info = ActionInfo {
-            command_digest: DigestInfo::new([0u8; 32], 0),
-            input_root_digest: DigestInfo::new([0u8; 32], 0),
-            timeout: Duration::MAX,
-            platform_properties: PlatformProperties {
-                properties: HashMap::new(),
-            },
-            priority: 0,
-            load_timestamp: make_system_time(0),
-            insert_timestamp: make_system_time(0),
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: instance_name.clone(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: action_digest,
-                salt: SALT,
-            },
-            skip_cache_lookup: true,
-        };
-        let mut client_action_state_receiver =
-            test_context.scheduler.add_action(action_info).await?;
-
-        let mut server_logs = HashMap::new();
-        server_logs.insert(
-            "log_name".to_string(),
-            LogFile {
-                digest: Some(DigestInfo::new([9u8; 32], 124).into()),
-                human_readable: false, // We only support non-human readable.
-            },
-        );
-        let result = ExecuteResult {
-            instance_name,
-            worker_id: test_context.worker_id.to_string(),
-            action_digest: Some(action_digest.into()),
-            salt: SALT,
-            digest_function: DigestHasherFunc::Sha256.proto_digest_func().into(),
-            result: Some(execute_result::Result::ExecuteResponse(ExecuteResponse {
-                result: Some(ProtoActionResult {
-                    output_files: vec![OutputFile {
-                        path: "some path1".to_string(),
-                        digest: Some(DigestInfo::new([8u8; 32], 124).into()),
-                        is_executable: true,
-                        contents: Default::default(), // We don't implement this.
-                        node_properties: None,
-                    }],
-                    output_file_symlinks: vec![OutputSymlink {
-                        path: "some path3".to_string(),
-                        target: "some target3".to_string(),
-                        node_properties: None,
-                    }],
-                    output_symlinks: vec![OutputSymlink {
-                        path: "some path3".to_string(),
-                        target: "some target3".to_string(),
-                        node_properties: None,
-                    }],
-                    output_directories: vec![OutputDirectory {
-                        path: "some path4".to_string(),
-                        tree_digest: Some(DigestInfo::new([12u8; 32], 124).into()),
-                        is_topologically_sorted: false,
-                    }],
-                    output_directory_symlinks: Default::default(), // Bazel deprecated this.
-                    exit_code: 5,
-                    stdout_raw: Default::default(), // We don't implement this.
-                    stdout_digest: Some(DigestInfo::new([10u8; 32], 124).into()),
-                    stderr_raw: Default::default(), // We don't implement this.
-                    stderr_digest: Some(DigestInfo::new([11u8; 32], 124).into()),
-                    execution_metadata: Some(ExecutedActionMetadata {
-                        worker: test_context.worker_id.to_string(),
-                        queued_timestamp: Some(make_system_time(1).into()),
-                        worker_start_timestamp: Some(make_system_time(2).into()),
-                        worker_completed_timestamp: Some(make_system_time(3).into()),
-                        input_fetch_start_timestamp: Some(make_system_time(4).into()),
-                        input_fetch_completed_timestamp: Some(make_system_time(5).into()),
-                        execution_start_timestamp: Some(make_system_time(6).into()),
-                        execution_completed_timestamp: Some(make_system_time(7).into()),
-                        output_upload_start_timestamp: Some(make_system_time(8).into()),
-                        output_upload_completed_timestamp: Some(make_system_time(9).into()),
-                        virtual_execution_duration: Some(prost_types::Duration {
-                            seconds: 1,
-                            nanos: 0,
-                        }),
-                        auxiliary_metadata: vec![],
-                    }),
-                }),
-                cached_result: false,
-                status: Some(ProtoStatus {
-                    code: 9,
-                    message: "foo".to_string(),
-                    details: Default::default(),
-                }),
-                server_logs,
-                message: "TODO(blaise.bruer) We should put a reference something like bb_browser"
-                    .to_string(),
-            })),
-        };
-        {
-            // Ensure our client thinks we are executing.
-            client_action_state_receiver.changed().await?;
-            let action_state = client_action_state_receiver.borrow();
-            assert_eq!(action_state.stage, ActionStage::Executing);
-        }
-
-        // Now send the result of our execution to the scheduler.
+    {
+        // Now send keep alive.
         test_context
             .worker_api_server
-            .execution_response(Request::new(result.clone()))
-            .await?;
-
-        {
-            // Check the result that the client would have received.
-            client_action_state_receiver.changed().await?;
-            let client_given_state = client_action_state_receiver.borrow();
-            let execute_response =
-                if let execute_result::Result::ExecuteResponse(v) = result.result.unwrap() {
-                    v
-                } else {
-                    panic!("Expected type to be ExecuteResponse");
-                };
-
-            assert_eq!(
-                client_given_state.stage,
-                execute_response.clone().try_into()?
-            );
-
-            // We just checked if conversion from ExecuteResponse into ActionStage was an exact mach.
-            // Now check if we cast the ActionStage into an ExecuteResponse we get the exact same struct.
-            assert_eq!(execute_response, client_given_state.stage.clone().into());
-        }
-        Ok(())
+            .keep_alive(Request::new(KeepAliveRequest {
+                worker_id: test_context.worker_id.to_string(),
+            }))
+            .await
+            .err_tip(|| "Error sending keep alive")?;
     }
+    {
+        // Now add 1 second and our worker should still exist in our map.
+        let timestamp = add_and_return_timestamp(1);
+        test_context
+            .scheduler
+            .remove_timedout_workers(timestamp)
+            .await?;
+        let worker_exists = test_context
+            .scheduler
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
+        assert!(worker_exists, "Expected worker to exist in map");
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std::error::Error>> {
+    let mut test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
+
+    // Send keep alive to client.
+    test_context
+        .scheduler
+        .send_keep_alive_to_worker_for_test(&test_context.worker_id)
+        .await
+        .err_tip(|| "Could not send keep alive to worker")?;
+
+    {
+        // Read stream and ensure it was a keep alive message.
+        let maybe_message = test_context.connection_worker_stream.next().await;
+        assert!(
+            maybe_message.is_some(),
+            "Expected next message in stream to exist"
+        );
+        let update_message = maybe_message
+            .unwrap()
+            .err_tip(|| "Expected success result")?
+            .update
+            .err_tip(|| "Expected update field to be populated")?;
+        assert_eq!(
+            update_message,
+            update_for_worker::Update::KeepAlive(()),
+            "Expected KeepAlive message"
+        );
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+pub async fn going_away_removes_worker_test() -> Result<(), Box<dyn std::error::Error>> {
+    let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
+
+    let worker_exists = test_context
+        .scheduler
+        .contains_worker_for_test(&test_context.worker_id)
+        .await;
+    assert!(worker_exists, "Expected worker to exist in worker map");
+
+    test_context
+        .scheduler
+        .remove_worker(test_context.worker_id)
+        .await;
+
+    let worker_exists = test_context
+        .scheduler
+        .contains_worker_for_test(&test_context.worker_id)
+        .await;
+    assert!(
+        !worker_exists,
+        "Expected worker to be removed from worker map"
+    );
+
+    Ok(())
+}
+
+fn make_system_time(time: u64) -> SystemTime {
+    UNIX_EPOCH.checked_add(Duration::from_secs(time)).unwrap()
+}
+
+#[nativelink_test]
+pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error::Error>> {
+    let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
+
+    const SALT: u64 = 5;
+    let action_digest = DigestInfo::new([7u8; 32], 123);
+    let instance_name = "instance_name".to_string();
+
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 0,
+        load_timestamp: make_system_time(0),
+        insert_timestamp: make_system_time(0),
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: instance_name.clone(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: action_digest,
+            salt: SALT,
+        },
+        skip_cache_lookup: true,
+    };
+    let mut client_action_state_receiver = test_context.scheduler.add_action(action_info).await?;
+
+    let mut server_logs = HashMap::new();
+    server_logs.insert(
+        "log_name".to_string(),
+        LogFile {
+            digest: Some(DigestInfo::new([9u8; 32], 124).into()),
+            human_readable: false, // We only support non-human readable.
+        },
+    );
+    let result = ExecuteResult {
+        instance_name,
+        worker_id: test_context.worker_id.to_string(),
+        action_digest: Some(action_digest.into()),
+        salt: SALT,
+        digest_function: DigestHasherFunc::Sha256.proto_digest_func().into(),
+        result: Some(execute_result::Result::ExecuteResponse(ExecuteResponse {
+            result: Some(ProtoActionResult {
+                output_files: vec![OutputFile {
+                    path: "some path1".to_string(),
+                    digest: Some(DigestInfo::new([8u8; 32], 124).into()),
+                    is_executable: true,
+                    contents: Default::default(), // We don't implement this.
+                    node_properties: None,
+                }],
+                output_file_symlinks: vec![OutputSymlink {
+                    path: "some path3".to_string(),
+                    target: "some target3".to_string(),
+                    node_properties: None,
+                }],
+                output_symlinks: vec![OutputSymlink {
+                    path: "some path3".to_string(),
+                    target: "some target3".to_string(),
+                    node_properties: None,
+                }],
+                output_directories: vec![OutputDirectory {
+                    path: "some path4".to_string(),
+                    tree_digest: Some(DigestInfo::new([12u8; 32], 124).into()),
+                    is_topologically_sorted: false,
+                }],
+                output_directory_symlinks: Default::default(), // Bazel deprecated this.
+                exit_code: 5,
+                stdout_raw: Default::default(), // We don't implement this.
+                stdout_digest: Some(DigestInfo::new([10u8; 32], 124).into()),
+                stderr_raw: Default::default(), // We don't implement this.
+                stderr_digest: Some(DigestInfo::new([11u8; 32], 124).into()),
+                execution_metadata: Some(ExecutedActionMetadata {
+                    worker: test_context.worker_id.to_string(),
+                    queued_timestamp: Some(make_system_time(1).into()),
+                    worker_start_timestamp: Some(make_system_time(2).into()),
+                    worker_completed_timestamp: Some(make_system_time(3).into()),
+                    input_fetch_start_timestamp: Some(make_system_time(4).into()),
+                    input_fetch_completed_timestamp: Some(make_system_time(5).into()),
+                    execution_start_timestamp: Some(make_system_time(6).into()),
+                    execution_completed_timestamp: Some(make_system_time(7).into()),
+                    output_upload_start_timestamp: Some(make_system_time(8).into()),
+                    output_upload_completed_timestamp: Some(make_system_time(9).into()),
+                    virtual_execution_duration: Some(prost_types::Duration {
+                        seconds: 1,
+                        nanos: 0,
+                    }),
+                    auxiliary_metadata: vec![],
+                }),
+            }),
+            cached_result: false,
+            status: Some(ProtoStatus {
+                code: 9,
+                message: "foo".to_string(),
+                details: Default::default(),
+            }),
+            server_logs,
+            message: "TODO(blaise.bruer) We should put a reference something like bb_browser"
+                .to_string(),
+        })),
+    };
+    {
+        // Ensure our client thinks we are executing.
+        client_action_state_receiver.changed().await?;
+        let action_state = client_action_state_receiver.borrow();
+        assert_eq!(action_state.stage, ActionStage::Executing);
+    }
+
+    // Now send the result of our execution to the scheduler.
+    test_context
+        .worker_api_server
+        .execution_response(Request::new(result.clone()))
+        .await?;
+
+    {
+        // Check the result that the client would have received.
+        client_action_state_receiver.changed().await?;
+        let client_given_state = client_action_state_receiver.borrow();
+        let execute_response =
+            if let execute_result::Result::ExecuteResponse(v) = result.result.unwrap() {
+                v
+            } else {
+                panic!("Expected type to be ExecuteResponse");
+            };
+
+        assert_eq!(
+            client_given_state.stage,
+            execute_response.clone().try_into()?
+        );
+
+        // We just checked if conversion from ExecuteResponse into ActionStage was an exact mach.
+        // Now check if we cast the ActionStage into an ExecuteResponse we get the exact same struct.
+        assert_eq!(execute_response, client_given_state.stage.clone().into());
+    }
+    Ok(())
 }

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -21,6 +21,7 @@ use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
+use pretty_assertions::assert_eq;
 use rand::{thread_rng, Rng};
 use tokio::io::AsyncWriteExt;
 
@@ -36,54 +37,47 @@ async fn make_temp_path(data: &str) -> OsString {
     OsString::from(format!("{dir}/{data}"))
 }
 
-#[cfg(test)]
-mod ac_utils_tests {
-    use pretty_assertions::assert_eq;
+const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
+const HASH1_SIZE: i64 = 147;
 
-    use super::*; // Must be declared in every module.
-
-    const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
-    const HASH1_SIZE: i64 = 147;
-
-    // Regression test for bug created when implementing ResumeableFileSlot
-    // where the timeout() success condition was breaking out of the outer
-    // loop resulting in the file always being created with <= 4096 bytes.
-    #[nativelink_test]
-    async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
-        let filepath = make_temp_path("test.txt").await;
-        let expected_data = vec![0x88; 1024 * 1024]; // 1MB.
-        let store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let digest = DigestInfo::try_new(HASH1, HASH1_SIZE)?; // Dummy hash data.
-        {
-            // Write 1MB of 0x88s to the file.
-            let mut file = tokio::fs::File::create(&filepath)
-                .await
-                .err_tip(|| "Could not open file")?;
-            file.write_all(&expected_data)
-                .await
-                .err_tip(|| "Could not write to file")?;
-            file.flush().await.err_tip(|| "Could not flush file")?;
-            file.sync_all().await.err_tip(|| "Could not sync file")?;
-        }
-        {
-            // Upload our file.
-            let resumeable_file = fs::open_file(filepath, u64::MAX).await?;
-            store
-                .update_with_whole_file(
-                    digest,
-                    resumeable_file,
-                    UploadSizeInfo::ExactSize(expected_data.len()),
-                )
-                .await?;
-        }
-        {
-            // Check to make sure the file was saved correctly to the store.
-            let store_data = store.get_part_unchunked(digest, 0, None).await?;
-            assert_eq!(store_data.len(), expected_data.len());
-            assert_eq!(store_data, expected_data);
-        }
-        Ok(())
+// Regression test for bug created when implementing ResumeableFileSlot
+// where the timeout() success condition was breaking out of the outer
+// loop resulting in the file always being created with <= 4096 bytes.
+#[nativelink_test]
+async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
+    let filepath = make_temp_path("test.txt").await;
+    let expected_data = vec![0x88; 1024 * 1024]; // 1MB.
+    let store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let digest = DigestInfo::try_new(HASH1, HASH1_SIZE)?; // Dummy hash data.
+    {
+        // Write 1MB of 0x88s to the file.
+        let mut file = tokio::fs::File::create(&filepath)
+            .await
+            .err_tip(|| "Could not open file")?;
+        file.write_all(&expected_data)
+            .await
+            .err_tip(|| "Could not write to file")?;
+        file.flush().await.err_tip(|| "Could not flush file")?;
+        file.sync_all().await.err_tip(|| "Could not sync file")?;
     }
+    {
+        // Upload our file.
+        let resumeable_file = fs::open_file(filepath, u64::MAX).await?;
+        store
+            .update_with_whole_file(
+                digest,
+                resumeable_file,
+                UploadSizeInfo::ExactSize(expected_data.len()),
+            )
+            .await?;
+    }
+    {
+        // Check to make sure the file was saved correctly to the store.
+        let store_data = store.get_part_unchunked(digest, 0, None).await?;
+        assert_eq!(store_data.len(), expected_data.len());
+        assert_eq!(store_data, expected_data);
+    }
+    Ok(())
 }

--- a/nativelink-store/tests/cas_utils_test.rs
+++ b/nativelink-store/tests/cas_utils_test.rs
@@ -12,50 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-mod cas_utils_tests {
-    use blake3::Hasher as Blake3;
-    use nativelink_store::cas_utils::is_zero_digest;
-    use nativelink_util::common::DigestInfo;
-    use sha2::{Digest, Sha256};
+use blake3::Hasher as Blake3;
+use nativelink_store::cas_utils::is_zero_digest;
+use nativelink_util::common::DigestInfo;
+use sha2::{Digest, Sha256};
 
-    #[test]
-    fn sha256_is_zero_digest() {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-        assert!(is_zero_digest(&digest));
-    }
+#[test]
+fn sha256_is_zero_digest() {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+    assert!(is_zero_digest(&digest));
+}
 
-    #[test]
-    fn sha256_is_non_zero_digest() {
-        let mut hasher = Sha256::new();
-        hasher.update(b"a");
-        let digest = DigestInfo {
-            packed_hash: hasher.finalize().into(),
-            size_bytes: 1,
-        };
-        assert!(!is_zero_digest(&digest));
-    }
+#[test]
+fn sha256_is_non_zero_digest() {
+    let mut hasher = Sha256::new();
+    hasher.update(b"a");
+    let digest = DigestInfo {
+        packed_hash: hasher.finalize().into(),
+        size_bytes: 1,
+    };
+    assert!(!is_zero_digest(&digest));
+}
 
-    #[test]
-    fn blake_is_zero_digest() {
-        let digest = DigestInfo {
-            packed_hash: Blake3::new().finalize().into(),
-            size_bytes: 0,
-        };
-        assert!(is_zero_digest(&digest));
-    }
+#[test]
+fn blake_is_zero_digest() {
+    let digest = DigestInfo {
+        packed_hash: Blake3::new().finalize().into(),
+        size_bytes: 0,
+    };
+    assert!(is_zero_digest(&digest));
+}
 
-    #[test]
-    fn blake_is_non_zero_digest() {
-        let mut hasher = Blake3::new();
-        hasher.update(b"a");
-        let digest = DigestInfo {
-            packed_hash: hasher.finalize().into(),
-            size_bytes: 1,
-        };
-        assert!(!is_zero_digest(&digest));
-    }
+#[test]
+fn blake_is_non_zero_digest() {
+    let mut hasher = Blake3::new();
+    hasher.update(b"a");
+    let digest = DigestInfo {
+        packed_hash: hasher.finalize().into(),
+        size_bytes: 1,
+    };
+    assert!(!is_zero_digest(&digest));
 }

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -28,228 +28,222 @@ use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::{Store, StoreLike};
 
-#[cfg(test)]
-mod completeness_checking_store_tests {
-    use super::*;
+const ROOT_FILE: DigestInfo = DigestInfo::new([0u8; 32], 0);
+const ROOT_DIRECTORY: DigestInfo = DigestInfo::new([1u8; 32], 0);
+const CHILD_FILE: DigestInfo = DigestInfo::new([2u8; 32], 0);
+const OUTPUT_FILE: DigestInfo = DigestInfo::new([4u8; 32], 0);
+const STDOUT: DigestInfo = DigestInfo::new([5u8; 32], 0);
+const STDERR: DigestInfo = DigestInfo::new([6u8; 32], 0);
 
-    const ROOT_FILE: DigestInfo = DigestInfo::new([0u8; 32], 0);
-    const ROOT_DIRECTORY: DigestInfo = DigestInfo::new([1u8; 32], 0);
-    const CHILD_FILE: DigestInfo = DigestInfo::new([2u8; 32], 0);
-    const OUTPUT_FILE: DigestInfo = DigestInfo::new([4u8; 32], 0);
-    const STDOUT: DigestInfo = DigestInfo::new([5u8; 32], 0);
-    const STDERR: DigestInfo = DigestInfo::new([6u8; 32], 0);
+async fn setup() -> Result<(Arc<CompletenessCheckingStore>, Arc<MemoryStore>, DigestInfo), Error> {
+    let backend_store = Store::new(Arc::new(MemoryStore::new(&MemoryStoreConfig::default())));
+    let cas_store = Arc::new(MemoryStore::new(&MemoryStoreConfig::default()));
+    let ac_store = Arc::new(CompletenessCheckingStore::new(
+        backend_store.clone(),
+        Store::new(cas_store.clone()),
+    ));
 
-    async fn setup() -> Result<(Arc<CompletenessCheckingStore>, Arc<MemoryStore>, DigestInfo), Error>
+    cas_store.update_oneshot(ROOT_FILE, "".into()).await?;
+    // Note: Explicitly not uploading `ROOT_DIRECTORY`. See: TraceMachina/nativelink#747.
+    cas_store.update_oneshot(CHILD_FILE, "".into()).await?;
+    cas_store.update_oneshot(OUTPUT_FILE, "".into()).await?;
+    cas_store.update_oneshot(STDOUT, "".into()).await?;
+    cas_store.update_oneshot(STDERR, "".into()).await?;
+
+    let tree = Tree {
+        root: Some(Directory {
+            files: vec![FileNode {
+                digest: Some(ROOT_FILE.into()),
+                ..Default::default()
+            }],
+            directories: vec![DirectoryNode {
+                digest: Some(ROOT_DIRECTORY.into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+        children: vec![Directory {
+            files: vec![FileNode {
+                digest: Some(CHILD_FILE.into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+
+    let tree_digest = serialize_and_upload_message(
+        &tree,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Blake3.hasher(),
+    )
+    .await?;
+
+    let output_directory = OutputDirectory {
+        tree_digest: Some(tree_digest.into()),
+        ..Default::default()
+    };
+
+    serialize_and_upload_message(
+        &output_directory,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Blake3.hasher(),
+    )
+    .await?;
+
+    let action_result = ProtoActionResult {
+        output_files: vec![OutputFile {
+            digest: Some(OUTPUT_FILE.into()),
+            ..Default::default()
+        }],
+        output_directories: vec![output_directory],
+        stdout_digest: Some(STDOUT.into()),
+        stderr_digest: Some(STDERR.into()),
+        ..Default::default()
+    };
+
+    // The structure of the action result is not following the spec, but is simplified for testing purposes.
+    let action_result_digest = serialize_and_upload_message(
+        &action_result,
+        ac_store.as_pin(),
+        &mut DigestHasherFunc::Blake3.hasher(),
+    )
+    .await?;
+
+    Ok((ac_store, cas_store, action_result_digest))
+}
+
+#[nativelink_test]
+async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
     {
-        let backend_store = Store::new(Arc::new(MemoryStore::new(&MemoryStoreConfig::default())));
-        let cas_store = Arc::new(MemoryStore::new(&MemoryStoreConfig::default()));
-        let ac_store = Arc::new(CompletenessCheckingStore::new(
-            backend_store.clone(),
-            Store::new(cas_store.clone()),
-        ));
+        // Completeness check should succeed when all digests exist in CAS.
 
-        cas_store.update_oneshot(ROOT_FILE, "".into()).await?;
-        // Note: Explicitly not uploading `ROOT_DIRECTORY`. See: TraceMachina/nativelink#747.
-        cas_store.update_oneshot(CHILD_FILE, "".into()).await?;
-        cas_store.update_oneshot(OUTPUT_FILE, "".into()).await?;
-        cas_store.update_oneshot(STDOUT, "".into()).await?;
-        cas_store.update_oneshot(STDERR, "".into()).await?;
+        let (ac_store, _cas_store, action_result_digest) = setup().await?;
 
-        let tree = Tree {
-            root: Some(Directory {
-                files: vec![FileNode {
-                    digest: Some(ROOT_FILE.into()),
-                    ..Default::default()
-                }],
-                directories: vec![DirectoryNode {
-                    digest: Some(ROOT_DIRECTORY.into()),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }),
-            children: vec![Directory {
-                files: vec![FileNode {
-                    digest: Some(CHILD_FILE.into()),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }],
-        };
-
-        let tree_digest = serialize_and_upload_message(
-            &tree,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Blake3.hasher(),
-        )
-        .await?;
-
-        let output_directory = OutputDirectory {
-            tree_digest: Some(tree_digest.into()),
-            ..Default::default()
-        };
-
-        serialize_and_upload_message(
-            &output_directory,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Blake3.hasher(),
-        )
-        .await?;
-
-        let action_result = ProtoActionResult {
-            output_files: vec![OutputFile {
-                digest: Some(OUTPUT_FILE.into()),
-                ..Default::default()
-            }],
-            output_directories: vec![output_directory],
-            stdout_digest: Some(STDOUT.into()),
-            stderr_digest: Some(STDERR.into()),
-            ..Default::default()
-        };
-
-        // The structure of the action result is not following the spec, but is simplified for testing purposes.
-        let action_result_digest = serialize_and_upload_message(
-            &action_result,
-            ac_store.as_pin(),
-            &mut DigestHasherFunc::Blake3.hasher(),
-        )
-        .await?;
-
-        Ok((ac_store, cas_store, action_result_digest))
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_some(),
+            "Results should be some with all items in CAS."
+        );
     }
 
-    #[nativelink_test]
-    async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
-        {
-            // Completeness check should succeed when all digests exist in CAS.
+    {
+        // Completeness check should fail when root file digest is missing.
 
-            let (ac_store, _cas_store, action_result_digest) = setup().await?;
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
 
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_some(),
-                "Results should be some with all items in CAS."
-            );
-        }
+        cas_store.remove_entry(ROOT_FILE.into()).await;
 
-        {
-            // Completeness check should fail when root file digest is missing.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(ROOT_FILE.into()).await;
-
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_none(),
-                "Results should be none with missing root file."
-            );
-        }
-
-        {
-            // Completeness check should fail when child file digest is missing.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(CHILD_FILE.into()).await;
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_none(),
-                "Results should be none with missing root file."
-            );
-        }
-
-        {
-            // Completeness check should fail when output file digest is missing.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(OUTPUT_FILE.into()).await;
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_none(),
-                "Results should be none with missing root file."
-            );
-        }
-
-        {
-            // Completeness check should fail when stdout digest is missing.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(STDOUT.into()).await;
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_none(),
-                "Results should be none with missing root file."
-            );
-        }
-
-        {
-            // Completeness check should fail when stderr digest is missing.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(STDERR.into()).await;
-            let res = ac_store
-                .has_many(&[action_result_digest.into()])
-                .await
-                .unwrap();
-            assert!(
-                res[0].is_none(),
-                "Results should be none with missing root file."
-            );
-        }
-
-        Ok(())
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_none(),
+            "Results should be none with missing root file."
+        );
     }
 
-    #[nativelink_test]
-    async fn verify_completeness_get() -> Result<(), Error> {
-        {
-            // Completeness check in get call should succeed when all digests exist in CAS.
+    {
+        // Completeness check should fail when child file digest is missing.
 
-            let (ac_store, _cas_store, action_result_digest) = setup().await?;
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
 
-            assert!(
-                ac_store
-                    .get_part_unchunked(action_result_digest, 0, None)
-                    .await
-                    .is_ok(),
-                ".get() should succeed with all items in CAS",
-            );
-        }
-
-        {
-            // Completeness check in get call should fail when digest is missing in CAS.
-
-            let (ac_store, cas_store, action_result_digest) = setup().await?;
-
-            cas_store.remove_entry(OUTPUT_FILE.into()).await;
-
-            assert!(
-                ac_store
-                    .get_part_unchunked(action_result_digest, 0, None)
-                    .await
-                    .is_err(),
-                ".get() should fail with item missing in CAS",
-            );
-        }
-
-        Ok(())
+        cas_store.remove_entry(CHILD_FILE.into()).await;
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_none(),
+            "Results should be none with missing root file."
+        );
     }
+
+    {
+        // Completeness check should fail when output file digest is missing.
+
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
+
+        cas_store.remove_entry(OUTPUT_FILE.into()).await;
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_none(),
+            "Results should be none with missing root file."
+        );
+    }
+
+    {
+        // Completeness check should fail when stdout digest is missing.
+
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
+
+        cas_store.remove_entry(STDOUT.into()).await;
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_none(),
+            "Results should be none with missing root file."
+        );
+    }
+
+    {
+        // Completeness check should fail when stderr digest is missing.
+
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
+
+        cas_store.remove_entry(STDERR.into()).await;
+        let res = ac_store
+            .has_many(&[action_result_digest.into()])
+            .await
+            .unwrap();
+        assert!(
+            res[0].is_none(),
+            "Results should be none with missing root file."
+        );
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn verify_completeness_get() -> Result<(), Error> {
+    {
+        // Completeness check in get call should succeed when all digests exist in CAS.
+
+        let (ac_store, _cas_store, action_result_digest) = setup().await?;
+
+        assert!(
+            ac_store
+                .get_part_unchunked(action_result_digest, 0, None)
+                .await
+                .is_ok(),
+            ".get() should succeed with all items in CAS",
+        );
+    }
+
+    {
+        // Completeness check in get call should fail when digest is missing in CAS.
+
+        let (ac_store, cas_store, action_result_digest) = setup().await?;
+
+        cas_store.remove_entry(OUTPUT_FILE.into()).await;
+
+        assert!(
+            ac_store
+                .get_part_unchunked(action_result_digest, 0, None)
+                .await
+                .is_err(),
+            ".get() should fail with item missing in CAS",
+        );
+    }
+
+    Ok(())
 }

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -31,6 +31,7 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::spawn;
 use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
+use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
@@ -63,485 +64,478 @@ fn extract_footer(data: &[u8]) -> Result<Footer, Error> {
         .map_err(|e| make_err!(Code::Internal, "Failed to deserialize header : {:?}", e))
 }
 
-#[cfg(test)]
-mod compression_store_tests {
-    use pretty_assertions::assert_eq;
+const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const DUMMY_DATA_SIZE: usize = 100; // Some dummy size to populate DigestInfo with.
+const MEGABYTE_SZ: usize = 1024 * 1024;
 
-    use super::*; // Must be declared in every module.
-
-    const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const DUMMY_DATA_SIZE: usize = 100; // Some dummy size to populate DigestInfo with.
-    const MEGABYTE_SZ: usize = 1024 * 1024;
-
-    #[nativelink_test]
-    async fn simple_smoke_test() -> Result<(), Error> {
-        let store = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-
-        const RAW_INPUT: &str = "123";
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
-        store.update_oneshot(digest, RAW_INPUT.into()).await?;
-
-        let store_data = store
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
-
-        assert_eq!(
-            from_utf8(&store_data[..]).unwrap(),
-            RAW_INPUT,
-            "Expected data to match"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn partial_reads_test() -> Result<(), Error> {
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        block_size: 10,
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
-
-        const RAW_DATA: [u8; 30] = [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, // BR.
-            10, 11, 12, 13, 14, 15, 16, 17, 18, 19, // BR.
-            20, 21, 22, 23, 24, 25, 26, 27, 28, 29, // BR.
-        ];
-
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
-        store
-            .update_oneshot(digest, RAW_DATA.as_ref().into())
-            .await?;
-
-        // Read through the store forcing lots of decompression steps at different offsets
-        // and different window sizes. This will ensure we get most edge cases for when
-        // we go across block boundaries inclusive, on the fence and exclusive.
-        for read_slice_size in 0..(RAW_DATA.len() + 5) {
-            for offset in 0..(RAW_DATA.len() + 5) {
-                let store_data = store
-                    .get_part_unchunked(digest, offset, Some(read_slice_size))
-                    .await
-                    .err_tip(|| {
-                        format!("Failed to get from inner store at {offset} - {read_slice_size}")
-                    })?;
-
-                let start_pos = cmp::min(RAW_DATA.len(), offset);
-                let end_pos = cmp::min(RAW_DATA.len(), offset + read_slice_size);
-                assert_eq!(
-                    &store_data,
-                    &RAW_DATA[start_pos..end_pos],
-                    "Expected data to match at {} - {}",
-                    offset,
-                    read_slice_size,
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn rand_5mb_smoke_test() -> Result<(), Error> {
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
-
-        let mut value = vec![0u8; 5 * MEGABYTE_SZ];
-        let mut rng = SmallRng::seed_from_u64(1);
-        rng.fill(&mut value[..]);
-
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
-        store.update_oneshot(digest, value.clone().into()).await?;
-
-        let store_data = store
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
-
-        assert_eq!(&store_data, &value, "Expected data to match");
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
-        let inner_store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(inner_store.clone()),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
-
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
-        store.update_oneshot(digest, vec![].into()).await?;
-
-        let store_data = store
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
-
-        assert_eq!(
-            store_data.len(),
-            0,
-            "Expected store data to have no data in it"
-        );
-
-        let compressed_data = Pin::new(inner_store.as_ref())
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
-        assert_eq!(
-            extract_footer(&compressed_data)?,
-            Footer {
-                indexes: vec![],
-                index_count: 0,
-                uncompressed_data_size: 0,
-                config: Lz4Config {
-                    block_size: DEFAULT_BLOCK_SIZE,
+#[nativelink_test]
+async fn simple_smoke_test() -> Result<(), Error> {
+    let store = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    ..Default::default()
                 },
-                version: CURRENT_STREAM_FORMAT_VERSION,
-            },
-            "Expected footers to match"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn check_header_test() -> Result<(), Error> {
-        const BLOCK_SIZE: u32 = 150;
-        const MAX_SIZE_INPUT: usize = 1024 * 1024; // 1MB.
-        let inner_store = Arc::new(MemoryStore::new(
+            ),
+        },
+        Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        block_size: BLOCK_SIZE,
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(inner_store.clone()),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
+        ))),
+    )
+    .err_tip(|| "Failed to create compression store")?;
 
-        const RAW_INPUT: &str = "123";
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    const RAW_INPUT: &str = "123";
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    store.update_oneshot(digest, RAW_INPUT.into()).await?;
 
-        let (mut tx, rx) = make_buf_channel_pair();
-        let send_fut = async move {
-            tx.send(RAW_INPUT.into()).await?;
-            tx.send_eof()
-        };
-        let (res1, res2) = futures::join!(
-            send_fut,
-            store.update(digest, rx, UploadSizeInfo::MaxSize(MAX_SIZE_INPUT))
-        );
-        res1.merge(res2)?;
+    let store_data = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
 
-        let compressed_data = Pin::new(inner_store.as_ref())
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
+    assert_eq!(
+        from_utf8(&store_data[..]).unwrap(),
+        RAW_INPUT,
+        "Expected data to match"
+    );
+    Ok(())
+}
 
-        let mut reader = Cursor::new(&compressed_data);
-        {
-            // Check version in header.
-            let version = reader.read_u8().await?;
-            assert_eq!(
-                version, CURRENT_STREAM_FORMAT_VERSION,
-                "Expected header version to match current version"
-            );
-        }
-        {
-            // Check block size.
-            let block_size = reader.read_u32_le().await?;
-            assert_eq!(block_size, BLOCK_SIZE, "Expected block size to match");
-        }
-        {
-            // Check upload_type and upload_size.
-            const MAX_SIZE_OPT_CODE: u32 = 1;
-            let upload_type = reader.read_u32_le().await?;
-            assert_eq!(
-                upload_type, MAX_SIZE_OPT_CODE,
-                "Expected enum size type to match"
-            );
-            let upload_size = reader.read_u32_le().await?;
-            assert_eq!(
-                upload_size, MAX_SIZE_INPUT as u32,
-                "Expected upload size to match"
-            );
-        }
-
-        // As a sanity check lets check our footer.
-        assert_eq!(
-            extract_footer(&compressed_data)?,
-            Footer {
-                indexes: vec![],
-                index_count: 0,
-                uncompressed_data_size: RAW_INPUT.len() as u64,
-                config: Lz4Config {
-                    block_size: BLOCK_SIZE
+#[nativelink_test]
+async fn partial_reads_test() -> Result<(), Error> {
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    block_size: 10,
+                    ..Default::default()
                 },
-                version: CURRENT_STREAM_FORMAT_VERSION,
-            },
-            "Expected footers to match"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn check_footer_test() -> Result<(), Error> {
-        const BLOCK_SIZE: u32 = 32 * 1024;
-        let inner_store = Arc::new(MemoryStore::new(
+            ),
+        },
+        Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        block_size: BLOCK_SIZE,
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(inner_store.clone()),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(&store_owned);
+        ))),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(&store_owned);
 
-        let mut value = vec![0u8; MEGABYTE_SZ / 4];
-        let data_len = value.len();
+    const RAW_DATA: [u8; 30] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, // BR.
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, // BR.
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, // BR.
+    ];
 
-        let mut rng = SmallRng::seed_from_u64(1);
-        // Fill first half of data with random data that is not compressible.
-        rng.fill(&mut value[..(data_len / 2)]);
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    store
+        .update_oneshot(digest, RAW_DATA.as_ref().into())
+        .await?;
 
-        let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
-        store.update_oneshot(digest, value.clone().into()).await?;
-
-        let compressed_data = Pin::new(inner_store.as_ref())
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get from inner store")?;
-
-        let mut pos = compressed_data.len();
-        {
-            // Check version in footer.
-            let version = compressed_data[pos - 1];
-            pos -= 1;
-            assert_eq!(
-                version, CURRENT_STREAM_FORMAT_VERSION,
-                "Expected footer version to match current version"
-            );
-        }
-        {
-            // Check block size in footer.
-            let block_size = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
-            pos -= 4;
-            assert_eq!(
-                block_size, BLOCK_SIZE,
-                "Expected uncompressed_data_size to match original data size"
-            );
-        }
-        {
-            // Check data size in footer.
-            let uncompressed_data_size =
-                u64::from_le_bytes(compressed_data[pos - 8..pos].try_into().unwrap());
-            pos -= 8;
-            assert_eq!(
-                uncompressed_data_size,
-                value.len() as u64,
-                "Expected uncompressed_data_size to match original data size"
-            );
-        }
-        const EXPECTED_INDEXES: [u32; 7] = [32898, 32898, 32898, 32898, 140, 140, 140];
-        let index_count = {
-            // Check index count in footer.
-            let index_count = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
-            pos -= 4;
-            assert_eq!(
-                index_count as usize,
-                EXPECTED_INDEXES.len(),
-                "Expected index_count to match"
-            );
-            index_count
-        };
-        {
-            // Check indexes in footer.
-            let byte_count = (index_count * 4) as usize;
-            let index_vec_raw = &compressed_data[pos - byte_count..pos];
-            pos -= byte_count;
-            let mut cursor = Cursor::new(index_vec_raw);
-            let mut i = 0;
-            while let Ok(index_pos) = cursor.read_u32_le().await {
-                assert_eq!(
-                    index_pos, EXPECTED_INDEXES[i],
-                    "Expected index to equal at position {}",
-                    i
-                );
-                i += 1;
-            }
-        }
-        {
-            // `bincode` adds the size again as a u64 before our index vector so check it too.
-            let bincode_index_count =
-                u64::from_le_bytes(compressed_data[pos - 8..pos].try_into().unwrap());
-            pos -= 8;
-            assert_eq!(
-                bincode_index_count, index_count as u64,
-                "Expected index_count and bincode_index_count to match"
-            );
-        }
-        {
-            // Check our footer length.
-            let footer_len = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
-            pos -= 4;
-            assert_eq!(
-                footer_len,
-                1 + 4 + 8 + 4 + (index_count * 4) + 8,
-                "Expected frame type to be footer"
-            );
-        }
-        {
-            // Check our frame type.
-            let frame_type = u8::from_le_bytes(compressed_data[pos - 1..pos].try_into().unwrap());
-            assert_eq!(
-                frame_type, FOOTER_FRAME_TYPE,
-                "Expected frame type to be footer"
-            );
-        }
-
-        // Just as one last sanity check lets check our deserialized footer.
-        assert_eq!(
-            extract_footer(&compressed_data)?,
-            Footer {
-                indexes: EXPECTED_INDEXES
-                    .map(|v| SliceIndex {
-                        position_from_prev_index: v
-                    })
-                    .to_vec(),
-                index_count: EXPECTED_INDEXES.len() as u32,
-                uncompressed_data_size: data_len as u64,
-                config: Lz4Config {
-                    block_size: BLOCK_SIZE
-                },
-                version: CURRENT_STREAM_FORMAT_VERSION,
-            },
-            "Expected footers to match"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn get_part_is_zero_digest() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-
-        const BLOCK_SIZE: u32 = 32 * 1024;
-        let inner_store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store_owned = CompressionStore::new(
-            nativelink_config::stores::CompressionStore {
-                backend: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
-                    nativelink_config::stores::Lz4Config {
-                        block_size: BLOCK_SIZE,
-                        ..Default::default()
-                    },
-                ),
-            },
-            Store::new(inner_store.clone()),
-        )
-        .err_tip(|| "Failed to create compression store")?;
-        let store = Pin::new(Arc::new(store_owned));
-
-        let (mut writer, mut reader) = make_buf_channel_pair();
-
-        let _drop_guard = spawn!("get_part_is_zero_digest", async move {
-            let _ = store
-                .as_ref()
-                .get_part(digest, &mut writer, 0, None)
+    // Read through the store forcing lots of decompression steps at different offsets
+    // and different window sizes. This will ensure we get most edge cases for when
+    // we go across block boundaries inclusive, on the fence and exclusive.
+    for read_slice_size in 0..(RAW_DATA.len() + 5) {
+        for offset in 0..(RAW_DATA.len() + 5) {
+            let store_data = store
+                .get_part_unchunked(digest, offset, Some(read_slice_size))
                 .await
-                .err_tip(|| "Failed to get_part");
-        });
+                .err_tip(|| {
+                    format!("Failed to get from inner store at {offset} - {read_slice_size}")
+                })?;
 
-        let file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading bytes")?;
-
-        let empty_bytes = Bytes::new();
-        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
-
-        Ok(())
+            let start_pos = cmp::min(RAW_DATA.len(), offset);
+            let end_pos = cmp::min(RAW_DATA.len(), offset + read_slice_size);
+            assert_eq!(
+                &store_data,
+                &RAW_DATA[start_pos..end_pos],
+                "Expected data to match at {} - {}",
+                offset,
+                read_slice_size,
+            );
+        }
     }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn rand_5mb_smoke_test() -> Result<(), Error> {
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    ..Default::default()
+                },
+            ),
+        },
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(&store_owned);
+
+    let mut value = vec![0u8; 5 * MEGABYTE_SZ];
+    let mut rng = SmallRng::seed_from_u64(1);
+    rng.fill(&mut value[..]);
+
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    store.update_oneshot(digest, value.clone().into()).await?;
+
+    let store_data = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
+
+    assert_eq!(&store_data, &value, "Expected data to match");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
+    let inner_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    ..Default::default()
+                },
+            ),
+        },
+        Store::new(inner_store.clone()),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(&store_owned);
+
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    store.update_oneshot(digest, vec![].into()).await?;
+
+    let store_data = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
+
+    assert_eq!(
+        store_data.len(),
+        0,
+        "Expected store data to have no data in it"
+    );
+
+    let compressed_data = Pin::new(inner_store.as_ref())
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
+    assert_eq!(
+        extract_footer(&compressed_data)?,
+        Footer {
+            indexes: vec![],
+            index_count: 0,
+            uncompressed_data_size: 0,
+            config: Lz4Config {
+                block_size: DEFAULT_BLOCK_SIZE,
+            },
+            version: CURRENT_STREAM_FORMAT_VERSION,
+        },
+        "Expected footers to match"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn check_header_test() -> Result<(), Error> {
+    const BLOCK_SIZE: u32 = 150;
+    const MAX_SIZE_INPUT: usize = 1024 * 1024; // 1MB.
+    let inner_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    block_size: BLOCK_SIZE,
+                    ..Default::default()
+                },
+            ),
+        },
+        Store::new(inner_store.clone()),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(&store_owned);
+
+    const RAW_INPUT: &str = "123";
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+
+    let (mut tx, rx) = make_buf_channel_pair();
+    let send_fut = async move {
+        tx.send(RAW_INPUT.into()).await?;
+        tx.send_eof()
+    };
+    let (res1, res2) = futures::join!(
+        send_fut,
+        store.update(digest, rx, UploadSizeInfo::MaxSize(MAX_SIZE_INPUT))
+    );
+    res1.merge(res2)?;
+
+    let compressed_data = Pin::new(inner_store.as_ref())
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
+
+    let mut reader = Cursor::new(&compressed_data);
+    {
+        // Check version in header.
+        let version = reader.read_u8().await?;
+        assert_eq!(
+            version, CURRENT_STREAM_FORMAT_VERSION,
+            "Expected header version to match current version"
+        );
+    }
+    {
+        // Check block size.
+        let block_size = reader.read_u32_le().await?;
+        assert_eq!(block_size, BLOCK_SIZE, "Expected block size to match");
+    }
+    {
+        // Check upload_type and upload_size.
+        const MAX_SIZE_OPT_CODE: u32 = 1;
+        let upload_type = reader.read_u32_le().await?;
+        assert_eq!(
+            upload_type, MAX_SIZE_OPT_CODE,
+            "Expected enum size type to match"
+        );
+        let upload_size = reader.read_u32_le().await?;
+        assert_eq!(
+            upload_size, MAX_SIZE_INPUT as u32,
+            "Expected upload size to match"
+        );
+    }
+
+    // As a sanity check lets check our footer.
+    assert_eq!(
+        extract_footer(&compressed_data)?,
+        Footer {
+            indexes: vec![],
+            index_count: 0,
+            uncompressed_data_size: RAW_INPUT.len() as u64,
+            config: Lz4Config {
+                block_size: BLOCK_SIZE
+            },
+            version: CURRENT_STREAM_FORMAT_VERSION,
+        },
+        "Expected footers to match"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn check_footer_test() -> Result<(), Error> {
+    const BLOCK_SIZE: u32 = 32 * 1024;
+    let inner_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    block_size: BLOCK_SIZE,
+                    ..Default::default()
+                },
+            ),
+        },
+        Store::new(inner_store.clone()),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(&store_owned);
+
+    let mut value = vec![0u8; MEGABYTE_SZ / 4];
+    let data_len = value.len();
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    // Fill first half of data with random data that is not compressible.
+    rng.fill(&mut value[..(data_len / 2)]);
+
+    let digest = DigestInfo::try_new(VALID_HASH, DUMMY_DATA_SIZE).unwrap();
+    store.update_oneshot(digest, value.clone().into()).await?;
+
+    let compressed_data = Pin::new(inner_store.as_ref())
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get from inner store")?;
+
+    let mut pos = compressed_data.len();
+    {
+        // Check version in footer.
+        let version = compressed_data[pos - 1];
+        pos -= 1;
+        assert_eq!(
+            version, CURRENT_STREAM_FORMAT_VERSION,
+            "Expected footer version to match current version"
+        );
+    }
+    {
+        // Check block size in footer.
+        let block_size = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
+        pos -= 4;
+        assert_eq!(
+            block_size, BLOCK_SIZE,
+            "Expected uncompressed_data_size to match original data size"
+        );
+    }
+    {
+        // Check data size in footer.
+        let uncompressed_data_size =
+            u64::from_le_bytes(compressed_data[pos - 8..pos].try_into().unwrap());
+        pos -= 8;
+        assert_eq!(
+            uncompressed_data_size,
+            value.len() as u64,
+            "Expected uncompressed_data_size to match original data size"
+        );
+    }
+    const EXPECTED_INDEXES: [u32; 7] = [32898, 32898, 32898, 32898, 140, 140, 140];
+    let index_count = {
+        // Check index count in footer.
+        let index_count = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
+        pos -= 4;
+        assert_eq!(
+            index_count as usize,
+            EXPECTED_INDEXES.len(),
+            "Expected index_count to match"
+        );
+        index_count
+    };
+    {
+        // Check indexes in footer.
+        let byte_count = (index_count * 4) as usize;
+        let index_vec_raw = &compressed_data[pos - byte_count..pos];
+        pos -= byte_count;
+        let mut cursor = Cursor::new(index_vec_raw);
+        let mut i = 0;
+        while let Ok(index_pos) = cursor.read_u32_le().await {
+            assert_eq!(
+                index_pos, EXPECTED_INDEXES[i],
+                "Expected index to equal at position {}",
+                i
+            );
+            i += 1;
+        }
+    }
+    {
+        // `bincode` adds the size again as a u64 before our index vector so check it too.
+        let bincode_index_count =
+            u64::from_le_bytes(compressed_data[pos - 8..pos].try_into().unwrap());
+        pos -= 8;
+        assert_eq!(
+            bincode_index_count, index_count as u64,
+            "Expected index_count and bincode_index_count to match"
+        );
+    }
+    {
+        // Check our footer length.
+        let footer_len = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
+        pos -= 4;
+        assert_eq!(
+            footer_len,
+            1 + 4 + 8 + 4 + (index_count * 4) + 8,
+            "Expected frame type to be footer"
+        );
+    }
+    {
+        // Check our frame type.
+        let frame_type = u8::from_le_bytes(compressed_data[pos - 1..pos].try_into().unwrap());
+        assert_eq!(
+            frame_type, FOOTER_FRAME_TYPE,
+            "Expected frame type to be footer"
+        );
+    }
+
+    // Just as one last sanity check lets check our deserialized footer.
+    assert_eq!(
+        extract_footer(&compressed_data)?,
+        Footer {
+            indexes: EXPECTED_INDEXES
+                .map(|v| SliceIndex {
+                    position_from_prev_index: v
+                })
+                .to_vec(),
+            index_count: EXPECTED_INDEXES.len() as u32,
+            uncompressed_data_size: data_len as u64,
+            config: Lz4Config {
+                block_size: BLOCK_SIZE
+            },
+            version: CURRENT_STREAM_FORMAT_VERSION,
+        },
+        "Expected footers to match"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_part_is_zero_digest() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+
+    const BLOCK_SIZE: u32 = 32 * 1024;
+    let inner_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store_owned = CompressionStore::new(
+        nativelink_config::stores::CompressionStore {
+            backend: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+                nativelink_config::stores::Lz4Config {
+                    block_size: BLOCK_SIZE,
+                    ..Default::default()
+                },
+            ),
+        },
+        Store::new(inner_store.clone()),
+    )
+    .err_tip(|| "Failed to create compression store")?;
+    let store = Pin::new(Arc::new(store_owned));
+
+    let (mut writer, mut reader) = make_buf_channel_pair();
+
+    let _drop_guard = spawn!("get_part_is_zero_digest", async move {
+        let _ = store
+            .as_ref()
+            .get_part(digest, &mut writer, 0, None)
+            .await
+            .err_tip(|| "Failed to get_part");
+    });
+
+    let file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading bytes")?;
+
+    let empty_bytes = Bytes::new();
+    assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+
+    Ok(())
 }

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -20,6 +20,7 @@ use nativelink_store::dedup_store::DedupStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{Store, StoreLike};
+use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -45,357 +46,350 @@ fn make_random_data(sz: usize) -> Vec<u8> {
     value
 }
 
-#[cfg(test)]
-mod dedup_store_tests {
-    use pretty_assertions::assert_eq;
+const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const VALID_HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
+const MEGABYTE_SZ: usize = 1024 * 1024;
 
-    use super::*; // Must be declared in every module.
-
-    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const VALID_HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
-    const MEGABYTE_SZ: usize = 1024 * 1024;
-
-    #[nativelink_test]
-    async fn simple_round_trip_test() -> Result<(), Error> {
-        let store = DedupStore::new(
-            &make_default_config(),
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Index store.
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Content store.
-        );
-
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(VALID_HASH1, MEGABYTE_SZ).unwrap();
-
-        store
-            .update_oneshot(digest, original_data.clone().into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
-
-        let rt_data = store
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Failed to get_part from dedup store")?;
-
-        assert_eq!(rt_data, original_data, "Expected round trip data to match");
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn check_missing_last_chunk_test() -> Result<(), Error> {
-        let content_store = Arc::new(MemoryStore::new(
+#[nativelink_test]
+async fn simple_round_trip_test() -> Result<(), Error> {
+    let store = DedupStore::new(
+        &make_default_config(),
+        Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store = DedupStore::new(
-            &make_default_config(),
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Index store.
-            Store::new(content_store.clone()),
-        );
-
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(VALID_HASH1, MEGABYTE_SZ).unwrap();
-
-        store
-            .update_oneshot(digest, original_data.into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
-
-        // This is the hash & size of the last chunk item in the content_store.
-        const LAST_CHUNK_HASH: &str =
-            "7c8608f5b079bef66c45bd67f7d8ede15d2e1830ea38fd8ad4c6de08b6f21a0c";
-        const LAST_CHUNK_SIZE: usize = 25779;
-
-        let did_delete = content_store
-            .remove_entry(
-                DigestInfo::try_new(LAST_CHUNK_HASH, LAST_CHUNK_SIZE)
-                    .unwrap()
-                    .into(),
-            )
-            .await;
-
-        assert_eq!(did_delete, true, "Expected item to exist in store");
-
-        let result = store.get_part_unchunked(digest, 0, None).await;
-        assert!(result.is_err(), "Expected result to be an error");
-        assert_eq!(
-            result.unwrap_err().code,
-            Code::NotFound,
-            "Expected result to not be found"
-        );
-        Ok(())
-    }
-
-    /// Test to ensure if we upload a bit of data then request just a slice of it, we get the
-    /// proper data out. Internal to DedupStore we only download the slices that contain the
-    /// requested data; this test covers that use case.
-    #[nativelink_test]
-    async fn fetch_part_test() -> Result<(), Error> {
-        let store = DedupStore::new(
-            &make_default_config(),
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Index store.
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Content store.
-        );
-
-        const DATA_SIZE: usize = MEGABYTE_SZ / 4;
-        let original_data = make_random_data(DATA_SIZE);
-        let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
-
-        store
-            .update_oneshot(digest, original_data.clone().into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
-
-        const ONE_THIRD_SZ: usize = DATA_SIZE / 3;
-        let rt_data = store
-            .get_part_unchunked(digest, ONE_THIRD_SZ, Some(ONE_THIRD_SZ))
-            .await
-            .err_tip(|| "Failed to get_part from dedup store")?;
-
-        assert_eq!(
-            rt_data.len(),
-            ONE_THIRD_SZ,
-            "Expected round trip sizes to match"
-        );
-        assert_eq!(
-            rt_data,
-            original_data[ONE_THIRD_SZ..(ONE_THIRD_SZ * 2)],
-            "Expected round trip data to match"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn check_length_not_set_with_chunk_read_beyond_first_chunk_regression_test(
-    ) -> Result<(), Error> {
-        let store = DedupStore::new(
-            &nativelink_config::stores::DedupStore {
-                index_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                content_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                min_size: 5,
-                normal_size: 6,
-                max_size: 7,
-                max_concurrent_fetch_per_get: 10,
-            },
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Index store.
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Content store.
-        );
-
-        const DATA_SIZE: usize = 30;
-        let original_data = make_random_data(DATA_SIZE);
-        let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
-
-        store
-            .update_oneshot(digest, original_data.clone().into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
-
-        // This value must be larger than `max_size` in the config above.
-        const START_READ_BYTE: usize = 7;
-        let rt_data = store
-            .get_part_unchunked(digest, START_READ_BYTE, None)
-            .await
-            .err_tip(|| "Failed to get_part from dedup store")?;
-
-        assert_eq!(
-            rt_data.len(),
-            DATA_SIZE - START_READ_BYTE,
-            "Expected round trip sizes to match"
-        );
-        assert_eq!(
-            rt_data,
-            original_data[START_READ_BYTE..],
-            "Expected round trip data to match"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
-        let store = DedupStore::new(
-            &nativelink_config::stores::DedupStore {
-                index_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                content_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                min_size: 5,
-                normal_size: 6,
-                max_size: 7,
-                max_concurrent_fetch_per_get: 10,
-            },
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Index store.
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))), // Content store.
-        );
-
-        const DATA_SIZE: usize = 30;
-        let original_data = make_random_data(DATA_SIZE);
-        let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
-        store
-            .update_oneshot(digest, original_data.clone().into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
-
-        for offset in 0..=DATA_SIZE {
-            for len in 0..DATA_SIZE {
-                // If reading at DATA_SIZE, we will set len to None to check that edge case.
-                let maybe_len = if offset == DATA_SIZE { None } else { Some(len) };
-                let len = if maybe_len.is_none() { DATA_SIZE } else { len };
-
-                let rt_data = store
-                    .get_part_unchunked(digest, offset, maybe_len)
-                    .await
-                    .err_tip(|| "Failed to get_part from dedup store")?;
-
-                let len_fenced = std::cmp::min(len, rt_data.len());
-                assert_eq!(
-                    rt_data.len(),
-                    len_fenced,
-                    "Expected round trip sizes to match"
-                );
-                assert_eq!(
-                    rt_data,
-                    original_data[offset..(offset + len_fenced)],
-                    "Expected round trip data to match"
-                );
-            }
-        }
-
-        // This value must be larger than `max_size` in the config above.
-        const START_READ_BYTE: usize = 10;
-        let rt_data = store
-            .get_part_unchunked(digest, START_READ_BYTE, None)
-            .await
-            .err_tip(|| "Failed to get_part from dedup store")?;
-
-        assert_eq!(
-            rt_data.len(),
-            DATA_SIZE - START_READ_BYTE,
-            "Expected round trip sizes to match"
-        );
-        assert_eq!(
-            rt_data,
-            original_data[START_READ_BYTE..],
-            "Expected round trip data to match"
-        );
-        Ok(())
-    }
-
-    /// Ensure that when we run a `.has()` on a dedup store it will check to ensure all indexed
-    /// content items exist instead of just checking the entry in the index store.
-    #[nativelink_test]
-    async fn has_checks_content_store() -> Result<(), Error> {
-        let index_store = Arc::new(MemoryStore::new(
+        ))), // Index store.
+        Store::new(Arc::new(MemoryStore::new(
             &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let content_store = Arc::new(MemoryStore::new(&nativelink_config::stores::MemoryStore {
-            eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                max_count: 10,
-                ..Default::default()
-            }),
-        }));
+        ))), // Content store.
+    );
 
-        let store = DedupStore::new(
-            &make_default_config(),
-            Store::new(index_store.clone()),
-            Store::new(content_store.clone()),
-        );
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH1, MEGABYTE_SZ).unwrap();
 
-        const DATA_SIZE: usize = MEGABYTE_SZ / 4;
-        let original_data = make_random_data(DATA_SIZE);
-        let digest1 = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+    store
+        .update_oneshot(digest, original_data.clone().into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
 
-        store
-            .update_oneshot(digest1, original_data.clone().into())
-            .await
-            .err_tip(|| "Failed to write data to dedup store")?;
+    let rt_data = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Failed to get_part from dedup store")?;
 
-        {
-            // Check to ensure we our baseline `.has()` succeeds.
-            let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
-            assert_eq!(size_info, Some(DATA_SIZE), "Expected sizes to match");
-        }
-        {
-            // There will be exactly 10 entries in our content_store based on our random seed data.
-            // If we add one more it will evict a single item from that will still be indexed.
-            // By doing this, we now check that it returns false when we call `.has()`.
-            const DATA2: &str = "1234";
-            let digest2 = DigestInfo::try_new(VALID_HASH2, DATA2.len()).unwrap();
-            store
-                .update_oneshot(digest2, DATA2.into())
+    assert_eq!(rt_data, original_data, "Expected round trip data to match");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn check_missing_last_chunk_test() -> Result<(), Error> {
+    let content_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store = DedupStore::new(
+        &make_default_config(),
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Index store.
+        Store::new(content_store.clone()),
+    );
+
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH1, MEGABYTE_SZ).unwrap();
+
+    store
+        .update_oneshot(digest, original_data.into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
+
+    // This is the hash & size of the last chunk item in the content_store.
+    const LAST_CHUNK_HASH: &str =
+        "7c8608f5b079bef66c45bd67f7d8ede15d2e1830ea38fd8ad4c6de08b6f21a0c";
+    const LAST_CHUNK_SIZE: usize = 25779;
+
+    let did_delete = content_store
+        .remove_entry(
+            DigestInfo::try_new(LAST_CHUNK_HASH, LAST_CHUNK_SIZE)
+                .unwrap()
+                .into(),
+        )
+        .await;
+
+    assert_eq!(did_delete, true, "Expected item to exist in store");
+
+    let result = store.get_part_unchunked(digest, 0, None).await;
+    assert!(result.is_err(), "Expected result to be an error");
+    assert_eq!(
+        result.unwrap_err().code,
+        Code::NotFound,
+        "Expected result to not be found"
+    );
+    Ok(())
+}
+
+/// Test to ensure if we upload a bit of data then request just a slice of it, we get the
+/// proper data out. Internal to DedupStore we only download the slices that contain the
+/// requested data; this test covers that use case.
+#[nativelink_test]
+async fn fetch_part_test() -> Result<(), Error> {
+    let store = DedupStore::new(
+        &make_default_config(),
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Index store.
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Content store.
+    );
+
+    const DATA_SIZE: usize = MEGABYTE_SZ / 4;
+    let original_data = make_random_data(DATA_SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+
+    store
+        .update_oneshot(digest, original_data.clone().into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
+
+    const ONE_THIRD_SZ: usize = DATA_SIZE / 3;
+    let rt_data = store
+        .get_part_unchunked(digest, ONE_THIRD_SZ, Some(ONE_THIRD_SZ))
+        .await
+        .err_tip(|| "Failed to get_part from dedup store")?;
+
+    assert_eq!(
+        rt_data.len(),
+        ONE_THIRD_SZ,
+        "Expected round trip sizes to match"
+    );
+    assert_eq!(
+        rt_data,
+        original_data[ONE_THIRD_SZ..(ONE_THIRD_SZ * 2)],
+        "Expected round trip data to match"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn check_length_not_set_with_chunk_read_beyond_first_chunk_regression_test(
+) -> Result<(), Error> {
+    let store = DedupStore::new(
+        &nativelink_config::stores::DedupStore {
+            index_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            content_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            min_size: 5,
+            normal_size: 6,
+            max_size: 7,
+            max_concurrent_fetch_per_get: 10,
+        },
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Index store.
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Content store.
+    );
+
+    const DATA_SIZE: usize = 30;
+    let original_data = make_random_data(DATA_SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+
+    store
+        .update_oneshot(digest, original_data.clone().into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
+
+    // This value must be larger than `max_size` in the config above.
+    const START_READ_BYTE: usize = 7;
+    let rt_data = store
+        .get_part_unchunked(digest, START_READ_BYTE, None)
+        .await
+        .err_tip(|| "Failed to get_part from dedup store")?;
+
+    assert_eq!(
+        rt_data.len(),
+        DATA_SIZE - START_READ_BYTE,
+        "Expected round trip sizes to match"
+    );
+    assert_eq!(
+        rt_data,
+        original_data[START_READ_BYTE..],
+        "Expected round trip data to match"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
+    let store = DedupStore::new(
+        &nativelink_config::stores::DedupStore {
+            index_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            content_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            min_size: 5,
+            normal_size: 6,
+            max_size: 7,
+            max_concurrent_fetch_per_get: 10,
+        },
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Index store.
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))), // Content store.
+    );
+
+    const DATA_SIZE: usize = 30;
+    let original_data = make_random_data(DATA_SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+    store
+        .update_oneshot(digest, original_data.clone().into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
+
+    for offset in 0..=DATA_SIZE {
+        for len in 0..DATA_SIZE {
+            // If reading at DATA_SIZE, we will set len to None to check that edge case.
+            let maybe_len = if offset == DATA_SIZE { None } else { Some(len) };
+            let len = if maybe_len.is_none() { DATA_SIZE } else { len };
+
+            let rt_data = store
+                .get_part_unchunked(digest, offset, maybe_len)
                 .await
-                .err_tip(|| "Failed to write data to dedup store")?;
+                .err_tip(|| "Failed to get_part from dedup store")?;
 
-            {
-                // Check our recently added entry is still valid.
-                let size_info = store.has(digest2).await.err_tip(|| "Failed to run .has")?;
-                assert_eq!(size_info, Some(DATA2.len()), "Expected sizes to match");
-            }
-            {
-                // Check our first added entry is now invalid (because part of it was evicted).
-                let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
-                assert_eq!(
-                    size_info, None,
-                    "Expected .has() to return None (not found)"
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Ensure that when we run a `.has()` on a dedup store and the index does not exist it will
-    /// properly return None.
-    #[nativelink_test]
-    async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
-        let index_store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let content_store = Arc::new(MemoryStore::new(&nativelink_config::stores::MemoryStore {
-            eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                max_count: 10,
-                ..Default::default()
-            }),
-        }));
-
-        let store = DedupStore::new(
-            &make_default_config(),
-            Store::new(index_store.clone()),
-            Store::new(content_store.clone()),
-        );
-
-        const DATA_SIZE: usize = 10;
-        let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
-
-        {
-            let size_info = store.has(digest).await.err_tip(|| "Failed to run .has")?;
+            let len_fenced = std::cmp::min(len, rt_data.len());
             assert_eq!(
-                size_info, None,
-                "Expected None to be returned, got {:?}",
-                size_info
+                rt_data.len(),
+                len_fenced,
+                "Expected round trip sizes to match"
+            );
+            assert_eq!(
+                rt_data,
+                original_data[offset..(offset + len_fenced)],
+                "Expected round trip data to match"
             );
         }
-        Ok(())
     }
+
+    // This value must be larger than `max_size` in the config above.
+    const START_READ_BYTE: usize = 10;
+    let rt_data = store
+        .get_part_unchunked(digest, START_READ_BYTE, None)
+        .await
+        .err_tip(|| "Failed to get_part from dedup store")?;
+
+    assert_eq!(
+        rt_data.len(),
+        DATA_SIZE - START_READ_BYTE,
+        "Expected round trip sizes to match"
+    );
+    assert_eq!(
+        rt_data,
+        original_data[START_READ_BYTE..],
+        "Expected round trip data to match"
+    );
+    Ok(())
+}
+
+/// Ensure that when we run a `.has()` on a dedup store it will check to ensure all indexed
+/// content items exist instead of just checking the entry in the index store.
+#[nativelink_test]
+async fn has_checks_content_store() -> Result<(), Error> {
+    let index_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let content_store = Arc::new(MemoryStore::new(&nativelink_config::stores::MemoryStore {
+        eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+            max_count: 10,
+            ..Default::default()
+        }),
+    }));
+
+    let store = DedupStore::new(
+        &make_default_config(),
+        Store::new(index_store.clone()),
+        Store::new(content_store.clone()),
+    );
+
+    const DATA_SIZE: usize = MEGABYTE_SZ / 4;
+    let original_data = make_random_data(DATA_SIZE);
+    let digest1 = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+
+    store
+        .update_oneshot(digest1, original_data.clone().into())
+        .await
+        .err_tip(|| "Failed to write data to dedup store")?;
+
+    {
+        // Check to ensure we our baseline `.has()` succeeds.
+        let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
+        assert_eq!(size_info, Some(DATA_SIZE), "Expected sizes to match");
+    }
+    {
+        // There will be exactly 10 entries in our content_store based on our random seed data.
+        // If we add one more it will evict a single item from that will still be indexed.
+        // By doing this, we now check that it returns false when we call `.has()`.
+        const DATA2: &str = "1234";
+        let digest2 = DigestInfo::try_new(VALID_HASH2, DATA2.len()).unwrap();
+        store
+            .update_oneshot(digest2, DATA2.into())
+            .await
+            .err_tip(|| "Failed to write data to dedup store")?;
+
+        {
+            // Check our recently added entry is still valid.
+            let size_info = store.has(digest2).await.err_tip(|| "Failed to run .has")?;
+            assert_eq!(size_info, Some(DATA2.len()), "Expected sizes to match");
+        }
+        {
+            // Check our first added entry is now invalid (because part of it was evicted).
+            let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
+            assert_eq!(
+                size_info, None,
+                "Expected .has() to return None (not found)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensure that when we run a `.has()` on a dedup store and the index does not exist it will
+/// properly return None.
+#[nativelink_test]
+async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
+    let index_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let content_store = Arc::new(MemoryStore::new(&nativelink_config::stores::MemoryStore {
+        eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+            max_count: 10,
+            ..Default::default()
+        }),
+    }));
+
+    let store = DedupStore::new(
+        &make_default_config(),
+        Store::new(index_store.clone()),
+        Store::new(content_store.clone()),
+    );
+
+    const DATA_SIZE: usize = 10;
+    let digest = DigestInfo::try_new(VALID_HASH1, DATA_SIZE).unwrap();
+
+    {
+        let size_info = store.has(digest).await.err_tip(|| "Failed to run .has")?;
+        assert_eq!(
+            size_info, None,
+            "Expected None to be returned, got {:?}",
+            size_info
+        );
+    }
+    Ok(())
 }

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -21,104 +21,100 @@ use nativelink_store::existence_cache_store::ExistenceCacheStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{Store, StoreLike};
+use pretty_assertions::assert_eq;
 
-#[cfg(test)]
-mod verify_store_tests {
-    use super::*;
+const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+#[nativelink_test]
+async fn simple_exist_cache_test() -> Result<(), Error> {
+    const VALUE: &str = "123";
+    let config = ExistenceCacheStoreConfig {
+        backend: StoreConfig::noop, // Note: Not used.
+        eviction_policy: Default::default(),
+    };
+    let inner_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let store = ExistenceCacheStore::new(&config, inner_store.clone());
 
-    #[nativelink_test]
-    async fn simple_exist_cache_test() -> Result<(), Error> {
-        const VALUE: &str = "123";
-        let config = ExistenceCacheStoreConfig {
-            backend: StoreConfig::noop, // Note: Not used.
-            eviction_policy: Default::default(),
-        };
-        let inner_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let store = ExistenceCacheStore::new(&config, inner_store.clone());
+    let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
+    store
+        .update_oneshot(digest, VALUE.into())
+        .await
+        .err_tip(|| "Failed to update store")?;
+    store.remove_from_cache(&digest).await;
 
-        let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
+    assert!(
+        !store.exists_in_cache(&digest).await,
+        "Expected digest to not exist in cache"
+    );
+
+    assert_eq!(
         store
-            .update_oneshot(digest, VALUE.into())
+            .has(digest)
             .await
-            .err_tip(|| "Failed to update store")?;
-        store.remove_from_cache(&digest).await;
+            .err_tip(|| "Failed to check store")?,
+        Some(VALUE.len()),
+        "Expected digest to exist in store"
+    );
 
-        assert!(
-            !store.exists_in_cache(&digest).await,
-            "Expected digest to not exist in cache"
-        );
+    assert!(
+        store.exists_in_cache(&digest).await,
+        "Expected digest to exist in cache in direct check"
+    );
+    Ok(())
+}
 
-        assert_eq!(
-            store
-                .has(digest)
-                .await
-                .err_tip(|| "Failed to check store")?,
-            Some(VALUE.len()),
-            "Expected digest to exist in store"
-        );
+#[nativelink_test]
+async fn update_flags_existance_cache_test() -> Result<(), Error> {
+    const VALUE: &str = "123";
+    let config = ExistenceCacheStoreConfig {
+        backend: StoreConfig::noop,
+        eviction_policy: Default::default(),
+    };
+    let inner_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let store = ExistenceCacheStore::new(&config, inner_store.clone());
 
-        assert!(
-            store.exists_in_cache(&digest).await,
-            "Expected digest to exist in cache in direct check"
-        );
-        Ok(())
-    }
+    let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
+    store
+        .update_oneshot(digest, VALUE.into())
+        .await
+        .err_tip(|| "Failed to update store")?;
 
-    #[nativelink_test]
-    async fn update_flags_existance_cache_test() -> Result<(), Error> {
-        const VALUE: &str = "123";
-        let config = ExistenceCacheStoreConfig {
-            backend: StoreConfig::noop,
-            eviction_policy: Default::default(),
-        };
-        let inner_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let store = ExistenceCacheStore::new(&config, inner_store.clone());
+    assert!(
+        store.exists_in_cache(&digest).await,
+        "Expected digest to exist in cache"
+    );
+    Ok(())
+}
 
-        let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
-        store
-            .update_oneshot(digest, VALUE.into())
-            .await
-            .err_tip(|| "Failed to update store")?;
+#[nativelink_test]
+async fn get_part_caches_if_exact_size_set() -> Result<(), Error> {
+    const VALUE: &str = "123";
+    let config = ExistenceCacheStoreConfig {
+        backend: StoreConfig::noop,
+        eviction_policy: Default::default(),
+    };
+    let inner_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
+    inner_store
+        .update_oneshot(digest, VALUE.into())
+        .await
+        .err_tip(|| "Failed to update store")?;
+    let store = ExistenceCacheStore::new(&config, inner_store.clone());
 
-        assert!(
-            store.exists_in_cache(&digest).await,
-            "Expected digest to exist in cache"
-        );
-        Ok(())
-    }
+    let _ = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "Expected get_part to succeed")?;
 
-    #[nativelink_test]
-    async fn get_part_caches_if_exact_size_set() -> Result<(), Error> {
-        const VALUE: &str = "123";
-        let config = ExistenceCacheStoreConfig {
-            backend: StoreConfig::noop,
-            eviction_policy: Default::default(),
-        };
-        let inner_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let digest = DigestInfo::try_new(VALID_HASH1, 3).unwrap();
-        inner_store
-            .update_oneshot(digest, VALUE.into())
-            .await
-            .err_tip(|| "Failed to update store")?;
-        let store = ExistenceCacheStore::new(&config, inner_store.clone());
-
-        let _ = store
-            .get_part_unchunked(digest, 0, None)
-            .await
-            .err_tip(|| "Expected get_part to succeed")?;
-
-        assert!(
-            store.exists_in_cache(&digest).await,
-            "Expected digest to exist in cache"
-        );
-        Ok(())
-    }
+    assert!(
+        store.exists_in_cache(&digest).await,
+        "Expected digest to exist in cache"
+    );
+    Ok(())
 }

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -27,6 +27,7 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
 use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike};
+use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -80,384 +81,375 @@ async fn check_data(
     Ok(())
 }
 
-#[cfg(test)]
-mod fast_slow_store_tests {
+const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn write_large_amount_to_both_stores_test() -> Result<(), Error> {
+    let (store, fast_store, slow_store) = make_stores();
 
-    use super::*; // Must be declared in every module.
+    let original_data = make_random_data(20 * MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
+    store
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
 
-    const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+    check_data(&store, digest, &original_data, "fast_slow").await?;
+    check_data(&fast_store, digest, &original_data, "fast").await?;
+    check_data(&slow_store, digest, &original_data, "slow").await?;
 
-    #[nativelink_test]
-    async fn write_large_amount_to_both_stores_test() -> Result<(), Error> {
-        let (store, fast_store, slow_store) = make_stores();
+    Ok(())
+}
 
-        let original_data = make_random_data(20 * MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
-        store
-            .update_oneshot(digest, original_data.clone().into())
-            .await?;
+#[nativelink_test]
+async fn fetch_slow_store_puts_in_fast_store_test() -> Result<(), Error> {
+    let (fast_slow_store, fast_store, slow_store) = make_stores();
 
-        check_data(&store, digest, &original_data, "fast_slow").await?;
-        check_data(&fast_store, digest, &original_data, "fast").await?;
-        check_data(&slow_store, digest, &original_data, "slow").await?;
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
+    slow_store
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
 
-        Ok(())
+    assert_eq!(
+        fast_slow_store.has(digest).await,
+        Ok(Some(original_data.len()))
+    );
+    assert_eq!(fast_store.has(digest).await, Ok(None));
+    assert_eq!(slow_store.has(digest).await, Ok(Some(original_data.len())));
+
+    // This get() request should place the data in fast_store too.
+    fast_slow_store.get_part_unchunked(digest, 0, None).await?;
+
+    // Now the data should exist in all the stores.
+    check_data(&fast_store, digest, &original_data, "fast_store").await?;
+    check_data(&slow_store, digest, &original_data, "slow_store").await?;
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn partial_reads_copy_full_to_fast_store_test() -> Result<(), Error> {
+    let (fast_slow_store, fast_store, slow_store) = make_stores();
+
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
+    slow_store
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+
+    // This get() request should place the data in fast_store too.
+    assert_eq!(
+        original_data[10..60],
+        fast_slow_store
+            .get_part_unchunked(digest, 10, Some(50))
+            .await?
+    );
+
+    // Full data should exist in the fast store even though only partially
+    // read.
+    check_data(&slow_store, digest, &original_data, "slow_store").await?;
+    check_data(&fast_store, digest, &original_data, "fast_store").await?;
+
+    Ok(())
+}
+
+#[test]
+fn calculate_range_test() {
+    let test = |start_range, end_range| FastSlowStore::calculate_range(&start_range, &end_range);
+    {
+        // Exact match.
+        let received_range = 0..1;
+        let send_range = 0..1;
+        let expected_results = Some(0..1);
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Minus one on received_range.
+        let received_range = 1..4;
+        let send_range = 1..5;
+        let expected_results = Some(0..3);
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Minus one on send_range.
+        let received_range = 1..5;
+        let send_range = 1..4;
+        let expected_results = Some(0..3);
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Should have already sent all data (start fence post).
+        let received_range = 1..2;
+        let send_range = 0..1;
+        let expected_results = None;
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Definiltly already sent data.
+        let received_range = 2..3;
+        let send_range = 0..1;
+        let expected_results = None;
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // All data should be sent (inside range).
+        let received_range = 3..4;
+        let send_range = 0..100;
+        let expected_results = Some(0..1); // Note: This is relative received_range.start.
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Subset of received data should be sent.
+        let received_range = 1..100;
+        let send_range = 3..4;
+        let expected_results = Some(2..3); // Note: This is relative received_range.start.
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // We are clearly not at the offset yet.
+        let received_range = 0..1;
+        let send_range = 3..4;
+        let expected_results = None;
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Not at offset yet (fence post).
+        let received_range = 0..1;
+        let send_range = 1..2;
+        let expected_results = None;
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+    {
+        // Head part of the received data should be sent.
+        let received_range = 1..3;
+        let send_range = 2..5;
+        let expected_results = Some(1..2);
+        assert_eq!(test(received_range, send_range), expected_results);
+    }
+}
+
+#[nativelink_test]
+async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
+    struct DropCheckStore {
+        drop_flag: Arc<AtomicBool>,
+        read_rx: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        eof_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        digest: Option<DigestInfo>,
     }
 
-    #[nativelink_test]
-    async fn fetch_slow_store_puts_in_fast_store_test() -> Result<(), Error> {
-        let (fast_slow_store, fast_store, slow_store) = make_stores();
-
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
-        slow_store
-            .update_oneshot(digest, original_data.clone().into())
-            .await?;
-
-        assert_eq!(
-            fast_slow_store.has(digest).await,
-            Ok(Some(original_data.len()))
-        );
-        assert_eq!(fast_store.has(digest).await, Ok(None));
-        assert_eq!(slow_store.has(digest).await, Ok(Some(original_data.len())));
-
-        // This get() request should place the data in fast_store too.
-        fast_slow_store.get_part_unchunked(digest, 0, None).await?;
-
-        // Now the data should exist in all the stores.
-        check_data(&fast_store, digest, &original_data, "fast_store").await?;
-        check_data(&slow_store, digest, &original_data, "slow_store").await?;
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn partial_reads_copy_full_to_fast_store_test() -> Result<(), Error> {
-        let (fast_slow_store, fast_store, slow_store) = make_stores();
-
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
-        slow_store
-            .update_oneshot(digest, original_data.clone().into())
-            .await?;
-
-        // This get() request should place the data in fast_store too.
-        assert_eq!(
-            original_data[10..60],
-            fast_slow_store
-                .get_part_unchunked(digest, 10, Some(50))
-                .await?
-        );
-
-        // Full data should exist in the fast store even though only partially
-        // read.
-        check_data(&slow_store, digest, &original_data, "slow_store").await?;
-        check_data(&fast_store, digest, &original_data, "fast_store").await?;
-
-        Ok(())
-    }
-
-    #[test]
-    fn calculate_range_test() {
-        let test =
-            |start_range, end_range| FastSlowStore::calculate_range(&start_range, &end_range);
-        {
-            // Exact match.
-            let received_range = 0..1;
-            let send_range = 0..1;
-            let expected_results = Some(0..1);
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Minus one on received_range.
-            let received_range = 1..4;
-            let send_range = 1..5;
-            let expected_results = Some(0..3);
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Minus one on send_range.
-            let received_range = 1..5;
-            let send_range = 1..4;
-            let expected_results = Some(0..3);
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Should have already sent all data (start fence post).
-            let received_range = 1..2;
-            let send_range = 0..1;
-            let expected_results = None;
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Definiltly already sent data.
-            let received_range = 2..3;
-            let send_range = 0..1;
-            let expected_results = None;
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // All data should be sent (inside range).
-            let received_range = 3..4;
-            let send_range = 0..100;
-            let expected_results = Some(0..1); // Note: This is relative received_range.start.
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Subset of received data should be sent.
-            let received_range = 1..100;
-            let send_range = 3..4;
-            let expected_results = Some(2..3); // Note: This is relative received_range.start.
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // We are clearly not at the offset yet.
-            let received_range = 0..1;
-            let send_range = 3..4;
-            let expected_results = None;
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Not at offset yet (fence post).
-            let received_range = 0..1;
-            let send_range = 1..2;
-            let expected_results = None;
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-        {
-            // Head part of the received data should be sent.
-            let received_range = 1..3;
-            let send_range = 2..5;
-            let expected_results = Some(1..2);
-            assert_eq!(test(received_range, send_range), expected_results);
-        }
-    }
-
-    #[nativelink_test]
-    async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
-        struct DropCheckStore {
-            drop_flag: Arc<AtomicBool>,
-            read_rx: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
-            eof_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
-            digest: Option<DigestInfo>,
-        }
-
-        #[async_trait]
-        impl StoreDriver for DropCheckStore {
-            async fn has_with_results(
-                self: Pin<&Self>,
-                digests: &[StoreKey<'_>],
-                results: &mut [Option<usize>],
-            ) -> Result<(), Error> {
-                if let Some(has_digest) = self.digest {
-                    for (digest, result) in digests.iter().zip(results.iter_mut()) {
-                        if *digest == has_digest.into() {
-                            *result = Some(has_digest.size_bytes as usize);
-                        }
+    #[async_trait]
+    impl StoreDriver for DropCheckStore {
+        async fn has_with_results(
+            self: Pin<&Self>,
+            digests: &[StoreKey<'_>],
+            results: &mut [Option<usize>],
+        ) -> Result<(), Error> {
+            if let Some(has_digest) = self.digest {
+                for (digest, result) in digests.iter().zip(results.iter_mut()) {
+                    if *digest == has_digest.into() {
+                        *result = Some(has_digest.size_bytes as usize);
                     }
                 }
-                Ok(())
             }
-
-            async fn update(
-                self: Pin<&Self>,
-                _digest: StoreKey<'_>,
-                mut reader: nativelink_util::buf_channel::DropCloserReadHalf,
-                _size_info: nativelink_util::store_trait::UploadSizeInfo,
-            ) -> Result<(), Error> {
-                // Gets called in the fast store and we don't need to do
-                // anything.  Should only complete when drain has finished.
-                reader.drain().await?;
-                let eof_tx = self.eof_tx.lock().unwrap().take();
-                if let Some(tx) = eof_tx {
-                    tx.send(())
-                        .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
-                }
-                let read_rx = self.read_rx.lock().unwrap().take();
-                if let Some(rx) = read_rx {
-                    rx.await.map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
-                }
-                Ok(())
-            }
-
-            async fn get_part(
-                self: Pin<&Self>,
-                key: StoreKey<'_>,
-                writer: &mut nativelink_util::buf_channel::DropCloserWriteHalf,
-                offset: usize,
-                length: Option<usize>,
-            ) -> Result<(), Error> {
-                // Gets called in the slow store and we provide the data that's
-                // sent to the upstream and the fast store.
-                let bytes = length.unwrap_or(key.into_digest().size_bytes as usize) - offset;
-                let data = vec![0_u8; bytes];
-                writer.send(Bytes::copy_from_slice(&data)).await?;
-                writer.send_eof()
-            }
-
-            fn inner_store(&self, _digest: Option<StoreKey>) -> &'_ dyn StoreDriver {
-                self
-            }
-
-            fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
-                self
-            }
-
-            fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
-                self
-            }
-
-            fn register_metrics(
-                self: Arc<Self>,
-                _registry: &mut nativelink_util::metrics_utils::Registry,
-            ) {
-            }
+            Ok(())
         }
 
-        impl Drop for DropCheckStore {
-            fn drop(&mut self) {
-                self.drop_flag.store(true, Ordering::Release);
+        async fn update(
+            self: Pin<&Self>,
+            _digest: StoreKey<'_>,
+            mut reader: nativelink_util::buf_channel::DropCloserReadHalf,
+            _size_info: nativelink_util::store_trait::UploadSizeInfo,
+        ) -> Result<(), Error> {
+            // Gets called in the fast store and we don't need to do
+            // anything.  Should only complete when drain has finished.
+            reader.drain().await?;
+            let eof_tx = self.eof_tx.lock().unwrap().take();
+            if let Some(tx) = eof_tx {
+                tx.send(())
+                    .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
             }
+            let read_rx = self.read_rx.lock().unwrap().take();
+            if let Some(rx) = read_rx {
+                rx.await.map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
+            }
+            Ok(())
         }
 
-        default_health_status_indicator!(DropCheckStore);
+        async fn get_part(
+            self: Pin<&Self>,
+            key: StoreKey<'_>,
+            writer: &mut nativelink_util::buf_channel::DropCloserWriteHalf,
+            offset: usize,
+            length: Option<usize>,
+        ) -> Result<(), Error> {
+            // Gets called in the slow store and we provide the data that's
+            // sent to the upstream and the fast store.
+            let bytes = length.unwrap_or(key.into_digest().size_bytes as usize) - offset;
+            let data = vec![0_u8; bytes];
+            writer.send(Bytes::copy_from_slice(&data)).await?;
+            writer.send_eof()
+        }
 
-        let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
-        let (fast_store_read_tx, fast_store_read_rx) = tokio::sync::oneshot::channel();
-        let (fast_store_eof_tx, fast_store_eof_rx) = tokio::sync::oneshot::channel();
-        let fast_store_dropped = Arc::new(AtomicBool::new(false));
-        let fast_store = Store::new(Arc::new(DropCheckStore {
-            drop_flag: fast_store_dropped.clone(),
-            eof_tx: Mutex::new(Some(fast_store_eof_tx)),
-            read_rx: Mutex::new(Some(fast_store_read_rx)),
-            digest: None,
-        }));
-        let slow_store_dropped = Arc::new(AtomicBool::new(false));
-        let slow_store = Store::new(Arc::new(DropCheckStore {
-            drop_flag: slow_store_dropped,
-            eof_tx: Mutex::new(None),
-            read_rx: Mutex::new(None),
-            digest: Some(digest),
-        }));
+        fn inner_store(&self, _digest: Option<StoreKey>) -> &'_ dyn StoreDriver {
+            self
+        }
 
-        let fast_slow_store = FastSlowStore::new(
-            &nativelink_config::stores::FastSlowStore {
-                fast: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                slow: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            fast_store,
-            slow_store,
-        );
+        fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+            self
+        }
 
-        let (tx, mut rx) = make_buf_channel_pair();
-        let (get_res, read_res) = tokio::join!(
-            async move {
-                // Drop get_part as soon as rx.drain() completes
-                tokio::select!(
-                    res = rx.drain() => res,
-                    res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes as usize)) => res,
-                )
-            },
-            async move {
-                fast_store_eof_rx
-                    .await
-                    .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
-                // Give a couple of cycles for dropping to occur if it's going to.
-                tokio::task::yield_now().await;
-                tokio::task::yield_now().await;
-                if fast_store_dropped.load(Ordering::Acquire) {
-                    return Err(make_err!(Code::Internal, "Fast store was dropped!"));
-                }
-                fast_store_read_tx
-                    .send(())
-                    .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
-                Ok::<_, Error>(())
-            }
-        );
-        get_res.merge(read_res)
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+            self
+        }
+
+        fn register_metrics(
+            self: Arc<Self>,
+            _registry: &mut nativelink_util::metrics_utils::Registry,
+        ) {
+        }
     }
 
-    #[nativelink_test]
-    async fn ignore_value_in_fast_store() -> Result<(), Error> {
-        let fast_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let slow_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let fast_slow_store = Arc::new(FastSlowStore::new(
-            &nativelink_config::stores::FastSlowStore {
-                fast: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                slow: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            fast_store.clone(),
-            slow_store,
-        ));
-        let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
-        fast_store
-            .update_oneshot(digest, make_random_data(100).into())
-            .await?;
-        assert!(
-            fast_slow_store.has(digest).await?.is_none(),
-            "Expected data to not exist in store"
-        );
-        Ok(())
+    impl Drop for DropCheckStore {
+        fn drop(&mut self) {
+            self.drop_flag.store(true, Ordering::Release);
+        }
     }
 
-    // Regression test for https://github.com/TraceMachina/nativelink/issues/665
-    #[nativelink_test]
-    async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
-        let fast_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let slow_store = Store::new(Arc::new(NoopStore::new()));
-        let fast_slow_store_config = nativelink_config::stores::FastSlowStore {
+    default_health_status_indicator!(DropCheckStore);
+
+    let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
+    let (fast_store_read_tx, fast_store_read_rx) = tokio::sync::oneshot::channel();
+    let (fast_store_eof_tx, fast_store_eof_rx) = tokio::sync::oneshot::channel();
+    let fast_store_dropped = Arc::new(AtomicBool::new(false));
+    let fast_store = Store::new(Arc::new(DropCheckStore {
+        drop_flag: fast_store_dropped.clone(),
+        eof_tx: Mutex::new(Some(fast_store_eof_tx)),
+        read_rx: Mutex::new(Some(fast_store_read_rx)),
+        digest: None,
+    }));
+    let slow_store_dropped = Arc::new(AtomicBool::new(false));
+    let slow_store = Store::new(Arc::new(DropCheckStore {
+        drop_flag: slow_store_dropped,
+        eof_tx: Mutex::new(None),
+        read_rx: Mutex::new(None),
+        digest: Some(digest),
+    }));
+
+    let fast_slow_store = FastSlowStore::new(
+        &nativelink_config::stores::FastSlowStore {
             fast: nativelink_config::stores::StoreConfig::memory(
                 nativelink_config::stores::MemoryStore::default(),
             ),
-            slow: nativelink_config::stores::StoreConfig::noop,
-        };
-        let fast_slow_store = Arc::new(FastSlowStore::new(
-            &fast_slow_store_config,
-            fast_store.clone(),
-            slow_store.clone(),
-        ));
+            slow: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        fast_store,
+        slow_store,
+    );
 
-        let data = make_random_data(100);
-        let digest = DigestInfo::try_new(VALID_HASH, data.len()).unwrap();
+    let (tx, mut rx) = make_buf_channel_pair();
+    let (get_res, read_res) = tokio::join!(
+        async move {
+            // Drop get_part as soon as rx.drain() completes
+            tokio::select!(
+                res = rx.drain() => res,
+                res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes as usize)) => res,
+            )
+        },
+        async move {
+            fast_store_eof_rx
+                .await
+                .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
+            // Give a couple of cycles for dropping to occur if it's going to.
+            tokio::task::yield_now().await;
+            tokio::task::yield_now().await;
+            if fast_store_dropped.load(Ordering::Acquire) {
+                return Err(make_err!(Code::Internal, "Fast store was dropped!"));
+            }
+            fast_store_read_tx
+                .send(())
+                .map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
+            Ok::<_, Error>(())
+        }
+    );
+    get_res.merge(read_res)
+}
 
-        assert_eq!(
-            fast_slow_store.has(digest).await,
-            Ok(None),
-            "Expected data to not exist in store"
-        );
+#[nativelink_test]
+async fn ignore_value_in_fast_store() -> Result<(), Error> {
+    let fast_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let slow_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let fast_slow_store = Arc::new(FastSlowStore::new(
+        &nativelink_config::stores::FastSlowStore {
+            fast: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            slow: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        fast_store.clone(),
+        slow_store,
+    ));
+    let digest = DigestInfo::try_new(VALID_HASH, 100).unwrap();
+    fast_store
+        .update_oneshot(digest, make_random_data(100).into())
+        .await?;
+    assert!(
+        fast_slow_store.has(digest).await?.is_none(),
+        "Expected data to not exist in store"
+    );
+    Ok(())
+}
 
-        // Upload some dummy data.
-        fast_store
-            .update_oneshot(digest, data.clone().into())
-            .await?;
+// Regression test for https://github.com/TraceMachina/nativelink/issues/665
+#[nativelink_test]
+async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
+    let fast_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let slow_store = Store::new(Arc::new(NoopStore::new()));
+    let fast_slow_store_config = nativelink_config::stores::FastSlowStore {
+        fast: nativelink_config::stores::StoreConfig::memory(
+            nativelink_config::stores::MemoryStore::default(),
+        ),
+        slow: nativelink_config::stores::StoreConfig::noop,
+    };
+    let fast_slow_store = Arc::new(FastSlowStore::new(
+        &fast_slow_store_config,
+        fast_store.clone(),
+        slow_store.clone(),
+    ));
 
-        assert_eq!(
-            fast_slow_store.has(digest).await,
-            Ok(Some(data.len())),
-            "Expected data to exist in store"
-        );
+    let data = make_random_data(100);
+    let digest = DigestInfo::try_new(VALID_HASH, data.len()).unwrap();
 
-        assert_eq!(
-            fast_slow_store.get_part_unchunked(digest, 0, None).await,
-            Ok(data.into()),
-            "Data read from store is not correct"
-        );
-        Ok(())
-    }
+    assert_eq!(
+        fast_slow_store.has(digest).await,
+        Ok(None),
+        "Expected data to not exist in store"
+    );
+
+    // Upload some dummy data.
+    fast_store
+        .update_oneshot(digest, data.clone().into())
+        .await?;
+
+    assert_eq!(
+        fast_slow_store.has(digest).await,
+        Ok(Some(data.len())),
+        "Expected data to exist in store"
+    );
+
+    assert_eq!(
+        fast_slow_store.get_part_unchunked(digest, 0, None).await,
+        Ok(data.into()),
+        "Data read from store is not correct"
+    );
+    Ok(())
 }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -43,10 +43,11 @@ use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
 use nativelink_util::{background_spawn, spawn};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+use pretty_assertions::assert_eq;
 use rand::{thread_rng, Rng};
 use serial_test::serial;
 use sha2::{Digest, Sha256};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::Barrier;
 use tokio::time::sleep;
 use tokio_stream::wrappers::ReadDirStream;
@@ -246,1307 +247,1291 @@ async fn wait_for_no_open_files() -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(test)]
-mod filesystem_store_tests {
-    use pretty_assertions::assert_eq;
-    use tokio::io::AsyncSeekExt;
+const HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
+const VALUE1: &str = "0123456789";
+const VALUE2: &str = "9876543210";
 
-    use super::*; // Must be declared in every module.
-
-    const HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const HASH2: &str = "0123456789abcdef000000000000000000020000000000000123456789abcdef";
-    const VALUE1: &str = "0123456789";
-    const VALUE2: &str = "9876543210";
-
-    #[serial]
-    #[nativelink_test]
-    async fn valid_results_after_shutdown_test() -> Result<(), Error> {
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-        {
-            let store = Store::new(
-                FilesystemStore::<FileEntryImpl>::new(
-                    &nativelink_config::stores::FilesystemStore {
-                        content_path: content_path.clone(),
-                        temp_path: temp_path.clone(),
-                        eviction_policy: None,
-                        block_size: 1,
-                        ..Default::default()
-                    },
-                )
-                .await?,
-            );
-
-            // Insert dummy value into store.
-            store.update_oneshot(digest, VALUE1.into()).await?;
-
-            assert_eq!(
-                store.has(digest).await,
-                Ok(Some(VALUE1.len())),
-                "Expected filesystem store to have hash: {}",
-                HASH1
-            );
-        }
-        {
-            // With a new store ensure content is still readable (ie: restores from shutdown).
-            let store = Box::pin(
-                FilesystemStore::<FileEntryImpl>::new(
-                    &nativelink_config::stores::FilesystemStore {
-                        content_path,
-                        temp_path,
-                        eviction_policy: None,
-                        ..Default::default()
-                    },
-                )
-                .await?,
-            );
-
-            let content = store.get_part_unchunked(digest, 0, None).await?;
-            assert_eq!(content, VALUE1.as_bytes());
-        }
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
-        let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
-        struct LocalHooks {}
-        impl FileEntryHooks for LocalHooks {
-            fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
-                DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-
-        let store = Box::pin(
-            FilesystemStore::<TestFileEntry<LocalHooks>>::new(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                        max_count: 3,
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                },
-            )
+#[serial]
+#[nativelink_test]
+async fn valid_results_after_shutdown_test() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+    {
+        let store = Store::new(
+            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                eviction_policy: None,
+                block_size: 1,
+                ..Default::default()
+            })
             .await?,
         );
 
-        store.update_oneshot(digest1, VALUE1.into()).await?;
+        // Insert dummy value into store.
+        store.update_oneshot(digest, VALUE1.into()).await?;
 
-        let expected_file_name = OsString::from(format!(
-            "{}/{}-{}",
-            content_path,
-            digest1.hash_str(),
-            digest1.size_bytes
-        ));
-        {
-            // Check to ensure our file exists where it should and content matches.
-            let data = read_file_contents(&expected_file_name).await?;
+        assert_eq!(
+            store.has(digest).await,
+            Ok(Some(VALUE1.len())),
+            "Expected filesystem store to have hash: {}",
+            HASH1
+        );
+    }
+    {
+        // With a new store ensure content is still readable (ie: restores from shutdown).
+        let store = Box::pin(
+            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+                content_path,
+                temp_path,
+                eviction_policy: None,
+                ..Default::default()
+            })
+            .await?,
+        );
+
+        let content = store.get_part_unchunked(digest, 0, None).await?;
+        assert_eq!(content, VALUE1.as_bytes());
+    }
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
+    struct LocalHooks {}
+    impl FileEntryHooks for LocalHooks {
+        fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
+            DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    let store = Box::pin(
+        FilesystemStore::<TestFileEntry<LocalHooks>>::new(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+                    max_count: 3,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )
+        .await?,
+    );
+
+    store.update_oneshot(digest1, VALUE1.into()).await?;
+
+    let expected_file_name = OsString::from(format!(
+        "{}/{}-{}",
+        content_path,
+        digest1.hash_str(),
+        digest1.size_bytes
+    ));
+    {
+        // Check to ensure our file exists where it should and content matches.
+        let data = read_file_contents(&expected_file_name).await?;
+        assert_eq!(
+            &data[..],
+            VALUE1.as_bytes(),
+            "Expected file content to match"
+        );
+    }
+
+    // Replace content.
+    store.update_oneshot(digest1, VALUE2.into()).await?;
+
+    {
+        // Check to ensure our file now has new content.
+        let data = read_file_contents(&expected_file_name).await?;
+        assert_eq!(
+            &data[..],
+            VALUE2.as_bytes(),
+            "Expected file content to match"
+        );
+    }
+
+    loop {
+        if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
+        .await
+        .err_tip(|| "Failed opening temp directory")?
+        .into_inner();
+    let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
+
+    if let Some(temp_dir_entry) = read_dir_stream.next().await {
+        let path = temp_dir_entry?.path();
+        panic!("No files should exist in temp directory, found: {path:?}");
+    }
+
+    Ok(())
+}
+
+// This test ensures that if a file is overridden and an open stream to the file already
+// exists, the open stream will continue to work properly and when the stream is done the
+// temporary file (of the object that was deleted) is cleaned up.
+#[serial]
+#[nativelink_test]
+async fn file_continues_to_stream_on_content_replace_test() -> Result<(), Error> {
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
+    struct LocalHooks {}
+    impl FileEntryHooks for LocalHooks {
+        fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
+            DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    let store = Arc::new(
+        FilesystemStore::<TestFileEntry<LocalHooks>>::new(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+                    max_count: 3,
+                    ..Default::default()
+                }),
+                block_size: 1,
+                read_buffer_size: 1,
+            },
+        )
+        .await?,
+    );
+
+    // Insert data into store.
+    store.update_oneshot(digest1, VALUE1.into()).await?;
+
+    let (writer, mut reader) = make_buf_channel_pair();
+    let store_clone = store.clone();
+    let digest1_clone = digest1;
+    background_spawn!(
+        "file_continues_to_stream_on_content_replace_test_store_get",
+        async move { store_clone.get(digest1_clone, writer).await },
+    );
+
+    {
+        // Check to ensure our first byte has been received. The future should be stalled here.
+        let first_byte = reader
+            .consume(Some(1))
+            .await
+            .err_tip(|| "Error reading first byte")?;
+        assert_eq!(
+            first_byte[0],
+            VALUE1.as_bytes()[0],
+            "Expected first byte to match"
+        );
+    }
+
+    // Replace content.
+    store.update_oneshot(digest1, VALUE2.into()).await?;
+
+    // Ensure we let any background tasks finish.
+    tokio::task::yield_now().await;
+
+    {
+        // Now ensure we only have 1 file in our temp path.
+        let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
+            .await
+            .err_tip(|| "Failed opening temp directory")?
+            .into_inner();
+        let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
+        let mut num_files = 0;
+        while let Some(temp_dir_entry) = read_dir_stream.next().await {
+            num_files += 1;
+            let path = temp_dir_entry?.path();
+            let data = read_file_contents(path.as_os_str()).await?;
             assert_eq!(
                 &data[..],
                 VALUE1.as_bytes(),
                 "Expected file content to match"
             );
         }
+        assert_eq!(
+            num_files, 1,
+            "There should only be one file in the temp directory"
+        );
+    }
 
-        // Replace content.
-        store.update_oneshot(digest1, VALUE2.into()).await?;
+    let remaining_file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading remaining bytes")?;
 
-        {
-            // Check to ensure our file now has new content.
-            let data = read_file_contents(&expected_file_name).await?;
-            assert_eq!(
-                &data[..],
-                VALUE2.as_bytes(),
-                "Expected file content to match"
-            );
+    assert_eq!(
+        &remaining_file_data,
+        VALUE1[1..].as_bytes(),
+        "Expected file content to match"
+    );
+
+    loop {
+        if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
+            break;
         }
+        tokio::task::yield_now().await;
+    }
 
-        loop {
-            if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-
+    {
+        // Now ensure our temp file was cleaned up.
         let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
             .await
             .err_tip(|| "Failed opening temp directory")?
             .into_inner();
         let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
-
         if let Some(temp_dir_entry) = read_dir_stream.next().await {
             let path = temp_dir_entry?.path();
             panic!("No files should exist in temp directory, found: {path:?}");
         }
-
-        Ok(())
     }
 
-    // This test ensures that if a file is overridden and an open stream to the file already
-    // exists, the open stream will continue to work properly and when the stream is done the
-    // temporary file (of the object that was deleted) is cleaned up.
-    #[serial]
-    #[nativelink_test]
-    async fn file_continues_to_stream_on_content_replace_test() -> Result<(), Error> {
-        let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
+    Ok(())
+}
 
-        static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
-        struct LocalHooks {}
-        impl FileEntryHooks for LocalHooks {
-            fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
-                DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
-            }
+// Eviction has a different code path than a file replacement, so we check that if a
+// file is evicted and has an open stream on it, it will stay alive and eventually
+// get deleted.
+#[serial]
+#[nativelink_test]
+async fn file_gets_cleans_up_on_cache_eviction() -> Result<(), Error> {
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let digest2 = DigestInfo::try_new(HASH2, VALUE2.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
+    struct LocalHooks {}
+    impl FileEntryHooks for LocalHooks {
+        fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
+            DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
         }
-
-        let store = Arc::new(
-            FilesystemStore::<TestFileEntry<LocalHooks>>::new(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                        max_count: 3,
-                        ..Default::default()
-                    }),
-                    block_size: 1,
-                    read_buffer_size: 1,
-                },
-            )
-            .await?,
-        );
-
-        // Insert data into store.
-        store.update_oneshot(digest1, VALUE1.into()).await?;
-
-        let (writer, mut reader) = make_buf_channel_pair();
-        let store_clone = store.clone();
-        let digest1_clone = digest1;
-        background_spawn!(
-            "file_continues_to_stream_on_content_replace_test_store_get",
-            async move { store_clone.get(digest1_clone, writer).await },
-        );
-
-        {
-            // Check to ensure our first byte has been received. The future should be stalled here.
-            let first_byte = reader
-                .consume(Some(1))
-                .await
-                .err_tip(|| "Error reading first byte")?;
-            assert_eq!(
-                first_byte[0],
-                VALUE1.as_bytes()[0],
-                "Expected first byte to match"
-            );
-        }
-
-        // Replace content.
-        store.update_oneshot(digest1, VALUE2.into()).await?;
-
-        // Ensure we let any background tasks finish.
-        tokio::task::yield_now().await;
-
-        {
-            // Now ensure we only have 1 file in our temp path.
-            let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
-                .await
-                .err_tip(|| "Failed opening temp directory")?
-                .into_inner();
-            let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
-            let mut num_files = 0;
-            while let Some(temp_dir_entry) = read_dir_stream.next().await {
-                num_files += 1;
-                let path = temp_dir_entry?.path();
-                let data = read_file_contents(path.as_os_str()).await?;
-                assert_eq!(
-                    &data[..],
-                    VALUE1.as_bytes(),
-                    "Expected file content to match"
-                );
-            }
-            assert_eq!(
-                num_files, 1,
-                "There should only be one file in the temp directory"
-            );
-        }
-
-        let remaining_file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading remaining bytes")?;
-
-        assert_eq!(
-            &remaining_file_data,
-            VALUE1[1..].as_bytes(),
-            "Expected file content to match"
-        );
-
-        loop {
-            if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-
-        {
-            // Now ensure our temp file was cleaned up.
-            let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
-                .await
-                .err_tip(|| "Failed opening temp directory")?
-                .into_inner();
-            let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
-            if let Some(temp_dir_entry) = read_dir_stream.next().await {
-                let path = temp_dir_entry?.path();
-                panic!("No files should exist in temp directory, found: {path:?}");
-            }
-        }
-
-        Ok(())
     }
 
-    // Eviction has a different code path than a file replacement, so we check that if a
-    // file is evicted and has an open stream on it, it will stay alive and eventually
-    // get deleted.
-    #[serial]
-    #[nativelink_test]
-    async fn file_gets_cleans_up_on_cache_eviction() -> Result<(), Error> {
-        let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        let digest2 = DigestInfo::try_new(HASH2, VALUE2.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        static DELETES_FINISHED: AtomicU32 = AtomicU32::new(0);
-        struct LocalHooks {}
-        impl FileEntryHooks for LocalHooks {
-            fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
-                DELETES_FINISHED.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-
-        let store = Arc::new(
-            FilesystemStore::<TestFileEntry<LocalHooks>>::new(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                        max_count: 1,
-                        ..Default::default()
-                    }),
-                    block_size: 1,
-                    read_buffer_size: 1,
-                },
-            )
-            .await?,
-        );
-
-        // Insert data into store.
-        store.update_oneshot(digest1, VALUE1.into()).await?;
-
-        let mut reader = {
-            let (writer, reader) = make_buf_channel_pair();
-            let store_clone = store.clone();
-            background_spawn!(
-                "file_gets_cleans_up_on_cache_eviction_store_get",
-                async move { store_clone.get(digest1, writer).await },
-            );
-            reader
-        };
-        // Ensure we have received 1 byte in our buffer. This will ensure we have a reference to
-        // our file open.
-        assert!(reader.peek().await.is_ok(), "Could not peek into reader");
-
-        // Insert new content. This will evict the old item.
-        store.update_oneshot(digest2, VALUE2.into()).await?;
-
-        // Ensure we let any background tasks finish.
-        tokio::task::yield_now().await;
-
-        {
-            // Now ensure we only have 1 file in our temp path.
-            let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
-                .await
-                .err_tip(|| "Failed opening temp directory")?
-                .into_inner();
-            let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
-            let mut num_files = 0;
-            while let Some(temp_dir_entry) = read_dir_stream.next().await {
-                num_files += 1;
-                let path = temp_dir_entry?.path();
-                let data = read_file_contents(path.as_os_str()).await?;
-                assert_eq!(
-                    &data[..],
-                    VALUE1.as_bytes(),
-                    "Expected file content to match"
-                );
-            }
-            assert_eq!(
-                num_files, 1,
-                "There should only be one file in the temp directory"
-            );
-        }
-
-        let reader_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading remaining bytes")?;
-
-        assert_eq!(&reader_data, VALUE1, "Expected file content to match");
-
-        loop {
-            if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-
-        {
-            // Now ensure our temp file was cleaned up.
-            let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
-                .await
-                .err_tip(|| "Failed opening temp directory")?
-                .into_inner();
-            let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
-            if let Some(temp_dir_entry) = read_dir_stream.next().await {
-                let path = temp_dir_entry?.path();
-                panic!("No files should exist in temp directory, found: {path:?}");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn atime_updates_on_get_part_test() -> Result<(), Error> {
-        let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
-                content_path: make_temp_path("content_path"),
-                temp_path: make_temp_path("temp_path"),
-                eviction_policy: None,
-                ..Default::default()
-            })
-            .await?,
-        );
-        // Insert data into store.
-        store.update_oneshot(digest1, VALUE1.into()).await?;
-
-        let file_entry = store.get_file_entry_for_digest(&digest1).await?;
-        file_entry
-            .get_file_path_locked(move |path| async move {
-                // Set atime to along time ago.
-                set_file_atime(&path, FileTime::from_system_time(SystemTime::UNIX_EPOCH))?;
-
-                // Check to ensure it was set to zero from previous command.
-                assert_eq!(
-                    fs::metadata(&path).await?.accessed()?,
-                    SystemTime::UNIX_EPOCH
-                );
-                Ok(())
-            })
-            .await?;
-
-        // Now touch digest1.
-        let data = store.get_part_unchunked(digest1, 0, None).await?;
-        assert_eq!(data, VALUE1.as_bytes());
-
-        file_entry
-            .get_file_path_locked(move |path| async move {
-                // Ensure it was updated.
-                assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
-                Ok(())
-            })
-            .await?;
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn oldest_entry_evicted_with_access_times_loaded_from_disk() -> Result<(), Error> {
-        // Note these are swapped to ensure they aren't in numerical order.
-        let digest1 = DigestInfo::try_new(HASH2, VALUE2.len())?;
-        let digest2 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-
-        let content_path = make_temp_path("content_path");
-        fs::create_dir_all(&content_path).await?;
-
-        // Make the two files on disk before loading the store.
-        let file1 = OsString::from(format!(
-            "{}/{}-{}",
-            content_path,
-            digest1.hash_str(),
-            digest1.size_bytes
-        ));
-        let file2 = OsString::from(format!(
-            "{}/{}-{}",
-            content_path,
-            digest2.hash_str(),
-            digest2.size_bytes
-        ));
-        write_file(&file1, VALUE1.as_bytes()).await?;
-        write_file(&file2, VALUE2.as_bytes()).await?;
-        set_file_atime(&file1, FileTime::from_unix_time(0, 0))?;
-        set_file_atime(&file2, FileTime::from_unix_time(1, 0))?;
-
-        // Load the existing store from disk.
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
-                content_path,
-                temp_path: make_temp_path("temp_path"),
+    let store = Arc::new(
+        FilesystemStore::<TestFileEntry<LocalHooks>>::new(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
                 eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                    max_bytes: 0,
-                    max_seconds: 0,
                     max_count: 1,
-                    evict_bytes: 0,
+                    ..Default::default()
                 }),
-                ..Default::default()
-            })
-            .await?,
-        );
-
-        // This should exist and not have been evicted.
-        store.get_file_entry_for_digest(&digest2).await?;
-        // This should have been evicted.
-        match store.get_file_entry_for_digest(&digest1).await {
-            Ok(_) => panic!("Oldest file should have been evicted."),
-            Err(error) => assert_eq!(error.code, Code::NotFound),
-        }
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn eviction_drops_file_test() -> Result<(), Error> {
-        let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
-
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
-                content_path: make_temp_path("content_path"),
-                temp_path: make_temp_path("temp_path"),
-                eviction_policy: None,
-                ..Default::default()
-            })
-            .await?,
-        );
-        // Insert data into store.
-        store.update_oneshot(digest1, VALUE1.into()).await?;
-
-        let file_entry = store.get_file_entry_for_digest(&digest1).await?;
-        file_entry
-            .get_file_path_locked(move |path| async move {
-                // Set atime to along time ago.
-                set_file_atime(&path, FileTime::from_system_time(SystemTime::UNIX_EPOCH))?;
-
-                // Check to ensure it was set to zero from previous command.
-                assert_eq!(
-                    fs::metadata(&path).await?.accessed()?,
-                    SystemTime::UNIX_EPOCH
-                );
-                Ok(())
-            })
-            .await?;
-
-        // Now touch digest1.
-        let data = store.get_part_unchunked(digest1, 0, None).await?;
-        assert_eq!(data, VALUE1.as_bytes());
-
-        file_entry
-            .get_file_path_locked(move |path| async move {
-                // Ensure it was updated.
-                assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
-                Ok(())
-            })
-            .await?;
-
-        Ok(())
-    }
-
-    // Test to ensure that if we are holding a reference to `FileEntry` and the contents are
-    // replaced, the `FileEntry` continues to use the old data.
-    // `FileEntry` file contents should be immutable for the lifetime of the object.
-    #[serial]
-    #[nativelink_test]
-    async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error> {
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
-
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
-                content_path: make_temp_path("content_path"),
-                temp_path: make_temp_path("temp_path"),
-                eviction_policy: None,
-                ..Default::default()
-            })
-            .await?,
-        );
-        // Insert data into store.
-        store.update_oneshot(digest, VALUE1.into()).await?;
-        let file_entry = store.get_file_entry_for_digest(&digest).await?;
-        {
-            // The file contents should equal our initial data.
-            let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
-            let mut file_contents = String::new();
-            reader
-                .as_reader()
-                .await?
-                .read_to_string(&mut file_contents)
-                .await?;
-            assert_eq!(file_contents, VALUE1);
-        }
-
-        // Now replace the data.
-        store.update_oneshot(digest, VALUE2.into()).await?;
-
-        {
-            // The file contents still equal our old data.
-            let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
-            let mut file_contents = String::new();
-            reader
-                .as_reader()
-                .await?
-                .read_to_string(&mut file_contents)
-                .await?;
-            assert_eq!(file_contents, VALUE1);
-        }
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn eviction_on_insert_calls_unref_once() -> Result<(), Error> {
-        const SMALL_VALUE: &str = "01";
-        const BIG_VALUE: &str = "0123";
-        let small_digest = DigestInfo::try_new(HASH1, SMALL_VALUE.len())?;
-        let big_digest = DigestInfo::try_new(HASH1, BIG_VALUE.len())?;
-
-        static UNREFED_DIGESTS: Lazy<Mutex<Vec<DigestInfo>>> = Lazy::new(|| Mutex::new(Vec::new()));
-        struct LocalHooks {}
-        impl FileEntryHooks for LocalHooks {
-            fn on_unref<Fe: FileEntry>(file_entry: &Fe) {
-                block_on(file_entry.get_file_path_locked(move |path_str| async move {
-                    let path = Path::new(&path_str);
-                    let digest =
-                        digest_from_filename(path.file_name().unwrap().to_str().unwrap()).unwrap();
-                    UNREFED_DIGESTS.lock().push(digest);
-                    Ok(())
-                }))
-                .unwrap();
-            }
-        }
-
-        let store = Box::pin(
-            FilesystemStore::<TestFileEntry<LocalHooks>>::new(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: make_temp_path("content_path"),
-                    temp_path: make_temp_path("temp_path"),
-                    eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
-                        max_bytes: 5,
-                        ..Default::default()
-                    }),
-                    block_size: 1,
-                    ..Default::default()
-                },
-            )
-            .await?,
-        );
-        // Insert data into store.
-        store
-            .update_oneshot(small_digest, SMALL_VALUE.into())
-            .await?;
-        store.update_oneshot(big_digest, BIG_VALUE.into()).await?;
-
-        {
-            // Our first digest should have been unrefed exactly once.
-            let unrefed_digests = UNREFED_DIGESTS.lock();
-            assert_eq!(
-                unrefed_digests.len(),
-                1,
-                "Expected exactly 1 unrefed digest"
-            );
-            assert_eq!(unrefed_digests[0], small_digest, "Expected digest to match");
-        }
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    #[allow(clippy::await_holding_refcell_ref)]
-    async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens(
-    ) -> Result<(), Error> {
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
-
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        static FILE_DELETED_BARRIER: Lazy<Arc<Barrier>> = Lazy::new(|| Arc::new(Barrier::new(2)));
-
-        struct LocalHooks {}
-        impl FileEntryHooks for LocalHooks {
-            fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
-                background_spawn!("rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_local_hooks_on_drop", FILE_DELETED_BARRIER.wait());
-            }
-        }
-
-        let store = Box::pin(
-            FilesystemStore::<TestFileEntry<LocalHooks>>::new(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    eviction_policy: None,
-                    ..Default::default()
-                },
-            )
-            .await?,
-        );
-
-        let (mut tx, rx) = make_buf_channel_pair();
-        let update_fut = Arc::new(async_lock::Mutex::new(store.update(
-            digest,
-            rx,
-            UploadSizeInfo::MaxSize(100),
-        )));
-        // This will process as much of the future as it can before it needs to pause.
-        // Our temp file will be created and opened and ready to have contents streamed
-        // to it.
-        assert_eq!(poll!(update_fut.lock().await.deref_mut())?, Poll::Pending);
-        const INITIAL_CONTENT: &str = "hello";
-        tx.send(INITIAL_CONTENT.into()).await?;
-
-        // Now we extract that temp file that is generated.
-        async fn wait_for_temp_file<Fut: Future<Output = Result<(), Error>>, F: Fn() -> Fut>(
-            temp_path: &str,
-            yield_fn: F,
-        ) -> Result<fs::DirEntry, Error> {
-            loop {
-                yield_fn().await?;
-                let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
-                let mut read_dir_stream = ReadDirStream::new(dir_handle);
-                if let Some(dir_entry) = read_dir_stream.next().await {
-                    assert!(
-                        read_dir_stream.next().await.is_none(),
-                        "There should only be one file in temp directory"
-                    );
-                    let dir_entry = dir_entry?;
-                    {
-                        // Some filesystems won't sync automatically, so force it.
-                        let mut file_handle =
-                            fs::open_file(dir_entry.path().into_os_string(), u64::MAX)
-                                .await
-                                .err_tip(|| "Failed to open temp file")?;
-                        // We don't care if it fails, this is only best attempt.
-                        let _ = file_handle
-                            .as_reader()
-                            .await?
-                            .get_ref()
-                            .as_ref()
-                            .sync_all()
-                            .await;
-                    }
-                    // Ensure we have written to the file too. This ensures we have an open file handle.
-                    // Failing to do this may result in the file existing, but the `update_fut` not actually
-                    // sending data to it yet.
-                    if dir_entry.metadata().await?.len() >= INITIAL_CONTENT.len() as u64 {
-                        return Ok(dir_entry);
-                    }
-                }
-            }
-            // Unreachable.
-        }
-        wait_for_temp_file(&temp_path, || {
-            let update_fut_clone = update_fut.clone();
-            async move {
-                // This will ensure we yield to our future and other potential spawns.
-                tokio::task::yield_now().await;
-                assert_eq!(
-                    poll!(update_fut_clone.lock().await.deref_mut())?,
-                    Poll::Pending
-                );
-                Ok(())
-            }
-        })
-        .await?;
-
-        // Now make it impossible for the file to be moved into the final path.
-        // This will trigger an error on `rename()`.
-        fs::remove_dir_all(&content_path).await?;
-
-        // Because send_eof() waits for shutdown of the rx side, we cannot just await in this thread.
-        background_spawn!(
-            "rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_send_eof",
-            async move {
-                tx.send_eof().unwrap();
+                block_size: 1,
+                read_buffer_size: 1,
             },
+        )
+        .await?,
+    );
+
+    // Insert data into store.
+    store.update_oneshot(digest1, VALUE1.into()).await?;
+
+    let mut reader = {
+        let (writer, reader) = make_buf_channel_pair();
+        let store_clone = store.clone();
+        background_spawn!(
+            "file_gets_cleans_up_on_cache_eviction_store_get",
+            async move { store_clone.get(digest1, writer).await },
         );
+        reader
+    };
+    // Ensure we have received 1 byte in our buffer. This will ensure we have a reference to
+    // our file open.
+    assert!(reader.peek().await.is_ok(), "Could not peek into reader");
 
-        // Now finish waiting on update(). This should reuslt in an error because we deleted our dest
-        // folder.
-        let update_result = update_fut.lock().await.deref_mut().await;
-        assert!(
-            update_result.is_err(),
-            "Expected update to fail due to temp file being deleted before rename"
-        );
+    // Insert new content. This will evict the old item.
+    store.update_oneshot(digest2, VALUE2.into()).await?;
 
-        // Delete may happen on another thread, so wait for it.
-        FILE_DELETED_BARRIER.wait().await;
+    // Ensure we let any background tasks finish.
+    tokio::task::yield_now().await;
 
-        // Now it should have cleaned up it's temp files.
-        {
-            // Ensure `temp_path` is empty.
-            let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
-            let mut read_dir_stream = ReadDirStream::new(dir_handle);
-            assert!(
-                read_dir_stream.next().await.is_none(),
-                "File found in temp_path after update() rename failure"
+    {
+        // Now ensure we only have 1 file in our temp path.
+        let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
+            .await
+            .err_tip(|| "Failed opening temp directory")?
+            .into_inner();
+        let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
+        let mut num_files = 0;
+        while let Some(temp_dir_entry) = read_dir_stream.next().await {
+            num_files += 1;
+            let path = temp_dir_entry?.path();
+            let data = read_file_contents(path.as_os_str()).await?;
+            assert_eq!(
+                &data[..],
+                VALUE1.as_bytes(),
+                "Expected file content to match"
             );
         }
-
-        // Finally ensure that our entry is not in the store.
         assert_eq!(
-            store.has(digest).await?,
-            None,
-            "Entry should not be in store"
+            num_files, 1,
+            "There should only be one file in the temp directory"
         );
-        Ok(())
     }
 
-    #[serial]
-    #[nativelink_test]
-    async fn get_part_timeout_test() -> Result<(), Error> {
-        let large_value = "x".repeat(1024);
-        let digest = DigestInfo::try_new(HASH1, large_value.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
+    let reader_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading remaining bytes")?;
 
-        let store = Arc::new(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
-            .await?,
-        );
+    assert_eq!(&reader_data, VALUE1, "Expected file content to match");
 
-        store
-            .update_oneshot(digest, large_value.clone().into())
-            .await?;
-
-        let (writer, mut reader) = make_buf_channel_pair();
-        let store_clone = store.clone();
-        let digest_clone = digest;
-
-        let _drop_guard = spawn!("get_part_timeout_test_get", async move {
-            store_clone.get(digest_clone, writer).await
-        });
-
-        let file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading bytes")?;
-
-        assert_eq!(
-            &file_data,
-            large_value.as_bytes(),
-            "Expected file content to match"
-        );
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn get_part_is_zero_digest() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        let store = Arc::new(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
-            .await?,
-        );
-
-        let store_clone = store.clone();
-        let (mut writer, mut reader) = make_buf_channel_pair();
-
-        let _drop_guard = spawn!("get_part_is_zero_digest_get_part", async move {
-            let _ = store_clone
-                .get_part(digest, &mut writer, 0, None)
-                .await
-                .err_tip(|| "Failed to get_part");
-        });
-
-        let file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading bytes")?;
-
-        let empty_bytes = Bytes::new();
-        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        let store = Arc::new(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
-            .await?,
-        );
-
-        let keys = vec![digest.into()];
-        let mut results = vec![None];
-        let _ = store
-            .has_with_results(&keys, &mut results)
-            .await
-            .err_tip(|| "Failed to get_part");
-        assert_eq!(results, vec!(Some(0)));
-
-        async fn wait_for_empty_content_file<
-            Fut: Future<Output = Result<(), Error>>,
-            F: Fn() -> Fut,
-        >(
-            content_path: &str,
-            digest: DigestInfo,
-            yield_fn: F,
-        ) -> Result<(), Error> {
-            loop {
-                yield_fn().await?;
-
-                let empty_digest_file_name = OsString::from(format!(
-                    "{}/{}-{}",
-                    content_path,
-                    digest.hash_str(),
-                    digest.size_bytes
-                ));
-
-                let file_metadata = fs::metadata(empty_digest_file_name)
-                    .await
-                    .err_tip(|| "Failed to open content file")?;
-
-                // Test that the empty digest file is created and contains an empty length.
-                if file_metadata.is_file() && file_metadata.len() == 0 {
-                    return Ok(());
-                }
-            }
-            // Unreachable.
+    loop {
+        if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
+            break;
         }
+        tokio::task::yield_now().await;
+    }
 
-        wait_for_empty_content_file(&content_path, digest, || async move {
-            tokio::task::yield_now().await;
+    {
+        // Now ensure our temp file was cleaned up.
+        let (_permit, temp_dir_handle) = fs::read_dir(temp_path.clone())
+            .await
+            .err_tip(|| "Failed opening temp directory")?
+            .into_inner();
+        let mut read_dir_stream = ReadDirStream::new(temp_dir_handle);
+        if let Some(temp_dir_entry) = read_dir_stream.next().await {
+            let path = temp_dir_entry?.path();
+            panic!("No files should exist in temp directory, found: {path:?}");
+        }
+    }
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn atime_updates_on_get_part_test() -> Result<(), Error> {
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+            content_path: make_temp_path("content_path"),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    // Insert data into store.
+    store.update_oneshot(digest1, VALUE1.into()).await?;
+
+    let file_entry = store.get_file_entry_for_digest(&digest1).await?;
+    file_entry
+        .get_file_path_locked(move |path| async move {
+            // Set atime to along time ago.
+            set_file_atime(&path, FileTime::from_system_time(SystemTime::UNIX_EPOCH))?;
+
+            // Check to ensure it was set to zero from previous command.
+            assert_eq!(
+                fs::metadata(&path).await?.accessed()?,
+                SystemTime::UNIX_EPOCH
+            );
             Ok(())
         })
         .await?;
 
-        Ok(())
-    }
+    // Now touch digest1.
+    let data = store.get_part_unchunked(digest1, 0, None).await?;
+    assert_eq!(data, VALUE1.as_bytes());
 
-    /// Regression test for: https://github.com/TraceMachina/nativelink/issues/495.
-    #[serial]
-    #[nativelink_test(flavor = "multi_thread")]
-    async fn update_file_future_drops_before_rename() -> Result<(), Error> {
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    file_entry
+        .get_file_path_locked(move |path| async move {
+            // Ensure it was updated.
+            assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+            Ok(())
+        })
+        .await?;
 
-        // Mutex can be used to signal to the rename function to pause execution.
-        static RENAME_REQUEST_PAUSE_MUX: async_lock::Mutex<()> = async_lock::Mutex::new(());
-        // Boolean used to know if the rename function is currently paused.
-        static RENAME_IS_PAUSED: AtomicBool = AtomicBool::new(false);
+    Ok(())
+}
 
-        let content_path = make_temp_path("content_path");
-        let store = Arc::pin(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: make_temp_path("temp_path"),
-                    eviction_policy: None,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| {
-                    // If someone locked our mutex, it means we need to pause, so we
-                    // simply request a lock on the same mutex.
-                    if RENAME_REQUEST_PAUSE_MUX.try_lock().is_none() {
-                        RENAME_IS_PAUSED.store(true, Ordering::Release);
-                        while RENAME_REQUEST_PAUSE_MUX.try_lock().is_none() {
-                            std::thread::sleep(Duration::from_millis(1));
-                        }
-                        RENAME_IS_PAUSED.store(false, Ordering::Release);
-                    }
-                    std::fs::rename(from, to)
-                },
-            )
-            .await?,
-        );
+#[serial]
+#[nativelink_test]
+async fn oldest_entry_evicted_with_access_times_loaded_from_disk() -> Result<(), Error> {
+    // Note these are swapped to ensure they aren't in numerical order.
+    let digest1 = DigestInfo::try_new(HASH2, VALUE2.len())?;
+    let digest2 = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
-        // Populate our first store entry.
-        let first_file_entry = {
-            store.update_oneshot(digest, VALUE1.into()).await?;
-            store.get_file_entry_for_digest(&digest).await?
-        };
+    let content_path = make_temp_path("content_path");
+    fs::create_dir_all(&content_path).await?;
 
-        // 1. Request the next rename function to block.
-        // 2. Request to replace our data.
-        // 3. When we are certain that our rename function is paused, drop
-        //    the replace/update future.
-        // 4. Then drop the lock.
-        {
-            let rename_pause_request_lock = RENAME_REQUEST_PAUSE_MUX.lock().await;
-            let mut update_fut = store.update_oneshot(digest, VALUE2.into()).boxed();
+    // Make the two files on disk before loading the store.
+    let file1 = OsString::from(format!(
+        "{}/{}-{}",
+        content_path,
+        digest1.hash_str(),
+        digest1.size_bytes
+    ));
+    let file2 = OsString::from(format!(
+        "{}/{}-{}",
+        content_path,
+        digest2.hash_str(),
+        digest2.size_bytes
+    ));
+    write_file(&file1, VALUE1.as_bytes()).await?;
+    write_file(&file2, VALUE2.as_bytes()).await?;
+    set_file_atime(&file1, FileTime::from_unix_time(0, 0))?;
+    set_file_atime(&file2, FileTime::from_unix_time(1, 0))?;
 
-            loop {
-                // Try to advance our update future.
-                assert_eq!(poll!(&mut update_fut), Poll::Pending);
-
-                // Once we are sure the rename fuction is paused break.
-                if RENAME_IS_PAUSED.load(Ordering::Acquire) {
-                    break;
-                }
-                // Give a little time for background/kernel threads to run.
-                sleep(Duration::from_millis(1)).await;
-            }
-            // Writing these out explicitly so users know this is what we are testing.
-            // Note: The order they are dropped matters.
-            drop(update_fut);
-            drop(rename_pause_request_lock);
-        }
-        // Grab the newly inserted item in our store.
-        let new_file_entry = store.get_file_entry_for_digest(&digest).await?;
-        assert!(
-            !Arc::ptr_eq(&first_file_entry, &new_file_entry),
-            "Expected file entries to not be the same"
-        );
-
-        // Ensure the entry we inserted was properly flagged as moved (from temp -> content dir).
-        new_file_entry
-            .get_file_path_locked(move |file_path| async move {
-                assert_eq!(
-                    file_path,
-                    OsString::from(format!(
-                        "{}/{}-{}",
-                        content_path,
-                        digest.hash_str(),
-                        digest.size_bytes
-                    ))
-                );
-                Ok(())
-            })
-            .await?;
-
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn deleted_file_removed_from_store() -> Result<(), Error> {
-        let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
-            .await?,
-        );
-
-        store.update_oneshot(digest, VALUE1.into()).await?;
-
-        let stored_file_path = OsString::from(format!(
-            "{}/{}-{}",
+    // Load the existing store from disk.
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
             content_path,
-            digest.hash_str(),
-            digest.size_bytes
-        ));
-        std::fs::remove_file(stored_file_path)?;
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+                max_bytes: 0,
+                max_seconds: 0,
+                max_count: 1,
+                evict_bytes: 0,
+            }),
+            ..Default::default()
+        })
+        .await?,
+    );
 
-        let digest_result = store
-            .has(digest)
-            .await
-            .err_tip(|| "Failed to execute has")?;
-        assert!(digest_result.is_none());
-
-        Ok(())
+    // This should exist and not have been evicted.
+    store.get_file_entry_for_digest(&digest2).await?;
+    // This should have been evicted.
+    match store.get_file_entry_for_digest(&digest1).await {
+        Ok(_) => panic!("Oldest file should have been evicted."),
+        Err(error) => assert_eq!(error.code, Code::NotFound),
     }
 
-    // Ensure that get_file_size() returns the correct number
-    // ceil(content length / block_size) * block_size
-    // assume block size 4K
-    // 1B data size = 4K size on disk
-    // 5K data size = 8K size on disk
-    #[serial]
-    #[nativelink_test]
-    async fn get_file_size_uses_block_size() -> Result<(), Error> {
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
+    Ok(())
+}
 
-        let value_1kb: String = "x".repeat(1024);
-        let value_5kb: String = "xabcd".repeat(1024);
+#[serial]
+#[nativelink_test]
+async fn eviction_drops_file_test() -> Result<(), Error> {
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
 
-        let digest_1kb = DigestInfo::try_new(HASH1, value_1kb.len())?;
-        let digest_5kb = DigestInfo::try_new(HASH2, value_5kb.len())?;
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+            content_path: make_temp_path("content_path"),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    // Insert data into store.
+    store.update_oneshot(digest1, VALUE1.into()).await?;
 
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
-            .await?,
-        );
+    let file_entry = store.get_file_entry_for_digest(&digest1).await?;
+    file_entry
+        .get_file_path_locked(move |path| async move {
+            // Set atime to along time ago.
+            set_file_atime(&path, FileTime::from_system_time(SystemTime::UNIX_EPOCH))?;
 
-        store.update_oneshot(digest_1kb, value_1kb.into()).await?;
-        let short_entry = store.get_file_entry_for_digest(&digest_1kb).await?;
-        assert_eq!(short_entry.size_on_disk(), 4 * 1024);
-
-        store.update_oneshot(digest_5kb, value_5kb.into()).await?;
-        let long_entry = store.get_file_entry_for_digest(&digest_5kb).await?;
-        assert_eq!(long_entry.size_on_disk(), 8 * 1024);
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn update_with_whole_file_closes_file() -> Result<(), Error> {
-        let mut permits = vec![];
-        // Grab all permits to ensure only 1 permit is available.
-        {
-            wait_for_no_open_files().await?;
-            while fs::OPEN_FILE_SEMAPHORE.available_permits() > 1 {
-                permits.push(fs::get_permit().await);
-            }
+            // Check to ensure it was set to zero from previous command.
             assert_eq!(
-                fs::OPEN_FILE_SEMAPHORE.available_permits(),
-                1,
-                "Expected 1 permit to be available"
+                fs::metadata(&path).await?.accessed()?,
+                SystemTime::UNIX_EPOCH
             );
+            Ok(())
+        })
+        .await?;
+
+    // Now touch digest1.
+    let data = store.get_part_unchunked(digest1, 0, None).await?;
+    assert_eq!(data, VALUE1.as_bytes());
+
+    file_entry
+        .get_file_path_locked(move |path| async move {
+            // Ensure it was updated.
+            assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+// Test to ensure that if we are holding a reference to `FileEntry` and the contents are
+// replaced, the `FileEntry` continues to use the old data.
+// `FileEntry` file contents should be immutable for the lifetime of the object.
+#[serial]
+#[nativelink_test]
+async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+            content_path: make_temp_path("content_path"),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    // Insert data into store.
+    store.update_oneshot(digest, VALUE1.into()).await?;
+    let file_entry = store.get_file_entry_for_digest(&digest).await?;
+    {
+        // The file contents should equal our initial data.
+        let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
+        let mut file_contents = String::new();
+        reader
+            .as_reader()
+            .await?
+            .read_to_string(&mut file_contents)
+            .await?;
+        assert_eq!(file_contents, VALUE1);
+    }
+
+    // Now replace the data.
+    store.update_oneshot(digest, VALUE2.into()).await?;
+
+    {
+        // The file contents still equal our old data.
+        let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
+        let mut file_contents = String::new();
+        reader
+            .as_reader()
+            .await?
+            .read_to_string(&mut file_contents)
+            .await?;
+        assert_eq!(file_contents, VALUE1);
+    }
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn eviction_on_insert_calls_unref_once() -> Result<(), Error> {
+    const SMALL_VALUE: &str = "01";
+    const BIG_VALUE: &str = "0123";
+    let small_digest = DigestInfo::try_new(HASH1, SMALL_VALUE.len())?;
+    let big_digest = DigestInfo::try_new(HASH1, BIG_VALUE.len())?;
+
+    static UNREFED_DIGESTS: Lazy<Mutex<Vec<DigestInfo>>> = Lazy::new(|| Mutex::new(Vec::new()));
+    struct LocalHooks {}
+    impl FileEntryHooks for LocalHooks {
+        fn on_unref<Fe: FileEntry>(file_entry: &Fe) {
+            block_on(file_entry.get_file_path_locked(move |path_str| async move {
+                let path = Path::new(&path_str);
+                let digest =
+                    digest_from_filename(path.file_name().unwrap().to_str().unwrap()).unwrap();
+                UNREFED_DIGESTS.lock().push(digest);
+                Ok(())
+            }))
+            .unwrap();
         }
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
+    }
 
-        let value = "x".repeat(1024);
+    let store = Box::pin(
+        FilesystemStore::<TestFileEntry<LocalHooks>>::new(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: make_temp_path("content_path"),
+                temp_path: make_temp_path("temp_path"),
+                eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+                    max_bytes: 5,
+                    ..Default::default()
+                }),
+                block_size: 1,
+                ..Default::default()
+            },
+        )
+        .await?,
+    );
+    // Insert data into store.
+    store
+        .update_oneshot(small_digest, SMALL_VALUE.into())
+        .await?;
+    store.update_oneshot(big_digest, BIG_VALUE.into()).await?;
 
-        let digest = DigestInfo::try_new(HASH1, value.len())?;
+    {
+        // Our first digest should have been unrefed exactly once.
+        let unrefed_digests = UNREFED_DIGESTS.lock();
+        assert_eq!(
+            unrefed_digests.len(),
+            1,
+            "Expected exactly 1 unrefed digest"
+        );
+        assert_eq!(unrefed_digests[0], small_digest, "Expected digest to match");
+    }
 
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+#[allow(clippy::await_holding_refcell_ref)]
+async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens() -> Result<(), Error>
+{
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    static FILE_DELETED_BARRIER: Lazy<Arc<Barrier>> = Lazy::new(|| Arc::new(Barrier::new(2)));
+
+    struct LocalHooks {}
+    impl FileEntryHooks for LocalHooks {
+        fn on_drop<Fe: FileEntry>(_file_entry: &Fe) {
+            background_spawn!("rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_local_hooks_on_drop", FILE_DELETED_BARRIER.wait());
+        }
+    }
+
+    let store = Box::pin(
+        FilesystemStore::<TestFileEntry<LocalHooks>>::new(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                eviction_policy: None,
+                ..Default::default()
+            },
+        )
+        .await?,
+    );
+
+    let (mut tx, rx) = make_buf_channel_pair();
+    let update_fut = Arc::new(async_lock::Mutex::new(store.update(
+        digest,
+        rx,
+        UploadSizeInfo::MaxSize(100),
+    )));
+    // This will process as much of the future as it can before it needs to pause.
+    // Our temp file will be created and opened and ready to have contents streamed
+    // to it.
+    assert_eq!(poll!(update_fut.lock().await.deref_mut())?, Poll::Pending);
+    const INITIAL_CONTENT: &str = "hello";
+    tx.send(INITIAL_CONTENT.into()).await?;
+
+    // Now we extract that temp file that is generated.
+    async fn wait_for_temp_file<Fut: Future<Output = Result<(), Error>>, F: Fn() -> Fut>(
+        temp_path: &str,
+        yield_fn: F,
+    ) -> Result<fs::DirEntry, Error> {
+        loop {
+            yield_fn().await?;
+            let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
+            let mut read_dir_stream = ReadDirStream::new(dir_handle);
+            if let Some(dir_entry) = read_dir_stream.next().await {
+                assert!(
+                    read_dir_stream.next().await.is_none(),
+                    "There should only be one file in temp directory"
+                );
+                let dir_entry = dir_entry?;
+                {
+                    // Some filesystems won't sync automatically, so force it.
+                    let mut file_handle =
+                        fs::open_file(dir_entry.path().into_os_string(), u64::MAX)
+                            .await
+                            .err_tip(|| "Failed to open temp file")?;
+                    // We don't care if it fails, this is only best attempt.
+                    let _ = file_handle
+                        .as_reader()
+                        .await?
+                        .get_ref()
+                        .as_ref()
+                        .sync_all()
+                        .await;
+                }
+                // Ensure we have written to the file too. This ensures we have an open file handle.
+                // Failing to do this may result in the file existing, but the `update_fut` not actually
+                // sending data to it yet.
+                if dir_entry.metadata().await?.len() >= INITIAL_CONTENT.len() as u64 {
+                    return Ok(dir_entry);
+                }
+            }
+        }
+        // Unreachable.
+    }
+    wait_for_temp_file(&temp_path, || {
+        let update_fut_clone = update_fut.clone();
+        async move {
+            // This will ensure we yield to our future and other potential spawns.
+            tokio::task::yield_now().await;
+            assert_eq!(
+                poll!(update_fut_clone.lock().await.deref_mut())?,
+                Poll::Pending
+            );
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Now make it impossible for the file to be moved into the final path.
+    // This will trigger an error on `rename()`.
+    fs::remove_dir_all(&content_path).await?;
+
+    // Because send_eof() waits for shutdown of the rx side, we cannot just await in this thread.
+    background_spawn!(
+        "rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens_send_eof",
+        async move {
+            tx.send_eof().unwrap();
+        },
+    );
+
+    // Now finish waiting on update(). This should reuslt in an error because we deleted our dest
+    // folder.
+    let update_result = update_fut.lock().await.deref_mut().await;
+    assert!(
+        update_result.is_err(),
+        "Expected update to fail due to temp file being deleted before rename"
+    );
+
+    // Delete may happen on another thread, so wait for it.
+    FILE_DELETED_BARRIER.wait().await;
+
+    // Now it should have cleaned up it's temp files.
+    {
+        // Ensure `temp_path` is empty.
+        let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
+        let mut read_dir_stream = ReadDirStream::new(dir_handle);
+        assert!(
+            read_dir_stream.next().await.is_none(),
+            "File found in temp_path after update() rename failure"
+        );
+    }
+
+    // Finally ensure that our entry is not in the store.
+    assert_eq!(
+        store.has(digest).await?,
+        None,
+        "Entry should not be in store"
+    );
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn get_part_timeout_test() -> Result<(), Error> {
+    let large_value = "x".repeat(1024);
+    let digest = DigestInfo::try_new(HASH1, large_value.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let store = Arc::new(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
                 content_path: content_path.clone(),
                 temp_path: temp_path.clone(),
                 read_buffer_size: 1,
                 ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    store
+        .update_oneshot(digest, large_value.clone().into())
+        .await?;
+
+    let (writer, mut reader) = make_buf_channel_pair();
+    let store_clone = store.clone();
+    let digest_clone = digest;
+
+    let _drop_guard = spawn!("get_part_timeout_test_get", async move {
+        store_clone.get(digest_clone, writer).await
+    });
+
+    let file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading bytes")?;
+
+    assert_eq!(
+        &file_data,
+        large_value.as_bytes(),
+        "Expected file content to match"
+    );
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn get_part_is_zero_digest() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let store = Arc::new(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                read_buffer_size: 1,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    let store_clone = store.clone();
+    let (mut writer, mut reader) = make_buf_channel_pair();
+
+    let _drop_guard = spawn!("get_part_is_zero_digest_get_part", async move {
+        let _ = store_clone
+            .get_part(digest, &mut writer, 0, None)
+            .await
+            .err_tip(|| "Failed to get_part");
+    });
+
+    let file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading bytes")?;
+
+    let empty_bytes = Bytes::new();
+    assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let store = Arc::new(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                read_buffer_size: 1,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    let keys = vec![digest.into()];
+    let mut results = vec![None];
+    let _ = store
+        .has_with_results(&keys, &mut results)
+        .await
+        .err_tip(|| "Failed to get_part");
+    assert_eq!(results, vec!(Some(0)));
+
+    async fn wait_for_empty_content_file<
+        Fut: Future<Output = Result<(), Error>>,
+        F: Fn() -> Fut,
+    >(
+        content_path: &str,
+        digest: DigestInfo,
+        yield_fn: F,
+    ) -> Result<(), Error> {
+        loop {
+            yield_fn().await?;
+
+            let empty_digest_file_name = OsString::from(format!(
+                "{}/{}-{}",
+                content_path,
+                digest.hash_str(),
+                digest.size_bytes
+            ));
+
+            let file_metadata = fs::metadata(empty_digest_file_name)
+                .await
+                .err_tip(|| "Failed to open content file")?;
+
+            // Test that the empty digest file is created and contains an empty length.
+            if file_metadata.is_file() && file_metadata.len() == 0 {
+                return Ok(());
+            }
+        }
+        // Unreachable.
+    }
+
+    wait_for_empty_content_file(&content_path, digest, || async move {
+        tokio::task::yield_now().await;
+        Ok(())
+    })
+    .await?;
+
+    Ok(())
+}
+
+/// Regression test for: https://github.com/TraceMachina/nativelink/issues/495.
+#[serial]
+#[nativelink_test(flavor = "multi_thread")]
+async fn update_file_future_drops_before_rename() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+
+    // Mutex can be used to signal to the rename function to pause execution.
+    static RENAME_REQUEST_PAUSE_MUX: async_lock::Mutex<()> = async_lock::Mutex::new(());
+    // Boolean used to know if the rename function is currently paused.
+    static RENAME_IS_PAUSED: AtomicBool = AtomicBool::new(false);
+
+    let content_path = make_temp_path("content_path");
+    let store = Arc::pin(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: make_temp_path("temp_path"),
+                eviction_policy: None,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| {
+                // If someone locked our mutex, it means we need to pause, so we
+                // simply request a lock on the same mutex.
+                if RENAME_REQUEST_PAUSE_MUX.try_lock().is_none() {
+                    RENAME_IS_PAUSED.store(true, Ordering::Release);
+                    while RENAME_REQUEST_PAUSE_MUX.try_lock().is_none() {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    RENAME_IS_PAUSED.store(false, Ordering::Release);
+                }
+                std::fs::rename(from, to)
+            },
+        )
+        .await?,
+    );
+
+    // Populate our first store entry.
+    let first_file_entry = {
+        store.update_oneshot(digest, VALUE1.into()).await?;
+        store.get_file_entry_for_digest(&digest).await?
+    };
+
+    // 1. Request the next rename function to block.
+    // 2. Request to replace our data.
+    // 3. When we are certain that our rename function is paused, drop
+    //    the replace/update future.
+    // 4. Then drop the lock.
+    {
+        let rename_pause_request_lock = RENAME_REQUEST_PAUSE_MUX.lock().await;
+        let mut update_fut = store.update_oneshot(digest, VALUE2.into()).boxed();
+
+        loop {
+            // Try to advance our update future.
+            assert_eq!(poll!(&mut update_fut), Poll::Pending);
+
+            // Once we are sure the rename fuction is paused break.
+            if RENAME_IS_PAUSED.load(Ordering::Acquire) {
+                break;
+            }
+            // Give a little time for background/kernel threads to run.
+            sleep(Duration::from_millis(1)).await;
+        }
+        // Writing these out explicitly so users know this is what we are testing.
+        // Note: The order they are dropped matters.
+        drop(update_fut);
+        drop(rename_pause_request_lock);
+    }
+    // Grab the newly inserted item in our store.
+    let new_file_entry = store.get_file_entry_for_digest(&digest).await?;
+    assert!(
+        !Arc::ptr_eq(&first_file_entry, &new_file_entry),
+        "Expected file entries to not be the same"
+    );
+
+    // Ensure the entry we inserted was properly flagged as moved (from temp -> content dir).
+    new_file_entry
+        .get_file_path_locked(move |file_path| async move {
+            assert_eq!(
+                file_path,
+                OsString::from(format!(
+                    "{}/{}-{}",
+                    content_path,
+                    digest.hash_str(),
+                    digest.size_bytes
+                ))
+            );
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn deleted_file_removed_from_store() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                read_buffer_size: 1,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    store.update_oneshot(digest, VALUE1.into()).await?;
+
+    let stored_file_path = OsString::from(format!(
+        "{}/{}-{}",
+        content_path,
+        digest.hash_str(),
+        digest.size_bytes
+    ));
+    std::fs::remove_file(stored_file_path)?;
+
+    let digest_result = store
+        .has(digest)
+        .await
+        .err_tip(|| "Failed to execute has")?;
+    assert!(digest_result.is_none());
+
+    Ok(())
+}
+
+// Ensure that get_file_size() returns the correct number
+// ceil(content length / block_size) * block_size
+// assume block size 4K
+// 1B data size = 4K size on disk
+// 5K data size = 8K size on disk
+#[serial]
+#[nativelink_test]
+async fn get_file_size_uses_block_size() -> Result<(), Error> {
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let value_1kb: String = "x".repeat(1024);
+    let value_5kb: String = "xabcd".repeat(1024);
+
+    let digest_1kb = DigestInfo::try_new(HASH1, value_1kb.len())?;
+    let digest_5kb = DigestInfo::try_new(HASH2, value_5kb.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                read_buffer_size: 1,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    store.update_oneshot(digest_1kb, value_1kb.into()).await?;
+    let short_entry = store.get_file_entry_for_digest(&digest_1kb).await?;
+    assert_eq!(short_entry.size_on_disk(), 4 * 1024);
+
+    store.update_oneshot(digest_5kb, value_5kb.into()).await?;
+    let long_entry = store.get_file_entry_for_digest(&digest_5kb).await?;
+    assert_eq!(long_entry.size_on_disk(), 8 * 1024);
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn update_with_whole_file_closes_file() -> Result<(), Error> {
+    let mut permits = vec![];
+    // Grab all permits to ensure only 1 permit is available.
+    {
+        wait_for_no_open_files().await?;
+        while fs::OPEN_FILE_SEMAPHORE.available_permits() > 1 {
+            permits.push(fs::get_permit().await);
+        }
+        assert_eq!(
+            fs::OPEN_FILE_SEMAPHORE.available_permits(),
+            1,
+            "Expected 1 permit to be available"
+        );
+    }
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let value = "x".repeat(1024);
+
+    let digest = DigestInfo::try_new(HASH1, value.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+            content_path: content_path.clone(),
+            temp_path: temp_path.clone(),
+            read_buffer_size: 1,
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest, value.clone().into()).await?;
+
+    let mut file = fs::create_file(OsString::from(format!("{temp_path}/dummy_file"))).await?;
+    {
+        let writer = file.as_writer().await?;
+        writer.write_all(value.as_bytes()).await?;
+        writer.as_mut().sync_all().await?;
+        writer.seek(tokio::io::SeekFrom::Start(0)).await?;
+    }
+
+    store
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .await?;
+    Ok(())
+}
+
+#[serial]
+#[nativelink_test]
+async fn update_with_whole_file_slow_path_when_low_file_descriptors() -> Result<(), Error> {
+    let mut permits = vec![];
+    // Grab all permits to ensure only 1 permit is available.
+    {
+        wait_for_no_open_files().await?;
+        while fs::OPEN_FILE_SEMAPHORE.available_permits() > 1 {
+            permits.push(fs::get_permit().await);
+        }
+        assert_eq!(
+            fs::OPEN_FILE_SEMAPHORE.available_permits(),
+            1,
+            "Expected 1 permit to be available"
+        );
+    }
+
+    let value = "x".repeat(1024);
+
+    let digest = DigestInfo::try_new(HASH1, value.len())?;
+
+    let store = FastSlowStore::new(
+        // Note: The config is not needed for this test, so use dummy data.
+        &nativelink_config::stores::FastSlowStore {
+            fast: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            slow: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        Store::new(
+            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+                content_path: make_temp_path("content_path"),
+                temp_path: make_temp_path("temp_path"),
+                read_buffer_size: 1,
+                ..Default::default()
             })
             .await?,
-        );
-        store.update_oneshot(digest, value.clone().into()).await?;
-
-        let mut file = fs::create_file(OsString::from(format!("{temp_path}/dummy_file"))).await?;
-        {
-            let writer = file.as_writer().await?;
-            writer.write_all(value.as_bytes()).await?;
-            writer.as_mut().sync_all().await?;
-            writer.seek(tokio::io::SeekFrom::Start(0)).await?;
-        }
-
-        store
-            .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
-            .await?;
-        Ok(())
-    }
-
-    #[serial]
-    #[nativelink_test]
-    async fn update_with_whole_file_slow_path_when_low_file_descriptors() -> Result<(), Error> {
-        let mut permits = vec![];
-        // Grab all permits to ensure only 1 permit is available.
-        {
-            wait_for_no_open_files().await?;
-            while fs::OPEN_FILE_SEMAPHORE.available_permits() > 1 {
-                permits.push(fs::get_permit().await);
-            }
-            assert_eq!(
-                fs::OPEN_FILE_SEMAPHORE.available_permits(),
-                1,
-                "Expected 1 permit to be available"
-            );
-        }
-
-        let value = "x".repeat(1024);
-
-        let digest = DigestInfo::try_new(HASH1, value.len())?;
-
-        let store = FastSlowStore::new(
-            // Note: The config is not needed for this test, so use dummy data.
-            &nativelink_config::stores::FastSlowStore {
-                fast: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                slow: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            Store::new(
-                FilesystemStore::<FileEntryImpl>::new(
-                    &nativelink_config::stores::FilesystemStore {
-                        content_path: make_temp_path("content_path"),
-                        temp_path: make_temp_path("temp_path"),
-                        read_buffer_size: 1,
-                        ..Default::default()
-                    },
-                )
-                .await?,
-            ),
-            Store::new(
-                FilesystemStore::<FileEntryImpl>::new(
-                    &nativelink_config::stores::FilesystemStore {
-                        content_path: make_temp_path("content_path1"),
-                        temp_path: make_temp_path("temp_path1"),
-                        read_buffer_size: 1,
-                        ..Default::default()
-                    },
-                )
-                .await?,
-            ),
-        );
-        store.update_oneshot(digest, value.clone().into()).await?;
-
-        let temp_path = make_temp_path("temp_path2");
-        fs::create_dir_all(&temp_path).await?;
-        let mut file = fs::create_file(OsString::from(format!("{temp_path}/dummy_file"))).await?;
-        {
-            let writer = file.as_writer().await?;
-            writer.write_all(value.as_bytes()).await?;
-            writer.as_mut().sync_all().await?;
-            writer.seek(tokio::io::SeekFrom::Start(0)).await?;
-        }
-
-        store
-            .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
-            .await?;
-        Ok(())
-    }
-
-    // Ensure that update_with_whole_file() moves the file without making a copy.
-    #[cfg(target_family = "unix")]
-    #[serial]
-    #[nativelink_test]
-    async fn update_with_whole_file_uses_same_inode() -> Result<(), Error> {
-        use std::os::unix::fs::MetadataExt;
-        let content_path = make_temp_path("content_path");
-        let temp_path = make_temp_path("temp_path");
-
-        let value: String = "x".repeat(1024);
-
-        let digest = DigestInfo::try_new(HASH1, value.len())?;
-
-        let store = Box::pin(
-            FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
-                &nativelink_config::stores::FilesystemStore {
-                    content_path: content_path.clone(),
-                    temp_path: temp_path.clone(),
-                    read_buffer_size: 1,
-                    ..Default::default()
-                },
-                |_| sleep(Duration::ZERO),
-                |from, to| std::fs::rename(from, to),
-            )
+        ),
+        Store::new(
+            FilesystemStore::<FileEntryImpl>::new(&nativelink_config::stores::FilesystemStore {
+                content_path: make_temp_path("content_path1"),
+                temp_path: make_temp_path("temp_path1"),
+                read_buffer_size: 1,
+                ..Default::default()
+            })
             .await?,
-        );
+        ),
+    );
+    store.update_oneshot(digest, value.clone().into()).await?;
 
-        let mut file =
-            fs::create_file(OsString::from(format!("{}/{}", temp_path, "dummy_file"))).await?;
-        let original_inode = file
-            .as_reader()
-            .await?
-            .get_ref()
-            .as_ref()
-            .metadata()
-            .await?
-            .ino();
-
-        let result = store
-            .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
-            .await?;
-        assert!(
-            result.is_none(),
-            "Expected filesystem store to consume the file"
-        );
-
-        let expected_file_name = OsString::from(format!(
-            "{}/{}-{}",
-            content_path,
-            digest.hash_str(),
-            digest.size_bytes
-        ));
-        let new_inode = fs::create_file(expected_file_name)
-            .await?
-            .as_reader()
-            .await?
-            .get_ref()
-            .as_ref()
-            .metadata()
-            .await?
-            .ino();
-        assert_eq!(
-            original_inode, new_inode,
-            "Expected the same inode for the file"
-        );
-
-        Ok(())
+    let temp_path = make_temp_path("temp_path2");
+    fs::create_dir_all(&temp_path).await?;
+    let mut file = fs::create_file(OsString::from(format!("{temp_path}/dummy_file"))).await?;
+    {
+        let writer = file.as_writer().await?;
+        writer.write_all(value.as_bytes()).await?;
+        writer.as_mut().sync_all().await?;
+        writer.seek(tokio::io::SeekFrom::Start(0)).await?;
     }
+
+    store
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .await?;
+    Ok(())
+}
+
+// Ensure that update_with_whole_file() moves the file without making a copy.
+#[cfg(target_family = "unix")]
+#[serial]
+#[nativelink_test]
+async fn update_with_whole_file_uses_same_inode() -> Result<(), Error> {
+    use std::os::unix::fs::MetadataExt;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let value: String = "x".repeat(1024);
+
+    let digest = DigestInfo::try_new(HASH1, value.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new_with_timeout_and_rename_fn(
+            &nativelink_config::stores::FilesystemStore {
+                content_path: content_path.clone(),
+                temp_path: temp_path.clone(),
+                read_buffer_size: 1,
+                ..Default::default()
+            },
+            |_| sleep(Duration::ZERO),
+            |from, to| std::fs::rename(from, to),
+        )
+        .await?,
+    );
+
+    let mut file =
+        fs::create_file(OsString::from(format!("{}/{}", temp_path, "dummy_file"))).await?;
+    let original_inode = file
+        .as_reader()
+        .await?
+        .get_ref()
+        .as_ref()
+        .metadata()
+        .await?
+        .ino();
+
+    let result = store
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .await?;
+    assert!(
+        result.is_none(),
+        "Expected filesystem store to consume the file"
+    );
+
+    let expected_file_name = OsString::from(format!(
+        "{}/{}-{}",
+        content_path,
+        digest.hash_str(),
+        digest.size_bytes
+    ));
+    let new_inode = fs::create_file(expected_file_name)
+        .await?
+        .as_reader()
+        .await?
+        .get_ref()
+        .as_ref()
+        .metadata()
+        .await?
+        .ino();
+    assert_eq!(
+        original_inode, new_inode,
+        "Expected the same inode for the file"
+    );
+
+    Ok(())
 }

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -24,6 +24,7 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::spawn;
 use nativelink_util::store_trait::StoreLike;
+use pretty_assertions::assert_eq;
 use sha2::{Digest, Sha256};
 
 const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
@@ -34,264 +35,257 @@ const TOO_LONG_HASH: &str = "0123456789abcdef00000000000000000001000000000000012
 const TOO_SHORT_HASH: &str = "100000000000000000000000000000000000000000000000000000000000001";
 const INVALID_HASH: &str = "g111111111111111111111111111111111111111111111111111111111111111";
 
-#[cfg(test)]
-mod memory_store_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn insert_one_item_then_update() -> Result<(), Error> {
+    const VALUE1: &str = "13";
+    const VALUE2: &str = "23";
+    let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
 
-    use super::*; // Must be declared in every module.
+    // Insert dummy value into store.
+    store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+            VALUE1.into(),
+        )
+        .await?;
+    assert_eq!(
+        store
+            .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?)
+            .await,
+        Ok(Some(VALUE1.len())),
+        "Expected memory store to have hash: {}",
+        VALID_HASH1
+    );
 
-    #[nativelink_test]
-    async fn insert_one_item_then_update() -> Result<(), Error> {
-        const VALUE1: &str = "13";
-        const VALUE2: &str = "23";
-        let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-
-        // Insert dummy value into store.
+    let store_data = {
+        // Now change value we just inserted.
         store
             .update_oneshot(
-                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                VALUE1.into(),
+                DigestInfo::try_new(VALID_HASH1, VALUE2.len())?,
+                VALUE2.into(),
             )
             .await?;
-        assert_eq!(
+        store
+            .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE2.len())?, 0, None)
+            .await?
+    };
+
+    assert_eq!(
+        store_data,
+        VALUE2.as_bytes(),
+        "Hash for key: {} did not update. Expected: {:#x?}, but got: {:#x?}",
+        VALID_HASH1,
+        VALUE2,
+        store_data
+    );
+    Ok(())
+}
+
+// Regression test for: https://github.com/TraceMachina/nativelink/issues/289.
+#[nativelink_test]
+async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
+    // Arbitrary value, this may be increased if we find out that this is
+    // too low for some kernels/operating systems.
+    const MAXIMUM_MEMORY_USAGE_INCREASE_PERC: f64 = 1.3; // 30% increase.
+
+    let mut sum_memory_usage_increase_perc: f64 = 0.0;
+    const MAX_STATS_ITERATIONS: usize = 100;
+    for _ in 0..MAX_STATS_ITERATIONS {
+        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+        let store = Pin::new(&store_owned);
+
+        let initial_virtual_mem = memory_stats()
+            .err_tip(|| "Failed to read memory.")?
+            .physical_mem;
+        for (i, hash) in [VALID_HASH1, VALID_HASH2, VALID_HASH3, VALID_HASH4]
+            .into_iter()
+            .enumerate()
+        {
+            // User a variety of sizes increasing up to 10MB each iteration.
+            // We do this to reduce the chance of memory page size masking the potential bug.
+            let reserved_size = 10_usize.pow(u32::try_from(i).expect("Cast failed") + 4);
+            let mut mut_data = BytesMut::with_capacity(reserved_size);
+            mut_data.put_bytes(u8::try_from(i).expect("Cast failed"), 1);
+            let data = mut_data.freeze();
+
+            let digest = DigestInfo::try_new(hash, data.len())?;
             store
-                .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?)
-                .await,
-            Ok(Some(VALUE1.len())),
-            "Expected memory store to have hash: {}",
-            VALID_HASH1
-        );
-
-        let store_data = {
-            // Now change value we just inserted.
-            store
-                .update_oneshot(
-                    DigestInfo::try_new(VALID_HASH1, VALUE2.len())?,
-                    VALUE2.into(),
-                )
-                .await?;
-            store
-                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE2.len())?, 0, None)
-                .await?
-        };
-
-        assert_eq!(
-            store_data,
-            VALUE2.as_bytes(),
-            "Hash for key: {} did not update. Expected: {:#x?}, but got: {:#x?}",
-            VALID_HASH1,
-            VALUE2,
-            store_data
-        );
-        Ok(())
-    }
-
-    // Regression test for: https://github.com/TraceMachina/nativelink/issues/289.
-    #[nativelink_test]
-    async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
-        // Arbitrary value, this may be increased if we find out that this is
-        // too low for some kernels/operating systems.
-        const MAXIMUM_MEMORY_USAGE_INCREASE_PERC: f64 = 1.3; // 30% increase.
-
-        let mut sum_memory_usage_increase_perc: f64 = 0.0;
-        const MAX_STATS_ITERATIONS: usize = 100;
-        for _ in 0..MAX_STATS_ITERATIONS {
-            let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-            let store = Pin::new(&store_owned);
-
-            let initial_virtual_mem = memory_stats()
-                .err_tip(|| "Failed to read memory.")?
-                .physical_mem;
-            for (i, hash) in [VALID_HASH1, VALID_HASH2, VALID_HASH3, VALID_HASH4]
-                .into_iter()
-                .enumerate()
-            {
-                // User a variety of sizes increasing up to 10MB each iteration.
-                // We do this to reduce the chance of memory page size masking the potential bug.
-                let reserved_size = 10_usize.pow(u32::try_from(i).expect("Cast failed") + 4);
-                let mut mut_data = BytesMut::with_capacity(reserved_size);
-                mut_data.put_bytes(u8::try_from(i).expect("Cast failed"), 1);
-                let data = mut_data.freeze();
-
-                let digest = DigestInfo::try_new(hash, data.len())?;
-                store
-                    .update_oneshot(digest, data)
-                    .await
-                    .err_tip(|| "Could not update store")?;
-            }
-
-            let new_virtual_mem = memory_stats()
-                .err_tip(|| "Failed to read memory.")?
-                .physical_mem;
-            sum_memory_usage_increase_perc += new_virtual_mem as f64 / initial_virtual_mem as f64;
+                .update_oneshot(digest, data)
+                .await
+                .err_tip(|| "Could not update store")?;
         }
-        assert!(
+
+        let new_virtual_mem = memory_stats()
+            .err_tip(|| "Failed to read memory.")?
+            .physical_mem;
+        sum_memory_usage_increase_perc += new_virtual_mem as f64 / initial_virtual_mem as f64;
+    }
+    assert!(
             (sum_memory_usage_increase_perc / MAX_STATS_ITERATIONS as f64) < MAXIMUM_MEMORY_USAGE_INCREASE_PERC,
             "Memory usage increased by {sum_memory_usage_increase_perc} perc, which is more than {MAXIMUM_MEMORY_USAGE_INCREASE_PERC} perc",
         );
-        Ok(())
-    }
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_partial() -> Result<(), Error> {
-        const VALUE1: &str = "1234";
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-        let store = Pin::new(&store_owned);
+#[nativelink_test]
+async fn read_partial() -> Result<(), Error> {
+    const VALUE1: &str = "1234";
+    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = Pin::new(&store_owned);
 
-        let digest = DigestInfo::try_new(VALID_HASH1, 4).unwrap();
-        store.update_oneshot(digest, VALUE1.into()).await?;
+    let digest = DigestInfo::try_new(VALID_HASH1, 4).unwrap();
+    store.update_oneshot(digest, VALUE1.into()).await?;
 
-        let store_data = store.get_part_unchunked(digest, 1, Some(2)).await?;
+    let store_data = store.get_part_unchunked(digest, 1, Some(2)).await?;
 
-        assert_eq!(
-            VALUE1[1..3].as_bytes(),
-            store_data,
-            "Expected partial data to match, expected '{:#x?}' got: {:#x?}'",
-            VALUE1[1..3].as_bytes(),
-            store_data,
-        );
-        Ok(())
-    }
+    assert_eq!(
+        VALUE1[1..3].as_bytes(),
+        store_data,
+        "Expected partial data to match, expected '{:#x?}' got: {:#x?}'",
+        VALUE1[1..3].as_bytes(),
+        store_data,
+    );
+    Ok(())
+}
 
-    // A bug was found where reading an empty value from memory store would result in an error
-    // due to internal EOF handling. This is an edge case test.
-    #[nativelink_test]
-    async fn read_zero_size_item_test() -> Result<(), Error> {
-        const VALUE: &str = "";
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-        let store = Pin::new(&store_owned);
+// A bug was found where reading an empty value from memory store would result in an error
+// due to internal EOF handling. This is an edge case test.
+#[nativelink_test]
+async fn read_zero_size_item_test() -> Result<(), Error> {
+    const VALUE: &str = "";
+    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = Pin::new(&store_owned);
 
-        // Insert dummy value into store.
+    // Insert dummy value into store.
+    store
+        .update_oneshot(DigestInfo::try_new(VALID_HASH1, VALUE.len())?, VALUE.into())
+        .await?;
+    assert_eq!(
         store
-            .update_oneshot(DigestInfo::try_new(VALID_HASH1, VALUE.len())?, VALUE.into())
-            .await?;
-        assert_eq!(
-            store
-                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE.len())?, 0, None,)
-                .await,
-            Ok("".into()),
-            "Expected memory store to have empty value"
-        );
-        Ok(())
-    }
+            .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE.len())?, 0, None,)
+            .await,
+        Ok("".into()),
+        "Expected memory store to have empty value"
+    );
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn errors_with_invalid_inputs() -> Result<(), Error> {
-        const VALUE1: &str = "123";
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-        let store = Pin::new(&store_owned);
-        {
-            // .has() tests.
-            async fn has_should_fail(store: Pin<&MemoryStore>, hash: &str, expected_size: usize) {
-                let digest = DigestInfo::try_new(hash, expected_size);
-                assert!(
-                    digest.is_err() || store.has(digest.unwrap()).await.is_err(),
-                    ".has() should have failed: {hash} {expected_size}",
-                );
-            }
-            has_should_fail(store, TOO_LONG_HASH, VALUE1.len()).await;
-            has_should_fail(store, TOO_SHORT_HASH, VALUE1.len()).await;
-            has_should_fail(store, INVALID_HASH, VALUE1.len()).await;
+#[nativelink_test]
+async fn errors_with_invalid_inputs() -> Result<(), Error> {
+    const VALUE1: &str = "123";
+    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = Pin::new(&store_owned);
+    {
+        // .has() tests.
+        async fn has_should_fail(store: Pin<&MemoryStore>, hash: &str, expected_size: usize) {
+            let digest = DigestInfo::try_new(hash, expected_size);
+            assert!(
+                digest.is_err() || store.has(digest.unwrap()).await.is_err(),
+                ".has() should have failed: {hash} {expected_size}",
+            );
         }
-        {
-            // .update() tests.
-            async fn update_should_fail<'a>(
-                store: Pin<&'a MemoryStore>,
-                hash: &'a str,
-                expected_size: usize,
-                value: &'static str,
-            ) {
-                let digest = DigestInfo::try_new(hash, expected_size);
-                assert!(
-                    digest.is_err()
-                        || store
-                            .update_oneshot(digest.unwrap(), value.into(),)
-                            .await
-                            .is_err(),
-                    ".has() should have failed: {hash} {expected_size} {value}",
-                );
-            }
-            update_should_fail(store, TOO_LONG_HASH, VALUE1.len(), VALUE1).await;
-            update_should_fail(store, TOO_SHORT_HASH, VALUE1.len(), VALUE1).await;
-            update_should_fail(store, INVALID_HASH, VALUE1.len(), VALUE1).await;
-        }
-        {
-            // .update() tests.
-            async fn get_should_fail<'a>(
-                store: Pin<&'a MemoryStore>,
-                hash: &'a str,
-                expected_size: usize,
-            ) {
-                let digest = DigestInfo::try_new(hash, expected_size);
-                assert!(
-                    digest.is_err()
-                        || store
-                            .get_part_unchunked(digest.unwrap(), 0, None)
-                            .await
-                            .is_err(),
-                    ".get() should have failed: {hash} {expected_size}",
-                );
-            }
-
-            get_should_fail(store, TOO_LONG_HASH, 1).await;
-            get_should_fail(store, TOO_SHORT_HASH, 1).await;
-            get_should_fail(store, INVALID_HASH, 1).await;
-            // With an empty store .get() should fail too.
-            get_should_fail(store, VALID_HASH1, 1).await;
-        }
-        Ok(())
+        has_should_fail(store, TOO_LONG_HASH, VALUE1.len()).await;
+        has_should_fail(store, TOO_SHORT_HASH, VALUE1.len()).await;
+        has_should_fail(store, INVALID_HASH, VALUE1.len()).await;
     }
-
-    #[nativelink_test]
-    async fn get_part_is_zero_digest() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-
-        let store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let store_clone = store.clone();
-        let (mut writer, mut reader) = make_buf_channel_pair();
-
-        let _drop_guard = spawn!("get_part_is_zero_digest", async move {
-            let _ = Pin::new(store_clone.as_ref())
-                .get_part(digest, &mut writer, 0, None)
-                .await
-                .err_tip(|| "Failed to get_part");
-        });
-
-        let file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading bytes")?;
-
-        let empty_bytes = Bytes::new();
-        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
-
-        Ok(())
+    {
+        // .update() tests.
+        async fn update_should_fail<'a>(
+            store: Pin<&'a MemoryStore>,
+            hash: &'a str,
+            expected_size: usize,
+            value: &'static str,
+        ) {
+            let digest = DigestInfo::try_new(hash, expected_size);
+            assert!(
+                digest.is_err()
+                    || store
+                        .update_oneshot(digest.unwrap(), value.into(),)
+                        .await
+                        .is_err(),
+                ".has() should have failed: {hash} {expected_size} {value}",
+            );
+        }
+        update_should_fail(store, TOO_LONG_HASH, VALUE1.len(), VALUE1).await;
+        update_should_fail(store, TOO_SHORT_HASH, VALUE1.len(), VALUE1).await;
+        update_should_fail(store, INVALID_HASH, VALUE1.len(), VALUE1).await;
     }
+    {
+        // .update() tests.
+        async fn get_should_fail<'a>(
+            store: Pin<&'a MemoryStore>,
+            hash: &'a str,
+            expected_size: usize,
+        ) {
+            let digest = DigestInfo::try_new(hash, expected_size);
+            assert!(
+                digest.is_err()
+                    || store
+                        .get_part_unchunked(digest.unwrap(), 0, None)
+                        .await
+                        .is_err(),
+                ".get() should have failed: {hash} {expected_size}",
+            );
+        }
 
-    #[nativelink_test]
-    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-        let keys = vec![digest.into()];
-        let mut results = vec![None];
+        get_should_fail(store, TOO_LONG_HASH, 1).await;
+        get_should_fail(store, TOO_SHORT_HASH, 1).await;
+        get_should_fail(store, INVALID_HASH, 1).await;
+        // With an empty store .get() should fail too.
+        get_should_fail(store, VALID_HASH1, 1).await;
+    }
+    Ok(())
+}
 
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-        let store = Pin::new(&store_owned);
+#[nativelink_test]
+async fn get_part_is_zero_digest() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
 
-        let _ = store
-            .as_ref()
-            .has_with_results(&keys, &mut results)
+    let store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let store_clone = store.clone();
+    let (mut writer, mut reader) = make_buf_channel_pair();
+
+    let _drop_guard = spawn!("get_part_is_zero_digest", async move {
+        let _ = Pin::new(store_clone.as_ref())
+            .get_part(digest, &mut writer, 0, None)
             .await
             .err_tip(|| "Failed to get_part");
-        assert_eq!(results, vec!(Some(0)));
+    });
 
-        Ok(())
-    }
+    let file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading bytes")?;
+
+    let empty_bytes = Bytes::new();
+    assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+    let keys = vec![digest.into()];
+    let mut results = vec![None];
+
+    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = Pin::new(&store_owned);
+
+    let _ = store
+        .as_ref()
+        .has_with_results(&keys, &mut results)
+        .await
+        .err_tip(|| "Failed to get_part");
+    assert_eq!(results, vec!(Some(0)));
+
+    Ok(())
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -20,6 +20,7 @@ use nativelink_store::redis_store::{LazyConnection, RedisStore};
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
+use pretty_assertions::assert_eq;
 use redis::{Pipeline, RedisError};
 use redis_test::{MockCmd, MockRedisConnection};
 
@@ -36,257 +37,252 @@ fn mock_uuid_generator() -> String {
         .to_string()
 }
 
-#[cfg(test)]
-mod redis_store_tests {
-    use super::*;
+struct MockRedisConnectionBuilder {
+    mock_cmds: Vec<MockCmd>,
+}
 
-    struct MockRedisConnectionBuilder {
-        mock_cmds: Vec<MockCmd>,
+impl MockRedisConnectionBuilder {
+    fn new() -> Self {
+        MockRedisConnectionBuilder { mock_cmds: vec![] }
     }
 
-    impl MockRedisConnectionBuilder {
-        fn new() -> Self {
-            MockRedisConnectionBuilder { mock_cmds: vec![] }
-        }
-
-        fn pipe(mut self, inputs: &[(&Command, &[&Arg], RedisResult)]) -> Self {
-            let mut pipe = Pipeline::new();
-            pipe.atomic();
-            let mut res_vec = vec![];
-            for (cmd, args, result) in inputs {
-                let mut command = redis::cmd(cmd);
-                for arg in args.iter() {
-                    command.arg(arg);
-                }
-                for res in result.as_ref().unwrap().iter() {
-                    res_vec.push(res.clone());
-                }
-                pipe.add_command(command);
+    fn pipe(mut self, inputs: &[(&Command, &[&Arg], RedisResult)]) -> Self {
+        let mut pipe = Pipeline::new();
+        pipe.atomic();
+        let mut res_vec = vec![];
+        for (cmd, args, result) in inputs {
+            let mut command = redis::cmd(cmd);
+            for arg in args.iter() {
+                command.arg(arg);
             }
-            self.mock_cmds.push(MockCmd::with_values(pipe, Ok(res_vec)));
-            self
-        }
-
-        fn cmd(mut self, cmd: &Command, args: &[&Arg], result: Result<&str, RedisError>) -> Self {
-            let mut cmd = redis::cmd(cmd);
-            for arg in args {
-                cmd.arg(arg);
+            for res in result.as_ref().unwrap().iter() {
+                res_vec.push(res.clone());
             }
-            self.mock_cmds.push(MockCmd::new(cmd, result));
-            self
+            pipe.add_command(command);
         }
+        self.mock_cmds.push(MockCmd::with_values(pipe, Ok(res_vec)));
+        self
+    }
 
-        fn build(self) -> MockRedisConnection {
-            MockRedisConnection::new(self.mock_cmds)
+    fn cmd(mut self, cmd: &Command, args: &[&Arg], result: Result<&str, RedisError>) -> Self {
+        let mut cmd = redis::cmd(cmd);
+        for arg in args {
+            cmd.arg(arg);
         }
+        self.mock_cmds.push(MockCmd::new(cmd, result));
+        self
     }
 
-    #[nativelink_test]
-    async fn upload_and_get_data() -> Result<(), Error> {
-        let data = Bytes::from_static(b"14");
-
-        let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
-        let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
-
-        let chunk_data = "14";
-
-        let redis_connection = MockRedisConnectionBuilder::new()
-            .pipe(&[("APPEND", &[TEMP_UUID, chunk_data], Ok(&[redis::Value::Nil]))])
-            .cmd("APPEND", &[&packed_hash_hex, ""], Ok(""))
-            .pipe(&[(
-                "RENAME",
-                &[TEMP_UUID, &packed_hash_hex],
-                Ok(&[redis::Value::Nil]),
-            )])
-            .pipe(&[(
-                "STRLEN",
-                &[&packed_hash_hex],
-                Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
-            )])
-            .cmd("GETRANGE", &[&packed_hash_hex, "0", "1"], Ok("14"))
-            .build();
-
-        let store = RedisStore::new_with_conn_and_name_generator(
-            LazyConnection::Connection(Ok(redis_connection)),
-            mock_uuid_generator,
-        );
-
-        store.update_oneshot(digest, data.clone()).await?;
-
-        let result = store.has(digest).await?;
-        assert!(
-            result.is_some(),
-            "Expected redis store to have hash: {VALID_HASH1}",
-        );
-
-        let result = store
-            .get_part_unchunked(digest, 0, Some(data.clone().len()))
-            .await?;
-
-        assert_eq!(result, data, "Expected redis store to have updated value",);
-
-        Ok(())
+    fn build(self) -> MockRedisConnection {
+        MockRedisConnection::new(self.mock_cmds)
     }
+}
 
-    #[nativelink_test]
-    async fn upload_empty_data() -> Result<(), Error> {
-        let data = Bytes::from_static(b"");
+#[nativelink_test]
+async fn upload_and_get_data() -> Result<(), Error> {
+    let data = Bytes::from_static(b"14");
 
-        let digest = ZERO_BYTE_DIGESTS[0];
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
 
-        let redis_connection = MockRedisConnectionBuilder::new().build();
+    let chunk_data = "14";
 
-        let store = RedisStore::new_with_conn_and_name_generator(
-            LazyConnection::Connection(Ok(redis_connection)),
-            mock_uuid_generator,
-        );
+    let redis_connection = MockRedisConnectionBuilder::new()
+        .pipe(&[("APPEND", &[TEMP_UUID, chunk_data], Ok(&[redis::Value::Nil]))])
+        .cmd("APPEND", &[&packed_hash_hex, ""], Ok(""))
+        .pipe(&[(
+            "RENAME",
+            &[TEMP_UUID, &packed_hash_hex],
+            Ok(&[redis::Value::Nil]),
+        )])
+        .pipe(&[(
+            "STRLEN",
+            &[&packed_hash_hex],
+            Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
+        )])
+        .cmd("GETRANGE", &[&packed_hash_hex, "0", "1"], Ok("14"))
+        .build();
 
-        store.update_oneshot(digest, data).await?;
+    let store = RedisStore::new_with_conn_and_name_generator(
+        LazyConnection::Connection(Ok(redis_connection)),
+        mock_uuid_generator,
+    );
 
-        let result = store.has(digest).await?;
-        assert!(
-            result.is_some(),
-            "Expected redis store to have hash: {VALID_HASH1}",
-        );
+    store.update_oneshot(digest, data.clone()).await?;
 
-        Ok(())
-    }
+    let result = store.has(digest).await?;
+    assert!(
+        result.is_some(),
+        "Expected redis store to have hash: {VALID_HASH1}",
+    );
 
-    #[nativelink_test]
-    async fn test_uploading_large_data() -> Result<(), Error> {
-        // Requires multiple chunks as data is larger than 64K
-        let data: Bytes = Bytes::from(vec![0u8; 65 * 1024]);
+    let result = store
+        .get_part_unchunked(digest, 0, Some(data.clone().len()))
+        .await?;
 
-        let digest = DigestInfo::try_new(VALID_HASH1, 1)?;
-        let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+    assert_eq!(result, data, "Expected redis store to have updated value",);
 
-        let chunk_data = std::str::from_utf8(&data).unwrap().to_string();
+    Ok(())
+}
 
-        let redis_connection = MockRedisConnectionBuilder::new()
-            .pipe(&[(
+#[nativelink_test]
+async fn upload_empty_data() -> Result<(), Error> {
+    let data = Bytes::from_static(b"");
+
+    let digest = ZERO_BYTE_DIGESTS[0];
+
+    let redis_connection = MockRedisConnectionBuilder::new().build();
+
+    let store = RedisStore::new_with_conn_and_name_generator(
+        LazyConnection::Connection(Ok(redis_connection)),
+        mock_uuid_generator,
+    );
+
+    store.update_oneshot(digest, data).await?;
+
+    let result = store.has(digest).await?;
+    assert!(
+        result.is_some(),
+        "Expected redis store to have hash: {VALID_HASH1}",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_uploading_large_data() -> Result<(), Error> {
+    // Requires multiple chunks as data is larger than 64K
+    let data: Bytes = Bytes::from(vec![0u8; 65 * 1024]);
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 1)?;
+    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+
+    let chunk_data = std::str::from_utf8(&data).unwrap().to_string();
+
+    let redis_connection = MockRedisConnectionBuilder::new()
+        .pipe(&[(
+            "APPEND",
+            &[TEMP_UUID, &chunk_data],
+            Ok(&[redis::Value::Nil]),
+        )])
+        .cmd(
+            "APPEND",
+            &[&packed_hash_hex, ""],
+            Ok(&hex::encode(&data[..])),
+        )
+        .pipe(&[(
+            "RENAME",
+            &[TEMP_UUID, &packed_hash_hex],
+            Ok(&[redis::Value::Nil]),
+        )])
+        .pipe(&[(
+            "STRLEN",
+            &[&packed_hash_hex],
+            Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
+        )])
+        .cmd(
+            "GETRANGE",
+            &[&packed_hash_hex, "0", "65535"],
+            Ok(&hex::encode(&data[..])),
+        )
+        .cmd(
+            "GETRANGE",
+            &[&packed_hash_hex, "65535", "65560"],
+            Ok(&hex::encode(&data[..])),
+        )
+        .build();
+
+    let store = RedisStore::new_with_conn_and_name_generator(
+        LazyConnection::Connection(Ok(redis_connection)),
+        mock_uuid_generator,
+    );
+
+    store.update_oneshot(digest, data.clone()).await?;
+
+    let result = store.has(digest).await?;
+    assert!(
+        result.is_some(),
+        "Expected redis store to have hash: {VALID_HASH1}",
+    );
+
+    let get_result: Bytes = store
+        .get_part_unchunked(digest, 0, Some(data.clone().len()))
+        .await?;
+
+    assert_eq!(
+        hex::encode(get_result).len(),
+        hex::encode(data.clone()).len(),
+        "Expected redis store to have updated value",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
+    let data = Bytes::from(vec![0u8; 10 * 1024]);
+    let data_p1 = Bytes::from(vec![0u8; 6 * 1024]);
+    let data_p2 = Bytes::from(vec![0u8; 4 * 1024]);
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+
+    let redis_connection = MockRedisConnectionBuilder::new()
+        .pipe(&[
+            (
                 "APPEND",
-                &[TEMP_UUID, &chunk_data],
+                &[TEMP_UUID, std::str::from_utf8(&data_p1).unwrap()],
                 Ok(&[redis::Value::Nil]),
-            )])
-            .cmd(
+            ),
+            (
                 "APPEND",
-                &[&packed_hash_hex, ""],
-                Ok(&hex::encode(&data[..])),
-            )
-            .pipe(&[(
-                "RENAME",
-                &[TEMP_UUID, &packed_hash_hex],
+                &[TEMP_UUID, std::str::from_utf8(&data_p2).unwrap()],
                 Ok(&[redis::Value::Nil]),
-            )])
-            .pipe(&[(
-                "STRLEN",
-                &[&packed_hash_hex],
-                Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
-            )])
-            .cmd(
-                "GETRANGE",
-                &[&packed_hash_hex, "0", "65535"],
-                Ok(&hex::encode(&data[..])),
-            )
-            .cmd(
-                "GETRANGE",
-                &[&packed_hash_hex, "65535", "65560"],
-                Ok(&hex::encode(&data[..])),
-            )
-            .build();
+            ),
+        ])
+        .cmd("APPEND", &[&packed_hash_hex, ""], Ok(""))
+        .pipe(&[(
+            "RENAME",
+            &[TEMP_UUID, &packed_hash_hex],
+            Ok(&[redis::Value::Nil]),
+        )])
+        .pipe(&[(
+            "STRLEN",
+            &[&packed_hash_hex],
+            Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
+        )])
+        .cmd(
+            "GETRANGE",
+            &[&packed_hash_hex, "0", "10239"],
+            Ok(std::str::from_utf8(&data).unwrap()),
+        )
+        .build();
 
-        let store = RedisStore::new_with_conn_and_name_generator(
-            LazyConnection::Connection(Ok(redis_connection)),
-            mock_uuid_generator,
-        );
+    let store = RedisStore::new_with_conn_and_name_generator(
+        LazyConnection::Connection(Ok(redis_connection)),
+        mock_uuid_generator,
+    );
 
-        store.update_oneshot(digest, data.clone()).await?;
+    let (mut tx, rx) = make_buf_channel_pair();
+    tx.send(data_p1).await?;
+    tokio::task::yield_now().await;
+    tx.send(data_p2).await?;
+    tx.send_eof()?;
+    store
+        .update(digest, rx, UploadSizeInfo::ExactSize(data.len()))
+        .await?;
 
-        let result = store.has(digest).await?;
-        assert!(
-            result.is_some(),
-            "Expected redis store to have hash: {VALID_HASH1}",
-        );
+    let result = store.has(digest).await?;
+    assert!(
+        result.is_some(),
+        "Expected redis store to have hash: {VALID_HASH1}",
+    );
 
-        let get_result: Bytes = store
-            .get_part_unchunked(digest, 0, Some(data.clone().len()))
-            .await?;
+    let result = store
+        .get_part_unchunked(digest, 0, Some(data.clone().len()))
+        .await?;
 
-        assert_eq!(
-            hex::encode(get_result).len(),
-            hex::encode(data.clone()).len(),
-            "Expected redis store to have updated value",
-        );
+    assert_eq!(result, data, "Expected redis store to have updated value",);
 
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
-        let data = Bytes::from(vec![0u8; 10 * 1024]);
-        let data_p1 = Bytes::from(vec![0u8; 6 * 1024]);
-        let data_p2 = Bytes::from(vec![0u8; 4 * 1024]);
-
-        let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
-        let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
-
-        let redis_connection = MockRedisConnectionBuilder::new()
-            .pipe(&[
-                (
-                    "APPEND",
-                    &[TEMP_UUID, std::str::from_utf8(&data_p1).unwrap()],
-                    Ok(&[redis::Value::Nil]),
-                ),
-                (
-                    "APPEND",
-                    &[TEMP_UUID, std::str::from_utf8(&data_p2).unwrap()],
-                    Ok(&[redis::Value::Nil]),
-                ),
-            ])
-            .cmd("APPEND", &[&packed_hash_hex, ""], Ok(""))
-            .pipe(&[(
-                "RENAME",
-                &[TEMP_UUID, &packed_hash_hex],
-                Ok(&[redis::Value::Nil]),
-            )])
-            .pipe(&[(
-                "STRLEN",
-                &[&packed_hash_hex],
-                Ok(&[redis::Value::Bulk(vec![redis::Value::Int(2)])]),
-            )])
-            .cmd(
-                "GETRANGE",
-                &[&packed_hash_hex, "0", "10239"],
-                Ok(std::str::from_utf8(&data).unwrap()),
-            )
-            .build();
-
-        let store = RedisStore::new_with_conn_and_name_generator(
-            LazyConnection::Connection(Ok(redis_connection)),
-            mock_uuid_generator,
-        );
-
-        let (mut tx, rx) = make_buf_channel_pair();
-        tx.send(data_p1).await?;
-        tokio::task::yield_now().await;
-        tx.send(data_p2).await?;
-        tx.send_eof()?;
-        store
-            .update(digest, rx, UploadSizeInfo::ExactSize(data.len()))
-            .await?;
-
-        let result = store.has(digest).await?;
-        assert!(
-            result.is_some(),
-            "Expected redis store to have hash: {VALID_HASH1}",
-        );
-
-        let result = store
-            .get_part_unchunked(digest, 0, Some(data.clone().len()))
-            .await?;
-
-        assert_eq!(result, data, "Expected redis store to have updated value",);
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -21,154 +21,148 @@ use nativelink_store::ref_store::RefStore;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{Store, StoreDriver, StoreLike};
+use pretty_assertions::assert_eq;
 
-#[cfg(test)]
-mod ref_store_tests {
-    use pretty_assertions::assert_eq; // Must be declared in every module.
+const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-    use super::*;
+fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
+    let store_manager = Arc::new(StoreManager::new());
 
-    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+    let memory_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    store_manager.add_store("foo", memory_store.clone());
 
-    fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
-        let store_manager = Arc::new(StoreManager::new());
+    let ref_store = Store::new(Arc::new(RefStore::new(
+        &nativelink_config::stores::RefStore {
+            name: "foo".to_string(),
+        },
+        Arc::downgrade(&store_manager),
+    )));
+    store_manager.add_store("bar", ref_store.clone());
+    (store_manager, memory_store, ref_store)
+}
 
-        let memory_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        store_manager.add_store("foo", memory_store.clone());
+#[nativelink_test]
+async fn has_test() -> Result<(), Error> {
+    let (_store_manager, memory_store, ref_store) = setup_stores();
 
-        let ref_store = Store::new(Arc::new(RefStore::new(
-            &nativelink_config::stores::RefStore {
-                name: "foo".to_string(),
-            },
-            Arc::downgrade(&store_manager),
-        )));
-        store_manager.add_store("bar", ref_store.clone());
-        (store_manager, memory_store, ref_store)
+    const VALUE1: &str = "13";
+    {
+        // Insert data into memory store.
+        memory_store
+            .update_oneshot(
+                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+                VALUE1.into(),
+            )
+            .await?;
     }
-
-    #[nativelink_test]
-    async fn has_test() -> Result<(), Error> {
-        let (_store_manager, memory_store, ref_store) = setup_stores();
-
-        const VALUE1: &str = "13";
-        {
-            // Insert data into memory store.
-            memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                    VALUE1.into(),
-                )
-                .await?;
-        }
-        {
-            // Now check if we check of ref_store has the data.
-            let has_result = ref_store
-                .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?)
-                .await;
-            assert_eq!(
-                has_result,
-                Ok(Some(VALUE1.len())),
-                "Expected ref store to have data in ref store : {}",
-                VALID_HASH1
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn get_test() -> Result<(), Error> {
-        let (_store_manager, memory_store, ref_store) = setup_stores();
-
-        const VALUE1: &str = "13";
-        {
-            // Insert data into memory store.
-            memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                    VALUE1.into(),
-                )
-                .await?;
-        }
-        {
-            // Now check if we read it from ref_store it has same data.
-            let data = ref_store
-                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                VALUE1.as_bytes(),
-                "Expected ref store to have data in ref store : {}",
-                VALID_HASH1
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn update_test() -> Result<(), Error> {
-        let (_store_manager, memory_store, ref_store) = setup_stores();
-
-        const VALUE1: &str = "13";
-        {
-            // Insert data into ref_store.
-            ref_store
-                .update_oneshot(
-                    DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                    VALUE1.into(),
-                )
-                .await?;
-        }
-        {
-            // Now check if we read it from memory_store it has same data.
-            let data = memory_store
-                .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                VALUE1.as_bytes(),
-                "Expected ref store to have data in memory store : {}",
-                VALID_HASH1
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn inner_store_test() -> Result<(), Error> {
-        let store_manager = Arc::new(StoreManager::new());
-
-        let memory_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        store_manager.add_store("mem_store", memory_store.clone());
-
-        let ref_store_inner = Store::new(Arc::new(RefStore::new(
-            &nativelink_config::stores::RefStore {
-                name: "mem_store".to_string(),
-            },
-            Arc::downgrade(&store_manager),
-        )));
-        store_manager.add_store("ref_store_inner", ref_store_inner.clone());
-
-        let ref_store_outer = Store::new(Arc::new(RefStore::new(
-            &nativelink_config::stores::RefStore {
-                name: "ref_store_inner".to_string(),
-            },
-            Arc::downgrade(&store_manager),
-        )));
-        store_manager.add_store("ref_store_outer", ref_store_outer.clone());
-
-        // Ensure the result of inner_store() points to exact same memory store.
+    {
+        // Now check if we check of ref_store has the data.
+        let has_result = ref_store
+            .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?)
+            .await;
         assert_eq!(
-            ref_store_outer.inner_store(Option::<DigestInfo>::None) as *const dyn StoreDriver
-                as *const (),
-            memory_store.into_inner().as_ref() as *const dyn StoreDriver as *const (),
-            "Expected inner store to be memory store"
+            has_result,
+            Ok(Some(VALUE1.len())),
+            "Expected ref store to have data in ref store : {}",
+            VALID_HASH1
         );
-        Ok(())
     }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_test() -> Result<(), Error> {
+    let (_store_manager, memory_store, ref_store) = setup_stores();
+
+    const VALUE1: &str = "13";
+    {
+        // Insert data into memory store.
+        memory_store
+            .update_oneshot(
+                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+                VALUE1.into(),
+            )
+            .await?;
+    }
+    {
+        // Now check if we read it from ref_store it has same data.
+        let data = ref_store
+            .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            VALUE1.as_bytes(),
+            "Expected ref store to have data in ref store : {}",
+            VALID_HASH1
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_test() -> Result<(), Error> {
+    let (_store_manager, memory_store, ref_store) = setup_stores();
+
+    const VALUE1: &str = "13";
+    {
+        // Insert data into ref_store.
+        ref_store
+            .update_oneshot(
+                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+                VALUE1.into(),
+            )
+            .await?;
+    }
+    {
+        // Now check if we read it from memory_store it has same data.
+        let data = memory_store
+            .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            VALUE1.as_bytes(),
+            "Expected ref store to have data in memory store : {}",
+            VALID_HASH1
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn inner_store_test() -> Result<(), Error> {
+    let store_manager = Arc::new(StoreManager::new());
+
+    let memory_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    store_manager.add_store("mem_store", memory_store.clone());
+
+    let ref_store_inner = Store::new(Arc::new(RefStore::new(
+        &nativelink_config::stores::RefStore {
+            name: "mem_store".to_string(),
+        },
+        Arc::downgrade(&store_manager),
+    )));
+    store_manager.add_store("ref_store_inner", ref_store_inner.clone());
+
+    let ref_store_outer = Store::new(Arc::new(RefStore::new(
+        &nativelink_config::stores::RefStore {
+            name: "ref_store_inner".to_string(),
+        },
+        Arc::downgrade(&store_manager),
+    )));
+    store_manager.add_store("ref_store_outer", ref_store_outer.clone());
+
+    // Ensure the result of inner_store() points to exact same memory store.
+    assert_eq!(
+        ref_store_outer.inner_store(Option::<DigestInfo>::None) as *const dyn StoreDriver
+            as *const (),
+        memory_store.into_inner().as_ref() as *const dyn StoreDriver as *const (),
+        "Expected inner store to be memory store"
+    );
+    Ok(())
 }

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -32,291 +32,286 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::spawn;
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
+use pretty_assertions::assert_eq;
 use sha2::{Digest, Sha256};
 
 // TODO(aaronmondal): Figure out how to test the connector retry mechanism.
 
-#[cfg(test)]
-mod s3_store_tests {
-    use pretty_assertions::assert_eq;
+const BUCKET_NAME: &str = "dummy-bucket-name";
+const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const REGION: &str = "testregion";
 
-    use super::*; // Must be declared in every module.
+#[nativelink_test]
+async fn simple_has_object_found() -> Result<(), Error> {
+    let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .header(header::CONTENT_LENGTH, "512")
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
 
-    const BUCKET_NAME: &str = "dummy-bucket-name";
-    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const REGION: &str = "testregion";
+    let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
+    let result = store.has(digest).await;
+    assert_eq!(
+        result,
+        Ok(Some(512)),
+        "Expected to find item, got: {result:?}"
+    );
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn simple_has_object_found() -> Result<(), Error> {
-        let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+#[nativelink_test]
+async fn simple_has_object_not_found() -> Result<(), Error> {
+    let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+    let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
+    let result = store.has(digest).await;
+    assert_eq!(
+        result,
+        Ok(None),
+        "Expected to not find item, got: {result:?}"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn simple_has_retries() -> Result<(), Error> {
+    let mock_client = StaticReplayClient::new(vec![
+        ReplayEvent::new(
             http::Request::builder().body(SdkBody::empty()).unwrap(),
             http::Response::builder()
-                .header(header::CONTENT_LENGTH, "512")
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(SdkBody::empty())
                 .unwrap(),
-        )]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-
-        let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
-        let result = store.has(digest).await;
-        assert_eq!(
-            result,
-            Ok(Some(512)),
-            "Expected to find item, got: {result:?}"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn simple_has_object_not_found() -> Result<(), Error> {
-        let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        ),
+        ReplayEvent::new(
             http::Request::builder().body(SdkBody::empty()).unwrap(),
             http::Response::builder()
-                .status(StatusCode::NOT_FOUND)
+                .status(StatusCode::SERVICE_UNAVAILABLE)
                 .body(SdkBody::empty())
                 .unwrap(),
-        )]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-        let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
-        let result = store.has(digest).await;
-        assert_eq!(
-            result,
-            Ok(None),
-            "Expected to not find item, got: {result:?}"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn simple_has_retries() -> Result<(), Error> {
-        let mock_client = StaticReplayClient::new(vec![
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::SERVICE_UNAVAILABLE)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::CONFLICT)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_LENGTH, "111")
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-        ]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                retry: nativelink_config::stores::Retry {
-                    max_retries: 1024,
-                    delay: 0.,
-                    jitter: 0.,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-
-        let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
-        let result = store.has(digest).await;
-        assert_eq!(
-            result,
-            Ok(Some(111)),
-            "Expected to find item, got: {:?}",
-            result
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn simple_update_ac() -> Result<(), Error> {
-        const AC_ENTRY_SIZE: u64 = 199;
-        const CONTENT_LENGTH: usize = 50;
-        let mut send_data = BytesMut::new();
-        for i in 0..CONTENT_LENGTH {
-            send_data.put_u8(((i % 93) + 33) as u8); // Printable characters only.
-        }
-        let send_data = send_data.freeze();
-
-        let (mock_client, request_receiver) =
-            aws_smithy_runtime::client::http::test_util::capture_request(Some(
-                aws_smithy_runtime_api::http::Response::new(
-                    StatusCode::OK.into(),
-                    SdkBody::empty(), // This is an upload, so server does not send a body.
-                )
-                .try_into_http02x()
+        ),
+        ReplayEvent::new(
+            http::Request::builder().body(SdkBody::empty()).unwrap(),
+            http::Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(SdkBody::empty())
                 .unwrap(),
-            ));
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-        let (mut tx, rx) = make_buf_channel_pair();
-        // Make future responsible for processing the datastream
-        // and forwarding it to the s3 backend/server.
-        let mut update_fut = Box::pin(async move {
-            store
-                .update(
-                    DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
-                    rx,
-                    UploadSizeInfo::ExactSize(CONTENT_LENGTH),
-                )
-                .await
-        });
-
-        // Extract out the body stream sent by the s3 store.
-        let body_stream = {
-            // We need to poll here to get the request sent, but future
-            // wont be done until we send all the data (which we do later).
-            assert_eq!(Poll::Pending, futures::poll!(&mut update_fut));
-            let sent_request = request_receiver.expect_request();
-            assert_eq!(sent_request.method(), "PUT");
-            assert_eq!(sent_request.uri(), format!("https://{BUCKET_NAME}.s3.{REGION}.amazonaws.com/{VALID_HASH1}-{AC_ENTRY_SIZE}?x-id=PutObject"));
-            ByteStream::from_body_0_4(sent_request.into_body())
-        };
-
-        let send_data_copy = send_data.clone();
-        // Create spawn that is responsible for sending the stream of data
-        // to the S3Store and processing/forwarding to the S3 backend.
-        let spawn_fut = spawn!("simple_update_ac", async move {
-            tokio::try_join!(update_fut, async move {
-                for i in 0..CONTENT_LENGTH {
-                    tx.send(send_data_copy.slice(i..(i + 1))).await?;
-                }
-                tx.send_eof()
-            })
-            .or_else(|e| {
-                // Printing error to make it easier to debug, since ordering
-                // of futures is not guaranteed.
-                eprintln!("Error updating or sending in spawn: {e:?}");
-                Err(e)
-            })
-        });
-
-        // Wait for all the data to be received by the s3 backend server.
-        let data_sent_to_s3 = body_stream
-            .collect()
-            .await
-            .map_err(|e| make_input_err!("{e:?}"))?;
-        assert_eq!(
-            send_data,
-            data_sent_to_s3.into_bytes(),
-            "Expected data to match"
-        );
-
-        // Collect our spawn future to ensure it completes without error.
-        spawn_fut
-            .await
-            .err_tip(|| "Failed to launch spawn")?
-            .err_tip(|| "In spawn")?;
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn simple_get_ac() -> Result<(), Error> {
-        const VALUE: &str = "23";
-        const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not VALUE.len().
-
-        let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        ),
+        ReplayEvent::new(
             http::Request::builder().body(SdkBody::empty()).unwrap(),
             http::Response::builder()
                 .status(StatusCode::OK)
-                .body(SdkBody::from(VALUE))
+                .header(header::CONTENT_LENGTH, "111")
+                .body(SdkBody::empty())
                 .unwrap(),
-        )]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
+        ),
+    ]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            retry: nativelink_config::stores::Retry {
+                max_retries: 1024,
+                delay: 0.,
+                jitter: 0.,
                 ..Default::default()
             },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
 
-        let store_data = store
-            .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?, 0, None)
-            .await?;
-        assert_eq!(
+    let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
+    let result = store.has(digest).await;
+    assert_eq!(
+        result,
+        Ok(Some(111)),
+        "Expected to find item, got: {:?}",
+        result
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn simple_update_ac() -> Result<(), Error> {
+    const AC_ENTRY_SIZE: u64 = 199;
+    const CONTENT_LENGTH: usize = 50;
+    let mut send_data = BytesMut::new();
+    for i in 0..CONTENT_LENGTH {
+        send_data.put_u8(((i % 93) + 33) as u8); // Printable characters only.
+    }
+    let send_data = send_data.freeze();
+
+    let (mock_client, request_receiver) =
+        aws_smithy_runtime::client::http::test_util::capture_request(Some(
+            aws_smithy_runtime_api::http::Response::new(
+                StatusCode::OK.into(),
+                SdkBody::empty(), // This is an upload, so server does not send a body.
+            )
+            .try_into_http02x()
+            .unwrap(),
+        ));
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+    let (mut tx, rx) = make_buf_channel_pair();
+    // Make future responsible for processing the datastream
+    // and forwarding it to the s3 backend/server.
+    let mut update_fut = Box::pin(async move {
+        store
+            .update(
+                DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
+                rx,
+                UploadSizeInfo::ExactSize(CONTENT_LENGTH),
+            )
+            .await
+    });
+
+    // Extract out the body stream sent by the s3 store.
+    let body_stream = {
+        // We need to poll here to get the request sent, but future
+        // wont be done until we send all the data (which we do later).
+        assert_eq!(Poll::Pending, futures::poll!(&mut update_fut));
+        let sent_request = request_receiver.expect_request();
+        assert_eq!(sent_request.method(), "PUT");
+        assert_eq!(sent_request.uri(), format!("https://{BUCKET_NAME}.s3.{REGION}.amazonaws.com/{VALID_HASH1}-{AC_ENTRY_SIZE}?x-id=PutObject"));
+        ByteStream::from_body_0_4(sent_request.into_body())
+    };
+
+    let send_data_copy = send_data.clone();
+    // Create spawn that is responsible for sending the stream of data
+    // to the S3Store and processing/forwarding to the S3 backend.
+    let spawn_fut = spawn!("simple_update_ac", async move {
+        tokio::try_join!(update_fut, async move {
+            for i in 0..CONTENT_LENGTH {
+                tx.send(send_data_copy.slice(i..(i + 1))).await?;
+            }
+            tx.send_eof()
+        })
+        .or_else(|e| {
+            // Printing error to make it easier to debug, since ordering
+            // of futures is not guaranteed.
+            eprintln!("Error updating or sending in spawn: {e:?}");
+            Err(e)
+        })
+    });
+
+    // Wait for all the data to be received by the s3 backend server.
+    let data_sent_to_s3 = body_stream
+        .collect()
+        .await
+        .map_err(|e| make_input_err!("{e:?}"))?;
+    assert_eq!(
+        send_data,
+        data_sent_to_s3.into_bytes(),
+        "Expected data to match"
+    );
+
+    // Collect our spawn future to ensure it completes without error.
+    spawn_fut
+        .await
+        .err_tip(|| "Failed to launch spawn")?
+        .err_tip(|| "In spawn")?;
+    Ok(())
+}
+
+#[nativelink_test]
+async fn simple_get_ac() -> Result<(), Error> {
+    const VALUE: &str = "23";
+    const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not VALUE.len().
+
+    let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .body(SdkBody::from(VALUE))
+            .unwrap(),
+    )]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+
+    let store_data = store
+        .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?, 0, None)
+        .await?;
+    assert_eq!(
             store_data,
             VALUE.as_bytes(),
             "Hash for key: {VALID_HASH1} did not insert. Expected: {VALUE:#x?}, but got: {store_data:#x?}",
         );
-        Ok(())
-    }
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn smoke_test_get_part() -> Result<(), Error> {
-        const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not raw_send_data.len().
-        const OFFSET: usize = 105;
-        const LENGTH: usize = 50_000; // Just a size that is not the same as the real data size.
-        let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+#[nativelink_test]
+async fn smoke_test_get_part() -> Result<(), Error> {
+    const AC_ENTRY_SIZE: u64 = 1000; // Any size that is not raw_send_data.len().
+    const OFFSET: usize = 105;
+    const LENGTH: usize = 50_000; // Just a size that is not the same as the real data size.
+    let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
             http::Request::builder()
                 .uri(format!(
                     "https://{BUCKET_NAME}.s3.{REGION}.amazonaws.com/{VALID_HASH1}-{AC_ENTRY_SIZE}?x-id=GetObject",
@@ -329,106 +324,106 @@ mod s3_store_tests {
                 .body(SdkBody::empty())
                 .unwrap(),
         )]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client.clone())
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client.clone())
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+
+    store
+        .get_part_unchunked(
+            DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
+            OFFSET,
+            Some(LENGTH),
+        )
+        .await?;
+
+    mock_client.assert_requests_match(&[]);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_part_simple_retries() -> Result<(), Error> {
+    let mock_client = StaticReplayClient::new(vec![
+        ReplayEvent::new(
+            http::Request::builder().body(SdkBody::empty()).unwrap(),
+            http::Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(SdkBody::empty())
+                .unwrap(),
+        ),
+        ReplayEvent::new(
+            http::Request::builder().body(SdkBody::empty()).unwrap(),
+            http::Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .body(SdkBody::empty())
+                .unwrap(),
+        ),
+        ReplayEvent::new(
+            http::Request::builder().body(SdkBody::empty()).unwrap(),
+            http::Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(SdkBody::empty())
+                .unwrap(),
+        ),
+        ReplayEvent::new(
+            http::Request::builder().body(SdkBody::empty()).unwrap(),
+            http::Response::builder()
+                .status(StatusCode::OK)
+                .body(SdkBody::empty())
+                .unwrap(),
+        ),
+    ]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            retry: nativelink_config::stores::Retry {
+                max_retries: 1024,
+                delay: 0.,
+                jitter: 0.,
                 ..Default::default()
             },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
 
-        store
-            .get_part_unchunked(
-                DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
-                OFFSET,
-                Some(LENGTH),
-            )
-            .await?;
+    let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
+    let result = store.get_part_unchunked(digest, 0, None).await;
+    assert!(result.is_ok(), "Expected to find item, got: {result:?}");
+    Ok(())
+}
 
-        mock_client.assert_requests_match(&[]);
-        Ok(())
+#[nativelink_test]
+async fn multipart_update_large_cas() -> Result<(), Error> {
+    // Same as in s3_store.
+    const MIN_MULTIPART_SIZE: usize = 5 * 1024 * 1024; // 5mb.
+    const AC_ENTRY_SIZE: usize = MIN_MULTIPART_SIZE * 2 + 50;
+
+    let mut send_data = Vec::with_capacity(AC_ENTRY_SIZE);
+    for i in 0..send_data.capacity() {
+        send_data.push(((i * 3) % 256) as u8);
     }
+    let digest = DigestInfo::try_new(VALID_HASH1, send_data.len())?;
 
-    #[nativelink_test]
-    async fn get_part_simple_retries() -> Result<(), Error> {
-        let mock_client = StaticReplayClient::new(vec![
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::SERVICE_UNAVAILABLE)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::CONFLICT)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-            ReplayEvent::new(
-                http::Request::builder().body(SdkBody::empty()).unwrap(),
-                http::Response::builder()
-                    .status(StatusCode::OK)
-                    .body(SdkBody::empty())
-                    .unwrap(),
-            ),
-        ]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                retry: nativelink_config::stores::Retry {
-                    max_retries: 1024,
-                    delay: 0.,
-                    jitter: 0.,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-
-        let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
-        let result = store.get_part_unchunked(digest, 0, None).await;
-        assert!(result.is_ok(), "Expected to find item, got: {result:?}");
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn multipart_update_large_cas() -> Result<(), Error> {
-        // Same as in s3_store.
-        const MIN_MULTIPART_SIZE: usize = 5 * 1024 * 1024; // 5mb.
-        const AC_ENTRY_SIZE: usize = MIN_MULTIPART_SIZE * 2 + 50;
-
-        let mut send_data = Vec::with_capacity(AC_ENTRY_SIZE);
-        for i in 0..send_data.capacity() {
-            send_data.push(((i * 3) % 256) as u8);
-        }
-        let digest = DigestInfo::try_new(VALID_HASH1, send_data.len())?;
-
-        let mock_client = StaticReplayClient::new(vec![
+    let mock_client = StaticReplayClient::new(vec![
             ReplayEvent::new(
                 http::Request::builder()
                     .uri(format!(
@@ -516,30 +511,30 @@ mod s3_store_tests {
                     .unwrap(),
             ),
         ]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client.clone())
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-        let _ = store.update_oneshot(digest, send_data.clone().into()).await;
-        mock_client.assert_requests_match(&[]);
-        Ok(())
-    }
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client.clone())
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+    let _ = store.update_oneshot(digest, send_data.clone().into()).await;
+    mock_client.assert_requests_match(&[]);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
-        const CAS_ENTRY_SIZE: usize = 10; // Length of "helloworld".
-        let (mut tx, channel_body) = Body::channel();
-        let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
+#[nativelink_test]
+async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
+    const CAS_ENTRY_SIZE: usize = 10; // Length of "helloworld".
+    let (mut tx, channel_body) = Body::channel();
+    let mock_client = StaticReplayClient::new(vec![ReplayEvent::new(
             http::Request::builder()
                 .uri(format!(
                     "https://{BUCKET_NAME}.s3.{REGION}.amazonaws.com/{VALID_HASH1}-{CAS_ENTRY_SIZE}?x-id=GetObject",
@@ -552,116 +547,115 @@ mod s3_store_tests {
                 .body(SdkBody::from_body_0_4(channel_body))
                 .unwrap(),
         )]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client.clone())
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client.clone())
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
 
-        let (_, get_part_result) = join!(
-            async move {
-                tx.send_data(Bytes::from_static(b"hello")).await?;
-                tx.send_data(Bytes::from_static(b"")).await?;
-                tx.send_data(Bytes::from_static(b"world")).await?;
-                Result::<(), hyper::Error>::Ok(())
-            },
-            store.get_part_unchunked(
-                DigestInfo::try_new(VALID_HASH1, CAS_ENTRY_SIZE)?,
-                0,
-                Some(CAS_ENTRY_SIZE),
-            )
-        );
-        assert_eq!(
-            get_part_result.err_tip(|| "Expected get_part_result to pass")?,
-            "helloworld".as_bytes()
-        );
+    let (_, get_part_result) = join!(
+        async move {
+            tx.send_data(Bytes::from_static(b"hello")).await?;
+            tx.send_data(Bytes::from_static(b"")).await?;
+            tx.send_data(Bytes::from_static(b"world")).await?;
+            Result::<(), hyper::Error>::Ok(())
+        },
+        store.get_part_unchunked(
+            DigestInfo::try_new(VALID_HASH1, CAS_ENTRY_SIZE)?,
+            0,
+            Some(CAS_ENTRY_SIZE),
+        )
+    );
+    assert_eq!(
+        get_part_result.err_tip(|| "Expected get_part_result to pass")?,
+        "helloworld".as_bytes()
+    );
 
-        mock_client.assert_requests_match(&[]);
-        Ok(())
-    }
+    mock_client.assert_requests_match(&[]);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn get_part_is_zero_digest() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
+#[nativelink_test]
+async fn get_part_is_zero_digest() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
 
-        let mock_client = StaticReplayClient::new(vec![]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = Arc::new(S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?);
-        let store_clone = store.clone();
-        let (mut writer, mut reader) = make_buf_channel_pair();
+    let mock_client = StaticReplayClient::new(vec![]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = Arc::new(S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?);
+    let store_clone = store.clone();
+    let (mut writer, mut reader) = make_buf_channel_pair();
 
-        let _drop_guard = spawn!("get_part_is_zero_digest", async move {
-            let _ = store_clone
-                .get_part(digest, &mut writer, 0, None)
-                .await
-                .err_tip(|| "Failed to get_part");
-        });
-
-        let file_data = reader
-            .consume(Some(1024))
-            .await
-            .err_tip(|| "Error reading bytes")?;
-
-        let empty_bytes = Bytes::new();
-        assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn has_with_results_on_zero_digests() -> Result<(), Error> {
-        let digest = DigestInfo {
-            packed_hash: Sha256::new().finalize().into(),
-            size_bytes: 0,
-        };
-        let keys = vec![digest.into()];
-        let mut results = vec![None];
-
-        let mock_client = StaticReplayClient::new(vec![]);
-        let test_config = Builder::new()
-            .behavior_version(BehaviorVersion::v2024_03_28())
-            .region(Region::from_static(REGION))
-            .http_client(mock_client)
-            .build();
-        let s3_client = aws_sdk_s3::Client::from_conf(test_config);
-        let store = S3Store::new_with_client_and_jitter(
-            &nativelink_config::stores::S3Store {
-                bucket: BUCKET_NAME.to_string(),
-                ..Default::default()
-            },
-            s3_client,
-            Arc::new(move |_delay| Duration::from_secs(0)),
-        )?;
-
-        let _ = store
-            .has_with_results(&keys, &mut results)
+    let _drop_guard = spawn!("get_part_is_zero_digest", async move {
+        let _ = store_clone
+            .get_part(digest, &mut writer, 0, None)
             .await
             .err_tip(|| "Failed to get_part");
-        assert_eq!(results, vec!(Some(0)));
+    });
 
-        Ok(())
-    }
+    let file_data = reader
+        .consume(Some(1024))
+        .await
+        .err_tip(|| "Error reading bytes")?;
+
+    let empty_bytes = Bytes::new();
+    assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_with_results_on_zero_digests() -> Result<(), Error> {
+    let digest = DigestInfo {
+        packed_hash: Sha256::new().finalize().into(),
+        size_bytes: 0,
+    };
+    let keys = vec![digest.into()];
+    let mut results = vec![None];
+
+    let mock_client = StaticReplayClient::new(vec![]);
+    let test_config = Builder::new()
+        .behavior_version(BehaviorVersion::v2024_03_28())
+        .region(Region::from_static(REGION))
+        .http_client(mock_client)
+        .build();
+    let s3_client = aws_sdk_s3::Client::from_conf(test_config);
+    let store = S3Store::new_with_client_and_jitter(
+        &nativelink_config::stores::S3Store {
+            bucket: BUCKET_NAME.to_string(),
+            ..Default::default()
+        },
+        s3_client,
+        Arc::new(move |_delay| Duration::from_secs(0)),
+    )?;
+
+    let _ = store
+        .has_with_results(&keys, &mut results)
+        .await
+        .err_tip(|| "Failed to get_part");
+    assert_eq!(results, vec!(Some(0)));
+
+    Ok(())
 }

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -21,6 +21,7 @@ use nativelink_store::shard_store::ShardStore;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::store_trait::{Store, StoreLike};
+use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -94,221 +95,213 @@ async fn verify_weights(
     Ok(())
 }
 
-#[cfg(test)]
-mod shard_store_tests {
+const STORE0_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+const STORE1_HASH: &str = "00000000EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
 
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn has_with_one_digest() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-    use super::*; // Must be declared in every module.
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    stores[0]
+        .update_oneshot(digest1, original_data.clone().into())
+        .await?;
 
-    const STORE0_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
-    const STORE1_HASH: &str = "00000000EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn has_with_one_digest() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
+#[nativelink_test]
+async fn has_with_many_digests_both_missing() -> Result<(), Error> {
+    let (shard_store, _stores) = make_stores(&[1, 1]);
 
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
-        stores[0]
-            .update_oneshot(digest1, original_data.clone().into())
-            .await?;
+    let missing_digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    let missing_digest2 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
 
-        assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn has_with_many_digests_both_missing() -> Result<(), Error> {
-        let (shard_store, _stores) = make_stores(&[1, 1]);
-
-        let missing_digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
-        let missing_digest2 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-
-        assert_eq!(
-            shard_store
-                .has_many(&[missing_digest1.into(), missing_digest2.into()])
-                .await,
-            Ok(vec![None, None])
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn has_with_many_digests_one_missing() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
-
-        let original_data = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
-        let missing_digest = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-        stores[0]
-            .update_oneshot(digest1, original_data.clone().into())
-            .await?;
-
-        assert_eq!(
-            shard_store
-                .has_many(&[digest1.into(), missing_digest.into()])
-                .await,
-            Ok(vec![Some(MEGABYTE_SZ), None])
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn has_with_many_digests_both_exist() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
-
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let original_data2 = make_random_data(2 * MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
-        let digest2 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-        stores[0]
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
-        stores[1]
-            .update_oneshot(digest2, original_data2.clone().into())
-            .await?;
-
-        assert_eq!(
-            shard_store
-                .has_many(&[digest1.into(), digest2.into()])
-                .await,
-            Ok(vec![Some(original_data1.len()), Some(original_data2.len())])
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn get_part_reads_store0() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
-
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
-        stores[0]
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
-
-        assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None).await,
-            Ok(original_data1.into())
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn get_part_reads_store1() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
-
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-        stores[1]
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
-
-        assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None).await,
-            Ok(original_data1.into())
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn upload_store0() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
-
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    assert_eq!(
         shard_store
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
+            .has_many(&[missing_digest1.into(), missing_digest2.into()])
+            .await,
+        Ok(vec![None, None])
+    );
+    Ok(())
+}
 
-        assert_eq!(
-            stores[0].get_part_unchunked(digest1, 0, None).await,
-            Ok(original_data1.into())
-        );
-        Ok(())
-    }
+#[nativelink_test]
+async fn has_with_many_digests_one_missing() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-    #[nativelink_test]
-    async fn upload_store1() -> Result<(), Error> {
-        let (shard_store, stores) = make_stores(&[1, 1]);
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    let missing_digest = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    stores[0]
+        .update_oneshot(digest1, original_data.clone().into())
+        .await?;
 
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    assert_eq!(
         shard_store
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
+            .has_many(&[digest1.into(), missing_digest.into()])
+            .await,
+        Ok(vec![Some(MEGABYTE_SZ), None])
+    );
+    Ok(())
+}
 
-        assert_eq!(
-            stores[1].get_part_unchunked(digest1, 0, None).await,
-            Ok(original_data1.into())
-        );
-        Ok(())
-    }
+#[nativelink_test]
+async fn has_with_many_digests_both_exist() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-    #[nativelink_test]
-    async fn upload_download_has_check() -> Result<(), Error> {
-        let (shard_store, _stores) = make_stores(&[1, 1]);
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data2 = make_random_data(2 * MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    let digest2 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    stores[0]
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
+    stores[1]
+        .update_oneshot(digest2, original_data2.clone().into())
+        .await?;
 
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-
-        assert_eq!(shard_store.has(digest1).await, Ok(None));
+    assert_eq!(
         shard_store
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
-        assert_eq!(
-            shard_store.get_part_unchunked(digest1, 0, None).await,
-            Ok(original_data1.into())
-        );
-        assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
-        Ok(())
-    }
+            .has_many(&[digest1.into(), digest2.into()])
+            .await,
+        Ok(vec![Some(original_data1.len()), Some(original_data2.len())])
+    );
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn weights_send_to_proper_store() -> Result<(), Error> {
-        // Very low chance anything will ever go to second store due to weights being so much diff.
-        let (shard_store, stores) = make_stores(&[100000, 1]);
+#[nativelink_test]
+async fn get_part_reads_store0() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-        let original_data1 = make_random_data(MEGABYTE_SZ);
-        let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
-        shard_store
-            .update_oneshot(digest1, original_data1.clone().into())
-            .await?;
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    stores[0]
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
 
-        assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ)));
-        assert_eq!(stores[1].has(digest1).await, Ok(None));
-        Ok(())
-    }
+    assert_eq!(
+        shard_store.get_part_unchunked(digest1, 0, None).await,
+        Ok(original_data1.into())
+    );
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn verify_weights_even_weights() -> Result<(), Error> {
-        verify_weights(
-            &[1, 1, 1, 1, 1, 1],
-            &[188, 168, 158, 175, 147, 164],
-            1000,
-            false,
-        )
-        .await
-    }
+#[nativelink_test]
+async fn get_part_reads_store1() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-    #[nativelink_test]
-    async fn verify_weights_mid_right_bias() -> Result<(), Error> {
-        verify_weights(&[1, 1, 1, 100, 1, 1], &[5, 13, 12, 956, 4, 10], 1000, false).await
-    }
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    stores[1]
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
 
-    #[nativelink_test]
-    async fn verify_weights_mid_left_bias() -> Result<(), Error> {
-        verify_weights(&[1, 1, 100, 1, 1, 1], &[5, 13, 962, 6, 4, 10], 1000, false).await
-    }
+    assert_eq!(
+        shard_store.get_part_unchunked(digest1, 0, None).await,
+        Ok(original_data1.into())
+    );
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn verify_weights_left_bias() -> Result<(), Error> {
-        verify_weights(&[100, 1, 1, 1, 1, 1], &[961, 11, 8, 6, 4, 10], 1000, false).await
-    }
+#[nativelink_test]
+async fn upload_store0() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
 
-    #[nativelink_test]
-    async fn verify_weights_right_bias() -> Result<(), Error> {
-        verify_weights(&[1, 1, 1, 1, 1, 100], &[5, 13, 12, 5, 11, 954], 1000, false).await
-    }
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
+    shard_store
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
+
+    assert_eq!(
+        stores[0].get_part_unchunked(digest1, 0, None).await,
+        Ok(original_data1.into())
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn upload_store1() -> Result<(), Error> {
+    let (shard_store, stores) = make_stores(&[1, 1]);
+
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    shard_store
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
+
+    assert_eq!(
+        stores[1].get_part_unchunked(digest1, 0, None).await,
+        Ok(original_data1.into())
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn upload_download_has_check() -> Result<(), Error> {
+    let (shard_store, _stores) = make_stores(&[1, 1]);
+
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+
+    assert_eq!(shard_store.has(digest1).await, Ok(None));
+    shard_store
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
+    assert_eq!(
+        shard_store.get_part_unchunked(digest1, 0, None).await,
+        Ok(original_data1.into())
+    );
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn weights_send_to_proper_store() -> Result<(), Error> {
+    // Very low chance anything will ever go to second store due to weights being so much diff.
+    let (shard_store, stores) = make_stores(&[100000, 1]);
+
+    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
+    shard_store
+        .update_oneshot(digest1, original_data1.clone().into())
+        .await?;
+
+    assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    assert_eq!(stores[1].has(digest1).await, Ok(None));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn verify_weights_even_weights() -> Result<(), Error> {
+    verify_weights(
+        &[1, 1, 1, 1, 1, 1],
+        &[188, 168, 158, 175, 147, 164],
+        1000,
+        false,
+    )
+    .await
+}
+
+#[nativelink_test]
+async fn verify_weights_mid_right_bias() -> Result<(), Error> {
+    verify_weights(&[1, 1, 1, 100, 1, 1], &[5, 13, 12, 956, 4, 10], 1000, false).await
+}
+
+#[nativelink_test]
+async fn verify_weights_mid_left_bias() -> Result<(), Error> {
+    verify_weights(&[1, 1, 100, 1, 1, 1], &[5, 13, 962, 6, 4, 10], 1000, false).await
+}
+
+#[nativelink_test]
+async fn verify_weights_left_bias() -> Result<(), Error> {
+    verify_weights(&[100, 1, 1, 1, 1, 1], &[961, 11, 8, 6, 4, 10], 1000, false).await
+}
+
+#[nativelink_test]
+async fn verify_weights_right_bias() -> Result<(), Error> {
+    verify_weights(&[1, 1, 1, 1, 1, 100], &[5, 13, 12, 5, 11, 954], 1000, false).await
 }

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -20,193 +20,184 @@ use nativelink_store::memory_store::MemoryStore;
 use nativelink_store::size_partitioning_store::SizePartitioningStore;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{Store, StoreLike};
+use pretty_assertions::assert_eq;
 
-#[cfg(test)]
-mod ref_store_tests {
-    use pretty_assertions::assert_eq; // Must be declared in every module.
+const BASE_SIZE_PART: u64 = 5;
 
-    use super::*;
+const SMALL_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const SMALL_VALUE: &str = "99";
 
-    const BASE_SIZE_PART: u64 = 5;
+const BIG_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+const BIG_VALUE: &str = "123456789";
 
-    const SMALL_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const SMALL_VALUE: &str = "99";
+fn setup_stores(size: u64) -> (SizePartitioningStore, Arc<MemoryStore>, Arc<MemoryStore>) {
+    let lower_memory_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
+    let upper_memory_store = Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    ));
 
-    const BIG_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
-    const BIG_VALUE: &str = "123456789";
+    let size_part_store = SizePartitioningStore::new(
+        &nativelink_config::stores::SizePartitioningStore {
+            size,
+            lower_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            upper_store: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        Store::new(lower_memory_store.clone()),
+        Store::new(upper_memory_store.clone()),
+    );
+    (size_part_store, lower_memory_store, upper_memory_store)
+}
 
-    fn setup_stores(size: u64) -> (SizePartitioningStore, Arc<MemoryStore>, Arc<MemoryStore>) {
-        let lower_memory_store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
-        let upper_memory_store = Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        ));
+#[nativelink_test]
+async fn has_test() -> Result<(), Error> {
+    let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
 
-        let size_part_store = SizePartitioningStore::new(
-            &nativelink_config::stores::SizePartitioningStore {
-                size,
-                lower_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                upper_store: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            Store::new(lower_memory_store.clone()),
-            Store::new(upper_memory_store.clone()),
+    {
+        // Insert data into lower store.
+        lower_memory_store
+            .update_oneshot(
+                DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
+                SMALL_VALUE.into(),
+            )
+            .await?;
+
+        // Insert data into upper store.
+        upper_memory_store
+            .update_oneshot(
+                DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
+                BIG_VALUE.into(),
+            )
+            .await?;
+    }
+    {
+        // Check if our partition store has small data.
+        let small_has_result = size_part_store
+            .has(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?)
+            .await;
+        assert_eq!(
+            small_has_result,
+            Ok(Some(SMALL_VALUE.len())),
+            "Expected size part store to have data in ref store : {}",
+            SMALL_HASH
         );
-        (size_part_store, lower_memory_store, upper_memory_store)
     }
-
-    #[nativelink_test]
-    async fn has_test() -> Result<(), Error> {
-        let (size_part_store, lower_memory_store, upper_memory_store) =
-            setup_stores(BASE_SIZE_PART);
-
-        {
-            // Insert data into lower store.
-            lower_memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
-                    SMALL_VALUE.into(),
-                )
-                .await?;
-
-            // Insert data into upper store.
-            upper_memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
-                    BIG_VALUE.into(),
-                )
-                .await?;
-        }
-        {
-            // Check if our partition store has small data.
-            let small_has_result = size_part_store
-                .has(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?)
-                .await;
-            assert_eq!(
-                small_has_result,
-                Ok(Some(SMALL_VALUE.len())),
-                "Expected size part store to have data in ref store : {}",
-                SMALL_HASH
-            );
-        }
-        {
-            // Check if our partition store has big data.
-            let small_has_result = size_part_store
-                .has(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?)
-                .await;
-            assert_eq!(
-                small_has_result,
-                Ok(Some(BIG_VALUE.len())),
-                "Expected size part store to have data in ref store : {}",
-                BIG_HASH
-            );
-        }
-        Ok(())
+    {
+        // Check if our partition store has big data.
+        let small_has_result = size_part_store
+            .has(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?)
+            .await;
+        assert_eq!(
+            small_has_result,
+            Ok(Some(BIG_VALUE.len())),
+            "Expected size part store to have data in ref store : {}",
+            BIG_HASH
+        );
     }
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn get_test() -> Result<(), Error> {
-        let (size_part_store, lower_memory_store, upper_memory_store) =
-            setup_stores(BASE_SIZE_PART);
+#[nativelink_test]
+async fn get_test() -> Result<(), Error> {
+    let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
 
-        {
-            // Insert data into lower store.
-            lower_memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
-                    SMALL_VALUE.into(),
-                )
-                .await?;
+    {
+        // Insert data into lower store.
+        lower_memory_store
+            .update_oneshot(
+                DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
+                SMALL_VALUE.into(),
+            )
+            .await?;
 
-            // Insert data into upper store.
-            upper_memory_store
-                .update_oneshot(
-                    DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
-                    BIG_VALUE.into(),
-                )
-                .await?;
-        }
-        {
-            // Read the partition store small data.
-            let data = size_part_store
-                .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                SMALL_VALUE.as_bytes(),
-                "Expected size part store to have data in ref store : {}",
-                SMALL_HASH
-            );
-        }
-        {
-            // Read the partition store big data.
-            let data = size_part_store
-                .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                BIG_VALUE.as_bytes(),
-                "Expected size part store to have data in ref store : {}",
-                BIG_HASH
-            );
-        }
-        Ok(())
+        // Insert data into upper store.
+        upper_memory_store
+            .update_oneshot(
+                DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
+                BIG_VALUE.into(),
+            )
+            .await?;
     }
-
-    #[nativelink_test]
-    async fn update_test() -> Result<(), Error> {
-        let (size_part_store, lower_memory_store, upper_memory_store) =
-            setup_stores(BASE_SIZE_PART);
-
-        {
-            // Insert small data into ref_store.
-            size_part_store
-                .update_oneshot(
-                    DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
-                    SMALL_VALUE.into(),
-                )
-                .await?;
-
-            // Insert small data into ref_store.
-            size_part_store
-                .update_oneshot(
-                    DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
-                    BIG_VALUE.into(),
-                )
-                .await?;
-        }
-        {
-            // Check if we read small data from size_partition_store it has same data.
-            let data = lower_memory_store
-                .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                SMALL_VALUE.as_bytes(),
-                "Expected size part store to have data in memory store : {}",
-                SMALL_HASH
-            );
-        }
-        {
-            // Check if we read big data from size_partition_store it has same data.
-            let data = upper_memory_store
-                .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
-                .await
-                .expect("Get should have succeeded");
-            assert_eq!(
-                data,
-                BIG_VALUE.as_bytes(),
-                "Expected size part store to have data in memory store : {}",
-                BIG_HASH
-            );
-        }
-        Ok(())
+    {
+        // Read the partition store small data.
+        let data = size_part_store
+            .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            SMALL_VALUE.as_bytes(),
+            "Expected size part store to have data in ref store : {}",
+            SMALL_HASH
+        );
     }
+    {
+        // Read the partition store big data.
+        let data = size_part_store
+            .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            BIG_VALUE.as_bytes(),
+            "Expected size part store to have data in ref store : {}",
+            BIG_HASH
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_test() -> Result<(), Error> {
+    let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
+
+    {
+        // Insert small data into ref_store.
+        size_part_store
+            .update_oneshot(
+                DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?,
+                SMALL_VALUE.into(),
+            )
+            .await?;
+
+        // Insert small data into ref_store.
+        size_part_store
+            .update_oneshot(
+                DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
+                BIG_VALUE.into(),
+            )
+            .await?;
+    }
+    {
+        // Check if we read small data from size_partition_store it has same data.
+        let data = lower_memory_store
+            .get_part_unchunked(DigestInfo::try_new(SMALL_HASH, SMALL_VALUE.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            SMALL_VALUE.as_bytes(),
+            "Expected size part store to have data in memory store : {}",
+            SMALL_HASH
+        );
+    }
+    {
+        // Check if we read big data from size_partition_store it has same data.
+        let data = upper_memory_store
+            .get_part_unchunked(DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?, 0, None)
+            .await
+            .expect("Get should have succeeded");
+        assert_eq!(
+            data,
+            BIG_VALUE.as_bytes(),
+            "Expected size part store to have data in memory store : {}",
+            BIG_HASH
+        );
+    }
+    Ok(())
 }

--- a/nativelink-util/tests/buf_channel_test.rs
+++ b/nativelink-util/tests/buf_channel_test.rs
@@ -19,259 +19,253 @@ use futures::poll;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_util::buf_channel::make_buf_channel_pair;
+use pretty_assertions::assert_eq;
 use tokio::try_join;
 
-#[cfg(test)]
-mod buf_channel_tests {
-    use pretty_assertions::assert_eq;
+const DATA1: &str = "foo";
+const DATA2: &str = "bar";
+const DATA3: &str = "foobar1234";
 
-    use super::*; // Must be declared in every module.
+#[nativelink_test]
+async fn smoke_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    tx.send(DATA1.into()).await?;
+    tx.send(DATA2.into()).await?;
+    assert_eq!(rx.recv().await?, DATA1);
+    assert_eq!(rx.recv().await?, DATA2);
+    Ok(())
+}
 
-    const DATA1: &str = "foo";
-    const DATA2: &str = "bar";
-    const DATA3: &str = "foobar1234";
+#[nativelink_test]
+async fn bytes_written_test() -> Result<(), Error> {
+    let (mut tx, _rx) = make_buf_channel_pair();
+    tx.send(DATA1.into()).await?;
+    assert_eq!(tx.get_bytes_written(), DATA1.len() as u64);
+    tx.send(DATA2.into()).await?;
+    assert_eq!(tx.get_bytes_written(), (DATA1.len() + DATA2.len()) as u64);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn smoke_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
+#[nativelink_test]
+async fn sending_eof_sets_pipe_broken_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let tx_fut = async move {
         tx.send(DATA1.into()).await?;
-        tx.send(DATA2.into()).await?;
-        assert_eq!(rx.recv().await?, DATA1);
-        assert_eq!(rx.recv().await?, DATA2);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn bytes_written_test() -> Result<(), Error> {
-        let (mut tx, _rx) = make_buf_channel_pair();
-        tx.send(DATA1.into()).await?;
-        assert_eq!(tx.get_bytes_written(), DATA1.len() as u64);
-        tx.send(DATA2.into()).await?;
-        assert_eq!(tx.get_bytes_written(), (DATA1.len() + DATA2.len()) as u64);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn sending_eof_sets_pipe_broken_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let tx_fut = async move {
-            tx.send(DATA1.into()).await?;
-            assert_eq!(tx.is_pipe_broken(), false);
-            tx.send_eof()?;
-            assert_eq!(tx.is_pipe_broken(), true);
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            assert_eq!(rx.recv().await?, Bytes::from(DATA1));
-            assert_eq!(rx.recv().await?, Bytes::new());
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn consume_all_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let tx_fut = async move {
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send_eof()?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            assert_eq!(
-                rx.consume(None).await?,
-                Bytes::from(format!("{DATA1}{DATA2}{DATA1}{DATA2}"))
-            );
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
-
-    /// Test to ensure data is optimized so that the exact same pointer is received
-    /// when calling `collect_all_with_size_hint` when a copy is not needed.
-    #[nativelink_test]
-    async fn consume_all_is_optimized_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let sent_data = Bytes::from(DATA1);
-        let send_data_ptr = sent_data.as_ptr();
-        let tx_fut = async move {
-            tx.send(sent_data).await?;
-            tx.send_eof()?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            // Because data is 1 chunk and an EOF, we should not need to copy
-            // and should get the exact same pointer.
-            let received_data = rx.consume(None).await?;
-            assert_eq!(received_data.as_ptr(), send_data_ptr);
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn consume_some_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let tx_fut = async move {
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send_eof()?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            let all_data = Bytes::from(format!("{DATA1}{DATA2}{DATA1}{DATA2}"));
-            assert_eq!(rx.consume(Some(1)).await?, all_data.slice(0..1));
-            assert_eq!(rx.consume(Some(3)).await?, all_data.slice(1..4));
-            assert_eq!(rx.consume(Some(4)).await?, all_data.slice(4..8));
-            // Last chunk take too much data and expect EOF to be hit.
-            assert_eq!(rx.consume(Some(100)).await?, all_data.slice(8..12));
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
-
-    /// This test ensures that when we are taking just one message in the stream,
-    /// we don't need to concat the data together and instead return a view to
-    /// the original data instead of making a copy.
-    #[nativelink_test]
-    async fn consume_some_optimized_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let first_chunk = Bytes::from(DATA1);
-        let first_chunk_ptr = first_chunk.as_ptr();
-        let tx_fut = async move {
-            tx.send(first_chunk).await?;
-            tx.send_eof()?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            assert_eq!(rx.consume(Some(1)).await?.as_ptr(), first_chunk_ptr);
-            assert_eq!(rx.consume(Some(100)).await?.as_ptr(), unsafe {
-                first_chunk_ptr.add(1)
-            });
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn consume_some_reads_eof() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        tx.send(DATA1.into()).await?;
-
-        let consume_fut = rx.consume(Some(DATA1.len()));
-        tokio::pin!(consume_fut);
-        assert_eq!(
-            poll!(&mut consume_fut),
-            Poll::Pending,
-            "Consume should not have completed yet"
-        );
+        assert_eq!(tx.is_pipe_broken(), false);
         tx.send_eof()?;
-        assert_eq!(consume_fut.await?, Bytes::from(DATA1));
-        Ok(())
-    }
+        assert_eq!(tx.is_pipe_broken(), true);
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        assert_eq!(rx.recv().await?, Bytes::from(DATA1));
+        assert_eq!(rx.recv().await?, Bytes::new());
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn simple_stream_test() -> Result<(), Error> {
-        use futures::StreamExt;
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let tx_fut = async move {
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send(DATA1.into()).await?;
-            tx.send(DATA2.into()).await?;
-            tx.send_eof()?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            assert_eq!(
-                rx.next().await.map(|v| v.err_tip(|| "")),
-                Some(Ok(Bytes::from(DATA1)))
-            );
-            assert_eq!(
-                rx.next().await.map(|v| v.err_tip(|| "")),
-                Some(Ok(Bytes::from(DATA2)))
-            );
-            assert_eq!(
-                rx.next().await.map(|v| v.err_tip(|| "")),
-                Some(Ok(Bytes::from(DATA1)))
-            );
-            assert_eq!(
-                rx.next().await.map(|v| v.err_tip(|| "")),
-                Some(Ok(Bytes::from(DATA2)))
-            );
-            assert_eq!(rx.next().await.map(|v| v.err_tip(|| "")), None);
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
+#[nativelink_test]
+async fn consume_all_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let tx_fut = async move {
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send_eof()?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        assert_eq!(
+            rx.consume(None).await?,
+            Bytes::from(format!("{DATA1}{DATA2}{DATA1}{DATA2}"))
+        );
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn send_and_take_fuzz_test() -> Result<(), Error> {
-        const DATA3_END_POS: usize = DATA3.len() + 1;
-        for data_size in 1..DATA3_END_POS {
-            let data: Vec<u8> = DATA3.as_bytes()[0..data_size].to_vec();
+/// Test to ensure data is optimized so that the exact same pointer is received
+/// when calling `collect_all_with_size_hint` when a copy is not needed.
+#[nativelink_test]
+async fn consume_all_is_optimized_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let sent_data = Bytes::from(DATA1);
+    let send_data_ptr = sent_data.as_ptr();
+    let tx_fut = async move {
+        tx.send(sent_data).await?;
+        tx.send_eof()?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        // Because data is 1 chunk and an EOF, we should not need to copy
+        // and should get the exact same pointer.
+        let received_data = rx.consume(None).await?;
+        assert_eq!(received_data.as_ptr(), send_data_ptr);
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
 
-            for write_size in 1..DATA3_END_POS {
-                for read_size in 1..DATA3_END_POS {
-                    let tx_data = Bytes::from(data.clone());
-                    let expected_data = Bytes::from(data.clone());
+#[nativelink_test]
+async fn consume_some_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let tx_fut = async move {
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send_eof()?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        let all_data = Bytes::from(format!("{DATA1}{DATA2}{DATA1}{DATA2}"));
+        assert_eq!(rx.consume(Some(1)).await?, all_data.slice(0..1));
+        assert_eq!(rx.consume(Some(3)).await?, all_data.slice(1..4));
+        assert_eq!(rx.consume(Some(4)).await?, all_data.slice(4..8));
+        // Last chunk take too much data and expect EOF to be hit.
+        assert_eq!(rx.consume(Some(100)).await?, all_data.slice(8..12));
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
 
-                    let (mut tx, mut rx) = make_buf_channel_pair();
+/// This test ensures that when we are taking just one message in the stream,
+/// we don't need to concat the data together and instead return a view to
+/// the original data instead of making a copy.
+#[nativelink_test]
+async fn consume_some_optimized_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let first_chunk = Bytes::from(DATA1);
+    let first_chunk_ptr = first_chunk.as_ptr();
+    let tx_fut = async move {
+        tx.send(first_chunk).await?;
+        tx.send_eof()?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        assert_eq!(rx.consume(Some(1)).await?.as_ptr(), first_chunk_ptr);
+        assert_eq!(rx.consume(Some(100)).await?.as_ptr(), unsafe {
+            first_chunk_ptr.add(1)
+        });
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
 
-                    let tx_fut = async move {
-                        for i in (0..data_size).step_by(write_size) {
-                            tx.send(tx_data.slice(i..std::cmp::min(data_size, i + write_size)))
-                                .await?;
-                        }
-                        tx.send_eof()?;
-                        Result::<(), Error>::Ok(())
-                    };
-                    let rx_fut = async move {
-                        let mut round_trip_data = BytesMut::new();
-                        for _ in (0..data_size).step_by(read_size) {
-                            round_trip_data.extend(rx.consume(Some(read_size)).await?.iter());
-                        }
-                        assert_eq!(round_trip_data.freeze(), expected_data);
-                        rx.drain().await?;
-                        Result::<(), Error>::Ok(())
-                    };
-                    try_join!(tx_fut, rx_fut)?;
-                }
+#[nativelink_test]
+async fn consume_some_reads_eof() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    tx.send(DATA1.into()).await?;
+
+    let consume_fut = rx.consume(Some(DATA1.len()));
+    tokio::pin!(consume_fut);
+    assert_eq!(
+        poll!(&mut consume_fut),
+        Poll::Pending,
+        "Consume should not have completed yet"
+    );
+    tx.send_eof()?;
+    assert_eq!(consume_fut.await?, Bytes::from(DATA1));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn simple_stream_test() -> Result<(), Error> {
+    use futures::StreamExt;
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let tx_fut = async move {
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send(DATA1.into()).await?;
+        tx.send(DATA2.into()).await?;
+        tx.send_eof()?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        assert_eq!(
+            rx.next().await.map(|v| v.err_tip(|| "")),
+            Some(Ok(Bytes::from(DATA1)))
+        );
+        assert_eq!(
+            rx.next().await.map(|v| v.err_tip(|| "")),
+            Some(Ok(Bytes::from(DATA2)))
+        );
+        assert_eq!(
+            rx.next().await.map(|v| v.err_tip(|| "")),
+            Some(Ok(Bytes::from(DATA1)))
+        );
+        assert_eq!(
+            rx.next().await.map(|v| v.err_tip(|| "")),
+            Some(Ok(Bytes::from(DATA2)))
+        );
+        assert_eq!(rx.next().await.map(|v| v.err_tip(|| "")), None);
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
+}
+
+#[nativelink_test]
+async fn send_and_take_fuzz_test() -> Result<(), Error> {
+    const DATA3_END_POS: usize = DATA3.len() + 1;
+    for data_size in 1..DATA3_END_POS {
+        let data: Vec<u8> = DATA3.as_bytes()[0..data_size].to_vec();
+
+        for write_size in 1..DATA3_END_POS {
+            for read_size in 1..DATA3_END_POS {
+                let tx_data = Bytes::from(data.clone());
+                let expected_data = Bytes::from(data.clone());
+
+                let (mut tx, mut rx) = make_buf_channel_pair();
+
+                let tx_fut = async move {
+                    for i in (0..data_size).step_by(write_size) {
+                        tx.send(tx_data.slice(i..std::cmp::min(data_size, i + write_size)))
+                            .await?;
+                    }
+                    tx.send_eof()?;
+                    Result::<(), Error>::Ok(())
+                };
+                let rx_fut = async move {
+                    let mut round_trip_data = BytesMut::new();
+                    for _ in (0..data_size).step_by(read_size) {
+                        round_trip_data.extend(rx.consume(Some(read_size)).await?.iter());
+                    }
+                    assert_eq!(round_trip_data.freeze(), expected_data);
+                    rx.drain().await?;
+                    Result::<(), Error>::Ok(())
+                };
+                try_join!(tx_fut, rx_fut)?;
             }
         }
-        Ok(())
     }
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn rx_gets_error_if_tx_drops_test() -> Result<(), Error> {
-        let (mut tx, mut rx) = make_buf_channel_pair();
-        let tx_fut = async move {
-            tx.send(DATA1.into()).await?;
-            Result::<(), Error>::Ok(())
-        };
-        let rx_fut = async move {
-            assert_eq!(rx.recv().await?, Bytes::from(DATA1));
-            assert_eq!(
-                rx.recv().await,
-                Err(make_err!(
-                    Code::Internal,
-                    "Sender dropped before sending EOF"
-                ))
-            );
-            Result::<(), Error>::Ok(())
-        };
-        try_join!(tx_fut, rx_fut)?;
-        Ok(())
-    }
+#[nativelink_test]
+async fn rx_gets_error_if_tx_drops_test() -> Result<(), Error> {
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let tx_fut = async move {
+        tx.send(DATA1.into()).await?;
+        Result::<(), Error>::Ok(())
+    };
+    let rx_fut = async move {
+        assert_eq!(rx.recv().await?, Bytes::from(DATA1));
+        assert_eq!(
+            rx.recv().await,
+            Err(make_err!(
+                Code::Internal,
+                "Sender dropped before sending EOF"
+            ))
+        );
+        Result::<(), Error>::Ok(())
+    };
+    try_join!(tx_fut, rx_fut)?;
+    Ok(())
 }

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -24,6 +24,7 @@ use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::evicting_map::{EvictingMap, InstantWrapper, LenEntry};
+use pretty_assertions::assert_eq;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct BytesWrapper(Bytes);
@@ -64,541 +65,536 @@ impl InstantWrapper for MockInstantWrapped {
     }
 }
 
-#[cfg(test)]
-mod evicting_map_tests {
-    use super::*;
+const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
+const HASH2: &str = "123456789abcdef000000000000000000000000000000000123456789abcdef1";
+const HASH3: &str = "23456789abcdef000000000000000000000000000000000123456789abcdef12";
+const HASH4: &str = "3456789abcdef000000000000000000000000000000000123456789abcdef012";
 
-    const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
-    const HASH2: &str = "123456789abcdef000000000000000000000000000000000123456789abcdef1";
-    const HASH3: &str = "23456789abcdef000000000000000000000000000000000123456789abcdef12";
-    const HASH4: &str = "3456789abcdef000000000000000000000000000000000123456789abcdef012";
+#[nativelink_test]
+async fn insert_purges_at_max_count() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 3,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::new().into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::new().into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::new().into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::new().into())
+        .await;
 
-    #[nativelink_test]
-    async fn insert_purges_at_max_count() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 3,
-                max_seconds: 0,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::new().into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::new().into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::new().into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::new().into())
-            .await;
-
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            Some(0),
-            "Expected map to have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            Some(0),
-            "Expected map to have item 3"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
-                .await,
-            Some(0),
-            "Expected map to have item 4"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn insert_purges_at_max_bytes() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 0,
-                max_bytes: 17,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-        const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
-            .await;
-
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 3"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 4"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 0,
-                max_bytes: 17,
-                evict_bytes: 9,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-        const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
-            .await;
-
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 3"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 4"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn insert_purges_at_max_seconds() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 5,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-
-        const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
-            .await;
-
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 3"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 4"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn get_refreshes_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 3,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-
-        const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
-            .await; // This will trigger an eviction.
-
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            Some(DATA.len()),
-            "Expected map to have item 3"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn unref_called_on_replace() -> Result<(), Error> {
-        #[derive(Debug)]
-        struct MockEntry {
-            data: Bytes,
-            unref_called: AtomicBool,
-        }
-
-        #[async_trait]
-        impl LenEntry for MockEntry {
-            fn len(&self) -> usize {
-                // Note: We are not testing this functionality.
-                0
-            }
-
-            fn is_empty(&self) -> bool {
-                unreachable!("We are not testing this functionality");
-            }
-
-            async fn touch(&self) -> bool {
-                // Do nothing. We are not testing this functionality.
-                true
-            }
-
-            async fn unref(&self) {
-                self.unref_called.store(true, Ordering::Relaxed);
-            }
-        }
-
-        let evicting_map = EvictingMap::<DigestInfo, Arc<MockEntry>, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 1,
-                max_seconds: 0,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-
-        const DATA1: &str = "12345678";
-        const DATA2: &str = "87654321";
-
-        let (entry1, entry2) = {
-            let entry1 = Arc::new(MockEntry {
-                data: Bytes::from(DATA1),
-                unref_called: AtomicBool::new(false),
-            });
-            evicting_map
-                .insert(DigestInfo::try_new(HASH1, 0)?, entry1.clone())
-                .await;
-
-            let entry2 = Arc::new(MockEntry {
-                data: Bytes::from(DATA2),
-                unref_called: AtomicBool::new(false),
-            });
-            evicting_map
-                .insert(DigestInfo::try_new(HASH1, 0)?, entry2.clone())
-                .await;
-            (entry1, entry2)
-        };
-
-        let existing_entry = evicting_map
-            .get(&DigestInfo::try_new(HASH1, 0)?)
-            .await
-            .unwrap();
-        assert_eq!(existing_entry.data, DATA2);
-
-        assert!(entry1.unref_called.load(Ordering::Relaxed));
-        assert!(!entry2.unref_called.load(Ordering::Relaxed));
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn contains_key_refreshes_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 3,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-
-        const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
-            .await;
-        MockClock::advance(Duration::from_secs(2));
+    assert_eq!(
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-            .await; // HASH1 should now be last to be evicted.
-        MockClock::advance(Duration::from_secs(2));
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
         evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
-            .await; // This will trigger an eviction.
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        Some(0),
+        "Expected map to have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        Some(0),
+        "Expected map to have item 3"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
+            .await,
+        Some(0),
+        "Expected map to have item 4"
+    );
 
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 1"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
-                .await,
-            None,
-            "Expected map to not have item 2"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
-                .await,
-            Some(8),
-            "Expected map to have item 3"
-        );
+    Ok(())
+}
 
-        Ok(())
+#[nativelink_test]
+async fn insert_purges_at_max_bytes() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 0,
+            max_bytes: 17,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+    const DATA: &str = "12345678";
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 3"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 4"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 0,
+            max_bytes: 17,
+            evict_bytes: 9,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+    const DATA: &str = "12345678";
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 3"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 4"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn insert_purges_at_max_seconds() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 5,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+
+    const DATA: &str = "12345678";
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH4, 0)?, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 3"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 4"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_refreshes_time() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 3,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+
+    const DATA: &str = "12345678";
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
+        .await; // This will trigger an eviction.
+
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        Some(DATA.len()),
+        "Expected map to have item 3"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn unref_called_on_replace() -> Result<(), Error> {
+    #[derive(Debug)]
+    struct MockEntry {
+        data: Bytes,
+        unref_called: AtomicBool,
     }
 
-    #[nativelink_test]
-    async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 0,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
+    #[async_trait]
+    impl LenEntry for MockEntry {
+        fn len(&self) -> usize {
+            // Note: We are not testing this functionality.
+            0
+        }
 
-        let value1 = BytesWrapper(Bytes::from_static(b"12345678"));
-        let value2 = BytesWrapper(Bytes::from_static(b"87654321"));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 1)?, value2.clone())
-            .await;
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
-                .await,
-            Some(value1.len()),
-            "HASH1/0 should exist"
-        );
-        assert_eq!(
-            evicting_map
-                .size_for_key(&DigestInfo::try_new(HASH1, 1)?)
-                .await,
-            Some(value2.len()),
-            "HASH1/1 should exist"
-        );
+        fn is_empty(&self) -> bool {
+            unreachable!("We are not testing this functionality");
+        }
 
-        assert_eq!(
-            evicting_map
-                .get(&DigestInfo::try_new(HASH1, 0)?)
-                .await
-                .unwrap(),
-            value1
-        );
-        assert_eq!(
-            evicting_map
-                .get(&DigestInfo::try_new(HASH1, 1)?)
-                .await
-                .unwrap(),
-            value2
-        );
+        async fn touch(&self) -> bool {
+            // Do nothing. We are not testing this functionality.
+            true
+        }
 
-        Ok(())
+        async fn unref(&self) {
+            self.unref_called.store(true, Ordering::Relaxed);
+        }
     }
 
-    #[nativelink_test]
-    async fn get_evicts_on_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 5,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
+    let evicting_map = EvictingMap::<DigestInfo, Arc<MockEntry>, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 1,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
 
-        const DATA: &str = "12345678";
-        let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
+    const DATA1: &str = "12345678";
+    const DATA2: &str = "87654321";
+
+    let (entry1, entry2) = {
+        let entry1 = Arc::new(MockEntry {
+            data: Bytes::from(DATA1),
+            unref_called: AtomicBool::new(false),
+        });
         evicting_map
-            .insert(digest_info1, Bytes::from(DATA).into())
+            .insert(DigestInfo::try_new(HASH1, 0)?, entry1.clone())
             .await;
 
-        // Getting from map before time has expired should return the value.
-        assert_eq!(
-            evicting_map.get(&digest_info1).await,
-            Some(Bytes::from(DATA).into())
-        );
-
-        MockClock::advance(Duration::from_secs(10));
-
-        // Getting from map after time has expired should return None.
-        assert_eq!(evicting_map.get(&digest_info1).await, None);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn remove_evicts_on_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-            &EvictionPolicy {
-                max_count: 0,
-                max_seconds: 5,
-                max_bytes: 0,
-                evict_bytes: 0,
-            },
-            MockInstantWrapped(MockInstant::now()),
-        );
-
-        const DATA: &str = "12345678";
-        let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
+        let entry2 = Arc::new(MockEntry {
+            data: Bytes::from(DATA2),
+            unref_called: AtomicBool::new(false),
+        });
         evicting_map
-            .insert(digest_info1, Bytes::from(DATA).into())
+            .insert(DigestInfo::try_new(HASH1, 0)?, entry2.clone())
             .await;
+        (entry1, entry2)
+    };
 
-        let digest_info2: DigestInfo = DigestInfo::try_new(HASH2, 0)?;
+    let existing_entry = evicting_map
+        .get(&DigestInfo::try_new(HASH1, 0)?)
+        .await
+        .unwrap();
+    assert_eq!(existing_entry.data, DATA2);
+
+    assert!(entry1.unref_called.load(Ordering::Relaxed));
+    assert!(!entry2.unref_called.load(Ordering::Relaxed));
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn contains_key_refreshes_time() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 3,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+
+    const DATA: &str = "12345678";
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH2, 0)?, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+        .await; // HASH1 should now be last to be evicted.
+    MockClock::advance(Duration::from_secs(2));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH3, 0)?, Bytes::from(DATA).into())
+        .await; // This will trigger an eviction.
+
+    assert_eq!(
         evicting_map
-            .insert(digest_info2, Bytes::from(DATA).into())
-            .await;
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 1"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
+            .await,
+        None,
+        "Expected map to not have item 2"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
+            .await,
+        Some(8),
+        "Expected map to have item 3"
+    );
 
-        // Removing digest before time has expired should return true.
-        assert!(evicting_map.remove(&digest_info2).await);
+    Ok(())
+}
 
-        MockClock::advance(Duration::from_secs(10));
+#[nativelink_test]
+async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
 
-        // Removing digest after time has expired should return false.
-        assert!(!evicting_map.remove(&digest_info1).await);
+    let value1 = BytesWrapper(Bytes::from_static(b"12345678"));
+    let value2 = BytesWrapper(Bytes::from_static(b"87654321"));
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
+        .await;
+    evicting_map
+        .insert(DigestInfo::try_new(HASH1, 1)?, value2.clone())
+        .await;
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 0)?)
+            .await,
+        Some(value1.len()),
+        "HASH1/0 should exist"
+    );
+    assert_eq!(
+        evicting_map
+            .size_for_key(&DigestInfo::try_new(HASH1, 1)?)
+            .await,
+        Some(value2.len()),
+        "HASH1/1 should exist"
+    );
 
-        Ok(())
-    }
+    assert_eq!(
+        evicting_map
+            .get(&DigestInfo::try_new(HASH1, 0)?)
+            .await
+            .unwrap(),
+        value1
+    );
+    assert_eq!(
+        evicting_map
+            .get(&DigestInfo::try_new(HASH1, 1)?)
+            .await
+            .unwrap(),
+        value2
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_evicts_on_time() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 5,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+
+    const DATA: &str = "12345678";
+    let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
+    evicting_map
+        .insert(digest_info1, Bytes::from(DATA).into())
+        .await;
+
+    // Getting from map before time has expired should return the value.
+    assert_eq!(
+        evicting_map.get(&digest_info1).await,
+        Some(Bytes::from(DATA).into())
+    );
+
+    MockClock::advance(Duration::from_secs(10));
+
+    // Getting from map after time has expired should return None.
+    assert_eq!(evicting_map.get(&digest_info1).await, None);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn remove_evicts_on_time() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 5,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped(MockInstant::now()),
+    );
+
+    const DATA: &str = "12345678";
+    let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
+    evicting_map
+        .insert(digest_info1, Bytes::from(DATA).into())
+        .await;
+
+    let digest_info2: DigestInfo = DigestInfo::try_new(HASH2, 0)?;
+    evicting_map
+        .insert(digest_info2, Bytes::from(DATA).into())
+        .await;
+
+    // Removing digest before time has expired should return true.
+    assert!(evicting_map.remove(&digest_info2).await);
+
+    MockClock::advance(Duration::from_secs(10));
+
+    // Removing digest after time has expired should return false.
+    assert!(!evicting_map.remove(&digest_info1).await);
+
+    Ok(())
 }

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use futures::stream::StreamExt;
 use nativelink_macro::nativelink_test;
 use nativelink_util::fastcdc::FastCDC;
+use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
@@ -38,173 +39,166 @@ async fn get_frames<T: AsyncRead + Unpin, D: Decoder>(
     Ok(frames)
 }
 
-#[cfg(test)]
-mod fastcdc_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn test_all_zeros() -> Result<(), std::io::Error> {
+    // For all zeros, always returns chunks of maximum size.
+    const ZERO_DATA: [u8; 10240] = [0u8; 10240];
+    let mut cursor = Cursor::new(&ZERO_DATA);
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(64, 256, 1024));
 
-    use super::*; // Must be declared in every module.
+    let mut total_data = 0;
+    while let Some(frame) = frame_reader.next().await {
+        let frame = frame?;
+        assert_eq!(frame.len(), 1024);
+        total_data += frame.len();
+    }
+    assert_eq!(ZERO_DATA.len(), total_data);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn test_all_zeros() -> Result<(), std::io::Error> {
-        // For all zeros, always returns chunks of maximum size.
-        const ZERO_DATA: [u8; 10240] = [0u8; 10240];
-        let mut cursor = Cursor::new(&ZERO_DATA);
-        let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(64, 256, 1024));
+#[nativelink_test]
+async fn test_sekien_16k_chunks() -> Result<(), Box<dyn std::error::Error>> {
+    let contents = include_bytes!("data/SekienAkashita.jpg");
+    let mut cursor = Cursor::new(&contents);
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(8192, 16384, 32768));
 
-        let mut total_data = 0;
-        while let Some(frame) = frame_reader.next().await {
-            let frame = frame?;
-            assert_eq!(frame.len(), 1024);
-            total_data += frame.len();
+    let mut frames = vec![];
+    let mut sum_frame_len = 0;
+    while let Some(frame) = frame_reader.next().await {
+        let frame = frame?;
+        sum_frame_len += frame.len();
+        frames.push(frame);
+    }
+    assert_eq!(frames.len(), 6);
+    assert_eq!(frames[0].len(), 22365);
+    assert_eq!(frames[1].len(), 8282);
+    assert_eq!(frames[2].len(), 16303);
+    assert_eq!(frames[3].len(), 18696);
+    assert_eq!(frames[4].len(), 32768);
+    assert_eq!(frames[5].len(), 11052);
+    assert_eq!(sum_frame_len, contents.len());
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_random_20mb_16k_chunks() -> Result<(), std::io::Error> {
+    let data = {
+        let mut data = vec![0u8; 20 * MEGABYTE_SZ];
+        let mut rng = SmallRng::seed_from_u64(1);
+        rng.fill(&mut data[..]);
+        data
+    };
+    let mut cursor = Cursor::new(&data);
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(1024, 2048, 4096));
+
+    let mut lens = vec![];
+    for frame in get_frames(&mut frame_reader).await? {
+        lens.push(frame.len());
+    }
+    lens.sort();
+    Ok(())
+}
+
+#[nativelink_test]
+async fn insert_garbage_check_boundarys_recover_test() -> Result<(), std::io::Error> {
+    let mut rand_data = {
+        let mut data = vec![0u8; 100_000];
+        let mut rng = SmallRng::seed_from_u64(1);
+        rng.fill(&mut data[..]);
+        data
+    };
+
+    let fast_cdc = FastCDC::new(1024, 2048, 4096);
+    let left_frames = {
+        let mut frame_reader = FramedRead::new(Cursor::new(&rand_data), fast_cdc.clone());
+        let frames: Vec<Bytes> = get_frames(&mut frame_reader).await?;
+
+        let mut frames_map = HashMap::new();
+        let mut pos = 0;
+        for frame in frames {
+            let frame_len = frame.len();
+            frames_map.insert(hex::encode(Sha256::digest(&frame[..])), (frame, pos));
+            pos += frame_len;
         }
-        assert_eq!(ZERO_DATA.len(), total_data);
-        Ok(())
+        frames_map
+    };
+
+    {
+        // Replace 2k of bytes and append one byte to middle.
+        let mut rng = SmallRng::seed_from_u64(2);
+        rng.fill(&mut rand_data[0..2000]);
+        rand_data.insert(rand_data.len() / 2, 0x71);
     }
 
-    #[nativelink_test]
-    async fn test_sekien_16k_chunks() -> Result<(), Box<dyn std::error::Error>> {
-        let contents = include_bytes!("data/SekienAkashita.jpg");
-        let mut cursor = Cursor::new(&contents);
-        let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(8192, 16384, 32768));
+    let mut right_frames = {
+        let mut frame_reader = FramedRead::new(Cursor::new(&rand_data), fast_cdc.clone());
+        let frames: Vec<Bytes> = get_frames(&mut frame_reader).await?;
 
-        let mut frames = vec![];
-        let mut sum_frame_len = 0;
-        while let Some(frame) = frame_reader.next().await {
-            let frame = frame?;
-            sum_frame_len += frame.len();
-            frames.push(frame);
+        let mut frames_map = HashMap::new();
+        let mut pos = 0;
+        for frame in frames {
+            let frame_len = frame.len();
+            frames_map.insert(hex::encode(Sha256::digest(&frame[..])), (frame, pos));
+            pos += frame_len;
         }
-        assert_eq!(frames.len(), 6);
-        assert_eq!(frames[0].len(), 22365);
-        assert_eq!(frames[1].len(), 8282);
-        assert_eq!(frames[2].len(), 16303);
-        assert_eq!(frames[3].len(), 18696);
-        assert_eq!(frames[4].len(), 32768);
-        assert_eq!(frames[5].len(), 11052);
-        assert_eq!(sum_frame_len, contents.len());
-        Ok(())
+        frames_map
+    };
+
+    let mut expected_missing_hashes = HashSet::<String>::new();
+    {
+        expected_missing_hashes
+            .insert("076a696917163caac2725f753bd2be2e902478c59cd92eeff012851da5868800".into());
+        expected_missing_hashes
+            .insert("b60ffdcaa8f833ca6a9900814e55d5a47b3205a6ac7d21aaadc64f889b556932".into());
+        expected_missing_hashes
+            .insert("11367bd6ecba2833556decd869ac714180456ab9ef815b167ffae947796377fd".into());
+
+        for key in left_frames.keys() {
+            let maybe_right_frame = right_frames.get(key);
+            if maybe_right_frame.is_none() {
+                assert_eq!(
+                    expected_missing_hashes.contains(key),
+                    true,
+                    "Expected to find: {}",
+                    key
+                );
+                expected_missing_hashes.remove(key);
+            } else {
+                right_frames.remove(key);
+            }
+        }
     }
-
-    #[nativelink_test]
-    async fn test_random_20mb_16k_chunks() -> Result<(), std::io::Error> {
-        let data = {
-            let mut data = vec![0u8; 20 * MEGABYTE_SZ];
-            let mut rng = SmallRng::seed_from_u64(1);
-            rng.fill(&mut data[..]);
-            data
-        };
-        let mut cursor = Cursor::new(&data);
-        let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(1024, 2048, 4096));
-
-        let mut lens = vec![];
-        for frame in get_frames(&mut frame_reader).await? {
-            lens.push(frame.len());
-        }
-        lens.sort();
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn insert_garbage_check_boundarys_recover_test() -> Result<(), std::io::Error> {
-        let mut rand_data = {
-            let mut data = vec![0u8; 100_000];
-            let mut rng = SmallRng::seed_from_u64(1);
-            rng.fill(&mut data[..]);
-            data
-        };
-
-        let fast_cdc = FastCDC::new(1024, 2048, 4096);
-        let left_frames = {
-            let mut frame_reader = FramedRead::new(Cursor::new(&rand_data), fast_cdc.clone());
-            let frames: Vec<Bytes> = get_frames(&mut frame_reader).await?;
-
-            let mut frames_map = HashMap::new();
-            let mut pos = 0;
-            for frame in frames {
-                let frame_len = frame.len();
-                frames_map.insert(hex::encode(Sha256::digest(&frame[..])), (frame, pos));
-                pos += frame_len;
-            }
-            frames_map
-        };
-
-        {
-            // Replace 2k of bytes and append one byte to middle.
-            let mut rng = SmallRng::seed_from_u64(2);
-            rng.fill(&mut rand_data[0..2000]);
-            rand_data.insert(rand_data.len() / 2, 0x71);
-        }
-
-        let mut right_frames = {
-            let mut frame_reader = FramedRead::new(Cursor::new(&rand_data), fast_cdc.clone());
-            let frames: Vec<Bytes> = get_frames(&mut frame_reader).await?;
-
-            let mut frames_map = HashMap::new();
-            let mut pos = 0;
-            for frame in frames {
-                let frame_len = frame.len();
-                frames_map.insert(hex::encode(Sha256::digest(&frame[..])), (frame, pos));
-                pos += frame_len;
-            }
-            frames_map
-        };
-
-        let mut expected_missing_hashes = HashSet::<String>::new();
-        {
-            expected_missing_hashes
-                .insert("076a696917163caac2725f753bd2be2e902478c59cd92eeff012851da5868800".into());
-            expected_missing_hashes
-                .insert("b60ffdcaa8f833ca6a9900814e55d5a47b3205a6ac7d21aaadc64f889b556932".into());
-            expected_missing_hashes
-                .insert("11367bd6ecba2833556decd869ac714180456ab9ef815b167ffae947796377fd".into());
-
-            for key in left_frames.keys() {
-                let maybe_right_frame = right_frames.get(key);
-                if maybe_right_frame.is_none() {
-                    assert_eq!(
-                        expected_missing_hashes.contains(key),
-                        true,
-                        "Expected to find: {}",
-                        key
-                    );
-                    expected_missing_hashes.remove(key);
-                } else {
-                    right_frames.remove(key);
-                }
-            }
-        }
-        let mut expected_new_hashes = HashMap::<String, usize>::new();
-        {
-            expected_new_hashes.insert(
-                "867f8da2007726835f89eca1e891c292f648660d0af8cfd169262d13d650fdbd".into(),
-                0,
-            );
-            expected_new_hashes.insert(
-                "21930b56aa9fd7dca4160be0e4c92f04b883ffda4cdb78704f73eca8b3b98036".into(),
-                1832,
-            );
-            expected_new_hashes.insert(
-                "0a58dd0fbd1b4942a83d12d3f143ca26cfa2e8b606065298cf37eebde9232a83".into(),
-                49296,
-            );
-
-            for (key, (_, pos)) in right_frames {
-                let expected_pos = expected_new_hashes.get(&key);
-                assert_eq!(Some(&pos), expected_pos, "For hash {}", key);
-                expected_new_hashes.remove(&key);
-            }
-        }
-        assert_eq!(
-            expected_missing_hashes.len(),
+    let mut expected_new_hashes = HashMap::<String, usize>::new();
+    {
+        expected_new_hashes.insert(
+            "867f8da2007726835f89eca1e891c292f648660d0af8cfd169262d13d650fdbd".into(),
             0,
-            "Some old hashes were not found"
         );
-        assert_eq!(
-            expected_new_hashes.len(),
-            0,
-            "Some new hashes were not consumed"
+        expected_new_hashes.insert(
+            "21930b56aa9fd7dca4160be0e4c92f04b883ffda4cdb78704f73eca8b3b98036".into(),
+            1832,
+        );
+        expected_new_hashes.insert(
+            "0a58dd0fbd1b4942a83d12d3f143ca26cfa2e8b606065298cf37eebde9232a83".into(),
+            49296,
         );
 
-        Ok(())
+        for (key, (_, pos)) in right_frames {
+            let expected_pos = expected_new_hashes.get(&key);
+            assert_eq!(Some(&pos), expected_pos, "For hash {}", key);
+            expected_new_hashes.remove(&key);
+        }
     }
+    assert_eq!(
+        expected_missing_hashes.len(),
+        0,
+        "Some old hashes were not found"
+    );
+    assert_eq!(
+        expected_new_hashes.len(),
+        0,
+        "Some new hashes were not consumed"
+    );
+
+    Ok(())
 }

--- a/nativelink-util/tests/fs_test.rs
+++ b/nativelink-util/tests/fs_test.rs
@@ -20,6 +20,7 @@ use std::str::from_utf8;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_util::common::fs;
+use pretty_assertions::assert_eq;
 use rand::{thread_rng, Rng};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::Semaphore;
@@ -38,149 +39,142 @@ async fn make_temp_path(data: &str) -> OsString {
 
 static TEST_EXCLUSIVE_SEMAPHORE: Semaphore = Semaphore::const_new(1);
 
-#[cfg(test)]
-mod fs_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn resumeable_file_slot_write_close_write_test() -> Result<(), Error> {
+    let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
+    let filename = make_temp_path("test_file.txt").await;
+    {
+        let mut file = fs::create_file(&filename).await?;
+        file.as_writer().await?.write_all(b"Hello").await?;
+        file.close_file().await?;
+        assert_eq!(fs::get_open_files_for_test(), 0);
+        file.as_writer().await?.write_all(b"Goodbye").await?;
+        assert_eq!(fs::get_open_files_for_test(), 1);
+        file.as_writer().await?.as_mut().sync_all().await?;
+    }
+    assert_eq!(fs::get_open_files_for_test(), 0);
+    {
+        let mut file = fs::open_file(&filename, u64::MAX).await?;
+        let mut contents = String::new();
+        file.as_reader()
+            .await?
+            .read_to_string(&mut contents)
+            .await?;
+        assert_eq!(contents, "HelloGoodbye");
+    }
+    Ok(())
+}
 
-    use super::*; // Must be declared in every module.
-
-    #[nativelink_test]
-    async fn resumeable_file_slot_write_close_write_test() -> Result<(), Error> {
-        let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
-        let filename = make_temp_path("test_file.txt").await;
+#[nativelink_test]
+async fn resumeable_file_slot_read_close_read_test() -> Result<(), Error> {
+    let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
+    const DUMMYDATA: &str = "DummyDataTest";
+    let filename = make_temp_path("test_file.txt").await;
+    {
+        let mut file = fs::create_file(&filename).await?;
+        file.as_writer()
+            .await?
+            .write_all(DUMMYDATA.as_bytes())
+            .await?;
+        file.as_writer().await?.as_mut().sync_all().await?;
+    }
+    {
+        let mut file = fs::open_file(&filename, u64::MAX).await?;
+        let mut contents = [0u8; 5];
         {
-            let mut file = fs::create_file(&filename).await?;
-            file.as_writer().await?.write_all(b"Hello").await?;
-            file.close_file().await?;
-            assert_eq!(fs::get_open_files_for_test(), 0);
-            file.as_writer().await?.write_all(b"Goodbye").await?;
-            assert_eq!(fs::get_open_files_for_test(), 1);
-            file.as_writer().await?.as_mut().sync_all().await?;
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "Dummy");
         }
+        file.close_file().await?;
+        {
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "DataT");
+        }
+        file.close_file().await?;
+        {
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 3);
+            assert_eq!(from_utf8(&contents[..3]).unwrap(), "est");
+        }
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn resumeable_file_slot_read_close_read_with_take_test() -> Result<(), Error> {
+    let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
+    const DUMMYDATA: &str = "DummyDataTest";
+    let filename = make_temp_path("test_file.txt").await;
+    {
+        let mut file = fs::create_file(&filename).await?;
+        file.as_writer()
+            .await?
+            .write_all(DUMMYDATA.as_bytes())
+            .await?;
+        file.as_writer().await?.as_mut().sync_all().await?;
+    }
+    {
+        let mut file = fs::open_file(&filename, 11).await?;
+        let mut contents = [0u8; 5];
+        {
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "Dummy");
+        }
+        assert_eq!(fs::get_open_files_for_test(), 1);
+        file.close_file().await?;
         assert_eq!(fs::get_open_files_for_test(), 0);
         {
-            let mut file = fs::open_file(&filename, u64::MAX).await?;
-            let mut contents = String::new();
-            file.as_reader()
-                .await?
-                .read_to_string(&mut contents)
-                .await?;
-            assert_eq!(contents, "HelloGoodbye");
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "DataT");
         }
-        Ok(())
+        assert_eq!(fs::get_open_files_for_test(), 1);
+        file.close_file().await?;
+        assert_eq!(fs::get_open_files_for_test(), 0);
+        {
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 1);
+            assert_eq!(from_utf8(&contents[..1]).unwrap(), "e");
+        }
     }
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn resumeable_file_slot_read_close_read_test() -> Result<(), Error> {
-        let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
-        const DUMMYDATA: &str = "DummyDataTest";
-        let filename = make_temp_path("test_file.txt").await;
-        {
-            let mut file = fs::create_file(&filename).await?;
-            file.as_writer()
-                .await?
-                .write_all(DUMMYDATA.as_bytes())
-                .await?;
-            file.as_writer().await?.as_mut().sync_all().await?;
-        }
-        {
-            let mut file = fs::open_file(&filename, u64::MAX).await?;
-            let mut contents = [0u8; 5];
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "Dummy");
-            }
-            file.close_file().await?;
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "DataT");
-            }
-            file.close_file().await?;
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 3);
-                assert_eq!(from_utf8(&contents[..3]).unwrap(), "est");
-            }
-        }
-        Ok(())
+#[nativelink_test]
+async fn resumeable_file_slot_read_close_read_with_take_and_seek_test() -> Result<(), Error> {
+    let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
+    const DUMMYDATA: &str = "DummyDataTest";
+    let filename = make_temp_path("test_file.txt").await;
+    {
+        let mut file = fs::create_file(&filename).await?;
+        file.as_writer()
+            .await?
+            .write_all(DUMMYDATA.as_bytes())
+            .await?;
+        file.as_writer().await?.as_mut().sync_all().await?;
     }
-
-    #[nativelink_test]
-    async fn resumeable_file_slot_read_close_read_with_take_test() -> Result<(), Error> {
-        let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
-        const DUMMYDATA: &str = "DummyDataTest";
-        let filename = make_temp_path("test_file.txt").await;
+    {
+        let mut file = fs::open_file(&filename, 11).await?;
+        file.as_reader()
+            .await?
+            .get_mut()
+            .seek(SeekFrom::Start(2))
+            .await?;
+        let mut contents = [0u8; 5];
         {
-            let mut file = fs::create_file(&filename).await?;
-            file.as_writer()
-                .await?
-                .write_all(DUMMYDATA.as_bytes())
-                .await?;
-            file.as_writer().await?.as_mut().sync_all().await?;
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "mmyDa");
         }
+        assert_eq!(fs::get_open_files_for_test(), 1);
+        file.close_file().await?;
+        assert_eq!(fs::get_open_files_for_test(), 0);
         {
-            let mut file = fs::open_file(&filename, 11).await?;
-            let mut contents = [0u8; 5];
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "Dummy");
-            }
-            assert_eq!(fs::get_open_files_for_test(), 1);
-            file.close_file().await?;
-            assert_eq!(fs::get_open_files_for_test(), 0);
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "DataT");
-            }
-            assert_eq!(fs::get_open_files_for_test(), 1);
-            file.close_file().await?;
-            assert_eq!(fs::get_open_files_for_test(), 0);
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 1);
-                assert_eq!(from_utf8(&contents[..1]).unwrap(), "e");
-            }
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
+            assert_eq!(from_utf8(&contents[..]).unwrap(), "taTes");
         }
-        Ok(())
+        file.close_file().await?;
+        assert_eq!(fs::get_open_files_for_test(), 0);
+        {
+            assert_eq!(file.as_reader().await?.read(&mut contents).await?, 1);
+            assert_eq!(from_utf8(&contents[..1]).unwrap(), "t");
+        }
     }
-
-    #[nativelink_test]
-    async fn resumeable_file_slot_read_close_read_with_take_and_seek_test() -> Result<(), Error> {
-        let _permit = TEST_EXCLUSIVE_SEMAPHORE.acquire().await; // One test at a time.
-        const DUMMYDATA: &str = "DummyDataTest";
-        let filename = make_temp_path("test_file.txt").await;
-        {
-            let mut file = fs::create_file(&filename).await?;
-            file.as_writer()
-                .await?
-                .write_all(DUMMYDATA.as_bytes())
-                .await?;
-            file.as_writer().await?.as_mut().sync_all().await?;
-        }
-        {
-            let mut file = fs::open_file(&filename, 11).await?;
-            file.as_reader()
-                .await?
-                .get_mut()
-                .seek(SeekFrom::Start(2))
-                .await?;
-            let mut contents = [0u8; 5];
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "mmyDa");
-            }
-            assert_eq!(fs::get_open_files_for_test(), 1);
-            file.close_file().await?;
-            assert_eq!(fs::get_open_files_for_test(), 0);
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 5);
-                assert_eq!(from_utf8(&contents[..]).unwrap(), "taTes");
-            }
-            file.close_file().await?;
-            assert_eq!(fs::get_open_files_for_test(), 0);
-            {
-                assert_eq!(file.as_reader().await?.read(&mut contents).await?, 1);
-                assert_eq!(from_utf8(&contents[..1]).unwrap(), "t");
-            }
-        }
-        Ok(())
-    }
+    Ok(())
 }

--- a/nativelink-util/tests/proto_stream_utils_test.rs
+++ b/nativelink-util/tests/proto_stream_utils_test.rs
@@ -24,70 +24,64 @@ use nativelink_util::proto_stream_utils::{
     WriteRequestStreamWrapper, WriteState, WriteStateWrapper,
 };
 use parking_lot::Mutex;
+use pretty_assertions::assert_eq;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-#[cfg(test)]
-mod proto_stream_utils_tests {
-    use pretty_assertions::assert_eq;
+const INSTANCE_NAME: &str = "test-instance";
 
-    use super::*; // Must be declared in every module.
+// Regression test for TraceMachina/nativelink#745.
+#[nativelink_test]
+async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Result<(), Error> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<WriteRequest, Error>>();
 
-    const INSTANCE_NAME: &str = "test-instance";
+    const RAW_DATA: &str = "thisdatafoo";
+    const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], RAW_DATA.len() as i64);
+    let message1 = WriteRequest {
+        resource_name: format!(
+            "{INSTANCE_NAME}/uploads/some-uuid/blobs/{}/{}",
+            DIGEST.hash_str(),
+            DIGEST.size_bytes
+        ),
+        write_offset: 0,
+        finish_write: false,
+        data: Bytes::from_static(RAW_DATA[..4].as_bytes()),
+    };
+    let message2 = WriteRequest {
+        resource_name: String::new(),
+        write_offset: 4,
+        finish_write: false,
+        data: Bytes::from_static(RAW_DATA[4..8].as_bytes()),
+    };
+    let message3 = WriteRequest {
+        resource_name: String::new(),
+        write_offset: 8,
+        finish_write: true,
+        data: Bytes::from_static(RAW_DATA[8..].as_bytes()),
+    };
 
-    // Regression test for TraceMachina/nativelink#745.
-    #[nativelink_test]
-    async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Result<(), Error> {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<WriteRequest, Error>>();
-
-        const RAW_DATA: &str = "thisdatafoo";
-        const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], RAW_DATA.len() as i64);
-        let message1 = WriteRequest {
-            resource_name: format!(
-                "{INSTANCE_NAME}/uploads/some-uuid/blobs/{}/{}",
-                DIGEST.hash_str(),
-                DIGEST.size_bytes
-            ),
-            write_offset: 0,
-            finish_write: false,
-            data: Bytes::from_static(RAW_DATA[..4].as_bytes()),
-        };
-        let message2 = WriteRequest {
-            resource_name: String::new(),
-            write_offset: 4,
-            finish_write: false,
-            data: Bytes::from_static(RAW_DATA[4..8].as_bytes()),
-        };
-        let message3 = WriteRequest {
-            resource_name: String::new(),
-            write_offset: 8,
-            finish_write: true,
-            data: Bytes::from_static(RAW_DATA[8..].as_bytes()),
-        };
-
-        {
-            tx.send(Ok(message1.clone())).unwrap();
-            tx.send(Ok(message2.clone())).unwrap();
-            tx.send(Ok(message3.clone())).unwrap();
-            drop(tx); // Close the channel.
-        }
-
-        let local_state = Arc::new(Mutex::new(WriteState::new(
-            INSTANCE_NAME.to_string(),
-            WriteRequestStreamWrapper::from(UnboundedReceiverStream::new(rx)).await?,
-        )));
-        let mut write_state_wrapper = WriteStateWrapper::new(local_state.clone());
-
-        {
-            // Ensure we transported our data properly.
-            assert_eq!(write_state_wrapper.next().await, Some(message1));
-            assert_eq!(write_state_wrapper.next().await, Some(message2));
-            assert_eq!(write_state_wrapper.next().await, Some(message3));
-            assert_eq!(write_state_wrapper.next().await, None);
-
-            // Ensure no stream errors were set.
-            assert_eq!(local_state.lock().take_read_stream_error(), None);
-        }
-
-        Ok(())
+    {
+        tx.send(Ok(message1.clone())).unwrap();
+        tx.send(Ok(message2.clone())).unwrap();
+        tx.send(Ok(message3.clone())).unwrap();
+        drop(tx); // Close the channel.
     }
+
+    let local_state = Arc::new(Mutex::new(WriteState::new(
+        INSTANCE_NAME.to_string(),
+        WriteRequestStreamWrapper::from(UnboundedReceiverStream::new(rx)).await?,
+    )));
+    let mut write_state_wrapper = WriteStateWrapper::new(local_state.clone());
+
+    {
+        // Ensure we transported our data properly.
+        assert_eq!(write_state_wrapper.next().await, Some(message1));
+        assert_eq!(write_state_wrapper.next().await, Some(message2));
+        assert_eq!(write_state_wrapper.next().await, Some(message3));
+        assert_eq!(write_state_wrapper.next().await, None);
+
+        // Ensure no stream errors were set.
+        assert_eq!(local_state.lock().take_read_stream_error(), None);
+    }
+
+    Ok(())
 }

--- a/nativelink-util/tests/resource_info_test.rs
+++ b/nativelink-util/tests/resource_info_test.rs
@@ -16,704 +16,694 @@ use std::borrow::Cow;
 
 use nativelink_macro::nativelink_test;
 use nativelink_util::resource_info::ResourceInfo;
+use pretty_assertions::assert_eq;
 
-#[cfg(test)]
-mod resource_info_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "instance_name/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    use super::*; // Must be declared in every module.
+#[nativelink_test]
+async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_blobs_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_blobs_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_compressed_blobs_compressor_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_compressed_blobs_compressor_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "blobs/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "blobs/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_compressed_blobs_compressor_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/compressed-blobs/zstd/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_blobs_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_compressed_blobs_compressor_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_blobs_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn std::error::Error>>
+{
+    const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_compressed_blobs_compressor_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std::error::Error>>
-    {
-        const RESOURCE_NAME: &str = "blobs/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "my/instance/name/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "my/instance/name");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
+    assert_eq!(resource_info.instance_name, "blobs");
+    assert_eq!(resource_info.uuid, None);
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "my/instance/name/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "my/instance/name");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "blobs/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
-        assert_eq!(resource_info.instance_name, "blobs");
-        assert_eq!(resource_info.uuid, None);
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(false));
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "BLOBS/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(ResourceInfo::new("", false).is_err());
+    assert!(ResourceInfo::new("/", false).is_err());
+    assert!(ResourceInfo::new("//", false).is_err());
+    assert!(ResourceInfo::new("///", false).is_err());
+    assert!(ResourceInfo::new("blobs/", false).is_err());
+    assert!(ResourceInfo::new("blobs//", false).is_err());
+    assert!(ResourceInfo::new("blobs///", false).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn read_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "BLOBS/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
-        Ok(())
-    }
+// Begin write tests.
 
-    #[nativelink_test]
-    async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
-        assert!(ResourceInfo::new("", false).is_err());
-        assert!(ResourceInfo::new("/", false).is_err());
-        assert!(ResourceInfo::new("//", false).is_err());
-        assert!(ResourceInfo::new("///", false).is_err());
-        assert!(ResourceInfo::new("blobs/", false).is_err());
-        assert!(ResourceInfo::new("blobs//", false).is_err());
-        assert!(ResourceInfo::new("blobs///", false).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    // Begin write tests.
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "instance_name/uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_blobs_digest_function_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str =
+        "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_blobs_digest_function_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, Some(Cow::Borrowed("blake3")));
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_uploads_uuid_blobs_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "instance_name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_uploads_uuid_blobs_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "instance_name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str =
-            "uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/INVALID/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, Some(Cow::Borrowed("zstd")));
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(
+        resource_info.optional_metadata,
+        Some(Cow::Borrowed("optional_metadata"))
+    );
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std::error::Error>>
-    {
-        const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/INVALID/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(
-            resource_info.optional_metadata,
-            Some(Cow::Borrowed("optional_metadata"))
-        );
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "my/instance/name");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
+    let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
+    assert_eq!(resource_info.instance_name, "blobs");
+    assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
+    assert_eq!(resource_info.compressor, None);
+    assert_eq!(resource_info.digest_function, None);
+    assert_eq!(resource_info.hash, "hash");
+    assert_eq!(resource_info.expected_size, 12345);
+    assert_eq!(resource_info.optional_metadata, None);
+    assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "my/instance/name");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_missing() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uuid/compressed-blobs/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
-        let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
-        assert_eq!(resource_info.instance_name, "blobs");
-        assert_eq!(resource_info.uuid, Some(Cow::Borrowed("uuid")));
-        assert_eq!(resource_info.compressor, None);
-        assert_eq!(resource_info.digest_function, None);
-        assert_eq!(resource_info.hash, "hash");
-        assert_eq!(resource_info.expected_size, 12345);
-        assert_eq!(resource_info.optional_metadata, None);
-        assert_eq!(RESOURCE_NAME, resource_info.to_string(true));
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_invalid() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "UPLOADS/uuid/compressed-blobs/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_missing() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uuid/compressed-blobs/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_invalid() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "UPLOADS/uuid/compressed-blobs/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/BLOBS/hash/12345";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
+}
 
-    #[nativelink_test]
-    async fn write_uploads_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/BLOBS/hash/12345";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn write_invalid_size_test() -> Result<(), Box<dyn std::error::Error>> {
-        const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/INVALID";
-        assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
-        Ok(())
-    }
+#[nativelink_test]
+async fn write_invalid_size_test() -> Result<(), Box<dyn std::error::Error>> {
+    const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/INVALID";
+    assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
+    Ok(())
 }

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -22,165 +22,159 @@ use nativelink_config::stores::Retry;
 use nativelink_error::{make_err, Code, Error};
 use nativelink_macro::nativelink_test;
 use nativelink_util::retry::{Retrier, RetryResult};
+use pretty_assertions::assert_eq;
 use tokio::time::Duration;
 
-#[cfg(test)]
-mod retry_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn retry_simple_success() -> Result<(), Error> {
+    let retrier = Retrier::new(
+        Arc::new(|_duration| Box::pin(ready(()))),
+        Arc::new(move |_delay| Duration::from_millis(1)),
+        Retry {
+            max_retries: 5,
+            ..Default::default()
+        },
+    );
+    let run_count = Arc::new(AtomicI32::new(0));
 
-    use super::*; // Must be declared in every module.
+    let result = Pin::new(&retrier)
+        .retry(repeat_with(|| {
+            run_count.fetch_add(1, Ordering::Relaxed);
+            RetryResult::Ok(true)
+        }))
+        .await?;
+    assert_eq!(
+        run_count.load(Ordering::Relaxed),
+        1,
+        "Expected function to be called once"
+    );
+    assert_eq!(result, true, "Expected result to succeed");
 
-    #[nativelink_test]
-    async fn retry_simple_success() -> Result<(), Error> {
-        let retrier = Retrier::new(
-            Arc::new(|_duration| Box::pin(ready(()))),
-            Arc::new(move |_delay| Duration::from_millis(1)),
-            Retry {
-                max_retries: 5,
-                ..Default::default()
-            },
-        );
-        let run_count = Arc::new(AtomicI32::new(0));
+    Ok(())
+}
 
+#[nativelink_test]
+async fn retry_fails_after_3_runs() -> Result<(), Error> {
+    let retrier = Retrier::new(
+        Arc::new(|_duration| Box::pin(ready(()))),
+        Arc::new(move |_delay| Duration::from_millis(1)),
+        Retry {
+            max_retries: 2,
+            ..Default::default()
+        },
+    );
+    let run_count = Arc::new(AtomicI32::new(0));
+    let result = Pin::new(&retrier)
+        .retry(repeat_with(|| {
+            run_count.fetch_add(1, Ordering::Relaxed);
+            RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+        }))
+        .await;
+    assert_eq!(
+        run_count.load(Ordering::Relaxed),
+        3,
+        "Expected function to be called"
+    );
+    assert_eq!(result.is_err(), true, "Expected result to error");
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Error { code: Unavailable, messages: [\"Dummy failure\", \"On attempt 3\"] }"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn retry_success_after_2_runs() -> Result<(), Error> {
+    let retrier = Retrier::new(
+        Arc::new(|_duration| Box::pin(ready(()))),
+        Arc::new(move |_delay| Duration::from_millis(1)),
+        Retry {
+            max_retries: 3,
+            ..Default::default()
+        },
+    );
+    let run_count = Arc::new(AtomicI32::new(0));
+
+    let result = Pin::new(&retrier)
+        .retry(repeat_with(|| {
+            run_count.fetch_add(1, Ordering::Relaxed);
+            if run_count.load(Ordering::Relaxed) == 2 {
+                return RetryResult::Ok(true);
+            }
+            RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
+        }))
+        .await?;
+    assert_eq!(
+        run_count.load(Ordering::Relaxed),
+        2,
+        "Expected function to be called"
+    );
+    assert_eq!(result, true, "Expected result to succeed");
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn retry_calls_sleep_fn() -> Result<(), Error> {
+    const EXPECTED_MS: u64 = 71;
+    let sleep_fn_run_count = Arc::new(AtomicI32::new(0));
+    let sleep_fn_run_count_copy = sleep_fn_run_count.clone();
+    let retrier = Retrier::new(
+        Arc::new(move |duration| {
+            // Note: Need to make another copy to make the compiler happy.
+            let sleep_fn_run_count_copy = sleep_fn_run_count_copy.clone();
+            Box::pin(async move {
+                // Remember: This function is called only on retries, not the first run.
+                sleep_fn_run_count_copy.fetch_add(1, Ordering::Relaxed);
+                assert_eq!(duration, Duration::from_millis(EXPECTED_MS));
+            })
+        }),
+        Arc::new(move |_delay| Duration::from_millis(EXPECTED_MS)),
+        Retry {
+            max_retries: 5,
+            ..Default::default()
+        },
+    );
+
+    {
+        // Try with retry limit hit.
         let result = Pin::new(&retrier)
             .retry(repeat_with(|| {
-                run_count.fetch_add(1, Ordering::Relaxed);
-                RetryResult::Ok(true)
-            }))
-            .await?;
-        assert_eq!(
-            run_count.load(Ordering::Relaxed),
-            1,
-            "Expected function to be called once"
-        );
-        assert_eq!(result, true, "Expected result to succeed");
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn retry_fails_after_3_runs() -> Result<(), Error> {
-        let retrier = Retrier::new(
-            Arc::new(|_duration| Box::pin(ready(()))),
-            Arc::new(move |_delay| Duration::from_millis(1)),
-            Retry {
-                max_retries: 2,
-                ..Default::default()
-            },
-        );
-        let run_count = Arc::new(AtomicI32::new(0));
-        let result = Pin::new(&retrier)
-            .retry(repeat_with(|| {
-                run_count.fetch_add(1, Ordering::Relaxed);
                 RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
             }))
             .await;
-        assert_eq!(
-            run_count.load(Ordering::Relaxed),
-            3,
-            "Expected function to be called"
-        );
-        assert_eq!(result.is_err(), true, "Expected result to error");
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Error { code: Unavailable, messages: [\"Dummy failure\", \"On attempt 3\"] }"
-        );
 
-        Ok(())
+        assert_eq!(result.is_err(), true, "Expected the retry to fail");
+        assert_eq!(
+            sleep_fn_run_count.load(Ordering::Relaxed),
+            5,
+            "Expected the sleep_fn to be called twice"
+        );
     }
-
-    #[nativelink_test]
-    async fn retry_success_after_2_runs() -> Result<(), Error> {
-        let retrier = Retrier::new(
-            Arc::new(|_duration| Box::pin(ready(()))),
-            Arc::new(move |_delay| Duration::from_millis(1)),
-            Retry {
-                max_retries: 3,
-                ..Default::default()
-            },
-        );
+    sleep_fn_run_count.store(0, Ordering::Relaxed); // Reset our counter.
+    {
+        // Try with 3 retries.
         let run_count = Arc::new(AtomicI32::new(0));
-
         let result = Pin::new(&retrier)
             .retry(repeat_with(|| {
                 run_count.fetch_add(1, Ordering::Relaxed);
-                if run_count.load(Ordering::Relaxed) == 2 {
+                // Remember: This function is only called every time, not just retries.
+                // We run the first time, then retry 2 additional times meaning 3 runs.
+                if run_count.load(Ordering::Relaxed) == 3 {
                     return RetryResult::Ok(true);
                 }
                 RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
             }))
             .await?;
+
+        assert_eq!(result, true, "Expected results to pass");
         assert_eq!(
-            run_count.load(Ordering::Relaxed),
+            sleep_fn_run_count.load(Ordering::Relaxed),
             2,
-            "Expected function to be called"
+            "Expected the sleep_fn to be called twice"
         );
-        assert_eq!(result, true, "Expected result to succeed");
-
-        Ok(())
     }
 
-    #[nativelink_test]
-    async fn retry_calls_sleep_fn() -> Result<(), Error> {
-        const EXPECTED_MS: u64 = 71;
-        let sleep_fn_run_count = Arc::new(AtomicI32::new(0));
-        let sleep_fn_run_count_copy = sleep_fn_run_count.clone();
-        let retrier = Retrier::new(
-            Arc::new(move |duration| {
-                // Note: Need to make another copy to make the compiler happy.
-                let sleep_fn_run_count_copy = sleep_fn_run_count_copy.clone();
-                Box::pin(async move {
-                    // Remember: This function is called only on retries, not the first run.
-                    sleep_fn_run_count_copy.fetch_add(1, Ordering::Relaxed);
-                    assert_eq!(duration, Duration::from_millis(EXPECTED_MS));
-                })
-            }),
-            Arc::new(move |_delay| Duration::from_millis(EXPECTED_MS)),
-            Retry {
-                max_retries: 5,
-                ..Default::default()
-            },
-        );
-
-        {
-            // Try with retry limit hit.
-            let result = Pin::new(&retrier)
-                .retry(repeat_with(|| {
-                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
-                }))
-                .await;
-
-            assert_eq!(result.is_err(), true, "Expected the retry to fail");
-            assert_eq!(
-                sleep_fn_run_count.load(Ordering::Relaxed),
-                5,
-                "Expected the sleep_fn to be called twice"
-            );
-        }
-        sleep_fn_run_count.store(0, Ordering::Relaxed); // Reset our counter.
-        {
-            // Try with 3 retries.
-            let run_count = Arc::new(AtomicI32::new(0));
-            let result = Pin::new(&retrier)
-                .retry(repeat_with(|| {
-                    run_count.fetch_add(1, Ordering::Relaxed);
-                    // Remember: This function is only called every time, not just retries.
-                    // We run the first time, then retry 2 additional times meaning 3 runs.
-                    if run_count.load(Ordering::Relaxed) == 3 {
-                        return RetryResult::Ok(true);
-                    }
-                    RetryResult::<bool>::Retry(make_err!(Code::Unavailable, "Dummy failure",))
-                }))
-                .await?;
-
-            assert_eq!(result, true, "Expected results to pass");
-            assert_eq!(
-                sleep_fn_run_count.load(Ordering::Relaxed),
-                2,
-                "Expected the sleep_fn to be called twice"
-            );
-        }
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -50,6 +50,7 @@ use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::store_trait::Store;
 use nativelink_worker::local_worker::new_local_worker;
+use pretty_assertions::assert_eq;
 use prost::Message;
 use rand::{thread_rng, Rng};
 use tokio::io::AsyncWriteExt;
@@ -72,665 +73,657 @@ fn make_temp_path(data: &str) -> String {
     )
 }
 
-#[cfg(test)]
-mod local_worker_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn platform_properties_smoke_test() -> Result<(), Error> {
+    let mut platform_properties = HashMap::new();
+    platform_properties.insert(
+        "foo".to_string(),
+        WorkerProperty::values(vec!["bar1".to_string(), "bar2".to_string()]),
+    );
+    platform_properties.insert(
+        "baz".to_string(),
+        // Note: new lines will result in two entries for same key.
+        #[cfg(target_family = "unix")]
+        WorkerProperty::query_cmd("printf 'hello\ngoodbye'".to_string()),
+        #[cfg(target_family = "windows")]
+        WorkerProperty::query_cmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
+    );
+    let mut test_context = setup_local_worker(platform_properties).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
 
-    use super::*; // Must be declared in every module.
+    // Now wait for our client to send `.connect_worker()` (which has our platform properties).
+    let mut supported_properties = test_context
+        .client
+        .expect_connect_worker(Ok(streaming_response))
+        .await;
+    // It is undefined which order these will be returned in, so we sort it.
+    supported_properties
+        .properties
+        .sort_by_key(Message::encode_to_vec);
+    assert_eq!(
+        supported_properties,
+        SupportedProperties {
+            properties: vec![
+                Property {
+                    name: "baz".to_string(),
+                    value: "hello".to_string(),
+                },
+                Property {
+                    name: "baz".to_string(),
+                    value: "goodbye".to_string(),
+                },
+                Property {
+                    name: "foo".to_string(),
+                    value: "bar1".to_string(),
+                },
+                Property {
+                    name: "foo".to_string(),
+                    value: "bar2".to_string(),
+                }
+            ]
+        }
+    );
 
-    #[nativelink_test]
-    async fn platform_properties_smoke_test() -> Result<(), Error> {
-        let mut platform_properties = HashMap::new();
-        platform_properties.insert(
-            "foo".to_string(),
-            WorkerProperty::values(vec!["bar1".to_string(), "bar2".to_string()]),
-        );
-        platform_properties.insert(
-            "baz".to_string(),
-            // Note: new lines will result in two entries for same key.
-            #[cfg(target_family = "unix")]
-            WorkerProperty::query_cmd("printf 'hello\ngoodbye'".to_string()),
-            #[cfg(target_family = "windows")]
-            WorkerProperty::query_cmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
-        );
-        let mut test_context = setup_local_worker(platform_properties).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+    Ok(())
+}
 
-        // Now wait for our client to send `.connect_worker()` (which has our platform properties).
-        let mut supported_properties = test_context
+#[nativelink_test]
+async fn reconnect_on_server_disconnect_test() -> Result<(), Box<dyn std::error::Error>> {
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
             .client
             .expect_connect_worker(Ok(streaming_response))
             .await;
-        // It is undefined which order these will be returned in, so we sort it.
-        supported_properties
-            .properties
-            .sort_by_key(Message::encode_to_vec);
-        assert_eq!(
-            supported_properties,
-            SupportedProperties {
-                properties: vec![
-                    Property {
-                        name: "baz".to_string(),
-                        value: "hello".to_string(),
-                    },
-                    Property {
-                        name: "baz".to_string(),
-                        value: "goodbye".to_string(),
-                    },
-                    Property {
-                        name: "foo".to_string(),
-                        value: "bar1".to_string(),
-                    },
-                    Property {
-                        name: "foo".to_string(),
-                        value: "bar2".to_string(),
-                    }
-                ]
-            }
-        );
-
-        Ok(())
+        assert_eq!(props, SupportedProperties::default());
     }
 
-    #[nativelink_test]
-    async fn reconnect_on_server_disconnect_test() -> Result<(), Box<dyn std::error::Error>> {
-        let mut test_context = setup_local_worker(HashMap::new()).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+    // Disconnect our grpc stream.
+    test_context.maybe_tx_stream.take().unwrap().abort();
 
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        // Disconnect our grpc stream.
-        test_context.maybe_tx_stream.take().unwrap().abort();
-
-        {
-            // Client should try to auto reconnect and check our properties again.
-            let (_, streaming_response) = setup_grpc_stream();
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn kill_all_called_on_disconnect() -> Result<(), Box<dyn std::error::Error>> {
-        let mut test_context = setup_local_worker(HashMap::new()).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
-
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        // Handle registration (kill_all not called unless registered).
-        let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
-        {
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::ConnectionResult(ConnectionResult {
-                        worker_id: "foobar".to_string(),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        // Disconnect our grpc stream.
-        tx_stream.abort();
-
-        // Check that kill_all is called.
-        test_context.actions_manager.expect_kill_all().await;
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::error::Error>> {
-        const SALT: u64 = 1000;
-
-        let mut test_context = setup_local_worker(HashMap::new()).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
-
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        let expected_worker_id = "foobar".to_string();
-
-        let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
-        {
-            // First initialize our worker by sending the response to the connection request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::ConnectionResult(ConnectionResult {
-                        worker_id: expected_worker_id.clone(),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        let action_digest = DigestInfo::new([3u8; 32], 10);
-        let action_info = ActionInfo {
-            command_digest: DigestInfo::new([1u8; 32], 10),
-            input_root_digest: DigestInfo::new([2u8; 32], 10),
-            timeout: Duration::from_secs(1),
-            platform_properties: PlatformProperties::default(),
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Blake3,
-                digest: action_digest,
-                salt: SALT,
-            },
-            skip_cache_lookup: true,
-        };
-
-        {
-            // Send execution request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::StartAction(StartExecute {
-                        execute_request: Some(action_info.into()),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-        let running_action = Arc::new(MockRunningAction::new());
-
-        // Send and wait for response from create_and_add_action to RunningActionsManager.
-        test_context
-            .actions_manager
-            .expect_create_and_add_action(Ok(running_action.clone()))
-            .await;
-
-        // Now the RunningAction needs to send a series of state updates. This shortcuts them
-        // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
-        running_action
-            .simple_expect_get_finished_result(Ok(ActionResult::default()))
-            .await?;
-
-        // Expect the action to be updated in the action cache.
-        let (_stored_digest, _stored_result, digest_hasher) = test_context
-            .actions_manager
-            .expect_cache_action_result()
-            .await;
-        assert_eq!(digest_hasher, DigestHasherFunc::Blake3);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Error>> {
-        const SALT: u64 = 1000;
-
-        let mut test_context = setup_local_worker(HashMap::new()).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
-
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        let expected_worker_id = "foobar".to_string();
-
-        let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
-        {
-            // First initialize our worker by sending the response to the connection request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::ConnectionResult(ConnectionResult {
-                        worker_id: expected_worker_id.clone(),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        let action_digest = DigestInfo::new([3u8; 32], 10);
-        let action_info = ActionInfo {
-            command_digest: DigestInfo::new([1u8; 32], 10),
-            input_root_digest: DigestInfo::new([2u8; 32], 10),
-            timeout: Duration::from_secs(1),
-            platform_properties: PlatformProperties::default(),
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: action_digest,
-                salt: SALT,
-            },
-            skip_cache_lookup: true,
-        };
-
-        {
-            // Send execution request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::StartAction(StartExecute {
-                        execute_request: Some(action_info.into()),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-        let action_result = ActionResult {
-            output_files: vec![],
-            output_folders: vec![],
-            output_file_symlinks: vec![],
-            output_directory_symlinks: vec![],
-            exit_code: 5,
-            stdout_digest: DigestInfo::new([21u8; 32], 10),
-            stderr_digest: DigestInfo::new([22u8; 32], 10),
-            execution_metadata: ExecutionMetadata {
-                worker: expected_worker_id.clone(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: SystemTime::UNIX_EPOCH,
-                worker_completed_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
-                input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
-                execution_start_timestamp: SystemTime::UNIX_EPOCH,
-                execution_completed_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
-                output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
-            },
-            server_logs: HashMap::new(),
-            error: None,
-            message: String::new(),
-        };
-        let running_action = Arc::new(MockRunningAction::new());
-
-        // Send and wait for response from create_and_add_action to RunningActionsManager.
-        test_context
-            .actions_manager
-            .expect_create_and_add_action(Ok(running_action.clone()))
-            .await;
-
-        // Now the RunningAction needs to send a series of state updates. This shortcuts them
-        // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
-        running_action
-            .simple_expect_get_finished_result(Ok(action_result.clone()))
-            .await?;
-
-        // Expect the action to be updated in the action cache.
-        let (stored_digest, stored_result, digest_hasher) = test_context
-            .actions_manager
-            .expect_cache_action_result()
-            .await;
-        assert_eq!(stored_digest, action_digest);
-        assert_eq!(stored_result, action_result.clone());
-        assert_eq!(digest_hasher, DigestHasherFunc::Sha256);
-
-        // Now our client should be notified that our runner finished.
-        let execution_response = test_context
-            .client
-            .expect_execution_response(Ok(Response::new(())))
-            .await;
-
-        // Now ensure the final results match our expectations.
-        assert_eq!(
-            execution_response,
-            ExecuteResult {
-                worker_id: expected_worker_id,
-                instance_name: INSTANCE_NAME.to_string(),
-                action_digest: Some(action_digest.into()),
-                salt: SALT,
-                digest_function: digest_function::Value::Sha256.into(),
-                result: Some(execute_result::Result::ExecuteResponse(
-                    ActionStage::Completed(action_result).into()
-                )),
-            }
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn std::error::Error>>
     {
-        let cas_store = Store::new(FastSlowStore::new(
-            &nativelink_config::stores::FastSlowStore {
-                // Note: These are not needed for this test, so we put dummy memory stores here.
-                fast: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                slow: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            Store::new(
-                <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
-                    content_path: make_temp_path("content_path"),
-                    temp_path: make_temp_path("temp_path"),
-                    ..Default::default()
-                })
-                .await?,
-            ),
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))),
-        ));
-        let ac_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let work_directory = make_temp_path("foo");
-        new_local_worker(
-            Arc::new(LocalWorkerConfig {
-                work_directory: work_directory.clone(),
-                ..Default::default()
-            }),
-            cas_store.clone(),
-            Some(ac_store),
-            cas_store,
-        )
-        .await?;
-
-        assert!(
-            fs::metadata(work_directory).await.is_ok(),
-            "Expected work_directory to be created"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn new_local_worker_removes_work_directory_before_start_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let cas_store = Store::new(FastSlowStore::new(
-            &nativelink_config::stores::FastSlowStore {
-                // Note: These are not needed for this test, so we put dummy memory stores here.
-                fast: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-                slow: nativelink_config::stores::StoreConfig::memory(
-                    nativelink_config::stores::MemoryStore::default(),
-                ),
-            },
-            Store::new(
-                <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
-                    content_path: make_temp_path("content_path"),
-                    temp_path: make_temp_path("temp_path"),
-                    ..Default::default()
-                })
-                .await?,
-            ),
-            Store::new(Arc::new(MemoryStore::new(
-                &nativelink_config::stores::MemoryStore::default(),
-            ))),
-        ));
-        let ac_store = Store::new(Arc::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )));
-        let work_directory = make_temp_path("foo");
-        fs::create_dir_all(format!("{}/{}", work_directory, "another_dir")).await?;
-        let mut file =
-            fs::create_file(OsString::from(format!("{}/{}", work_directory, "foo.txt"))).await?;
-        file.as_writer().await?.write_all(b"Hello, world!").await?;
-        file.as_writer().await?.as_mut().sync_all().await?;
-        drop(file);
-        new_local_worker(
-            Arc::new(LocalWorkerConfig {
-                work_directory: work_directory.clone(),
-                ..Default::default()
-            }),
-            cas_store.clone(),
-            Some(ac_store),
-            cas_store,
-        )
-        .await?;
-
-        let work_directory_path_buf = PathBuf::from(work_directory);
-
-        assert!(
-            work_directory_path_buf.read_dir()?.next().is_none(),
-            "Expected work_directory to have removed all files and to be empty"
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::error::Error>> {
-        let temp_path = make_temp_path("scripts");
-        fs::create_dir_all(temp_path.clone()).await?;
-        #[cfg(target_family = "unix")]
-        let precondition_script = {
-            let precondition_script = format!("{temp_path}/precondition.sh");
-            // We use std::fs::File here because we sometimes get strange bugs here
-            // that result in: "Text file busy (os error 26)" if it is an executeable.
-            // It is likley because somewhere the file descriotor does not get closed
-            // in tokio's async context.
-            let mut file = std::fs::File::create(OsString::from(&precondition_script))?;
-            file.write_all(b"#!/bin/sh\nexit 1\n")?;
-            file.set_permissions(Permissions::from_mode(0o777))?;
-            file.sync_all()?;
-            drop(file);
-            precondition_script
-        };
-        #[cfg(target_family = "windows")]
-        let precondition_script = {
-            let precondition_script = format!("{}/precondition.bat", temp_path);
-            let mut file = std::fs::File::create(OsString::from(&precondition_script))?;
-            file.write_all(b"@echo off\r\nexit 1")?;
-            file.sync_all()?;
-            drop(file);
-            precondition_script
-        };
-        // TODO(#527) Sleep to reduce flakey chances.
-        tokio::time::sleep(Duration::from_millis(250)).await;
-        let local_worker_config = LocalWorkerConfig {
-            experimental_precondition_script: Some(precondition_script),
-            ..Default::default()
-        };
-
-        let mut test_context = setup_local_worker_with_config(local_worker_config).await;
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
-
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        let expected_worker_id = "foobar".to_string();
-
-        let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
-        {
-            // First initialize our worker by sending the response to the connection request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::ConnectionResult(ConnectionResult {
-                        worker_id: expected_worker_id.clone(),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        const SALT: u64 = 1000;
-        let action_digest = DigestInfo::new([3u8; 32], 10);
-        let action_info = ActionInfo {
-            command_digest: DigestInfo::new([1u8; 32], 10),
-            input_root_digest: DigestInfo::new([2u8; 32], 10),
-            timeout: Duration::from_secs(1),
-            platform_properties: PlatformProperties::default(),
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Sha256,
-                digest: action_digest,
-                salt: SALT,
-            },
-            skip_cache_lookup: true,
-        };
-
-        {
-            // Send execution request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::StartAction(StartExecute {
-                        execute_request: Some(action_info.into()),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        // Now our client should be notified that our runner finished.
-        let execution_response = test_context
+        // Client should try to auto reconnect and check our properties again.
+        let (_, streaming_response) = setup_grpc_stream();
+        let props = test_context
             .client
-            .expect_execution_response(Ok(Response::new(())))
+            .expect_connect_worker(Ok(streaming_response))
             .await;
-
-        #[cfg(target_family = "unix")]
-        const EXPECTED_MSG: &str = "Preconditions script returned status exit status: 1 - ";
-        #[cfg(target_family = "windows")]
-        const EXPECTED_MSG: &str = "Preconditions script returned status exit code: 1 - ";
-
-        // Now ensure the final results match our expectations.
-        assert_eq!(
-            execution_response,
-            ExecuteResult {
-                worker_id: expected_worker_id,
-                instance_name: INSTANCE_NAME.to_string(),
-                action_digest: Some(action_digest.into()),
-                salt: SALT,
-                digest_function: digest_function::Value::Sha256.into(),
-                result: Some(execute_result::Result::InternalError(
-                    make_err!(Code::ResourceExhausted, "{}", EXPECTED_MSG,).into()
-                )),
-            }
-        );
-
-        Ok(())
+        assert_eq!(props, SupportedProperties::default());
     }
 
-    #[nativelink_test]
-    async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Error>> {
-        const SALT: u64 = 1000;
+    Ok(())
+}
 
-        let mut test_context = setup_local_worker(HashMap::new()).await;
+#[nativelink_test]
+async fn kill_all_called_on_disconnect() -> Result<(), Box<dyn std::error::Error>> {
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
 
-        let streaming_response = test_context.maybe_streaming_response.take().unwrap();
-
-        {
-            // Ensure our worker connects and properties were sent.
-            let props = test_context
-                .client
-                .expect_connect_worker(Ok(streaming_response))
-                .await;
-            assert_eq!(props, SupportedProperties::default());
-        }
-
-        // Handle registration (kill_all not called unless registered).
-        let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
-        {
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::ConnectionResult(ConnectionResult {
-                        worker_id: "foobar".to_string(),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        let action_digest = DigestInfo::new([3u8; 32], 10);
-        let action_info = ActionInfo {
-            command_digest: DigestInfo::new([1u8; 32], 10),
-            input_root_digest: DigestInfo::new([2u8; 32], 10),
-            timeout: Duration::from_secs(1),
-            platform_properties: PlatformProperties::default(),
-            priority: 0,
-            load_timestamp: SystemTime::UNIX_EPOCH,
-            insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: INSTANCE_NAME.to_string(),
-                digest_function: DigestHasherFunc::Blake3,
-                digest: action_digest,
-                salt: SALT,
-            },
-            skip_cache_lookup: true,
-        };
-
-        {
-            // Send execution request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::StartAction(StartExecute {
-                        execute_request: Some(action_info.clone().into()),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-        let running_action = Arc::new(MockRunningAction::new());
-
-        // Send and wait for response from create_and_add_action to RunningActionsManager.
-        test_context
-            .actions_manager
-            .expect_create_and_add_action(Ok(running_action.clone()))
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
+            .client
+            .expect_connect_worker(Ok(streaming_response))
             .await;
-
-        let action_id = action_info.unique_qualifier.get_hash();
-        {
-            // Send kill request.
-            tx_stream
-                .send_data(encode_stream_proto(&UpdateForWorker {
-                    update: Some(Update::KillActionRequest(KillActionRequest {
-                        action_id: hex::encode(action_id),
-                    })),
-                })?)
-                .await
-                .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
-        }
-
-        let killed_action_id = test_context.actions_manager.expect_kill_action().await;
-
-        // Make sure that the killed action is the one we intended
-        assert_eq!(killed_action_id, action_id);
-
-        Ok(())
+        assert_eq!(props, SupportedProperties::default());
     }
+
+    // Handle registration (kill_all not called unless registered).
+    let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    {
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: "foobar".to_string(),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    // Disconnect our grpc stream.
+    tx_stream.abort();
+
+    // Check that kill_all is called.
+    test_context.actions_manager.expect_kill_all().await;
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::error::Error>> {
+    const SALT: u64 = 1000;
+
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
+            .client
+            .expect_connect_worker(Ok(streaming_response))
+            .await;
+        assert_eq!(props, SupportedProperties::default());
+    }
+
+    let expected_worker_id = "foobar".to_string();
+
+    let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    {
+        // First initialize our worker by sending the response to the connection request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: expected_worker_id.clone(),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    let action_digest = DigestInfo::new([3u8; 32], 10);
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: PlatformProperties::default(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Blake3,
+            digest: action_digest,
+            salt: SALT,
+        },
+        skip_cache_lookup: true,
+    };
+
+    {
+        // Send execution request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::StartAction(StartExecute {
+                    execute_request: Some(action_info.into()),
+                    salt: SALT,
+                    queued_timestamp: None,
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+    let running_action = Arc::new(MockRunningAction::new());
+
+    // Send and wait for response from create_and_add_action to RunningActionsManager.
+    test_context
+        .actions_manager
+        .expect_create_and_add_action(Ok(running_action.clone()))
+        .await;
+
+    // Now the RunningAction needs to send a series of state updates. This shortcuts them
+    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
+    running_action
+        .simple_expect_get_finished_result(Ok(ActionResult::default()))
+        .await?;
+
+    // Expect the action to be updated in the action cache.
+    let (_stored_digest, _stored_result, digest_hasher) = test_context
+        .actions_manager
+        .expect_cache_action_result()
+        .await;
+    assert_eq!(digest_hasher, DigestHasherFunc::Blake3);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Error>> {
+    const SALT: u64 = 1000;
+
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
+            .client
+            .expect_connect_worker(Ok(streaming_response))
+            .await;
+        assert_eq!(props, SupportedProperties::default());
+    }
+
+    let expected_worker_id = "foobar".to_string();
+
+    let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    {
+        // First initialize our worker by sending the response to the connection request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: expected_worker_id.clone(),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    let action_digest = DigestInfo::new([3u8; 32], 10);
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: PlatformProperties::default(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: action_digest,
+            salt: SALT,
+        },
+        skip_cache_lookup: true,
+    };
+
+    {
+        // Send execution request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::StartAction(StartExecute {
+                    execute_request: Some(action_info.into()),
+                    salt: SALT,
+                    queued_timestamp: None,
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+    let action_result = ActionResult {
+        output_files: vec![],
+        output_folders: vec![],
+        output_file_symlinks: vec![],
+        output_directory_symlinks: vec![],
+        exit_code: 5,
+        stdout_digest: DigestInfo::new([21u8; 32], 10),
+        stderr_digest: DigestInfo::new([22u8; 32], 10),
+        execution_metadata: ExecutionMetadata {
+            worker: expected_worker_id.clone(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: SystemTime::UNIX_EPOCH,
+            worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+            execution_start_timestamp: SystemTime::UNIX_EPOCH,
+            execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+        },
+        server_logs: HashMap::new(),
+        error: None,
+        message: String::new(),
+    };
+    let running_action = Arc::new(MockRunningAction::new());
+
+    // Send and wait for response from create_and_add_action to RunningActionsManager.
+    test_context
+        .actions_manager
+        .expect_create_and_add_action(Ok(running_action.clone()))
+        .await;
+
+    // Now the RunningAction needs to send a series of state updates. This shortcuts them
+    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
+    running_action
+        .simple_expect_get_finished_result(Ok(action_result.clone()))
+        .await?;
+
+    // Expect the action to be updated in the action cache.
+    let (stored_digest, stored_result, digest_hasher) = test_context
+        .actions_manager
+        .expect_cache_action_result()
+        .await;
+    assert_eq!(stored_digest, action_digest);
+    assert_eq!(stored_result, action_result.clone());
+    assert_eq!(digest_hasher, DigestHasherFunc::Sha256);
+
+    // Now our client should be notified that our runner finished.
+    let execution_response = test_context
+        .client
+        .expect_execution_response(Ok(Response::new(())))
+        .await;
+
+    // Now ensure the final results match our expectations.
+    assert_eq!(
+        execution_response,
+        ExecuteResult {
+            worker_id: expected_worker_id,
+            instance_name: INSTANCE_NAME.to_string(),
+            action_digest: Some(action_digest.into()),
+            salt: SALT,
+            digest_function: digest_function::Value::Sha256.into(),
+            result: Some(execute_result::Result::ExecuteResponse(
+                ActionStage::Completed(action_result).into()
+            )),
+        }
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn std::error::Error>> {
+    let cas_store = Store::new(FastSlowStore::new(
+        &nativelink_config::stores::FastSlowStore {
+            // Note: These are not needed for this test, so we put dummy memory stores here.
+            fast: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            slow: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        Store::new(
+            <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
+                content_path: make_temp_path("content_path"),
+                temp_path: make_temp_path("temp_path"),
+                ..Default::default()
+            })
+            .await?,
+        ),
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))),
+    ));
+    let ac_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let work_directory = make_temp_path("foo");
+    new_local_worker(
+        Arc::new(LocalWorkerConfig {
+            work_directory: work_directory.clone(),
+            ..Default::default()
+        }),
+        cas_store.clone(),
+        Some(ac_store),
+        cas_store,
+    )
+    .await?;
+
+    assert!(
+        fs::metadata(work_directory).await.is_ok(),
+        "Expected work_directory to be created"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn new_local_worker_removes_work_directory_before_start_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cas_store = Store::new(FastSlowStore::new(
+        &nativelink_config::stores::FastSlowStore {
+            // Note: These are not needed for this test, so we put dummy memory stores here.
+            fast: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+            slow: nativelink_config::stores::StoreConfig::memory(
+                nativelink_config::stores::MemoryStore::default(),
+            ),
+        },
+        Store::new(
+            <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
+                content_path: make_temp_path("content_path"),
+                temp_path: make_temp_path("temp_path"),
+                ..Default::default()
+            })
+            .await?,
+        ),
+        Store::new(Arc::new(MemoryStore::new(
+            &nativelink_config::stores::MemoryStore::default(),
+        ))),
+    ));
+    let ac_store = Store::new(Arc::new(MemoryStore::new(
+        &nativelink_config::stores::MemoryStore::default(),
+    )));
+    let work_directory = make_temp_path("foo");
+    fs::create_dir_all(format!("{}/{}", work_directory, "another_dir")).await?;
+    let mut file =
+        fs::create_file(OsString::from(format!("{}/{}", work_directory, "foo.txt"))).await?;
+    file.as_writer().await?.write_all(b"Hello, world!").await?;
+    file.as_writer().await?.as_mut().sync_all().await?;
+    drop(file);
+    new_local_worker(
+        Arc::new(LocalWorkerConfig {
+            work_directory: work_directory.clone(),
+            ..Default::default()
+        }),
+        cas_store.clone(),
+        Some(ac_store),
+        cas_store,
+    )
+    .await?;
+
+    let work_directory_path_buf = PathBuf::from(work_directory);
+
+    assert!(
+        work_directory_path_buf.read_dir()?.next().is_none(),
+        "Expected work_directory to have removed all files and to be empty"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_path = make_temp_path("scripts");
+    fs::create_dir_all(temp_path.clone()).await?;
+    #[cfg(target_family = "unix")]
+    let precondition_script = {
+        let precondition_script = format!("{temp_path}/precondition.sh");
+        // We use std::fs::File here because we sometimes get strange bugs here
+        // that result in: "Text file busy (os error 26)" if it is an executeable.
+        // It is likley because somewhere the file descriotor does not get closed
+        // in tokio's async context.
+        let mut file = std::fs::File::create(OsString::from(&precondition_script))?;
+        file.write_all(b"#!/bin/sh\nexit 1\n")?;
+        file.set_permissions(Permissions::from_mode(0o777))?;
+        file.sync_all()?;
+        drop(file);
+        precondition_script
+    };
+    #[cfg(target_family = "windows")]
+    let precondition_script = {
+        let precondition_script = format!("{}/precondition.bat", temp_path);
+        let mut file = std::fs::File::create(OsString::from(&precondition_script))?;
+        file.write_all(b"@echo off\r\nexit 1")?;
+        file.sync_all()?;
+        drop(file);
+        precondition_script
+    };
+    // TODO(#527) Sleep to reduce flakey chances.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let local_worker_config = LocalWorkerConfig {
+        experimental_precondition_script: Some(precondition_script),
+        ..Default::default()
+    };
+
+    let mut test_context = setup_local_worker_with_config(local_worker_config).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
+            .client
+            .expect_connect_worker(Ok(streaming_response))
+            .await;
+        assert_eq!(props, SupportedProperties::default());
+    }
+
+    let expected_worker_id = "foobar".to_string();
+
+    let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    {
+        // First initialize our worker by sending the response to the connection request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: expected_worker_id.clone(),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    const SALT: u64 = 1000;
+    let action_digest = DigestInfo::new([3u8; 32], 10);
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: PlatformProperties::default(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: action_digest,
+            salt: SALT,
+        },
+        skip_cache_lookup: true,
+    };
+
+    {
+        // Send execution request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::StartAction(StartExecute {
+                    execute_request: Some(action_info.into()),
+                    salt: SALT,
+                    queued_timestamp: None,
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    // Now our client should be notified that our runner finished.
+    let execution_response = test_context
+        .client
+        .expect_execution_response(Ok(Response::new(())))
+        .await;
+
+    #[cfg(target_family = "unix")]
+    const EXPECTED_MSG: &str = "Preconditions script returned status exit status: 1 - ";
+    #[cfg(target_family = "windows")]
+    const EXPECTED_MSG: &str = "Preconditions script returned status exit code: 1 - ";
+
+    // Now ensure the final results match our expectations.
+    assert_eq!(
+        execution_response,
+        ExecuteResult {
+            worker_id: expected_worker_id,
+            instance_name: INSTANCE_NAME.to_string(),
+            action_digest: Some(action_digest.into()),
+            salt: SALT,
+            digest_function: digest_function::Value::Sha256.into(),
+            result: Some(execute_result::Result::InternalError(
+                make_err!(Code::ResourceExhausted, "{}", EXPECTED_MSG,).into()
+            )),
+        }
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Error>> {
+    const SALT: u64 = 1000;
+
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    {
+        // Ensure our worker connects and properties were sent.
+        let props = test_context
+            .client
+            .expect_connect_worker(Ok(streaming_response))
+            .await;
+        assert_eq!(props, SupportedProperties::default());
+    }
+
+    // Handle registration (kill_all not called unless registered).
+    let mut tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    {
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: "foobar".to_string(),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    let action_digest = DigestInfo::new([3u8; 32], 10);
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: PlatformProperties::default(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Blake3,
+            digest: action_digest,
+            salt: SALT,
+        },
+        skip_cache_lookup: true,
+    };
+
+    {
+        // Send execution request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::StartAction(StartExecute {
+                    execute_request: Some(action_info.clone().into()),
+                    salt: SALT,
+                    queued_timestamp: None,
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+    let running_action = Arc::new(MockRunningAction::new());
+
+    // Send and wait for response from create_and_add_action to RunningActionsManager.
+    test_context
+        .actions_manager
+        .expect_create_and_add_action(Ok(running_action.clone()))
+        .await;
+
+    let action_id = action_info.unique_qualifier.get_hash();
+    {
+        // Send kill request.
+        tx_stream
+            .send_data(encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::KillActionRequest(KillActionRequest {
+                    action_id: hex::encode(action_id),
+                })),
+            })?)
+            .await
+            .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+    }
+
+    let killed_action_id = test_context.actions_manager.expect_kill_action().await;
+
+    // Make sure that the killed action is the one we intended
+    assert_eq!(killed_action_id, action_id);
+
+    Ok(())
 }

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -54,6 +54,7 @@ use nativelink_worker::running_actions_manager::{
     RunningActionsManager, RunningActionsManagerArgs, RunningActionsManagerImpl,
 };
 use once_cell::sync::Lazy;
+use pretty_assertions::assert_eq;
 use prost::Message;
 use rand::{thread_rng, Rng};
 use tokio::sync::oneshot;
@@ -140,2182 +141,312 @@ fn increment_clock(time: &mut SystemTime) -> SystemTime {
     previous_time
 }
 
-#[cfg(test)]
-mod running_actions_manager_tests {
-    use pretty_assertions::assert_eq;
+#[nativelink_test]
+async fn download_to_directory_file_download_test() -> Result<(), Box<dyn std::error::Error>> {
+    const FILE1_NAME: &str = "file1.txt";
+    const FILE1_CONTENT: &str = "HELLOFILE1";
+    const FILE2_NAME: &str = "file2.exec";
+    const FILE2_CONTENT: &str = "HELLOFILE2";
+    const FILE2_MODE: u32 = 0o710;
+    const FILE2_MTIME: u64 = 5;
 
-    use super::*; // Must be declared in every module.
+    let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
 
-    #[nativelink_test]
-    async fn download_to_directory_file_download_test() -> Result<(), Box<dyn std::error::Error>> {
-        const FILE1_NAME: &str = "file1.txt";
-        const FILE1_CONTENT: &str = "HELLOFILE1";
-        const FILE2_NAME: &str = "file2.exec";
-        const FILE2_CONTENT: &str = "HELLOFILE2";
-        const FILE2_MODE: u32 = 0o710;
-        const FILE2_MTIME: u64 = 5;
+    let root_directory_digest = {
+        // Make and insert (into store) our digest info needed to create our directory & files.
+        let file1_content_digest = DigestInfo::new([2u8; 32], 32);
+        slow_store
+            .as_ref()
+            .update_oneshot(file1_content_digest, FILE1_CONTENT.into())
+            .await?;
+        let file2_content_digest = DigestInfo::new([3u8; 32], 32);
+        slow_store
+            .as_ref()
+            .update_oneshot(file2_content_digest, FILE2_CONTENT.into())
+            .await?;
 
-        let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
+        let root_directory_digest = DigestInfo::new([1u8; 32], 32);
+        let root_directory = Directory {
+            files: vec![
+                FileNode {
+                    name: FILE1_NAME.to_string(),
+                    digest: Some(file1_content_digest.into()),
+                    is_executable: false,
+                    node_properties: None,
+                },
+                FileNode {
+                    name: FILE2_NAME.to_string(),
+                    digest: Some(file2_content_digest.into()),
+                    is_executable: true,
+                    node_properties: Some(NodeProperties {
+                        properties: vec![],
+                        mtime: Some(
+                            SystemTime::UNIX_EPOCH
+                                .checked_add(Duration::from_secs(FILE2_MTIME))
+                                .unwrap()
+                                .into(),
+                        ),
+                        unix_mode: Some(FILE2_MODE),
+                    }),
+                },
+            ],
+            ..Default::default()
+        };
 
-        let root_directory_digest = {
-            // Make and insert (into store) our digest info needed to create our directory & files.
+        slow_store
+            .as_ref()
+            .update_oneshot(root_directory_digest, root_directory.encode_to_vec().into())
+            .await?;
+        root_directory_digest
+    };
+
+    let download_dir = {
+        // Tell it to download the digest info to a directory.
+        let download_dir = make_temp_path("download_dir");
+        fs::create_dir_all(&download_dir)
+            .await
+            .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
+        download_to_directory(
+            cas_store.as_ref(),
+            fast_store.as_pin(),
+            &root_directory_digest,
+            &download_dir,
+        )
+        .await?;
+        download_dir
+    };
+    {
+        // Now ensure that our download_dir has the files.
+        let file1_content = fs::read(format!("{download_dir}/{FILE1_NAME}")).await?;
+        assert_eq!(std::str::from_utf8(&file1_content)?, FILE1_CONTENT);
+
+        let file2_path = format!("{download_dir}/{FILE2_NAME}");
+        let file2_content = fs::read(&file2_path).await?;
+        assert_eq!(std::str::from_utf8(&file2_content)?, FILE2_CONTENT);
+
+        let file2_metadata = fs::metadata(&file2_path).await?;
+        // Note: We sent 0o710, but because is_executable was set it turns into 0o711.
+        #[cfg(target_family = "unix")]
+        assert_eq!(file2_metadata.mode() & 0o777, FILE2_MODE | 0o111);
+        assert_eq!(
+            file2_metadata
+                .modified()?
+                .duration_since(SystemTime::UNIX_EPOCH)?
+                .as_secs(),
+            FILE2_MTIME
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn std::error::Error>> {
+    const DIRECTORY1_NAME: &str = "folder1";
+    const FILE1_NAME: &str = "file1.txt";
+    const FILE1_CONTENT: &str = "HELLOFILE1";
+    const DIRECTORY2_NAME: &str = "folder2";
+
+    let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
+
+    let root_directory_digest = {
+        // Make and insert (into store) our digest info needed to create our directory & files.
+        let directory1_digest = DigestInfo::new([1u8; 32], 32);
+        {
             let file1_content_digest = DigestInfo::new([2u8; 32], 32);
             slow_store
                 .as_ref()
                 .update_oneshot(file1_content_digest, FILE1_CONTENT.into())
                 .await?;
-            let file2_content_digest = DigestInfo::new([3u8; 32], 32);
-            slow_store
-                .as_ref()
-                .update_oneshot(file2_content_digest, FILE2_CONTENT.into())
-                .await?;
-
-            let root_directory_digest = DigestInfo::new([1u8; 32], 32);
-            let root_directory = Directory {
-                files: vec![
-                    FileNode {
-                        name: FILE1_NAME.to_string(),
-                        digest: Some(file1_content_digest.into()),
-                        is_executable: false,
-                        node_properties: None,
-                    },
-                    FileNode {
-                        name: FILE2_NAME.to_string(),
-                        digest: Some(file2_content_digest.into()),
-                        is_executable: true,
-                        node_properties: Some(NodeProperties {
-                            properties: vec![],
-                            mtime: Some(
-                                SystemTime::UNIX_EPOCH
-                                    .checked_add(Duration::from_secs(FILE2_MTIME))
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            unix_mode: Some(FILE2_MODE),
-                        }),
-                    },
-                ],
-                ..Default::default()
-            };
-
-            slow_store
-                .as_ref()
-                .update_oneshot(root_directory_digest, root_directory.encode_to_vec().into())
-                .await?;
-            root_directory_digest
-        };
-
-        let download_dir = {
-            // Tell it to download the digest info to a directory.
-            let download_dir = make_temp_path("download_dir");
-            fs::create_dir_all(&download_dir)
-                .await
-                .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
-            download_to_directory(
-                cas_store.as_ref(),
-                fast_store.as_pin(),
-                &root_directory_digest,
-                &download_dir,
-            )
-            .await?;
-            download_dir
-        };
-        {
-            // Now ensure that our download_dir has the files.
-            let file1_content = fs::read(format!("{download_dir}/{FILE1_NAME}")).await?;
-            assert_eq!(std::str::from_utf8(&file1_content)?, FILE1_CONTENT);
-
-            let file2_path = format!("{download_dir}/{FILE2_NAME}");
-            let file2_content = fs::read(&file2_path).await?;
-            assert_eq!(std::str::from_utf8(&file2_content)?, FILE2_CONTENT);
-
-            let file2_metadata = fs::metadata(&file2_path).await?;
-            // Note: We sent 0o710, but because is_executable was set it turns into 0o711.
-            #[cfg(target_family = "unix")]
-            assert_eq!(file2_metadata.mode() & 0o777, FILE2_MODE | 0o111);
-            assert_eq!(
-                file2_metadata
-                    .modified()?
-                    .duration_since(SystemTime::UNIX_EPOCH)?
-                    .as_secs(),
-                FILE2_MTIME
-            );
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn std::error::Error>>
-    {
-        const DIRECTORY1_NAME: &str = "folder1";
-        const FILE1_NAME: &str = "file1.txt";
-        const FILE1_CONTENT: &str = "HELLOFILE1";
-        const DIRECTORY2_NAME: &str = "folder2";
-
-        let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
-
-        let root_directory_digest = {
-            // Make and insert (into store) our digest info needed to create our directory & files.
-            let directory1_digest = DigestInfo::new([1u8; 32], 32);
-            {
-                let file1_content_digest = DigestInfo::new([2u8; 32], 32);
-                slow_store
-                    .as_ref()
-                    .update_oneshot(file1_content_digest, FILE1_CONTENT.into())
-                    .await?;
-                let directory1 = Directory {
-                    files: vec![FileNode {
-                        name: FILE1_NAME.to_string(),
-                        digest: Some(file1_content_digest.into()),
-                        ..Default::default()
-                    }],
-                    ..Default::default()
-                };
-                slow_store
-                    .as_ref()
-                    .update_oneshot(directory1_digest, directory1.encode_to_vec().into())
-                    .await?;
-            }
-            let directory2_digest = DigestInfo::new([3u8; 32], 32);
-            {
-                // Now upload an empty directory.
-                slow_store
-                    .as_ref()
-                    .update_oneshot(
-                        directory2_digest,
-                        Directory::default().encode_to_vec().into(),
-                    )
-                    .await?;
-            }
-            let root_directory_digest = DigestInfo::new([5u8; 32], 32);
-            {
-                let root_directory = Directory {
-                    directories: vec![
-                        DirectoryNode {
-                            name: DIRECTORY1_NAME.to_string(),
-                            digest: Some(directory1_digest.into()),
-                        },
-                        DirectoryNode {
-                            name: DIRECTORY2_NAME.to_string(),
-                            digest: Some(directory2_digest.into()),
-                        },
-                    ],
-                    ..Default::default()
-                };
-                slow_store
-                    .as_ref()
-                    .update_oneshot(root_directory_digest, root_directory.encode_to_vec().into())
-                    .await?;
-            }
-            root_directory_digest
-        };
-
-        let download_dir = {
-            // Tell it to download the digest info to a directory.
-            let download_dir = make_temp_path("download_dir");
-            fs::create_dir_all(&download_dir)
-                .await
-                .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
-            download_to_directory(
-                cas_store.as_ref(),
-                fast_store.as_pin(),
-                &root_directory_digest,
-                &download_dir,
-            )
-            .await?;
-            download_dir
-        };
-        {
-            // Now ensure that our download_dir has the files.
-            let file1_content = fs::read(format!("{download_dir}/{DIRECTORY1_NAME}/{FILE1_NAME}"))
-                .await
-                .err_tip(|| "On file_1 read")?;
-            assert_eq!(std::str::from_utf8(&file1_content)?, FILE1_CONTENT);
-
-            let folder2_path = format!("{download_dir}/{DIRECTORY2_NAME}");
-            let folder2_metadata = fs::metadata(&folder2_path)
-                .await
-                .err_tip(|| "On folder2_metadata metadata")?;
-            assert_eq!(folder2_metadata.is_dir(), true);
-        }
-        Ok(())
-    }
-
-    // Windows does not support symlinks.
-    #[cfg(not(target_family = "windows"))]
-    #[nativelink_test]
-    async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn std::error::Error>>
-    {
-        const FILE_NAME: &str = "file.txt";
-        const FILE_CONTENT: &str = "HELLOFILE";
-        const SYMLINK_NAME: &str = "symlink_file.txt";
-        const SYMLINK_TARGET: &str = "file.txt";
-
-        let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
-
-        let root_directory_digest = {
-            // Make and insert (into store) our digest info needed to create our directory & files.
-            let file_content_digest = DigestInfo::new([1u8; 32], 32);
-            slow_store
-                .as_ref()
-                .update_oneshot(file_content_digest, FILE_CONTENT.into())
-                .await?;
-
-            let root_directory_digest = DigestInfo::new([2u8; 32], 32);
-            let root_directory = Directory {
+            let directory1 = Directory {
                 files: vec![FileNode {
-                    name: FILE_NAME.to_string(),
-                    digest: Some(file_content_digest.into()),
-                    is_executable: false,
-                    node_properties: None,
-                }],
-                symlinks: vec![SymlinkNode {
-                    name: SYMLINK_NAME.to_string(),
-                    target: SYMLINK_TARGET.to_string(),
-                    node_properties: None,
+                    name: FILE1_NAME.to_string(),
+                    digest: Some(file1_content_digest.into()),
+                    ..Default::default()
                 }],
                 ..Default::default()
             };
-
+            slow_store
+                .as_ref()
+                .update_oneshot(directory1_digest, directory1.encode_to_vec().into())
+                .await?;
+        }
+        let directory2_digest = DigestInfo::new([3u8; 32], 32);
+        {
+            // Now upload an empty directory.
+            slow_store
+                .as_ref()
+                .update_oneshot(
+                    directory2_digest,
+                    Directory::default().encode_to_vec().into(),
+                )
+                .await?;
+        }
+        let root_directory_digest = DigestInfo::new([5u8; 32], 32);
+        {
+            let root_directory = Directory {
+                directories: vec![
+                    DirectoryNode {
+                        name: DIRECTORY1_NAME.to_string(),
+                        digest: Some(directory1_digest.into()),
+                    },
+                    DirectoryNode {
+                        name: DIRECTORY2_NAME.to_string(),
+                        digest: Some(directory2_digest.into()),
+                    },
+                ],
+                ..Default::default()
+            };
             slow_store
                 .as_ref()
                 .update_oneshot(root_directory_digest, root_directory.encode_to_vec().into())
                 .await?;
-            root_directory_digest
-        };
-
-        let download_dir = {
-            // Tell it to download the digest info to a directory.
-            let download_dir = make_temp_path("download_dir");
-            fs::create_dir_all(&download_dir)
-                .await
-                .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
-            download_to_directory(
-                cas_store.as_ref(),
-                fast_store.as_pin(),
-                &root_directory_digest,
-                &download_dir,
-            )
-            .await?;
-            download_dir
-        };
-        {
-            // Now ensure that our download_dir has the files.
-            let symlink_path = format!("{download_dir}/{SYMLINK_NAME}");
-            let symlink_content = fs::read(&symlink_path)
-                .await
-                .err_tip(|| "On symlink read")?;
-            assert_eq!(std::str::from_utf8(&symlink_content)?, FILE_CONTENT);
-
-            let symlink_metadata = fs::symlink_metadata(&symlink_path)
-                .await
-                .err_tip(|| "On symlink symlink_metadata")?;
-            assert_eq!(symlink_metadata.is_symlink(), true);
         }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn ensure_output_files_full_directories_are_created_no_working_directory_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        {
-            const SALT: u64 = 55;
-            let command = Command {
-                arguments: vec!["touch".to_string(), "./some/path/test.txt".to_string()],
-                output_files: vec!["some/path/test.txt".to_string()],
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory {
-                    directories: vec![DirectoryNode {
-                        name: "some_cwd".to_string(),
-                        digest: Some(
-                            serialize_and_upload_message(
-                                &Directory::default(),
-                                cas_store.as_pin(),
-                                &mut DigestHasherFunc::Sha256.hasher(),
-                            )
-                            .await?
-                            .into(),
-                        ),
-                    }],
-                    ..Default::default()
-                },
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    },
-                )
-                .await?;
-
-            let running_action = running_action.clone().prepare_action().await?;
-
-            // The folder should have been created for our output file.
-            assert_eq!(
-                fs::metadata(format!(
-                    "{}/{}",
-                    running_action.get_work_directory(),
-                    "some/path"
-                ))
-                .await
-                .is_ok(),
-                true,
-                "Expected path to exist"
-            );
-
-            running_action.cleanup().await?;
-        };
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn ensure_output_files_full_directories_are_created_test(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        {
-            const SALT: u64 = 55;
-            let working_directory = "some_cwd";
-            let command = Command {
-                arguments: vec!["touch".to_string(), "./some/path/test.txt".to_string()],
-                output_files: vec!["some/path/test.txt".to_string()],
-                working_directory: working_directory.to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory {
-                    directories: vec![DirectoryNode {
-                        name: "some_cwd".to_string(),
-                        digest: Some(
-                            serialize_and_upload_message(
-                                &Directory::default(),
-                                cas_store.as_pin(),
-                                &mut DigestHasherFunc::Sha256.hasher(),
-                            )
-                            .await?
-                            .into(),
-                        ),
-                    }],
-                    ..Default::default()
-                },
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    },
-                )
-                .await?;
-
-            let running_action = running_action.clone().prepare_action().await?;
-
-            // The folder should have been created for our output file.
-            assert_eq!(
-                fs::metadata(format!(
-                    "{}/{}/{}",
-                    running_action.get_work_directory(),
-                    working_directory,
-                    "some/path"
-                ))
-                .await
-                .is_ok(),
-                true,
-                "Expected path to exist"
-            );
-
-            running_action.cleanup().await?;
-        };
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        let action_result = {
-            const SALT: u64 = 55;
-            #[cfg(target_family = "unix")]
-            let arguments = vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                "printf '123 ' > ./test.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
-                    .to_string(),
-            ];
-            #[cfg(target_family = "windows")]
-            let arguments = vec![
-                "cmd".to_string(),
-                "/C".to_string(),
-                // Note: Windows adds two spaces after 'set /p=XXX'.
-                "echo | set /p=123> ./test.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
-                    .to_string(),
-            ];
-            let working_directory = "some_cwd";
-            let command = Command {
-                arguments,
-                output_paths: vec!["test.txt".to_string()],
-                working_directory: working_directory.to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Blake3.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory {
-                    directories: vec![DirectoryNode {
-                        name: working_directory.to_string(),
-                        digest: Some(
-                            serialize_and_upload_message(
-                                &Directory::default(),
-                                cas_store.as_pin(),
-                                &mut DigestHasherFunc::Blake3.hasher(),
-                            )
-                            .await?
-                            .into(),
-                        ),
-                    }],
-                    ..Default::default()
-                },
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Blake3.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Blake3.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Blake3.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        let file_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&file_content)?, "123 ");
-        let stdout_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
-        let stderr_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
-        let mut clock_time = make_system_time(0);
-        assert_eq!(
-            action_result,
-            ActionResult {
-                output_files: vec![FileInfo {
-                    name_or_path: NameOrPath::Path("test.txt".to_string()),
-                    digest: DigestInfo::try_new(
-                        "3f488ba478fc6716c756922c9f34ebd7e84b85c3e03e33e22e7a3736cafdc6d8",
-                        4
-                    )?,
-                    is_executable: false,
-                }],
-                stdout_digest: DigestInfo::try_new(
-                    "af1720193ae81515067a3ef39f0dfda3ad54a1a9d216e55d32fe5c1e178c6a7d",
-                    11
-                )?,
-                stderr_digest: DigestInfo::try_new(
-                    "65e0abbae32a3aedaf040b654c6f02ace03c7690c17a8415a90fc2ec9c809a16",
-                    12
-                )?,
-                exit_code: 0,
-                output_folders: vec![],
-                output_file_symlinks: vec![],
-                output_directory_symlinks: vec![],
-                server_logs: HashMap::new(),
-                execution_metadata: ExecutionMetadata {
-                    worker: WORKER_ID.to_string(),
-                    queued_timestamp: SystemTime::UNIX_EPOCH,
-                    worker_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_completed_timestamp: increment_clock(&mut clock_time),
-                    execution_start_timestamp: increment_clock(&mut clock_time),
-                    execution_completed_timestamp: increment_clock(&mut clock_time),
-                    output_upload_start_timestamp: increment_clock(&mut clock_time),
-                    output_upload_completed_timestamp: increment_clock(&mut clock_time),
-                    worker_completed_timestamp: increment_clock(&mut clock_time),
-                },
-                error: None,
-                message: String::new(),
-            }
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        let action_result = {
-            const SALT: u64 = 55;
-            #[cfg(target_family = "unix")]
-            let arguments = vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                "printf '123 ' > ./test.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
-                    .to_string(),
-            ];
-            #[cfg(target_family = "windows")]
-            let arguments = vec![
-                "cmd".to_string(),
-                "/C".to_string(),
-                // Note: Windows adds two spaces after 'set /p=XXX'.
-                "echo | set /p=123> ./test.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
-                    .to_string(),
-            ];
-            let working_directory = "some_cwd";
-            let command = Command {
-                arguments,
-                output_paths: vec!["test.txt".to_string()],
-                working_directory: working_directory.to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory {
-                    directories: vec![DirectoryNode {
-                        name: working_directory.to_string(),
-                        digest: Some(
-                            serialize_and_upload_message(
-                                &Directory::default(),
-                                cas_store.as_pin(),
-                                &mut DigestHasherFunc::Sha256.hasher(),
-                            )
-                            .await?
-                            .into(),
-                        ),
-                    }],
-                    ..Default::default()
-                },
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        let file_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&file_content)?, "123 ");
-        let stdout_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
-        let stderr_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
-        let mut clock_time = make_system_time(0);
-        assert_eq!(
-            action_result,
-            ActionResult {
-                output_files: vec![FileInfo {
-                    name_or_path: NameOrPath::Path("test.txt".to_string()),
-                    digest: DigestInfo::try_new(
-                        "c69e10a5f54f4e28e33897fbd4f8701595443fa8c3004aeaa20dd4d9a463483b",
-                        4
-                    )?,
-                    is_executable: false,
-                }],
-                stdout_digest: DigestInfo::try_new(
-                    "15019a676f057d97d1ad3af86f3cc1e623cb33b18ff28422bbe3248d2471cc94",
-                    11
-                )?,
-                stderr_digest: DigestInfo::try_new(
-                    "2375ab8a01ca11e1ea7606dfb58756c153d49733cde1dbfb5a1e00f39afacf06",
-                    12
-                )?,
-                exit_code: 0,
-                output_folders: vec![],
-                output_file_symlinks: vec![],
-                output_directory_symlinks: vec![],
-                server_logs: HashMap::new(),
-                execution_metadata: ExecutionMetadata {
-                    worker: WORKER_ID.to_string(),
-                    queued_timestamp: SystemTime::UNIX_EPOCH,
-                    worker_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_completed_timestamp: increment_clock(&mut clock_time),
-                    execution_start_timestamp: increment_clock(&mut clock_time),
-                    execution_completed_timestamp: increment_clock(&mut clock_time),
-                    output_upload_start_timestamp: increment_clock(&mut clock_time),
-                    output_upload_completed_timestamp: increment_clock(&mut clock_time),
-                    worker_completed_timestamp: increment_clock(&mut clock_time),
-                },
-                error: None,
-                message: String::new(),
-            }
-        );
-        Ok(())
-    }
-
-    // Windows does not support symlinks.
-    #[cfg(not(target_family = "windows"))]
-    #[nativelink_test]
-    async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        let queued_timestamp = make_system_time(1000);
-        let action_result = {
-            const SALT: u64 = 55;
-            let command = Command {
-                arguments: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    concat!(
-                        "mkdir -p dir1/dir2 && ",
-                        "echo foo > dir1/file && ",
-                        "touch dir1/file2 && ",
-                        "ln -s ../file dir1/dir2/sym &&",
-                        "ln -s /dev/null empty_sym",
-                    )
-                    .to_string(),
-                ],
-                output_paths: vec!["dir1".to_string(), "empty_sym".to_string()],
-                working_directory: ".".to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory::default(),
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: Some(queued_timestamp.into()),
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        let tree = get_and_decode_digest::<Tree>(
-            slow_store.as_ref(),
-            action_result.output_folders[0].tree_digest.into(),
-        )
-        .await?;
-        let root_directory = Directory {
-            files: vec![
-                FileNode {
-                    name: "file".to_string(),
-                    digest: Some(
-                        DigestInfo::try_new(
-                            "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-                            4,
-                        )?
-                        .into(),
-                    ),
-                    ..Default::default()
-                },
-                FileNode {
-                    name: "file2".to_string(),
-                    digest: Some(
-                        DigestInfo::try_new(
-                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                            0,
-                        )?
-                        .into(),
-                    ),
-                    ..Default::default()
-                },
-            ],
-            directories: vec![DirectoryNode {
-                name: "dir2".to_string(),
-                digest: Some(
-                    DigestInfo::try_new(
-                        "cce0098e0b0f1d785edb0da50beedb13e27dcd459b091b2f8f82543cb7cd0527",
-                        16,
-                    )?
-                    .into(),
-                ),
-            }],
-            ..Default::default()
-        };
-        assert_eq!(
-            tree,
-            Tree {
-                root: Some(root_directory.clone()),
-                children: vec![
-                    Directory {
-                        symlinks: vec![SymlinkNode {
-                            name: "sym".to_string(),
-                            target: "../file".to_string(),
-                            ..Default::default()
-                        }],
-                        ..Default::default()
-                    },
-                    root_directory
-                ],
-            }
-        );
-        let mut clock_time = make_system_time(0);
-        assert_eq!(
-            action_result,
-            ActionResult {
-                output_files: vec![],
-                stdout_digest: DigestInfo::try_new(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                    0
-                )?,
-                stderr_digest: DigestInfo::try_new(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                    0
-                )?,
-                exit_code: 0,
-                output_folders: vec![DirectoryInfo {
-                    path: "dir1".to_string(),
-                    tree_digest: DigestInfo::try_new(
-                        "adbb04fa6e166e663c1310bbf8ba494e468b1b6c33e1e5346e2216b6904c9917",
-                        490
-                    )?,
-                }],
-                output_file_symlinks: vec![SymlinkInfo {
-                    name_or_path: NameOrPath::Path("empty_sym".to_string()),
-                    target: "/dev/null".to_string(),
-                }],
-                output_directory_symlinks: vec![],
-                server_logs: HashMap::new(),
-                execution_metadata: ExecutionMetadata {
-                    worker: WORKER_ID.to_string(),
-                    queued_timestamp,
-                    worker_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_completed_timestamp: increment_clock(&mut clock_time),
-                    execution_start_timestamp: increment_clock(&mut clock_time),
-                    execution_completed_timestamp: increment_clock(&mut clock_time),
-                    output_upload_start_timestamp: increment_clock(&mut clock_time),
-                    output_upload_completed_timestamp: increment_clock(&mut clock_time),
-                    worker_completed_timestamp: increment_clock(&mut clock_time),
-                },
-                error: None,
-                message: String::new(),
-            }
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        let queued_timestamp = make_system_time(1000);
-
-        #[cfg(target_family = "unix")]
-        let arguments = vec!["sh".to_string(), "-c".to_string(), "exit 33".to_string()];
-        #[cfg(target_family = "windows")]
-        let arguments = vec!["cmd".to_string(), "/C".to_string(), "exit 33".to_string()];
-
-        let action_result = {
-            const SALT: u64 = 55;
-            let command = Command {
-                arguments,
-                output_paths: vec![],
-                working_directory: ".".to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory::default(),
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: Some(queued_timestamp.into()),
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        let mut clock_time = make_system_time(0);
-        assert_eq!(
-            action_result,
-            ActionResult {
-                output_files: vec![],
-                stdout_digest: DigestInfo::try_new(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                    0
-                )?,
-                stderr_digest: DigestInfo::try_new(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                    0
-                )?,
-                exit_code: 33,
-                output_folders: vec![],
-                output_file_symlinks: vec![],
-                output_directory_symlinks: vec![],
-                server_logs: HashMap::new(),
-                execution_metadata: ExecutionMetadata {
-                    worker: WORKER_ID.to_string(),
-                    queued_timestamp,
-                    worker_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_completed_timestamp: increment_clock(&mut clock_time),
-                    execution_start_timestamp: increment_clock(&mut clock_time),
-                    execution_completed_timestamp: increment_clock(&mut clock_time),
-                    output_upload_start_timestamp: increment_clock(&mut clock_time),
-                    output_upload_completed_timestamp: increment_clock(&mut clock_time),
-                    worker_completed_timestamp: increment_clock(&mut clock_time),
-                },
-                error: None,
-                message: String::new(),
-            }
-        );
-        let mut dir_stream = fs::read_dir(&root_action_directory).await?;
-        assert!(
-            dir_stream.as_mut().next_entry().await?.is_none(),
-            "Expected empty directory at {root_action_directory}"
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-        const SALT: u64 = 55;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-
-        #[cfg(target_family = "unix")]
-        let arguments = vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "sleep infinity".to_string(),
-        ];
-        #[cfg(target_family = "windows")]
-        // Windows is weird with timeout, so we use ping. See:
-        // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
-        let arguments = vec![
-            "cmd".to_string(),
-            "/C".to_string(),
-            "ping -n 99999 127.0.0.1".to_string(),
-        ];
-
-        let command = Command {
-            arguments,
-            output_paths: vec![],
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let action = Action {
-            command_digest: Some(command_digest.into()),
-            input_root_digest: Some(input_root_digest.into()),
-            ..Default::default()
-        };
-        let action_digest = serialize_and_upload_message(
-            &action,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        let running_action_impl = running_actions_manager
-            .clone()
-            .create_and_add_action(
-                WORKER_ID.to_string(),
-                StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        action_digest: Some(action_digest.into()),
-                        digest_function: ProtoDigestFunction::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: SALT,
-                    queued_timestamp: Some(make_system_time(1000).into()),
-                },
-            )
-            .await?;
-
-        // Start the action and kill it at the same time.
-        let result = futures::join!(
-            run_action(running_action_impl),
-            running_actions_manager.kill_all()
-        )
-        .0?;
-
-        // Check that the action was killed.
-        #[cfg(target_family = "unix")]
-        assert_eq!(9, result.exit_code);
-        // Note: Windows kill command returns exit code 1.
-        #[cfg(target_family = "windows")]
-        assert_eq!(1, result.exit_code);
-
-        Ok(())
-    }
-
-    // This script runs a command under a wrapper script set in a config.
-    // The wrapper script will print a constant string to stderr, and the test itself will
-    // print to stdout. We then check the results of both to make sure the shell script was
-    // invoked and the actual command was invoked under the shell script.
-    #[nativelink_test]
-    async fn entrypoint_does_invoke_if_set() -> Result<(), Box<dyn std::error::Error>> {
-        #[cfg(target_family = "unix")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-#!/bin/bash
-# Print some static text to stderr. This is what the test uses to
-# make sure the script did run.
->&2 printf \"Wrapper script did run\"
-
-# Now run the real command.
-exec \"$@\"
-";
-        #[cfg(target_family = "windows")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-@echo off
-:: Print some static text to stderr. This is what the test uses to
-:: make sure the script did run.
-echo | set /p=\"Wrapper script did run\" 1>&2
-
-:: Run command, but morph the echo to ensure it doesn't
-:: add a new line to the end of the output.
-%1 | set /p=%2
-exit 0
-";
-        const WORKER_ID: &str = "foo_worker_id";
-        const SALT: u64 = 66;
-        const EXPECTED_STDOUT: &str = "Action did run";
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let test_wrapper_script = {
-            let test_wrapper_dir = make_temp_path("wrapper_dir");
-            fs::create_dir_all(&test_wrapper_dir).await?;
-            #[cfg(target_family = "unix")]
-            let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
-            #[cfg(target_family = "windows")]
-            let test_wrapper_script =
-                OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
-
-            // We use std::fs::File here because we sometimes get strange bugs here
-            // that result in: "Text file busy (os error 26)" if it is an executeable.
-            // It is likley because somewhere the file descriotor does not get closed
-            // in tokio's async context.
-            let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
-            test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
-            #[cfg(target_family = "unix")]
-            test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
-            test_wrapper_script_handle.sync_all()?;
-            drop(test_wrapper_script_handle);
-
-            test_wrapper_script
-        };
-
-        // TODO(#527) Sleep to reduce flakey chances.
-        tokio::time::sleep(Duration::from_millis(250)).await;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration {
-                    entrypoint: Some(test_wrapper_script.into_string().unwrap()),
-                    additional_environment: None,
-                },
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-        #[cfg(target_family = "unix")]
-        let arguments = vec!["printf".to_string(), EXPECTED_STDOUT.to_string()];
-        #[cfg(target_family = "windows")]
-        let arguments = vec!["echo".to_string(), EXPECTED_STDOUT.to_string()];
-        let command = Command {
-            arguments,
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let action = Action {
-            command_digest: Some(command_digest.into()),
-            input_root_digest: Some(input_root_digest.into()),
-            ..Default::default()
-        };
-        let action_digest = serialize_and_upload_message(
-            &action,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        let running_action_impl = running_actions_manager
-            .clone()
-            .create_and_add_action(
-                WORKER_ID.to_string(),
-                StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        action_digest: Some(action_digest.into()),
-                        digest_function: ProtoDigestFunction::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: SALT,
-                    queued_timestamp: Some(make_system_time(1000).into()),
-                },
-            )
-            .await?;
-
-        let result = run_action(running_action_impl).await?;
-        assert_eq!(result.exit_code, 0, "Exit code should be 0");
-
-        let expected_stdout = DigestHasherFunc::Sha256
-            .hasher()
-            .compute_from_reader(Cursor::new(EXPECTED_STDOUT))
-            .await?;
-        // Note: This string should match what is in worker_for_test.sh
-        let expected_stderr = DigestHasherFunc::Sha256
-            .hasher()
-            .compute_from_reader(Cursor::new("Wrapper script did run"))
-            .await?;
-        assert_eq!(expected_stdout, result.stdout_digest);
-        assert_eq!(expected_stderr, result.stderr_digest);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn entrypoint_injects_properties() -> Result<(), Box<dyn std::error::Error>> {
-        #[cfg(target_family = "unix")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-#!/bin/bash
-# Print some static text to stderr. This is what the test uses to
-# make sure the script did run.
->&2 printf \"Wrapper script did run with property $PROPERTY $VALUE $INNER_TIMEOUT\"
-
-# Now run the real command.
-exec \"$@\"
-";
-        #[cfg(target_family = "windows")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-@echo off
-:: Print some static text to stderr. This is what the test uses to
-:: make sure the script did run.
-echo | set /p=\"Wrapper script did run with property %PROPERTY% %VALUE% %INNER_TIMEOUT%\" 1>&2
-
-:: Run command, but morph the echo to ensure it doesn't
-:: add a new line to the end of the output.
-%1 | set /p=%2
-exit 0
-";
-        const WORKER_ID: &str = "foo_worker_id";
-        const SALT: u64 = 66;
-        const EXPECTED_STDOUT: &str = "Action did run";
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let test_wrapper_script = {
-            let test_wrapper_dir = make_temp_path("wrapper_dir");
-            fs::create_dir_all(&test_wrapper_dir).await?;
-            #[cfg(target_family = "unix")]
-            let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
-            #[cfg(target_family = "windows")]
-            let test_wrapper_script =
-                OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
-
-            // We use std::fs::File here because we sometimes get strange bugs here
-            // that result in: "Text file busy (os error 26)" if it is an executeable.
-            // It is likley because somewhere the file descriotor does not get closed
-            // in tokio's async context.
-            let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
-            test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
-            #[cfg(target_family = "unix")]
-            test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
-            test_wrapper_script_handle.sync_all()?;
-            drop(test_wrapper_script_handle);
-
-            test_wrapper_script
-        };
-
-        // TODO(#527) Sleep to reduce flakey chances.
-        tokio::time::sleep(Duration::from_millis(250)).await;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration {
-                    entrypoint: Some(test_wrapper_script.into_string().unwrap()),
-                    additional_environment: Some(HashMap::from([
-                        (
-                            "PROPERTY".to_string(),
-                            EnvironmentSource::property("property_name".to_string()),
-                        ),
-                        (
-                            "VALUE".to_string(),
-                            EnvironmentSource::value("raw_value".to_string()),
-                        ),
-                        (
-                            "INNER_TIMEOUT".to_string(),
-                            EnvironmentSource::timeout_millis,
-                        ),
-                    ])),
-                },
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-        #[cfg(target_family = "unix")]
-        let arguments = vec!["printf".to_string(), EXPECTED_STDOUT.to_string()];
-        #[cfg(target_family = "windows")]
-        let arguments = vec!["echo".to_string(), EXPECTED_STDOUT.to_string()];
-        let command = Command {
-            arguments,
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        const TASK_TIMEOUT: Duration = Duration::from_secs(122);
-        let action = Action {
-            command_digest: Some(command_digest.into()),
-            input_root_digest: Some(input_root_digest.into()),
-            platform: Some(Platform {
-                properties: vec![Property {
-                    name: "property_name".into(),
-                    value: "property_value".into(),
-                }],
-            }),
-            timeout: Some(prost_types::Duration {
-                seconds: TASK_TIMEOUT.as_secs() as i64,
-                nanos: 0,
-            }),
-            ..Default::default()
-        };
-        let action_digest = serialize_and_upload_message(
-            &action,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        let running_action_impl = running_actions_manager
-            .clone()
-            .create_and_add_action(
-                WORKER_ID.to_string(),
-                StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        action_digest: Some(action_digest.into()),
-                        digest_function: ProtoDigestFunction::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: SALT,
-                    queued_timestamp: Some(make_system_time(1000).into()),
-                },
-            )
-            .await?;
-
-        let result = run_action(running_action_impl).await?;
-        assert_eq!(result.exit_code, 0, "Exit code should be 0");
-
-        let expected_stdout = DigestHasherFunc::Sha256
-            .hasher()
-            .compute_from_reader(Cursor::new(EXPECTED_STDOUT))
-            .await?;
-        // Note: This string should match what is in worker_for_test.sh
-        let expected_stderr =
-            "Wrapper script did run with property property_value raw_value 122000";
-        let expected_stderr_digest = DigestHasherFunc::Sha256
-            .hasher()
-            .compute_from_reader(Cursor::new(expected_stderr))
-            .await?;
-
-        let actual_stderr: prost::bytes::Bytes = cas_store
-            .as_ref()
-            .get_part_unchunked(result.stderr_digest, 0, None)
-            .await?;
-        let actual_stderr_decoded = std::str::from_utf8(&actual_stderr)?;
-        assert_eq!(expected_stderr, actual_stderr_decoded);
-        assert_eq!(expected_stdout, result.stdout_digest);
-        assert_eq!(expected_stderr_digest, result.stderr_digest);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn entrypoint_sends_timeout_via_side_channel() -> Result<(), Box<dyn std::error::Error>> {
-        #[cfg(target_family = "unix")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-#!/bin/bash
-echo '{\"failure\":\"timeout\"}' > \"$SIDE_CHANNEL_FILE\"
-exit 1
-";
-        #[cfg(target_family = "windows")]
-        const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
-@echo off
-echo | set /p={\"failure\":\"timeout\"} 1>&2 > %SIDE_CHANNEL_FILE%
-exit 1
-";
-        const WORKER_ID: &str = "foo_worker_id";
-        const SALT: u64 = 66;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let test_wrapper_script = {
-            let test_wrapper_dir = make_temp_path("wrapper_dir");
-            fs::create_dir_all(&test_wrapper_dir).await?;
-            #[cfg(target_family = "unix")]
-            let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
-            #[cfg(target_family = "windows")]
-            let test_wrapper_script =
-                OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
-
-            // We use std::fs::File here because we sometimes get strange bugs here
-            // that result in: "Text file busy (os error 26)" if it is an executeable.
-            // It is likley because somewhere the file descriotor does not get closed
-            // in tokio's async context.
-            let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
-            test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
-            #[cfg(target_family = "unix")]
-            test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
-            test_wrapper_script_handle.sync_all()?;
-            drop(test_wrapper_script_handle);
-
-            test_wrapper_script
-        };
-
-        // TODO(#527) Sleep to reduce flakey chances.
-        tokio::time::sleep(Duration::from_millis(250)).await;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration {
-                    entrypoint: Some(test_wrapper_script.into_string().unwrap()),
-                    additional_environment: Some(HashMap::from([(
-                        "SIDE_CHANNEL_FILE".to_string(),
-                        EnvironmentSource::side_channel_file,
-                    )])),
-                },
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-        let arguments = vec!["true".to_string()];
-        let command = Command {
-            arguments,
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let action = Action {
-            command_digest: Some(command_digest.into()),
-            input_root_digest: Some(input_root_digest.into()),
-            ..Default::default()
-        };
-        let action_digest = serialize_and_upload_message(
-            &action,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        let running_action_impl = running_actions_manager
-            .clone()
-            .create_and_add_action(
-                WORKER_ID.to_string(),
-                StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        action_digest: Some(action_digest.into()),
-                        digest_function: ProtoDigestFunction::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: SALT,
-                    queued_timestamp: Some(make_system_time(1000).into()),
-                },
-            )
-            .await?;
-
-        let result = run_action(running_action_impl).await?;
-        assert_eq!(result.exit_code, 1, "Exit code should be 1");
-        assert_eq!(
-            result.error.err_tip(|| "Error should exist")?.code,
-            Code::DeadlineExceeded
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error::Error>> {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: String::new(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            output_files: vec![FileInfo {
-                name_or_path: NameOrPath::Path("test.txt".to_string()),
-                digest: DigestInfo::try_new(
-                    "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
-                    3,
-                )?,
-                is_executable: false,
-            }],
-            stdout_digest: DigestInfo::try_new(
-                "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
-                10,
-            )?,
-            stderr_digest: DigestInfo::try_new(
-                "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
-                10,
-            )?,
-            exit_code: 0,
-            output_folders: vec![],
-            output_file_symlinks: vec![],
-            output_directory_symlinks: vec![],
-            server_logs: HashMap::new(),
-            execution_metadata: ExecutionMetadata {
-                worker: "WORKER_ID".to_string(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: make_system_time(0),
-                input_fetch_start_timestamp: make_system_time(1),
-                input_fetch_completed_timestamp: make_system_time(2),
-                execution_start_timestamp: make_system_time(3),
-                execution_completed_timestamp: make_system_time(4),
-                output_upload_start_timestamp: make_system_time(5),
-                output_upload_completed_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-            },
-            error: None,
-            message: String::new(),
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
-            .await?;
-
-        let retrieved_result =
-            get_and_decode_digest::<ProtoActionResult>(ac_store.as_ref(), action_digest.into())
-                .await?;
-
-        let proto_result: ProtoActionResult = action_result.into();
-        assert_eq!(proto_result, retrieved_result);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn std::error::Error>>
-    {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: String::new(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::everything,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            output_files: vec![FileInfo {
-                name_or_path: NameOrPath::Path("test.txt".to_string()),
-                digest: DigestInfo::try_new(
-                    "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
-                    3,
-                )?,
-                is_executable: false,
-            }],
-            stdout_digest: DigestInfo::try_new(
-                "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
-                10,
-            )?,
-            stderr_digest: DigestInfo::try_new(
-                "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
-                10,
-            )?,
-            exit_code: 1,
-            output_folders: vec![],
-            output_file_symlinks: vec![],
-            output_directory_symlinks: vec![],
-            server_logs: HashMap::new(),
-            execution_metadata: ExecutionMetadata {
-                worker: "WORKER_ID".to_string(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: make_system_time(0),
-                input_fetch_start_timestamp: make_system_time(1),
-                input_fetch_completed_timestamp: make_system_time(2),
-                execution_start_timestamp: make_system_time(3),
-                execution_completed_timestamp: make_system_time(4),
-                output_upload_start_timestamp: make_system_time(5),
-                output_upload_completed_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-            },
-            error: None,
-            message: String::new(),
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
-            .await?;
-
-        let retrieved_result =
-            get_and_decode_digest::<ProtoActionResult>(ac_store.as_ref(), action_digest.into())
-                .await?;
-
-        let proto_result: ProtoActionResult = action_result.into();
-        assert_eq!(proto_result, retrieved_result);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: String::new(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_historical_results_strategy: Some(
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
-                        ),
-                        success_message_template:
-                            "{historical_results_hash}-{historical_results_size}".to_string(),
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            output_files: vec![FileInfo {
-                name_or_path: NameOrPath::Path("test.txt".to_string()),
-                digest: DigestInfo::try_new(
-                    "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
-                    3,
-                )?,
-                is_executable: false,
-            }],
-            stdout_digest: DigestInfo::try_new(
-                "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
-                10,
-            )?,
-            stderr_digest: DigestInfo::try_new(
-                "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
-                10,
-            )?,
-            exit_code: 0,
-            output_folders: vec![],
-            output_file_symlinks: vec![],
-            output_directory_symlinks: vec![],
-            server_logs: HashMap::new(),
-            execution_metadata: ExecutionMetadata {
-                worker: "WORKER_ID".to_string(),
-                queued_timestamp: SystemTime::UNIX_EPOCH,
-                worker_start_timestamp: make_system_time(0),
-                input_fetch_start_timestamp: make_system_time(1),
-                input_fetch_completed_timestamp: make_system_time(2),
-                execution_start_timestamp: make_system_time(3),
-                execution_completed_timestamp: make_system_time(4),
-                output_upload_start_timestamp: make_system_time(5),
-                output_upload_completed_timestamp: make_system_time(6),
-                worker_completed_timestamp: make_system_time(7),
-            },
-            error: None,
-            message: String::new(),
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
-            .await?;
-
-        assert!(!action_result.message.is_empty(), "Message should be set");
-
-        let historical_digest = {
-            let (historical_results_hash, historical_results_size) = action_result
-                .message
-                .split_once('-')
-                .expect("Message should be in format {hash}-{size}");
-
-            DigestInfo::try_new(
-                historical_results_hash,
-                historical_results_size.parse::<i64>()?,
-            )?
-        };
-        let retrieved_result = get_and_decode_digest::<HistoricalExecuteResponse>(
+        root_directory_digest
+    };
+
+    let download_dir = {
+        // Tell it to download the digest info to a directory.
+        let download_dir = make_temp_path("download_dir");
+        fs::create_dir_all(&download_dir)
+            .await
+            .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
+        download_to_directory(
             cas_store.as_ref(),
-            historical_digest.into(),
+            fast_store.as_pin(),
+            &root_directory_digest,
+            &download_dir,
         )
         .await?;
-
-        assert_eq!(
-            HistoricalExecuteResponse {
-                action_digest: Some(action_digest.into()),
-                execute_response: Some(ExecuteResponse {
-                    result: Some(action_result.into()),
-                    status: Some(Default::default()),
-                    ..Default::default()
-                }),
-            },
-            retrieved_result
-        );
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>>
+        download_dir
+    };
     {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
+        // Now ensure that our download_dir has the files.
+        let file1_content = fs::read(format!("{download_dir}/{DIRECTORY1_NAME}/{FILE1_NAME}"))
+            .await
+            .err_tip(|| "On file_1 read")?;
+        assert_eq!(std::str::from_utf8(&file1_content)?, FILE1_CONTENT);
 
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: String::new(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_historical_results_strategy: Some(
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
-                        ),
-                        success_message_template:
-                            "{historical_results_hash}-{historical_results_size}".to_string(),
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
+        let folder2_path = format!("{download_dir}/{DIRECTORY2_NAME}");
+        let folder2_metadata = fs::metadata(&folder2_path)
+            .await
+            .err_tip(|| "On folder2_metadata metadata")?;
+        assert_eq!(folder2_metadata.is_dir(), true);
+    }
+    Ok(())
+}
 
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            exit_code: 1,
-            ..Default::default()
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+// Windows does not support symlinks.
+#[cfg(not(target_family = "windows"))]
+#[nativelink_test]
+async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn std::error::Error>> {
+    const FILE_NAME: &str = "file.txt";
+    const FILE_CONTENT: &str = "HELLOFILE";
+    const SYMLINK_NAME: &str = "symlink_file.txt";
+    const SYMLINK_TARGET: &str = "file.txt";
+
+    let (fast_store, slow_store, cas_store, _ac_store) = setup_stores().await?;
+
+    let root_directory_digest = {
+        // Make and insert (into store) our digest info needed to create our directory & files.
+        let file_content_digest = DigestInfo::new([1u8; 32], 32);
+        slow_store
+            .as_ref()
+            .update_oneshot(file_content_digest, FILE_CONTENT.into())
             .await?;
 
-        assert!(
-            action_result.message.is_empty(),
-            "Message should not be set"
-        );
-        Ok(())
+        let root_directory_digest = DigestInfo::new([2u8; 32], 32);
+        let root_directory = Directory {
+            files: vec![FileNode {
+                name: FILE_NAME.to_string(),
+                digest: Some(file_content_digest.into()),
+                is_executable: false,
+                node_properties: None,
+            }],
+            symlinks: vec![SymlinkNode {
+                name: SYMLINK_NAME.to_string(),
+                target: SYMLINK_TARGET.to_string(),
+                node_properties: None,
+            }],
+            ..Default::default()
+        };
+
+        slow_store
+            .as_ref()
+            .update_oneshot(root_directory_digest, root_directory.encode_to_vec().into())
+            .await?;
+        root_directory_digest
+    };
+
+    let download_dir = {
+        // Tell it to download the digest info to a directory.
+        let download_dir = make_temp_path("download_dir");
+        fs::create_dir_all(&download_dir)
+            .await
+            .err_tip(|| format!("Could not make download_dir : {download_dir}"))?;
+        download_to_directory(
+            cas_store.as_ref(),
+            fast_store.as_pin(),
+            &root_directory_digest,
+            &download_dir,
+        )
+        .await?;
+        download_dir
+    };
+    {
+        // Now ensure that our download_dir has the files.
+        let symlink_path = format!("{download_dir}/{SYMLINK_NAME}");
+        let symlink_content = fs::read(&symlink_path)
+            .await
+            .err_tip(|| "On symlink read")?;
+        assert_eq!(std::str::from_utf8(&symlink_content)?, FILE_CONTENT);
+
+        let symlink_metadata = fs::symlink_metadata(&symlink_path)
+            .await
+            .err_tip(|| "On symlink symlink_metadata")?;
+        assert_eq!(symlink_metadata.is_symlink(), true);
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn ensure_output_files_full_directories_are_created_no_working_directory_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
     }
 
-    #[nativelink_test]
-    async fn infra_failure_does_cache_in_historical_results(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
 
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-            root_action_directory: String::new(),
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
             execution_configuration: ExecutionConfiguration::default(),
             cas_store: cas_store.clone(),
             ac_store: Some(Store::new(ac_store.clone())),
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
-                upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::failures_only,
-                ),
-                failure_message_template: "{historical_results_hash}-{historical_results_size}".to_string(),
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
             timeout_handled_externally: false,
-        })?);
-
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            exit_code: 0,
-            error: Some(make_input_err!("test error")),
-            ..Default::default()
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
-            .await?;
-
-        assert!(!action_result.message.is_empty(), "Message should be set");
-
-        let historical_digest = {
-            let (historical_results_hash, historical_results_size) = action_result
-                .message
-                .split_once('-')
-                .expect("Message should be in format {hash}-{size}");
-
-            DigestInfo::try_new(
-                historical_results_hash,
-                historical_results_size.parse::<i64>()?,
-            )?
-        };
-
-        let retrieved_result = get_and_decode_digest::<HistoricalExecuteResponse>(
-            cas_store.as_ref(),
-            historical_digest.into(),
-        )
-        .await?;
-
-        assert_eq!(
-            HistoricalExecuteResponse {
-                action_digest: Some(action_digest.into()),
-                execute_response: Some(ExecuteResponse {
-                    result: Some(action_result.into()),
-                    status: Some(make_input_err!("test error").into()),
-                    ..Default::default()
-                }),
-            },
-            retrieved_result
-        );
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::Error>> {
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: String::new(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
-                        success_message_template: "{action_digest_hash}-{action_digest_size}"
-                            .to_string(),
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-
-        let action_digest = DigestInfo::new([2u8; 32], 32);
-        let mut action_result = ActionResult {
-            exit_code: 0,
-            ..Default::default()
-        };
-        running_actions_manager
-            .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
-            .await?;
-
-        assert!(!action_result.message.is_empty(), "Message should be set");
-
-        let action_result_digest = {
-            let (action_result_hash, action_result_size) = action_result
-                .message
-                .split_once('-')
-                .expect("Message should be in format {hash}-{size}");
-
-            DigestInfo::try_new(action_result_hash, action_result_size.parse::<i64>()?)?
-        };
-
-        let retrieved_result = get_and_decode_digest::<ProtoActionResult>(
-            ac_store.as_ref(),
-            action_result_digest.into(),
-        )
-        .await?;
-
-        let proto_result: ProtoActionResult = action_result.into();
-        assert_eq!(proto_result, retrieved_result);
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn std::error::Error>>
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
     {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-
-        #[cfg(target_family = "unix")]
-        let arguments = vec!["true".to_string()];
-        #[cfg(target_family = "windows")]
-        let arguments = vec![
-            "cmd".to_string(),
-            "/C".to_string(),
-            "exit".to_string(),
-            "0".to_string(),
-        ];
-
+        const SALT: u64 = 55;
         let command = Command {
-            arguments,
-            output_paths: vec![],
-            working_directory: ".".to_string(),
+            arguments: vec!["touch".to_string(), "./some/path/test.txt".to_string()],
+            output_files: vec!["some/path/test.txt".to_string()],
             ..Default::default()
         };
         let command_digest = serialize_and_upload_message(
@@ -2325,322 +456,21 @@ exit 1
         )
         .await?;
         let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        {
-            // Test to ensure that the task timeout is choosen if it is less than the max timeout.
-            static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
-            const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
-            const TASK_TIMEOUT: Duration = Duration::from_secs(10);
-
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                timeout: Some(prost_types::Duration {
-                    seconds: TASK_TIMEOUT.as_secs() as i64,
-                    nanos: 0,
-                }),
+            &Directory {
+                directories: vec![DirectoryNode {
+                    name: "some_cwd".to_string(),
+                    digest: Some(
+                        serialize_and_upload_message(
+                            &Directory::default(),
+                            cas_store.as_pin(),
+                            &mut DigestHasherFunc::Sha256.hasher(),
+                        )
+                        .await?
+                        .into(),
+                    ),
+                }],
                 ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-                RunningActionsManagerArgs {
-                    root_action_directory: root_action_directory.clone(),
-                    execution_configuration: ExecutionConfiguration::default(),
-                    cas_store: cas_store.clone(),
-                    ac_store: Some(Store::new(ac_store.clone())),
-                    historical_store: Store::new(cas_store.clone()),
-                    upload_action_result_config:
-                        &nativelink_config::cas_server::UploadActionResultConfig {
-                            upload_ac_results_strategy:
-                                nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                            ..Default::default()
-                        },
-                    max_action_timeout: MAX_TIMEOUT_DURATION,
-                    timeout_handled_externally: false,
-                },
-                Callbacks {
-                    now_fn: test_monotonic_clock,
-                    sleep_fn: |duration| {
-                        SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
-                        Box::pin(futures::future::pending())
-                    },
-                },
-            )?);
-
-            running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: 0,
-                        queued_timestamp: Some(make_system_time(1000).into()),
-                    },
-                )
-                .and_then(|action| {
-                    action
-                        .clone()
-                        .prepare_action()
-                        .and_then(RunningAction::execute)
-                        .then(|result| async move {
-                            if let Err(e) = action.cleanup().await {
-                                return Result::<ActionResult, Error>::Err(e).merge(result);
-                            }
-                            result
-                        })
-                })
-                .await?;
-            assert_eq!(
-                SENT_TIMEOUT.load(Ordering::Relaxed),
-                TASK_TIMEOUT.as_millis() as i64
-            );
-        }
-        {
-            // Ensure if no timeout is set use max timeout.
-            static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
-            const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
-            const TASK_TIMEOUT: Duration = Duration::from_secs(0);
-
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                timeout: Some(prost_types::Duration {
-                    seconds: TASK_TIMEOUT.as_secs() as i64,
-                    nanos: 0,
-                }),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-                RunningActionsManagerArgs {
-                    root_action_directory: root_action_directory.clone(),
-                    execution_configuration: ExecutionConfiguration::default(),
-                    cas_store: cas_store.clone(),
-                    ac_store: Some(Store::new(ac_store.clone())),
-                    historical_store: Store::new(cas_store.clone()),
-                    upload_action_result_config:
-                        &nativelink_config::cas_server::UploadActionResultConfig {
-                            upload_ac_results_strategy:
-                                nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                            ..Default::default()
-                        },
-                    max_action_timeout: MAX_TIMEOUT_DURATION,
-                    timeout_handled_externally: false,
-                },
-                Callbacks {
-                    now_fn: test_monotonic_clock,
-                    sleep_fn: |duration| {
-                        SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
-                        Box::pin(futures::future::pending())
-                    },
-                },
-            )?);
-
-            running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: 0,
-                        queued_timestamp: Some(make_system_time(1000).into()),
-                    },
-                )
-                .and_then(|action| {
-                    action
-                        .clone()
-                        .prepare_action()
-                        .and_then(RunningAction::execute)
-                        .then(|result| async move {
-                            if let Err(e) = action.cleanup().await {
-                                return Result::<ActionResult, Error>::Err(e).merge(result);
-                            }
-                            result
-                        })
-                })
-                .await?;
-            assert_eq!(
-                SENT_TIMEOUT.load(Ordering::Relaxed),
-                MAX_TIMEOUT_DURATION.as_millis() as i64
-            );
-        }
-        {
-            // Ensure we reject tasks that have a timeout set too high.
-            static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
-            const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
-            const TASK_TIMEOUT: Duration = Duration::from_secs(200);
-
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                timeout: Some(prost_types::Duration {
-                    seconds: TASK_TIMEOUT.as_secs() as i64,
-                    nanos: 0,
-                }),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-                RunningActionsManagerArgs {
-                    root_action_directory: root_action_directory.clone(),
-                    execution_configuration: ExecutionConfiguration::default(),
-                    cas_store: cas_store.clone(),
-                    ac_store: Some(Store::new(ac_store.clone())),
-                    historical_store: Store::new(cas_store.clone()),
-                    upload_action_result_config:
-                        &nativelink_config::cas_server::UploadActionResultConfig {
-                            upload_ac_results_strategy:
-                                nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                            ..Default::default()
-                        },
-                    max_action_timeout: MAX_TIMEOUT_DURATION,
-                    timeout_handled_externally: false,
-                },
-                Callbacks {
-                    now_fn: test_monotonic_clock,
-                    sleep_fn: |duration| {
-                        SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
-                        Box::pin(futures::future::pending())
-                    },
-                },
-            )?);
-
-            let result = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: 0,
-                        queued_timestamp: Some(make_system_time(1000).into()),
-                    },
-                )
-                .and_then(|action| {
-                    action
-                        .clone()
-                        .prepare_action()
-                        .and_then(RunningAction::execute)
-                        .then(|result| async move {
-                            if let Err(e) = action.cleanup().await {
-                                return Result::<ActionResult, Error>::Err(e).merge(result);
-                            }
-                            result
-                        })
-                })
-                .await;
-            assert_eq!(SENT_TIMEOUT.load(Ordering::Relaxed), -1);
-            assert_eq!(result.err().unwrap().code, Code::InvalidArgument);
-        }
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        type StaticOneshotTuple =
-            Mutex<(Option<oneshot::Sender<()>>, Option<oneshot::Receiver<()>>)>;
-        static TIMEOUT_ONESHOT: Lazy<StaticOneshotTuple> = Lazy::new(|| {
-            let (tx, rx) = oneshot::channel();
-            Mutex::new((Some(tx), Some(rx)))
-        });
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
             },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| {
-                    Box::pin(async move {
-                        let rx = TIMEOUT_ONESHOT.lock().unwrap().1.take().unwrap();
-                        rx.await.expect("Could not receive timeout signal");
-                    })
-                },
-            },
-        )?);
-
-        #[cfg(target_family = "unix")]
-        let arguments = vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "sleep infinity".to_string(),
-        ];
-        #[cfg(target_family = "windows")]
-        // Windows is weird with timeout, so we use ping. See:
-        // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
-        let arguments = vec![
-            "cmd".to_string(),
-            "/C".to_string(),
-            "ping -n 99999 127.0.0.1".to_string(),
-        ];
-
-        let command = Command {
-            arguments,
-            output_paths: vec![],
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
             cas_store.as_pin(),
             &mut DigestHasherFunc::Sha256.hasher(),
         )
@@ -2657,7 +487,7 @@ exit 1
         )
         .await?;
 
-        let execute_results_fut = running_actions_manager
+        let running_action = running_actions_manager
             .create_and_add_action(
                 WORKER_ID.to_string(),
                 StartExecute {
@@ -2666,323 +496,733 @@ exit 1
                         digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
                     }),
-                    salt: 0,
-                    queued_timestamp: Some(make_system_time(1000).into()),
-                },
-            )
-            .and_then(|action| {
-                action
-                    .clone()
-                    .prepare_action()
-                    .and_then(RunningAction::execute)
-                    .and_then(RunningAction::upload_results)
-                    .and_then(RunningAction::get_finished_result)
-                    .then(|result| async move {
-                        if let Err(e) = action.cleanup().await {
-                            return Result::<ActionResult, Error>::Err(e).merge(result);
-                        }
-                        result
-                    })
-            });
-
-        let (results, _) = tokio::join!(execute_results_fut, async move {
-            tokio::task::yield_now().await;
-            let tx = TIMEOUT_ONESHOT.lock().unwrap().0.take().unwrap();
-            tx.send(()).expect("Could not send timeout signal");
-        });
-        assert_eq!(results?.error.unwrap().code, Code::DeadlineExceeded);
-
-        Ok(())
-    }
-
-    #[nativelink_test]
-    async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-
-        #[cfg(target_family = "unix")]
-        let arguments = vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "sleep infinity".to_string(),
-        ];
-        #[cfg(target_family = "windows")]
-        // Windows is weird with timeout, so we use ping. See:
-        // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
-        let arguments = vec![
-            "cmd".to_string(),
-            "/C".to_string(),
-            "ping -n 99999 127.0.0.1".to_string(),
-        ];
-
-        let command = Command {
-            arguments,
-            output_paths: vec![],
-            working_directory: ".".to_string(),
-            ..Default::default()
-        };
-        let command_digest = serialize_and_upload_message(
-            &command,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let input_root_digest = serialize_and_upload_message(
-            &Directory::default(),
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-        let action = Action {
-            command_digest: Some(command_digest.into()),
-            input_root_digest: Some(input_root_digest.into()),
-            ..Default::default()
-        };
-        let action_digest = serialize_and_upload_message(
-            &action,
-            cas_store.as_pin(),
-            &mut DigestHasherFunc::Sha256.hasher(),
-        )
-        .await?;
-
-        let (cleanup_tx, cleanup_rx) = oneshot::channel();
-        let cleanup_was_requested = AtomicBool::new(false);
-        let action = running_actions_manager
-            .create_and_add_action(
-                WORKER_ID.to_string(),
-                StartExecute {
-                    execute_request: Some(ExecuteRequest {
-                        action_digest: Some(action_digest.into()),
-                        digest_function: ProtoDigestFunction::Sha256.into(),
-                        ..Default::default()
-                    }),
-                    salt: 0,
-                    queued_timestamp: Some(make_system_time(1000).into()),
+                    salt: SALT,
+                    queued_timestamp: None,
                 },
             )
             .await?;
-        let execute_results_fut = action
-            .clone()
-            .prepare_action()
-            .and_then(RunningAction::execute)
-            .and_then(RunningAction::upload_results)
-            .and_then(RunningAction::get_finished_result)
-            .then(|result| async {
-                cleanup_was_requested.store(true, Ordering::Release);
-                cleanup_rx.await.expect("Could not receive cleanup signal");
-                if let Err(e) = action.cleanup().await {
-                    return Result::<ActionResult, Error>::Err(e).merge(result);
-                }
-                result
-            });
 
-        tokio::pin!(execute_results_fut);
-        {
-            // Advance the action as far as possible and ensure we are not waiting on cleanup.
-            for _ in 0..100 {
-                assert!(futures::poll!(&mut execute_results_fut).is_pending());
-                tokio::task::yield_now().await;
-            }
-            assert_eq!(cleanup_was_requested.load(Ordering::Acquire), false);
-        }
+        let running_action = running_action.clone().prepare_action().await?;
 
-        let kill_all_fut = running_actions_manager.kill_all();
-        tokio::pin!(kill_all_fut);
-
-        {
-            // * Advance the action as far as possible.
-            // * Ensure we are now waiting on cleanup.
-            // * Ensure our kill_action is still pending.
-            while !cleanup_was_requested.load(Ordering::Acquire) {
-                // Wait for cleanup to be triggered.
-                tokio::task::yield_now().await;
-                assert!(futures::poll!(&mut execute_results_fut).is_pending());
-                assert!(futures::poll!(&mut kill_all_fut).is_pending());
-            }
-        }
-        // Allow cleanup, which allows execute_results_fut to advance.
-        cleanup_tx.send(()).expect("Could not send cleanup signal");
-        // Advance our two futures to completion now.
-        let result = execute_results_fut.await;
-        kill_all_fut.await;
-        {
-            // Ensure our results are correct.
-            let action_result = result?;
-            let err = action_result
-                .error
-                .as_ref()
-                .err_tip(|| format!("No error exists in result : {action_result:?}"))?;
-            assert_eq!(
-                err.code,
-                Code::Aborted,
-                "Expected Aborted : {action_result:?}"
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Regression Test for Issue #675
-    #[cfg(target_family = "unix")]
-    #[nativelink_test]
-    async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-        const FILE_1_NAME: &str = "file1";
-
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
-            RunningActionsManagerArgs {
-                root_action_directory,
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                execution_configuration: ExecutionConfiguration::default(),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
-                        ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            },
-            Callbacks {
-                now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
-            },
-        )?);
-        // Create and run an action which
-        // creates a file with owner executable permissions.
-        let action_result = {
-            let command = Command {
-                arguments: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    format!("touch {FILE_1_NAME} && chmod 700 {FILE_1_NAME}").to_string(),
-                ],
-                output_paths: vec![FILE_1_NAME.to_string()],
-                working_directory: ".".to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory::default(),
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        // Ensure the file copied from worker to CAS is executable.
-        assert!(
-            action_result.output_files[0].is_executable,
-            "Expected output file to be executable"
+        // The folder should have been created for our output file.
+        assert_eq!(
+            fs::metadata(format!(
+                "{}/{}",
+                running_action.get_work_directory(),
+                "some/path"
+            ))
+            .await
+            .is_ok(),
+            true,
+            "Expected path to exist"
         );
-        Ok(())
+
+        running_action.cleanup().await?;
+    };
+    Ok(())
+}
+
+#[nativelink_test]
+async fn ensure_output_files_full_directories_are_created_test(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
     }
 
-    #[nativelink_test]
-    async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
 
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-        let temp_action_directory = make_temp_path("root_action_directory/temp");
-        fs::create_dir_all(&temp_action_directory).await?;
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    {
+        const SALT: u64 = 55;
+        let working_directory = "some_cwd";
+        let command = Command {
+            arguments: vec!["touch".to_string(), "./some/path/test.txt".to_string()],
+            output_files: vec!["some/path/test.txt".to_string()],
+            working_directory: working_directory.to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                directories: vec![DirectoryNode {
+                    name: "some_cwd".to_string(),
+                    digest: Some(
+                        serialize_and_upload_message(
+                            &Directory::default(),
+                            cas_store.as_pin(),
+                            &mut DigestHasherFunc::Sha256.hasher(),
+                        )
+                        .await?
+                        .into(),
+                    ),
+                }],
+                ..Default::default()
+            },
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
 
-        let running_actions_manager =
-            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
-                root_action_directory: root_action_directory.clone(),
-                execution_configuration: ExecutionConfiguration::default(),
-                cas_store: cas_store.clone(),
-                ac_store: Some(Store::new(ac_store.clone())),
-                historical_store: Store::new(cas_store.clone()),
-                upload_action_result_config:
-                    &nativelink_config::cas_server::UploadActionResultConfig {
-                        upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+        let running_action = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
                         ..Default::default()
-                    },
-                max_action_timeout: Duration::MAX,
-                timeout_handled_externally: false,
-            })?);
-        let queued_timestamp = make_system_time(1000);
+                    }),
+                    salt: SALT,
+                    queued_timestamp: None,
+                },
+            )
+            .await?;
 
+        let running_action = running_action.clone().prepare_action().await?;
+
+        // The folder should have been created for our output file.
+        assert_eq!(
+            fs::metadata(format!(
+                "{}/{}/{}",
+                running_action.get_work_directory(),
+                working_directory,
+                "some/path"
+            ))
+            .await
+            .is_ok(),
+            true,
+            "Expected path to exist"
+        );
+
+        running_action.cleanup().await?;
+    };
+    Ok(())
+}
+
+#[nativelink_test]
+async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    let action_result = {
+        const SALT: u64 = 55;
         #[cfg(target_family = "unix")]
-        let arguments = vec!["sh".to_string(), "-c".to_string(), "exit 0".to_string()];
+        let arguments = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '123 ' > ./test.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
+                .to_string(),
+        ];
         #[cfg(target_family = "windows")]
-        let arguments = vec!["cmd".to_string(), "/C".to_string(), "exit 0".to_string()];
+            let arguments = vec![
+                "cmd".to_string(),
+                "/C".to_string(),
+                // Note: Windows adds two spaces after 'set /p=XXX'.
+                "echo | set /p=123> ./test.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
+                    .to_string(),
+            ];
+        let working_directory = "some_cwd";
+        let command = Command {
+            arguments,
+            output_paths: vec!["test.txt".to_string()],
+            working_directory: working_directory.to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Blake3.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                directories: vec![DirectoryNode {
+                    name: working_directory.to_string(),
+                    digest: Some(
+                        serialize_and_upload_message(
+                            &Directory::default(),
+                            cas_store.as_pin(),
+                            &mut DigestHasherFunc::Blake3.hasher(),
+                        )
+                        .await?
+                        .into(),
+                    ),
+                }],
+                ..Default::default()
+            },
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Blake3.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Blake3.hasher(),
+        )
+        .await?;
 
+        let running_action_impl = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Blake3.into(),
+                        ..Default::default()
+                    }),
+                    salt: SALT,
+                    queued_timestamp: None,
+                },
+            )
+            .await?;
+
+        run_action(running_action_impl.clone()).await?
+    };
+    let file_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.output_files[0].digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&file_content)?, "123 ");
+    let stdout_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stdout_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
+    let stderr_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stderr_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
+    let mut clock_time = make_system_time(0);
+    assert_eq!(
+        action_result,
+        ActionResult {
+            output_files: vec![FileInfo {
+                name_or_path: NameOrPath::Path("test.txt".to_string()),
+                digest: DigestInfo::try_new(
+                    "3f488ba478fc6716c756922c9f34ebd7e84b85c3e03e33e22e7a3736cafdc6d8",
+                    4
+                )?,
+                is_executable: false,
+            }],
+            stdout_digest: DigestInfo::try_new(
+                "af1720193ae81515067a3ef39f0dfda3ad54a1a9d216e55d32fe5c1e178c6a7d",
+                11
+            )?,
+            stderr_digest: DigestInfo::try_new(
+                "65e0abbae32a3aedaf040b654c6f02ace03c7690c17a8415a90fc2ec9c809a16",
+                12
+            )?,
+            exit_code: 0,
+            output_folders: vec![],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
+            server_logs: HashMap::new(),
+            execution_metadata: ExecutionMetadata {
+                worker: WORKER_ID.to_string(),
+                queued_timestamp: SystemTime::UNIX_EPOCH,
+                worker_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_completed_timestamp: increment_clock(&mut clock_time),
+                execution_start_timestamp: increment_clock(&mut clock_time),
+                execution_completed_timestamp: increment_clock(&mut clock_time),
+                output_upload_start_timestamp: increment_clock(&mut clock_time),
+                output_upload_completed_timestamp: increment_clock(&mut clock_time),
+                worker_completed_timestamp: increment_clock(&mut clock_time),
+            },
+            error: None,
+            message: String::new(),
+        }
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    let action_result = {
+        const SALT: u64 = 55;
+        #[cfg(target_family = "unix")]
+        let arguments = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '123 ' > ./test.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
+                .to_string(),
+        ];
+        #[cfg(target_family = "windows")]
+            let arguments = vec![
+                "cmd".to_string(),
+                "/C".to_string(),
+                // Note: Windows adds two spaces after 'set /p=XXX'.
+                "echo | set /p=123> ./test.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
+                    .to_string(),
+            ];
+        let working_directory = "some_cwd";
+        let command = Command {
+            arguments,
+            output_paths: vec!["test.txt".to_string()],
+            working_directory: working_directory.to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                directories: vec![DirectoryNode {
+                    name: working_directory.to_string(),
+                    digest: Some(
+                        serialize_and_upload_message(
+                            &Directory::default(),
+                            cas_store.as_pin(),
+                            &mut DigestHasherFunc::Sha256.hasher(),
+                        )
+                        .await?
+                        .into(),
+                    ),
+                }],
+                ..Default::default()
+            },
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        let running_action_impl = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    salt: SALT,
+                    queued_timestamp: None,
+                },
+            )
+            .await?;
+
+        run_action(running_action_impl.clone()).await?
+    };
+    let file_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.output_files[0].digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&file_content)?, "123 ");
+    let stdout_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stdout_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
+    let stderr_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stderr_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
+    let mut clock_time = make_system_time(0);
+    assert_eq!(
+        action_result,
+        ActionResult {
+            output_files: vec![FileInfo {
+                name_or_path: NameOrPath::Path("test.txt".to_string()),
+                digest: DigestInfo::try_new(
+                    "c69e10a5f54f4e28e33897fbd4f8701595443fa8c3004aeaa20dd4d9a463483b",
+                    4
+                )?,
+                is_executable: false,
+            }],
+            stdout_digest: DigestInfo::try_new(
+                "15019a676f057d97d1ad3af86f3cc1e623cb33b18ff28422bbe3248d2471cc94",
+                11
+            )?,
+            stderr_digest: DigestInfo::try_new(
+                "2375ab8a01ca11e1ea7606dfb58756c153d49733cde1dbfb5a1e00f39afacf06",
+                12
+            )?,
+            exit_code: 0,
+            output_folders: vec![],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
+            server_logs: HashMap::new(),
+            execution_metadata: ExecutionMetadata {
+                worker: WORKER_ID.to_string(),
+                queued_timestamp: SystemTime::UNIX_EPOCH,
+                worker_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_completed_timestamp: increment_clock(&mut clock_time),
+                execution_start_timestamp: increment_clock(&mut clock_time),
+                execution_completed_timestamp: increment_clock(&mut clock_time),
+                output_upload_start_timestamp: increment_clock(&mut clock_time),
+                output_upload_completed_timestamp: increment_clock(&mut clock_time),
+                worker_completed_timestamp: increment_clock(&mut clock_time),
+            },
+            error: None,
+            message: String::new(),
+        }
+    );
+    Ok(())
+}
+
+// Windows does not support symlinks.
+#[cfg(not(target_family = "windows"))]
+#[nativelink_test]
+async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    let queued_timestamp = make_system_time(1000);
+    let action_result = {
+        const SALT: u64 = 55;
+        let command = Command {
+            arguments: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                concat!(
+                    "mkdir -p dir1/dir2 && ",
+                    "echo foo > dir1/file && ",
+                    "touch dir1/file2 && ",
+                    "ln -s ../file dir1/dir2/sym &&",
+                    "ln -s /dev/null empty_sym",
+                )
+                .to_string(),
+            ],
+            output_paths: vec!["dir1".to_string(), "empty_sym".to_string()],
+            working_directory: ".".to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory::default(),
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        let running_action_impl = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    salt: SALT,
+                    queued_timestamp: Some(queued_timestamp.into()),
+                },
+            )
+            .await?;
+
+        run_action(running_action_impl.clone()).await?
+    };
+    let tree = get_and_decode_digest::<Tree>(
+        slow_store.as_ref(),
+        action_result.output_folders[0].tree_digest.into(),
+    )
+    .await?;
+    let root_directory = Directory {
+        files: vec![
+            FileNode {
+                name: "file".to_string(),
+                digest: Some(
+                    DigestInfo::try_new(
+                        "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
+                        4,
+                    )?
+                    .into(),
+                ),
+                ..Default::default()
+            },
+            FileNode {
+                name: "file2".to_string(),
+                digest: Some(
+                    DigestInfo::try_new(
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                        0,
+                    )?
+                    .into(),
+                ),
+                ..Default::default()
+            },
+        ],
+        directories: vec![DirectoryNode {
+            name: "dir2".to_string(),
+            digest: Some(
+                DigestInfo::try_new(
+                    "cce0098e0b0f1d785edb0da50beedb13e27dcd459b091b2f8f82543cb7cd0527",
+                    16,
+                )?
+                .into(),
+            ),
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        tree,
+        Tree {
+            root: Some(root_directory.clone()),
+            children: vec![
+                Directory {
+                    symlinks: vec![SymlinkNode {
+                        name: "sym".to_string(),
+                        target: "../file".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                root_directory
+            ],
+        }
+    );
+    let mut clock_time = make_system_time(0);
+    assert_eq!(
+        action_result,
+        ActionResult {
+            output_files: vec![],
+            stdout_digest: DigestInfo::try_new(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                0
+            )?,
+            stderr_digest: DigestInfo::try_new(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                0
+            )?,
+            exit_code: 0,
+            output_folders: vec![DirectoryInfo {
+                path: "dir1".to_string(),
+                tree_digest: DigestInfo::try_new(
+                    "adbb04fa6e166e663c1310bbf8ba494e468b1b6c33e1e5346e2216b6904c9917",
+                    490
+                )?,
+            }],
+            output_file_symlinks: vec![SymlinkInfo {
+                name_or_path: NameOrPath::Path("empty_sym".to_string()),
+                target: "/dev/null".to_string(),
+            }],
+            output_directory_symlinks: vec![],
+            server_logs: HashMap::new(),
+            execution_metadata: ExecutionMetadata {
+                worker: WORKER_ID.to_string(),
+                queued_timestamp,
+                worker_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_completed_timestamp: increment_clock(&mut clock_time),
+                execution_start_timestamp: increment_clock(&mut clock_time),
+                execution_completed_timestamp: increment_clock(&mut clock_time),
+                output_upload_start_timestamp: increment_clock(&mut clock_time),
+                output_upload_completed_timestamp: increment_clock(&mut clock_time),
+                worker_completed_timestamp: increment_clock(&mut clock_time),
+            },
+            error: None,
+            message: String::new(),
+        }
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    let queued_timestamp = make_system_time(1000);
+
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["sh".to_string(), "-c".to_string(), "exit 33".to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec!["cmd".to_string(), "/C".to_string(), "exit 33".to_string()];
+
+    let action_result = {
         const SALT: u64 = 55;
         let command = Command {
             arguments,
@@ -3029,45 +1269,1061 @@ exit 1
             )
             .await?;
 
-        run_action(running_action_impl.clone()).await?;
+        run_action(running_action_impl.clone()).await?
+    };
+    let mut clock_time = make_system_time(0);
+    assert_eq!(
+        action_result,
+        ActionResult {
+            output_files: vec![],
+            stdout_digest: DigestInfo::try_new(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                0
+            )?,
+            stderr_digest: DigestInfo::try_new(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                0
+            )?,
+            exit_code: 33,
+            output_folders: vec![],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
+            server_logs: HashMap::new(),
+            execution_metadata: ExecutionMetadata {
+                worker: WORKER_ID.to_string(),
+                queued_timestamp,
+                worker_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_completed_timestamp: increment_clock(&mut clock_time),
+                execution_start_timestamp: increment_clock(&mut clock_time),
+                execution_completed_timestamp: increment_clock(&mut clock_time),
+                output_upload_start_timestamp: increment_clock(&mut clock_time),
+                output_upload_completed_timestamp: increment_clock(&mut clock_time),
+                worker_completed_timestamp: increment_clock(&mut clock_time),
+            },
+            error: None,
+            message: String::new(),
+        }
+    );
+    let mut dir_stream = fs::read_dir(&root_action_directory).await?;
+    assert!(
+        dir_stream.as_mut().next_entry().await?.is_none(),
+        "Expected empty directory at {root_action_directory}"
+    );
+    Ok(())
+}
 
-        let mut dir_stream = fs::read_dir(&root_action_directory).await?;
-        assert!(
-            dir_stream.as_mut().next_entry().await?.is_none(),
-            "Expected empty directory at {root_action_directory}"
-        );
-        Ok(())
+#[nativelink_test]
+async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+    const SALT: u64 = 55;
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    #[cfg(target_family = "unix")]
+    let arguments = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "sleep infinity".to_string(),
+    ];
+    #[cfg(target_family = "windows")]
+    // Windows is weird with timeout, so we use ping. See:
+    // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
+    let arguments = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "ping -n 99999 127.0.0.1".to_string(),
+    ];
+
+    let command = Command {
+        arguments,
+        output_paths: vec![],
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .clone()
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+
+    // Start the action and kill it at the same time.
+    let result = futures::join!(
+        run_action(running_action_impl),
+        running_actions_manager.kill_all()
+    )
+    .0?;
+
+    // Check that the action was killed.
+    #[cfg(target_family = "unix")]
+    assert_eq!(9, result.exit_code);
+    // Note: Windows kill command returns exit code 1.
+    #[cfg(target_family = "windows")]
+    assert_eq!(1, result.exit_code);
+
+    Ok(())
+}
+
+// This script runs a command under a wrapper script set in a config.
+// The wrapper script will print a constant string to stderr, and the test itself will
+// print to stdout. We then check the results of both to make sure the shell script was
+// invoked and the actual command was invoked under the shell script.
+#[nativelink_test]
+async fn entrypoint_does_invoke_if_set() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_family = "unix")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+#!/bin/bash
+# Print some static text to stderr. This is what the test uses to
+# make sure the script did run.
+>&2 printf \"Wrapper script did run\"
+
+# Now run the real command.
+exec \"$@\"
+";
+    #[cfg(target_family = "windows")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+@echo off
+:: Print some static text to stderr. This is what the test uses to
+:: make sure the script did run.
+echo | set /p=\"Wrapper script did run\" 1>&2
+
+:: Run command, but morph the echo to ensure it doesn't
+:: add a new line to the end of the output.
+%1 | set /p=%2
+exit 0
+";
+    const WORKER_ID: &str = "foo_worker_id";
+    const SALT: u64 = 66;
+    const EXPECTED_STDOUT: &str = "Action did run";
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let test_wrapper_script = {
+        let test_wrapper_dir = make_temp_path("wrapper_dir");
+        fs::create_dir_all(&test_wrapper_dir).await?;
+        #[cfg(target_family = "unix")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
+        #[cfg(target_family = "windows")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
+
+        // We use std::fs::File here because we sometimes get strange bugs here
+        // that result in: "Text file busy (os error 26)" if it is an executeable.
+        // It is likley because somewhere the file descriotor does not get closed
+        // in tokio's async context.
+        let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
+        test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
+        #[cfg(target_family = "unix")]
+        test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
+        test_wrapper_script_handle.sync_all()?;
+        drop(test_wrapper_script_handle);
+
+        test_wrapper_script
+    };
+
+    // TODO(#527) Sleep to reduce flakey chances.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration {
+                entrypoint: Some(test_wrapper_script.into_string().unwrap()),
+                additional_environment: None,
+            },
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["printf".to_string(), EXPECTED_STDOUT.to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec!["echo".to_string(), EXPECTED_STDOUT.to_string()];
+    let command = Command {
+        arguments,
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .clone()
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+
+    let result = run_action(running_action_impl).await?;
+    assert_eq!(result.exit_code, 0, "Exit code should be 0");
+
+    let expected_stdout = DigestHasherFunc::Sha256
+        .hasher()
+        .compute_from_reader(Cursor::new(EXPECTED_STDOUT))
+        .await?;
+    // Note: This string should match what is in worker_for_test.sh
+    let expected_stderr = DigestHasherFunc::Sha256
+        .hasher()
+        .compute_from_reader(Cursor::new("Wrapper script did run"))
+        .await?;
+    assert_eq!(expected_stdout, result.stdout_digest);
+    assert_eq!(expected_stderr, result.stderr_digest);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn entrypoint_injects_properties() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_family = "unix")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+#!/bin/bash
+# Print some static text to stderr. This is what the test uses to
+# make sure the script did run.
+>&2 printf \"Wrapper script did run with property $PROPERTY $VALUE $INNER_TIMEOUT\"
+
+# Now run the real command.
+exec \"$@\"
+";
+    #[cfg(target_family = "windows")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+@echo off
+:: Print some static text to stderr. This is what the test uses to
+:: make sure the script did run.
+echo | set /p=\"Wrapper script did run with property %PROPERTY% %VALUE% %INNER_TIMEOUT%\" 1>&2
+
+:: Run command, but morph the echo to ensure it doesn't
+:: add a new line to the end of the output.
+%1 | set /p=%2
+exit 0
+";
+    const WORKER_ID: &str = "foo_worker_id";
+    const SALT: u64 = 66;
+    const EXPECTED_STDOUT: &str = "Action did run";
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let test_wrapper_script = {
+        let test_wrapper_dir = make_temp_path("wrapper_dir");
+        fs::create_dir_all(&test_wrapper_dir).await?;
+        #[cfg(target_family = "unix")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
+        #[cfg(target_family = "windows")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
+
+        // We use std::fs::File here because we sometimes get strange bugs here
+        // that result in: "Text file busy (os error 26)" if it is an executeable.
+        // It is likley because somewhere the file descriotor does not get closed
+        // in tokio's async context.
+        let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
+        test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
+        #[cfg(target_family = "unix")]
+        test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
+        test_wrapper_script_handle.sync_all()?;
+        drop(test_wrapper_script_handle);
+
+        test_wrapper_script
+    };
+
+    // TODO(#527) Sleep to reduce flakey chances.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration {
+                entrypoint: Some(test_wrapper_script.into_string().unwrap()),
+                additional_environment: Some(HashMap::from([
+                    (
+                        "PROPERTY".to_string(),
+                        EnvironmentSource::property("property_name".to_string()),
+                    ),
+                    (
+                        "VALUE".to_string(),
+                        EnvironmentSource::value("raw_value".to_string()),
+                    ),
+                    (
+                        "INNER_TIMEOUT".to_string(),
+                        EnvironmentSource::timeout_millis,
+                    ),
+                ])),
+            },
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["printf".to_string(), EXPECTED_STDOUT.to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec!["echo".to_string(), EXPECTED_STDOUT.to_string()];
+    let command = Command {
+        arguments,
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    const TASK_TIMEOUT: Duration = Duration::from_secs(122);
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        platform: Some(Platform {
+            properties: vec![Property {
+                name: "property_name".into(),
+                value: "property_value".into(),
+            }],
+        }),
+        timeout: Some(prost_types::Duration {
+            seconds: TASK_TIMEOUT.as_secs() as i64,
+            nanos: 0,
+        }),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .clone()
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+
+    let result = run_action(running_action_impl).await?;
+    assert_eq!(result.exit_code, 0, "Exit code should be 0");
+
+    let expected_stdout = DigestHasherFunc::Sha256
+        .hasher()
+        .compute_from_reader(Cursor::new(EXPECTED_STDOUT))
+        .await?;
+    // Note: This string should match what is in worker_for_test.sh
+    let expected_stderr = "Wrapper script did run with property property_value raw_value 122000";
+    let expected_stderr_digest = DigestHasherFunc::Sha256
+        .hasher()
+        .compute_from_reader(Cursor::new(expected_stderr))
+        .await?;
+
+    let actual_stderr: prost::bytes::Bytes = cas_store
+        .as_ref()
+        .get_part_unchunked(result.stderr_digest, 0, None)
+        .await?;
+    let actual_stderr_decoded = std::str::from_utf8(&actual_stderr)?;
+    assert_eq!(expected_stderr, actual_stderr_decoded);
+    assert_eq!(expected_stdout, result.stdout_digest);
+    assert_eq!(expected_stderr_digest, result.stderr_digest);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn entrypoint_sends_timeout_via_side_channel() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_family = "unix")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+#!/bin/bash
+echo '{\"failure\":\"timeout\"}' > \"$SIDE_CHANNEL_FILE\"
+exit 1
+";
+    #[cfg(target_family = "windows")]
+    const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
+@echo off
+echo | set /p={\"failure\":\"timeout\"} 1>&2 > %SIDE_CHANNEL_FILE%
+exit 1
+";
+    const WORKER_ID: &str = "foo_worker_id";
+    const SALT: u64 = 66;
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let test_wrapper_script = {
+        let test_wrapper_dir = make_temp_path("wrapper_dir");
+        fs::create_dir_all(&test_wrapper_dir).await?;
+        #[cfg(target_family = "unix")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "/test_wrapper_script.sh");
+        #[cfg(target_family = "windows")]
+        let test_wrapper_script = OsString::from(test_wrapper_dir + "\\test_wrapper_script.bat");
+
+        // We use std::fs::File here because we sometimes get strange bugs here
+        // that result in: "Text file busy (os error 26)" if it is an executeable.
+        // It is likley because somewhere the file descriotor does not get closed
+        // in tokio's async context.
+        let mut test_wrapper_script_handle = std::fs::File::create(&test_wrapper_script)?;
+        test_wrapper_script_handle.write_all(TEST_WRAPPER_SCRIPT_CONTENT.as_bytes())?;
+        #[cfg(target_family = "unix")]
+        test_wrapper_script_handle.set_permissions(Permissions::from_mode(0o777))?;
+        test_wrapper_script_handle.sync_all()?;
+        drop(test_wrapper_script_handle);
+
+        test_wrapper_script
+    };
+
+    // TODO(#527) Sleep to reduce flakey chances.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration {
+                entrypoint: Some(test_wrapper_script.into_string().unwrap()),
+                additional_environment: Some(HashMap::from([(
+                    "SIDE_CHANNEL_FILE".to_string(),
+                    EnvironmentSource::side_channel_file,
+                )])),
+            },
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+    let arguments = vec!["true".to_string()];
+    let command = Command {
+        arguments,
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .clone()
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+
+    let result = run_action(running_action_impl).await?;
+    assert_eq!(result.exit_code, 1, "Exit code should be 1");
+    assert_eq!(
+        result.error.err_tip(|| "Error should exist")?.code,
+        Code::DeadlineExceeded
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        output_files: vec![FileInfo {
+            name_or_path: NameOrPath::Path("test.txt".to_string()),
+            digest: DigestInfo::try_new(
+                "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+                3,
+            )?,
+            is_executable: false,
+        }],
+        stdout_digest: DigestInfo::try_new(
+            "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
+            10,
+        )?,
+        stderr_digest: DigestInfo::try_new(
+            "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
+            10,
+        )?,
+        exit_code: 0,
+        output_folders: vec![],
+        output_file_symlinks: vec![],
+        output_directory_symlinks: vec![],
+        server_logs: HashMap::new(),
+        execution_metadata: ExecutionMetadata {
+            worker: "WORKER_ID".to_string(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: make_system_time(0),
+            input_fetch_start_timestamp: make_system_time(1),
+            input_fetch_completed_timestamp: make_system_time(2),
+            execution_start_timestamp: make_system_time(3),
+            execution_completed_timestamp: make_system_time(4),
+            output_upload_start_timestamp: make_system_time(5),
+            output_upload_completed_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+        },
+        error: None,
+        message: String::new(),
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    let retrieved_result =
+        get_and_decode_digest::<ProtoActionResult>(ac_store.as_ref(), action_digest.into()).await?;
+
+    let proto_result: ProtoActionResult = action_result.into();
+    assert_eq!(proto_result, retrieved_result);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::everything,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        output_files: vec![FileInfo {
+            name_or_path: NameOrPath::Path("test.txt".to_string()),
+            digest: DigestInfo::try_new(
+                "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+                3,
+            )?,
+            is_executable: false,
+        }],
+        stdout_digest: DigestInfo::try_new(
+            "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
+            10,
+        )?,
+        stderr_digest: DigestInfo::try_new(
+            "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
+            10,
+        )?,
+        exit_code: 1,
+        output_folders: vec![],
+        output_file_symlinks: vec![],
+        output_directory_symlinks: vec![],
+        server_logs: HashMap::new(),
+        execution_metadata: ExecutionMetadata {
+            worker: "WORKER_ID".to_string(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: make_system_time(0),
+            input_fetch_start_timestamp: make_system_time(1),
+            input_fetch_completed_timestamp: make_system_time(2),
+            execution_start_timestamp: make_system_time(3),
+            execution_completed_timestamp: make_system_time(4),
+            output_upload_start_timestamp: make_system_time(5),
+            output_upload_completed_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+        },
+        error: None,
+        message: String::new(),
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    let retrieved_result =
+        get_and_decode_digest::<ProtoActionResult>(ac_store.as_ref(), action_digest.into()).await?;
+
+    let proto_result: ProtoActionResult = action_result.into();
+    assert_eq!(proto_result, retrieved_result);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_historical_results_strategy: Some(
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                ),
+                success_message_template: "{historical_results_hash}-{historical_results_size}"
+                    .to_string(),
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        output_files: vec![FileInfo {
+            name_or_path: NameOrPath::Path("test.txt".to_string()),
+            digest: DigestInfo::try_new(
+                "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+                3,
+            )?,
+            is_executable: false,
+        }],
+        stdout_digest: DigestInfo::try_new(
+            "426afaf613d8cfdd9fa8addcc030ae6c95a7950ae0301164af1d5851012081d5",
+            10,
+        )?,
+        stderr_digest: DigestInfo::try_new(
+            "7b2e400d08b8e334e3172d105be308b506c6036c62a9bde5c509d7808b28b213",
+            10,
+        )?,
+        exit_code: 0,
+        output_folders: vec![],
+        output_file_symlinks: vec![],
+        output_directory_symlinks: vec![],
+        server_logs: HashMap::new(),
+        execution_metadata: ExecutionMetadata {
+            worker: "WORKER_ID".to_string(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: make_system_time(0),
+            input_fetch_start_timestamp: make_system_time(1),
+            input_fetch_completed_timestamp: make_system_time(2),
+            execution_start_timestamp: make_system_time(3),
+            execution_completed_timestamp: make_system_time(4),
+            output_upload_start_timestamp: make_system_time(5),
+            output_upload_completed_timestamp: make_system_time(6),
+            worker_completed_timestamp: make_system_time(7),
+        },
+        error: None,
+        message: String::new(),
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    assert!(!action_result.message.is_empty(), "Message should be set");
+
+    let historical_digest = {
+        let (historical_results_hash, historical_results_size) = action_result
+            .message
+            .split_once('-')
+            .expect("Message should be in format {hash}-{size}");
+
+        DigestInfo::try_new(
+            historical_results_hash,
+            historical_results_size.parse::<i64>()?,
+        )?
+    };
+    let retrieved_result = get_and_decode_digest::<HistoricalExecuteResponse>(
+        cas_store.as_ref(),
+        historical_digest.into(),
+    )
+    .await?;
+
+    assert_eq!(
+        HistoricalExecuteResponse {
+            action_digest: Some(action_digest.into()),
+            execute_response: Some(ExecuteResponse {
+                result: Some(action_result.into()),
+                status: Some(Default::default()),
+                ..Default::default()
+            }),
+        },
+        retrieved_result
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_historical_results_strategy: Some(
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                ),
+                success_message_template: "{historical_results_hash}-{historical_results_size}"
+                    .to_string(),
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        exit_code: 1,
+        ..Default::default()
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    assert!(
+        action_result.message.is_empty(),
+        "Message should not be set"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn infra_failure_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_historical_results_strategy: Some(
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::failures_only,
+                ),
+                failure_message_template: "{historical_results_hash}-{historical_results_size}"
+                    .to_string(),
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        exit_code: 0,
+        error: Some(make_input_err!("test error")),
+        ..Default::default()
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    assert!(!action_result.message.is_empty(), "Message should be set");
+
+    let historical_digest = {
+        let (historical_results_hash, historical_results_size) = action_result
+            .message
+            .split_once('-')
+            .expect("Message should be in format {hash}-{size}");
+
+        DigestInfo::try_new(
+            historical_results_hash,
+            historical_results_size.parse::<i64>()?,
+        )?
+    };
+
+    let retrieved_result = get_and_decode_digest::<HistoricalExecuteResponse>(
+        cas_store.as_ref(),
+        historical_digest.into(),
+    )
+    .await?;
+
+    assert_eq!(
+        HistoricalExecuteResponse {
+            action_digest: Some(action_digest.into()),
+            execute_response: Some(ExecuteResponse {
+                result: Some(action_result.into()),
+                status: Some(make_input_err!("test error").into()),
+                ..Default::default()
+            }),
+        },
+        retrieved_result
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: String::new(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                success_message_template: "{action_digest_hash}-{action_digest_size}".to_string(),
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+
+    let action_digest = DigestInfo::new([2u8; 32], 32);
+    let mut action_result = ActionResult {
+        exit_code: 0,
+        ..Default::default()
+    };
+    running_actions_manager
+        .cache_action_result(action_digest, &mut action_result, DigestHasherFunc::Sha256)
+        .await?;
+
+    assert!(!action_result.message.is_empty(), "Message should be set");
+
+    let action_result_digest = {
+        let (action_result_hash, action_result_size) = action_result
+            .message
+            .split_once('-')
+            .expect("Message should be in format {hash}-{size}");
+
+        DigestInfo::try_new(action_result_hash, action_result_size.parse::<i64>()?)?
+    };
+
+    let retrieved_result =
+        get_and_decode_digest::<ProtoActionResult>(ac_store.as_ref(), action_result_digest.into())
+            .await?;
+
+    let proto_result: ProtoActionResult = action_result.into();
+    assert_eq!(proto_result, retrieved_result);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
     }
 
-    // We've experienced deadlocks when uploading, so make only a single permit available and
-    // check it's able to handle uploading some directories with some files in.
-    // Be default this test is ignored because it *must* be run single threaded... to run this
-    // test execute:
-    // cargo test -p nativelink-worker --test running_actions_manager_test -- --test-threads=1 --ignored
-    #[nativelink_test]
-    #[ignore]
-    async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
 
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
 
-        let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_action_directory");
-        fs::create_dir_all(&root_action_directory).await?;
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["true".to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "exit".to_string(),
+        "0".to_string(),
+    ];
 
-        // Take all but one FD permit away.
-        let _permits = futures::stream::iter(1..fs::OPEN_FILE_SEMAPHORE.available_permits())
-            .then(|_| fs::OPEN_FILE_SEMAPHORE.acquire())
-            .try_collect::<Vec<_>>()
-            .await?;
-        assert_eq!(1, fs::OPEN_FILE_SEMAPHORE.available_permits());
+    let command = Command {
+        arguments,
+        output_paths: vec![],
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    {
+        // Test to ensure that the task timeout is choosen if it is less than the max timeout.
+        static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
+        const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
+        const TASK_TIMEOUT: Duration = Duration::from_secs(10);
+
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            timeout: Some(prost_types::Duration {
+                seconds: TASK_TIMEOUT.as_secs() as i64,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_action_directory,
+                root_action_directory: root_action_directory.clone(),
                 execution_configuration: ExecutionConfiguration::default(),
                 cas_store: cas_store.clone(),
                 ac_store: Some(Store::new(ac_store.clone())),
@@ -3078,179 +2334,75 @@ exit 1
                             nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                         ..Default::default()
                     },
-                max_action_timeout: Duration::MAX,
+                max_action_timeout: MAX_TIMEOUT_DURATION,
                 timeout_handled_externally: false,
             },
             Callbacks {
                 now_fn: test_monotonic_clock,
-                sleep_fn: |_duration| Box::pin(futures::future::pending()),
+                sleep_fn: |duration| {
+                    SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
+                    Box::pin(futures::future::pending())
+                },
             },
         )?);
-        let action_result = {
-            const SALT: u64 = 55;
-            #[cfg(target_family = "unix")]
-            let arguments = vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                "printf '123 ' > ./test.txt; mkdir ./tst; printf '456 ' > ./tst/tst.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
-                    .to_string(),
-            ];
-            #[cfg(target_family = "windows")]
-            let arguments = vec![
-                "cmd".to_string(),
-                "/C".to_string(),
-                // Note: Windows adds two spaces after 'set /p=XXX'.
-                "echo | set /p=123> ./test.txt & mkdir ./tst & echo | set /p=456> ./tst/tst.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
-                    .to_string(),
-            ];
-            let working_directory = "some_cwd";
-            let command = Command {
-                arguments,
-                output_paths: vec!["test.txt".to_string(), "tst".to_string()],
-                working_directory: working_directory.to_string(),
-                ..Default::default()
-            };
-            let command_digest = serialize_and_upload_message(
-                &command,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-            let input_root_digest = serialize_and_upload_message(
-                &Directory {
-                    directories: vec![DirectoryNode {
-                        name: working_directory.to_string(),
-                        digest: Some(
-                            serialize_and_upload_message(
-                                &Directory::default(),
-                                cas_store.as_pin(),
-                                &mut DigestHasherFunc::Sha256.hasher(),
-                            )
-                            .await?
-                            .into(),
-                        ),
-                    }],
-                    ..Default::default()
+
+        running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    salt: 0,
+                    queued_timestamp: Some(make_system_time(1000).into()),
                 },
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
             )
+            .and_then(|action| {
+                action
+                    .clone()
+                    .prepare_action()
+                    .and_then(RunningAction::execute)
+                    .then(|result| async move {
+                        if let Err(e) = action.cleanup().await {
+                            return Result::<ActionResult, Error>::Err(e).merge(result);
+                        }
+                        result
+                    })
+            })
             .await?;
-            let action = Action {
-                command_digest: Some(command_digest.into()),
-                input_root_digest: Some(input_root_digest.into()),
-                ..Default::default()
-            };
-            let action_digest = serialize_and_upload_message(
-                &action,
-                cas_store.as_pin(),
-                &mut DigestHasherFunc::Sha256.hasher(),
-            )
-            .await?;
-
-            let running_action_impl = running_actions_manager
-                .create_and_add_action(
-                    WORKER_ID.to_string(),
-                    StartExecute {
-                        execute_request: Some(ExecuteRequest {
-                            action_digest: Some(action_digest.into()),
-                            digest_function: ProtoDigestFunction::Sha256.into(),
-                            ..Default::default()
-                        }),
-                        salt: SALT,
-                        queued_timestamp: None,
-                    },
-                )
-                .await?;
-
-            run_action(running_action_impl.clone()).await?
-        };
-        let file_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.output_files[0].digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&file_content)?, "123 ");
-        let stdout_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stdout_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
-        let stderr_content = slow_store
-            .as_ref()
-            .get_part_unchunked(action_result.stderr_digest, 0, None)
-            .await?;
-        assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
-        let mut clock_time = make_system_time(0);
         assert_eq!(
-            action_result,
-            ActionResult {
-                output_files: vec![FileInfo {
-                    name_or_path: NameOrPath::Path("test.txt".to_string()),
-                    digest: DigestInfo::try_new(
-                        "c69e10a5f54f4e28e33897fbd4f8701595443fa8c3004aeaa20dd4d9a463483b",
-                        4
-                    )?,
-                    is_executable: false,
-                }],
-                stdout_digest: DigestInfo::try_new(
-                    "15019a676f057d97d1ad3af86f3cc1e623cb33b18ff28422bbe3248d2471cc94",
-                    11
-                )?,
-                stderr_digest: DigestInfo::try_new(
-                    "2375ab8a01ca11e1ea7606dfb58756c153d49733cde1dbfb5a1e00f39afacf06",
-                    12
-                )?,
-                exit_code: 0,
-                output_folders: vec![DirectoryInfo {
-                    path: "tst".to_string(),
-                    tree_digest: DigestInfo::try_new(
-                        "95711c1905d4898a70209dd6e98241dcafb479c00241a1ea4ed8415710d706f3",
-                        166,
-                    )?,
-                },],
-                output_file_symlinks: vec![],
-                output_directory_symlinks: vec![],
-                server_logs: HashMap::new(),
-                execution_metadata: ExecutionMetadata {
-                    worker: WORKER_ID.to_string(),
-                    queued_timestamp: SystemTime::UNIX_EPOCH,
-                    worker_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_start_timestamp: increment_clock(&mut clock_time),
-                    input_fetch_completed_timestamp: increment_clock(&mut clock_time),
-                    execution_start_timestamp: increment_clock(&mut clock_time),
-                    execution_completed_timestamp: increment_clock(&mut clock_time),
-                    output_upload_start_timestamp: increment_clock(&mut clock_time),
-                    output_upload_completed_timestamp: increment_clock(&mut clock_time),
-                    worker_completed_timestamp: increment_clock(&mut clock_time),
-                },
-                error: None,
-                message: String::new(),
-            }
+            SENT_TIMEOUT.load(Ordering::Relaxed),
+            TASK_TIMEOUT.as_millis() as i64
         );
-        Ok(())
     }
+    {
+        // Ensure if no timeout is set use max timeout.
+        static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
+        const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
+        const TASK_TIMEOUT: Duration = Duration::from_secs(0);
 
-    #[nativelink_test]
-    async fn running_actions_manager_respects_action_timeout(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        const WORKER_ID: &str = "foo_worker_id";
-        const SALT: u64 = 66;
-
-        let (_, _, cas_store, ac_store) = setup_stores().await?;
-        let root_action_directory = make_temp_path("root_work_directory");
-        fs::create_dir_all(&root_action_directory).await?;
-
-        // Ignore the sleep and immediately timeout.
-        static ACTION_TIMEOUT: i64 = 1;
-        fn test_monotonic_clock() -> SystemTime {
-            static CLOCK: AtomicU64 = AtomicU64::new(0);
-            monotonic_clock(&CLOCK)
-        }
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            timeout: Some(prost_types::Duration {
+                seconds: TASK_TIMEOUT.as_secs() as i64,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
 
         let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
             RunningActionsManagerArgs {
-                root_action_directory,
-                execution_configuration: Default::default(),
+                root_action_directory: root_action_directory.clone(),
+                execution_configuration: ExecutionConfiguration::default(),
                 cas_store: cas_store.clone(),
                 ac_store: Some(Store::new(ac_store.clone())),
                 historical_store: Store::new(cas_store.clone()),
@@ -3260,30 +2412,457 @@ exit 1
                             nativelink_config::cas_server::UploadCacheResultsStrategy::never,
                         ..Default::default()
                     },
-                max_action_timeout: Duration::MAX,
+                max_action_timeout: MAX_TIMEOUT_DURATION,
                 timeout_handled_externally: false,
             },
             Callbacks {
                 now_fn: test_monotonic_clock,
-                // If action_timeout is the passed duration then return immeidately,
-                // which will cause the action to be killed and pass the test,
-                // otherwise return pending and fail the test.
                 sleep_fn: |duration| {
-                    assert_eq!(duration.as_secs(), ACTION_TIMEOUT as u64);
-                    Box::pin(futures::future::ready(()))
+                    SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
+                    Box::pin(futures::future::pending())
                 },
             },
         )?);
-        #[cfg(target_family = "unix")]
-        let arguments = vec!["sh".to_string(), "-c".to_string(), "sleep 2".to_string()];
-        #[cfg(target_family = "windows")]
-        let arguments = vec![
-            "cmd".to_string(),
-            "/C".to_string(),
-            "ping -n 99999 127.0.0.1".to_string(),
-        ];
+
+        running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    salt: 0,
+                    queued_timestamp: Some(make_system_time(1000).into()),
+                },
+            )
+            .and_then(|action| {
+                action
+                    .clone()
+                    .prepare_action()
+                    .and_then(RunningAction::execute)
+                    .then(|result| async move {
+                        if let Err(e) = action.cleanup().await {
+                            return Result::<ActionResult, Error>::Err(e).merge(result);
+                        }
+                        result
+                    })
+            })
+            .await?;
+        assert_eq!(
+            SENT_TIMEOUT.load(Ordering::Relaxed),
+            MAX_TIMEOUT_DURATION.as_millis() as i64
+        );
+    }
+    {
+        // Ensure we reject tasks that have a timeout set too high.
+        static SENT_TIMEOUT: AtomicI64 = AtomicI64::new(-1);
+        const MAX_TIMEOUT_DURATION: Duration = Duration::from_secs(100);
+        const TASK_TIMEOUT: Duration = Duration::from_secs(200);
+
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            timeout: Some(prost_types::Duration {
+                seconds: TASK_TIMEOUT.as_secs() as i64,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+            RunningActionsManagerArgs {
+                root_action_directory: root_action_directory.clone(),
+                execution_configuration: ExecutionConfiguration::default(),
+                cas_store: cas_store.clone(),
+                ac_store: Some(Store::new(ac_store.clone())),
+                historical_store: Store::new(cas_store.clone()),
+                upload_action_result_config:
+                    &nativelink_config::cas_server::UploadActionResultConfig {
+                        upload_ac_results_strategy:
+                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                        ..Default::default()
+                    },
+                max_action_timeout: MAX_TIMEOUT_DURATION,
+                timeout_handled_externally: false,
+            },
+            Callbacks {
+                now_fn: test_monotonic_clock,
+                sleep_fn: |duration| {
+                    SENT_TIMEOUT.store(duration.as_millis() as i64, Ordering::Relaxed);
+                    Box::pin(futures::future::pending())
+                },
+            },
+        )?);
+
+        let result = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    salt: 0,
+                    queued_timestamp: Some(make_system_time(1000).into()),
+                },
+            )
+            .and_then(|action| {
+                action
+                    .clone()
+                    .prepare_action()
+                    .and_then(RunningAction::execute)
+                    .then(|result| async move {
+                        if let Err(e) = action.cleanup().await {
+                            return Result::<ActionResult, Error>::Err(e).merge(result);
+                        }
+                        result
+                    })
+            })
+            .await;
+        assert_eq!(SENT_TIMEOUT.load(Ordering::Relaxed), -1);
+        assert_eq!(result.err().unwrap().code, Code::InvalidArgument);
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    type StaticOneshotTuple = Mutex<(Option<oneshot::Sender<()>>, Option<oneshot::Receiver<()>>)>;
+    static TIMEOUT_ONESHOT: Lazy<StaticOneshotTuple> = Lazy::new(|| {
+        let (tx, rx) = oneshot::channel();
+        Mutex::new((Some(tx), Some(rx)))
+    });
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| {
+                Box::pin(async move {
+                    let rx = TIMEOUT_ONESHOT.lock().unwrap().1.take().unwrap();
+                    rx.await.expect("Could not receive timeout signal");
+                })
+            },
+        },
+    )?);
+
+    #[cfg(target_family = "unix")]
+    let arguments = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "sleep infinity".to_string(),
+    ];
+    #[cfg(target_family = "windows")]
+    // Windows is weird with timeout, so we use ping. See:
+    // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
+    let arguments = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "ping -n 99999 127.0.0.1".to_string(),
+    ];
+
+    let command = Command {
+        arguments,
+        output_paths: vec![],
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let execute_results_fut = running_actions_manager
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .and_then(|action| {
+            action
+                .clone()
+                .prepare_action()
+                .and_then(RunningAction::execute)
+                .and_then(RunningAction::upload_results)
+                .and_then(RunningAction::get_finished_result)
+                .then(|result| async move {
+                    if let Err(e) = action.cleanup().await {
+                        return Result::<ActionResult, Error>::Err(e).merge(result);
+                    }
+                    result
+                })
+        });
+
+    let (results, _) = tokio::join!(execute_results_fut, async move {
+        tokio::task::yield_now().await;
+        let tx = TIMEOUT_ONESHOT.lock().unwrap().0.take().unwrap();
+        tx.send(()).expect("Could not send timeout signal");
+    });
+    assert_eq!(results?.error.unwrap().code, Code::DeadlineExceeded);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+
+    #[cfg(target_family = "unix")]
+    let arguments = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "sleep infinity".to_string(),
+    ];
+    #[cfg(target_family = "windows")]
+    // Windows is weird with timeout, so we use ping. See:
+    // https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately
+    let arguments = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "ping -n 99999 127.0.0.1".to_string(),
+    ];
+
+    let command = Command {
+        arguments,
+        output_paths: vec![],
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let (cleanup_tx, cleanup_rx) = oneshot::channel();
+    let cleanup_was_requested = AtomicBool::new(false);
+    let action = running_actions_manager
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: 0,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+    let execute_results_fut = action
+        .clone()
+        .prepare_action()
+        .and_then(RunningAction::execute)
+        .and_then(RunningAction::upload_results)
+        .and_then(RunningAction::get_finished_result)
+        .then(|result| async {
+            cleanup_was_requested.store(true, Ordering::Release);
+            cleanup_rx.await.expect("Could not receive cleanup signal");
+            if let Err(e) = action.cleanup().await {
+                return Result::<ActionResult, Error>::Err(e).merge(result);
+            }
+            result
+        });
+
+    tokio::pin!(execute_results_fut);
+    {
+        // Advance the action as far as possible and ensure we are not waiting on cleanup.
+        for _ in 0..100 {
+            assert!(futures::poll!(&mut execute_results_fut).is_pending());
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(cleanup_was_requested.load(Ordering::Acquire), false);
+    }
+
+    let kill_all_fut = running_actions_manager.kill_all();
+    tokio::pin!(kill_all_fut);
+
+    {
+        // * Advance the action as far as possible.
+        // * Ensure we are now waiting on cleanup.
+        // * Ensure our kill_action is still pending.
+        while !cleanup_was_requested.load(Ordering::Acquire) {
+            // Wait for cleanup to be triggered.
+            tokio::task::yield_now().await;
+            assert!(futures::poll!(&mut execute_results_fut).is_pending());
+            assert!(futures::poll!(&mut kill_all_fut).is_pending());
+        }
+    }
+    // Allow cleanup, which allows execute_results_fut to advance.
+    cleanup_tx.send(()).expect("Could not send cleanup signal");
+    // Advance our two futures to completion now.
+    let result = execute_results_fut.await;
+    kill_all_fut.await;
+    {
+        // Ensure our results are correct.
+        let action_result = result?;
+        let err = action_result
+            .error
+            .as_ref()
+            .err_tip(|| format!("No error exists in result : {action_result:?}"))?;
+        assert_eq!(
+            err.code,
+            Code::Aborted,
+            "Expected Aborted : {action_result:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Regression Test for Issue #675
+#[cfg(target_family = "unix")]
+#[nativelink_test]
+async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+    const FILE_1_NAME: &str = "file1";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            execution_configuration: ExecutionConfiguration::default(),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    // Create and run an action which
+    // creates a file with owner executable permissions.
+    let action_result = {
         let command = Command {
-            arguments,
+            arguments: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("touch {FILE_1_NAME} && chmod 700 {FILE_1_NAME}").to_string(),
+            ],
+            output_paths: vec![FILE_1_NAME.to_string()],
             working_directory: ".".to_string(),
             ..Default::default()
         };
@@ -3302,16 +2881,6 @@ exit 1
         let action = Action {
             command_digest: Some(command_digest.into()),
             input_root_digest: Some(input_root_digest.into()),
-            platform: Some(Platform {
-                properties: vec![Property {
-                    name: "property_name".into(),
-                    value: "property_value".into(),
-                }],
-            }),
-            timeout: Some(prost_types::Duration {
-                seconds: ACTION_TIMEOUT,
-                nanos: 0,
-            }),
             ..Default::default()
         };
         let action_digest = serialize_and_upload_message(
@@ -3322,7 +2891,226 @@ exit 1
         .await?;
 
         let running_action_impl = running_actions_manager
-            .clone()
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        run_action(running_action_impl.clone()).await?
+    };
+    // Ensure the file copied from worker to CAS is executable.
+    assert!(
+        action_result.output_files[0].is_executable,
+        "Expected output file to be executable"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+    let temp_action_directory = make_temp_path("root_action_directory/temp");
+    fs::create_dir_all(&temp_action_directory).await?;
+
+    let running_actions_manager =
+        Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+            root_action_directory: root_action_directory.clone(),
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        })?);
+    let queued_timestamp = make_system_time(1000);
+
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["sh".to_string(), "-c".to_string(), "exit 0".to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec!["cmd".to_string(), "/C".to_string(), "exit 0".to_string()];
+
+    const SALT: u64 = 55;
+    let command = Command {
+        arguments,
+        output_paths: vec![],
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(queued_timestamp.into()),
+            },
+        )
+        .await?;
+
+    run_action(running_action_impl.clone()).await?;
+
+    let mut dir_stream = fs::read_dir(&root_action_directory).await?;
+    assert!(
+        dir_stream.as_mut().next_entry().await?.is_none(),
+        "Expected empty directory at {root_action_directory}"
+    );
+    Ok(())
+}
+
+// We've experienced deadlocks when uploading, so make only a single permit available and
+// check it's able to handle uploading some directories with some files in.
+// Be default this test is ignored because it *must* be run single threaded... to run this
+// test execute:
+// cargo test -p nativelink-worker --test running_actions_manager_test -- --test-threads=1 --ignored
+#[nativelink_test]
+#[ignore]
+async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
+    const WORKER_ID: &str = "foo_worker_id";
+
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
+    }
+
+    let (_, slow_store, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_action_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    // Take all but one FD permit away.
+    let _permits = futures::stream::iter(1..fs::OPEN_FILE_SEMAPHORE.available_permits())
+        .then(|_| fs::OPEN_FILE_SEMAPHORE.acquire())
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(1, fs::OPEN_FILE_SEMAPHORE.available_permits());
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: ExecutionConfiguration::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            sleep_fn: |_duration| Box::pin(futures::future::pending()),
+        },
+    )?);
+    let action_result = {
+        const SALT: u64 = 55;
+        #[cfg(target_family = "unix")]
+            let arguments = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf '123 ' > ./test.txt; mkdir ./tst; printf '456 ' > ./tst/tst.txt; printf 'foo-stdout '; >&2 printf 'bar-stderr  '"
+                    .to_string(),
+            ];
+        #[cfg(target_family = "windows")]
+            let arguments = vec![
+                "cmd".to_string(),
+                "/C".to_string(),
+                // Note: Windows adds two spaces after 'set /p=XXX'.
+                "echo | set /p=123> ./test.txt & mkdir ./tst & echo | set /p=456> ./tst/tst.txt & echo | set /p=foo-stdout & echo | set /p=bar-stderr 1>&2 & exit 0"
+                    .to_string(),
+            ];
+        let working_directory = "some_cwd";
+        let command = Command {
+            arguments,
+            output_paths: vec!["test.txt".to_string(), "tst".to_string()],
+            working_directory: working_directory.to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                directories: vec![DirectoryNode {
+                    name: working_directory.to_string(),
+                    digest: Some(
+                        serialize_and_upload_message(
+                            &Directory::default(),
+                            cas_store.as_pin(),
+                            &mut DigestHasherFunc::Sha256.hasher(),
+                        )
+                        .await?
+                        .into(),
+                    ),
+                }],
+                ..Default::default()
+            },
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        let running_action_impl = running_actions_manager
             .create_and_add_action(
                 WORKER_ID.to_string(),
                 StartExecute {
@@ -3332,17 +3120,189 @@ exit 1
                         ..Default::default()
                     }),
                     salt: SALT,
-                    queued_timestamp: Some(make_system_time(1000).into()),
+                    queued_timestamp: None,
                 },
             )
             .await?;
 
-        let result = run_action(running_action_impl).await?;
+        run_action(running_action_impl.clone()).await?
+    };
+    let file_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.output_files[0].digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&file_content)?, "123 ");
+    let stdout_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stdout_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stdout_content)?, "foo-stdout ");
+    let stderr_content = slow_store
+        .as_ref()
+        .get_part_unchunked(action_result.stderr_digest, 0, None)
+        .await?;
+    assert_eq!(from_utf8(&stderr_content)?, "bar-stderr  ");
+    let mut clock_time = make_system_time(0);
+    assert_eq!(
+        action_result,
+        ActionResult {
+            output_files: vec![FileInfo {
+                name_or_path: NameOrPath::Path("test.txt".to_string()),
+                digest: DigestInfo::try_new(
+                    "c69e10a5f54f4e28e33897fbd4f8701595443fa8c3004aeaa20dd4d9a463483b",
+                    4
+                )?,
+                is_executable: false,
+            }],
+            stdout_digest: DigestInfo::try_new(
+                "15019a676f057d97d1ad3af86f3cc1e623cb33b18ff28422bbe3248d2471cc94",
+                11
+            )?,
+            stderr_digest: DigestInfo::try_new(
+                "2375ab8a01ca11e1ea7606dfb58756c153d49733cde1dbfb5a1e00f39afacf06",
+                12
+            )?,
+            exit_code: 0,
+            output_folders: vec![DirectoryInfo {
+                path: "tst".to_string(),
+                tree_digest: DigestInfo::try_new(
+                    "95711c1905d4898a70209dd6e98241dcafb479c00241a1ea4ed8415710d706f3",
+                    166,
+                )?,
+            },],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
+            server_logs: HashMap::new(),
+            execution_metadata: ExecutionMetadata {
+                worker: WORKER_ID.to_string(),
+                queued_timestamp: SystemTime::UNIX_EPOCH,
+                worker_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_start_timestamp: increment_clock(&mut clock_time),
+                input_fetch_completed_timestamp: increment_clock(&mut clock_time),
+                execution_start_timestamp: increment_clock(&mut clock_time),
+                execution_completed_timestamp: increment_clock(&mut clock_time),
+                output_upload_start_timestamp: increment_clock(&mut clock_time),
+                output_upload_completed_timestamp: increment_clock(&mut clock_time),
+                worker_completed_timestamp: increment_clock(&mut clock_time),
+            },
+            error: None,
+            message: String::new(),
+        }
+    );
+    Ok(())
+}
 
-        #[cfg(target_family = "unix")]
-        assert_eq!(result.exit_code, 9, "Action process should be been killed");
-        #[cfg(target_family = "windows")]
-        assert_eq!(result.exit_code, 1, "Action process should be been killed");
-        Ok(())
+#[nativelink_test]
+async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn std::error::Error>>
+{
+    const WORKER_ID: &str = "foo_worker_id";
+    const SALT: u64 = 66;
+
+    let (_, _, cas_store, ac_store) = setup_stores().await?;
+    let root_action_directory = make_temp_path("root_work_directory");
+    fs::create_dir_all(&root_action_directory).await?;
+
+    // Ignore the sleep and immediately timeout.
+    static ACTION_TIMEOUT: i64 = 1;
+    fn test_monotonic_clock() -> SystemTime {
+        static CLOCK: AtomicU64 = AtomicU64::new(0);
+        monotonic_clock(&CLOCK)
     }
+
+    let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+        RunningActionsManagerArgs {
+            root_action_directory,
+            execution_configuration: Default::default(),
+            cas_store: cas_store.clone(),
+            ac_store: Some(Store::new(ac_store.clone())),
+            historical_store: Store::new(cas_store.clone()),
+            upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
+                upload_ac_results_strategy:
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                ..Default::default()
+            },
+            max_action_timeout: Duration::MAX,
+            timeout_handled_externally: false,
+        },
+        Callbacks {
+            now_fn: test_monotonic_clock,
+            // If action_timeout is the passed duration then return immeidately,
+            // which will cause the action to be killed and pass the test,
+            // otherwise return pending and fail the test.
+            sleep_fn: |duration| {
+                assert_eq!(duration.as_secs(), ACTION_TIMEOUT as u64);
+                Box::pin(futures::future::ready(()))
+            },
+        },
+    )?);
+    #[cfg(target_family = "unix")]
+    let arguments = vec!["sh".to_string(), "-c".to_string(), "sleep 2".to_string()];
+    #[cfg(target_family = "windows")]
+    let arguments = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "ping -n 99999 127.0.0.1".to_string(),
+    ];
+    let command = Command {
+        arguments,
+        working_directory: ".".to_string(),
+        ..Default::default()
+    };
+    let command_digest = serialize_and_upload_message(
+        &command,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = serialize_and_upload_message(
+        &Directory::default(),
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        platform: Some(Platform {
+            properties: vec![Property {
+                name: "property_name".into(),
+                value: "property_value".into(),
+            }],
+        }),
+        timeout: Some(prost_types::Duration {
+            seconds: ACTION_TIMEOUT,
+            nanos: 0,
+        }),
+        ..Default::default()
+    };
+    let action_digest = serialize_and_upload_message(
+        &action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+
+    let running_action_impl = running_actions_manager
+        .clone()
+        .create_and_add_action(
+            WORKER_ID.to_string(),
+            StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                }),
+                salt: SALT,
+                queued_timestamp: Some(make_system_time(1000).into()),
+            },
+        )
+        .await?;
+
+    let result = run_action(running_action_impl).await?;
+
+    #[cfg(target_family = "unix")]
+    assert_eq!(result.exit_code, 9, "Action process should be been killed");
+    #[cfg(target_family = "windows")]
+    assert_eq!(result.exit_code, 1, "Action process should be been killed");
+    Ok(())
 }


### PR DESCRIPTION
# Description

Integration tests are compiled into their own binaries, which are then
executed. As such, there's no need to wrap integration tests in modules:

```rust
// in `tests/some_test.rs`
use some::dependency;

#[cfg(test)]
mod some_integration_test {
  use super::*;

  // Some tests go here.
}
```

This is common practice in unit tests, which if not gated behind a
`cfg` flag are included in the final release binary. We were mistakenly
doing the same thing in integration tests, where it was unnecessary.

This PR just removes all those module declarations.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...` passes

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/975)
<!-- Reviewable:end -->
