### PR TITLE
Add dev build profile and remove lto from CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,19 @@ rust-version = "1.77.2"
 lto = true
 opt-level = 3
 
+[profile.dev]
+lto = false
+opt-level = 0
+strip = false
+debug = true
+
 # Prefer this profile in CI, for instance via `cargo test --all --profile=smol`.
 # It reduces the size of the `target` directory from ~12GB to ~1GB.
 [profile.smol]
-inherits = "release"
-lto = "thin"
+inherits = "dev"
 opt-level = "z"
 strip = true
+debug = false
 
 [[bin]]
 name = "nativelink"


### PR DESCRIPTION
Adds a dev build profile that disables lto and optimizations for faster compilation times. Changes CI preferred build profile to inherit from dev profile and overrides it to strip all symbol and debuginfo, optimize for binary size, turn off loop vectorization and debuginfo generation.

Fixes All the Failing precommit checks

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/976)
<!-- Reviewable:end -->
