### PR TITLE
Update `Vale` CI action to handle large diffs

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -16,8 +16,9 @@ jobs:
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Run Vale
-        uses: >- # Custom commit, last pinned 2023.12.30.
-          errata-ai/vale-action@c99f2dfd2aeaedb3d4bb16f385841830b9164d31
+        uses: >- # Custom commit, last pinned 2024.06.06.
+          errata-ai/vale-action@91ac403e8d26f5aa1b3feaa86ca63065936a85b6
         with:
           filter_mode: file
           reporter: github-pr-check
+          reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.17.5/reviewdog_0.17.5_Linux_x86_64.tar.gz


### PR DESCRIPTION
# Description

This PR helps us to avoid running into the issue described in
<https://github.com/reviewdog/reviewdog/issues/1696>, where diffs that
are too large will cause Vale to fail

The diff between the versions of Vale and the new one can be viewed
[here](https://github.com/errata-ai/vale-action/compare/c99f2d..91ac40).
Since they also allow you to specify which version of reviewdog to use,
we'll use the most recent one which includes all the changes made so far
that are supposed to fix the issue with large diffs.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It hasn't, but we'll see how it runs on this PR.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/978)
<!-- Reviewable:end -->
