### PR TITLE
Introduce basic rustdoc infrastructure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,36 @@ rust_binary(
     ],
 )
 
+filegroup(
+    name = "docs",
+    srcs = [
+        "//nativelink-config:docs",
+        "//nativelink-error:docs",
+        "//nativelink-macro:docs",
+        "//nativelink-proto:docs",
+        "//nativelink-scheduler:docs",
+        "//nativelink-service:docs",
+        "//nativelink-store:docs",
+        "//nativelink-util:docs",
+        "//nativelink-worker:docs",
+    ],
+)
+
+test_suite(
+    name = "doctests",
+    tests = [
+        "//nativelink-config:doc_test",
+        "//nativelink-error:doc_test",
+        "//nativelink-macro:doc_test",
+        "//nativelink-proto:doc_test",
+        "//nativelink-scheduler:doc_test",
+        "//nativelink-service:doc_test",
+        "//nativelink-store:doc_test",
+        "//nativelink-util:doc_test",
+        "//nativelink-worker:doc_test",
+    ],
+)
+
 genrule(
     name = "dummy_test_sh",
     outs = ["dummy_test.sh"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,6 +300,32 @@ This will automatically apply some fixes like automated line fixes and format
 changes. Note that changed files aren't automatically staged. Use `git add` to
 add the changed files manually to the staging area.
 
+## Generating documentation
+
+Automatically generated documentation is still under construction. To view the
+documentation for the `nativelink-*` crates, run the `docs` command in the nix
+flake:
+
+```bash
+docs
+```
+
+To build individual crate-level docs:
+
+```bash
+# All docs
+bazel build docs
+
+# A single crate
+bazel build nativelink-config:docs
+```
+
+To run documentation tests with Bazel:
+
+```bash
+bazel test doctests
+```
+
 ## Writing documentation
 
 NativeLink largely follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
         src = pkgs.lib.cleanSourceWith {
           src = craneLib.path ./.;
           filter = path: type:
-            (builtins.match "^.+/data/SekienAkashita\\.jpg" path != null)
+            (builtins.match "^.*(data/SekienSkashita\.jpg|nativelink-config/README\.md)" path != null)
             || (craneLib.filterCargoSources path type);
         };
 
@@ -141,6 +141,8 @@
         generate-toolchains = import ./tools/generate-toolchains.nix {inherit pkgs;};
 
         native-cli = import ./native-cli/default.nix {inherit pkgs;};
+
+        docs = pkgs.callPackage ./tools/docs.nix {rust = stable-rust.default;};
 
         inherit (nix2container.packages.${system}.nix2container) pullImage;
         inherit (nix2container.packages.${system}.nix2container) buildImage;
@@ -275,6 +277,7 @@
               generate-toolchains
               customClang
               native-cli
+              docs
             ]
             ++ maybeDarwinDeps;
           shellHook = ''

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -15,6 +15,9 @@ rust_library(
         "src/serde_utils.rs",
         "src/stores.rs",
     ],
+    compile_data = [
+        "README.md",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:byte-unit",
@@ -44,6 +47,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-config",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/nativelink-config/src/lib.rs
+++ b/nativelink-config/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc = include_str!("../README.md")]
+
 pub mod cas_server;
 pub mod schedulers;
 pub mod serde_utils;

--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -59,7 +59,7 @@ where
     deserializer.deserialize_any(USizeVisitor::<T>(PhantomData::<T> {}))
 }
 
-/// Same as convert_numeric_with_shellexpand, but supports Option<T>.
+/// Same as convert_numeric_with_shellexpand, but supports `Option<T>`.
 pub fn convert_optional_numeric_with_shellexpand<'de, D, T, E>(
     deserializer: D,
 ) -> Result<Option<T>, D::Error>
@@ -113,7 +113,7 @@ pub fn convert_string_with_shellexpand<'de, D: Deserializer<'de>>(
     Ok((*(shellexpand::env(&value).map_err(de::Error::custom)?)).to_string())
 }
 
-/// Same as convert_string_with_shellexpand, but supports Vec<String>.
+/// Same as convert_string_with_shellexpand, but supports `Vec<String>`.
 pub fn convert_vec_string_with_shellexpand<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Vec<String>, D::Error> {
@@ -127,7 +127,7 @@ pub fn convert_vec_string_with_shellexpand<'de, D: Deserializer<'de>>(
         .collect()
 }
 
-/// Same as convert_string_with_shellexpand, but supports Option<String>.
+/// Same as convert_string_with_shellexpand, but supports `Option<String>`.
 pub fn convert_optional_string_with_shellexpand<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Option<String>, D::Error> {

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -1,4 +1,9 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+)
 
 rust_library(
     name = "nativelink-error",
@@ -15,4 +20,16 @@ rust_library(
         "@crates//:tokio",
         "@crates//:tonic",
     ],
+)
+
+rust_doc(
+    name = "docs",
+    crate = ":nativelink-error",
+    visibility = ["//visibility:public"],
+)
+
+rust_doc_test(
+    name = "doc_test",
+    timeout = "short",
+    crate = ":nativelink-error",
 )

--- a/nativelink-macro/BUILD.bazel
+++ b/nativelink-macro/BUILD.bazel
@@ -1,6 +1,7 @@
 load(
     "@rules_rust//rust:defs.bzl",
     "rust_doc",
+    "rust_doc_test",
     "rust_proc_macro",
 )
 
@@ -19,5 +20,12 @@ rust_proc_macro(
 
 rust_doc(
     name = "docs",
+    crate = ":nativelink-macro",
+    visibility = ["//visibility:public"],
+)
+
+rust_doc_test(
+    name = "doc_test",
+    timeout = "short",
     crate = ":nativelink-macro",
 )

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 
 [lib]
-crate_type = ["proc-macro"]
+proc-macro = true
 
 [dependencies]
 # TODO(allada) We currently need to pin these to specific version.

--- a/nativelink-proto/BUILD.bazel
+++ b/nativelink-proto/BUILD.bazel
@@ -1,4 +1,10 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+)
 
 PROTO_NAMES = [
     "build.bazel.remote.execution.v2",
@@ -107,4 +113,16 @@ py_test(
         ":gen_rs_protos",
     ],
     main = "update_protos.py",
+)
+
+rust_doc(
+    name = "docs",
+    crate = ":nativelink-proto",
+    visibility = ["//visibility:public"],
+)
+
+rust_doc_test(
+    name = "doc_test",
+    timeout = "short",
+    crate = ":nativelink-proto",
 )

--- a/nativelink-proto/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/nativelink-proto/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1869,11 +1869,13 @@ message DigestFunction {
     //   3. A single invocation is made to the SHA-256 block cipher with
     //      the following parameters:
     //
-    //          M = Hash(left) || Hash(right)
-    //          H = {
-    //              0xcbbb9d5d, 0x629a292a, 0x9159015a, 0x152fecd8,
-    //              0x67332667, 0x8eb44a87, 0xdb0c2e0d, 0x47b5481d,
-    //          }
+    //      ```text
+    //      M = Hash(left) || Hash(right)
+    //      H = {
+    //          0xcbbb9d5d, 0x629a292a, 0x9159015a, 0x152fecd8,
+    //          0x67332667, 0x8eb44a87, 0xdb0c2e0d, 0x47b5481d,
+    //      }
+    //      ```
     //
     //      The values of H are the leading fractional parts of the
     //      square roots of the 9th to the 16th prime number (23 to 53).
@@ -1884,7 +1886,9 @@ message DigestFunction {
     //   4. The hash of the full blob can then be obtained by
     //      concatenating the outputs of the block cipher:
     //
-    //          Hash(blob) = a || b || c || d || e || f || g || h
+    //      ```text
+    //      Hash(blob) = a || b || c || d || e || f || g || h
+    //      ```
     //
     //      Addition of the original values of H, as normally done
     //      through the use of the Davies-Meyer structure, is not

--- a/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
+++ b/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
@@ -1566,11 +1566,13 @@ pub mod digest_function {
         ///    3. A single invocation is made to the SHA-256 block cipher with
         ///       the following parameters:
         ///
-        ///           M = Hash(left) || Hash(right)
-        ///           H = {
-        ///               0xcbbb9d5d, 0x629a292a, 0x9159015a, 0x152fecd8,
-        ///               0x67332667, 0x8eb44a87, 0xdb0c2e0d, 0x47b5481d,
-        ///           }
+        ///       ```text
+        ///       M = Hash(left) || Hash(right)
+        ///       H = {
+        ///           0xcbbb9d5d, 0x629a292a, 0x9159015a, 0x152fecd8,
+        ///           0x67332667, 0x8eb44a87, 0xdb0c2e0d, 0x47b5481d,
+        ///       }
+        ///       ```
         ///
         ///       The values of H are the leading fractional parts of the
         ///       square roots of the 9th to the 16th prime number (23 to 53).
@@ -1581,7 +1583,9 @@ pub mod digest_function {
         ///    4. The hash of the full blob can then be obtained by
         ///       concatenating the outputs of the block cipher:
         ///
-        ///           Hash(blob) = a || b || c || d || e || f || g || h
+        ///       ```text
+        ///       Hash(blob) = a || b || c || d || e || f || g || h
+        ///       ```
         ///
         ///       Addition of the original values of H, as normally done
         ///       through the use of the Davies-Meyer structure, is not

--- a/nativelink-proto/genproto/google.api.pb.rs
+++ b/nativelink-proto/genproto/google.api.pb.rs
@@ -58,19 +58,21 @@ pub struct Http {
 ///
 /// Example:
 ///
-///      service Messaging {
-///        rpc GetMessage(GetMessageRequest) returns (Message) {
-///          option (google.api.http) = {
-///              get: "/v1/{name=messages/*}"
-///          };
-///        }
-///      }
-///      message GetMessageRequest {
-///        string name = 1; // Mapped to URL path.
-///      }
-///      message Message {
-///        string text = 1; // The resource content.
-///      }
+/// ```text
+/// service Messaging {
+///    rpc GetMessage(GetMessageRequest) returns (Message) {
+///      option (google.api.http) = {
+///          get: "/v1/{name=messages/*}"
+///      };
+///    }
+/// }
+/// message GetMessageRequest {
+///    string name = 1; // Mapped to URL path.
+/// }
+/// message Message {
+///    string text = 1; // The resource content.
+/// }
+/// ```
 ///
 /// This enables an HTTP REST to gRPC mapping as below:
 ///
@@ -82,21 +84,23 @@ pub struct Http {
 /// automatically become HTTP query parameters if there is no HTTP request body.
 /// For example:
 ///
-///      service Messaging {
-///        rpc GetMessage(GetMessageRequest) returns (Message) {
-///          option (google.api.http) = {
-///              get:"/v1/messages/{message_id}"
-///          };
-///        }
-///      }
-///      message GetMessageRequest {
-///        message SubMessage {
-///          string subfield = 1;
-///        }
-///        string message_id = 1; // Mapped to URL path.
-///        int64 revision = 2;    // Mapped to URL query parameter `revision`.
-///        SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
-///      }
+/// ```text
+/// service Messaging {
+///    rpc GetMessage(GetMessageRequest) returns (Message) {
+///      option (google.api.http) = {
+///          get:"/v1/messages/{message_id}"
+///      };
+///    }
+/// }
+/// message GetMessageRequest {
+///    message SubMessage {
+///      string subfield = 1;
+///    }
+///    string message_id = 1; // Mapped to URL path.
+///    int64 revision = 2;    // Mapped to URL query parameter `revision`.
+///    SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+/// }
+/// ```
 ///
 /// This enables a HTTP JSON to RPC mapping as below:
 ///
@@ -117,18 +121,20 @@ pub struct Http {
 /// specifies the mapping. Consider a REST update method on the
 /// message resource collection:
 ///
-///      service Messaging {
-///        rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-///          option (google.api.http) = {
-///            patch: "/v1/messages/{message_id}"
-///            body: "message"
-///          };
-///        }
-///      }
-///      message UpdateMessageRequest {
-///        string message_id = 1; // mapped to the URL
-///        Message message = 2;   // mapped to the body
-///      }
+/// ```text
+/// service Messaging {
+///    rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+///      option (google.api.http) = {
+///        patch: "/v1/messages/{message_id}"
+///        body: "message"
+///      };
+///    }
+/// }
+/// message UpdateMessageRequest {
+///    string message_id = 1; // mapped to the URL
+///    Message message = 2;   // mapped to the body
+/// }
+/// ```
 ///
 /// The following HTTP JSON to RPC mapping is enabled, where the
 /// representation of the JSON in the request body is determined by
@@ -144,19 +150,20 @@ pub struct Http {
 /// request body.  This enables the following alternative definition of
 /// the update method:
 ///
-///      service Messaging {
-///        rpc UpdateMessage(Message) returns (Message) {
-///          option (google.api.http) = {
-///            patch: "/v1/messages/{message_id}"
-///            body: "*"
-///          };
-///        }
-///      }
-///      message Message {
-///        string message_id = 1;
-///        string text = 2;
-///      }
-///
+/// ```text
+/// service Messaging {
+///    rpc UpdateMessage(Message) returns (Message) {
+///      option (google.api.http) = {
+///        patch: "/v1/messages/{message_id}"
+///        body: "*"
+///      };
+///    }
+/// }
+/// message Message {
+///    string message_id = 1;
+///    string text = 2;
+/// }
+/// ```
 ///
 /// The following HTTP JSON to RPC mapping is enabled:
 ///
@@ -174,20 +181,22 @@ pub struct Http {
 /// It is possible to define multiple HTTP methods for one RPC by using
 /// the `additional_bindings` option. Example:
 ///
-///      service Messaging {
-///        rpc GetMessage(GetMessageRequest) returns (Message) {
-///          option (google.api.http) = {
-///            get: "/v1/messages/{message_id}"
-///            additional_bindings {
-///              get: "/v1/users/{user_id}/messages/{message_id}"
-///            }
-///          };
+/// ```proto
+/// service Messaging {
+///    rpc GetMessage(GetMessageRequest) returns (Message) {
+///      option (google.api.http) = {
+///        get: "/v1/messages/{message_id}"
+///        additional_bindings {
+///          get: "/v1/users/{user_id}/messages/{message_id}"
 ///        }
-///      }
-///      message GetMessageRequest {
-///        string message_id = 1;
-///        string user_id = 2;
-///      }
+///      };
+///    }
+/// }
+/// message GetMessageRequest {
+///    string message_id = 1;
+///    string user_id = 2;
+/// }
+/// ```
 ///
 /// This enables the following two alternative HTTP JSON to RPC mappings:
 ///
@@ -215,12 +224,14 @@ pub struct Http {
 ///
 /// ### Path template syntax
 ///
-///      Template = "/" Segments \[ Verb \] ;
-///      Segments = Segment { "/" Segment } ;
-///      Segment  = "*" | "**" | LITERAL | Variable ;
-///      Variable = "{" FieldPath \[ "=" Segments \] "}" ;
-///      FieldPath = IDENT { "." IDENT } ;
-///      Verb     = ":" LITERAL ;
+/// ```text
+/// Template = "/" Segments \[ Verb \] ;
+/// Segments = Segment { "/" Segment } ;
+/// Segment  = "*" | "**" | LITERAL | Variable ;
+/// Variable = "{" FieldPath \[ "=" Segments \] "}" ;
+/// FieldPath = IDENT { "." IDENT } ;
+/// Verb     = ":" LITERAL ;
+/// ```
 ///
 /// The syntax `*` matches a single URL path segment. The syntax `**` matches
 /// zero or more URL path segments, which must be the last part of the URL path
@@ -269,11 +280,13 @@ pub struct Http {
 ///
 /// Example:
 ///
+/// ```yaml
 ///      http:
 ///        rules:
 ///          # Selects a gRPC method and applies HttpRule to it.
 ///          - selector: example.v1.Messaging.GetMessage
 ///            get: /v1/messages/{message_id}/{sub.subfield}
+/// ```
 ///
 /// ## Special notes
 ///

--- a/nativelink-proto/google/api/http.proto
+++ b/nativelink-proto/google/api/http.proto
@@ -66,19 +66,21 @@ message Http {
 //
 // Example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//             get: "/v1/{name=messages/*}"
-//         };
-//       }
-//     }
-//     message GetMessageRequest {
-//       string name = 1; // Mapped to URL path.
-//     }
-//     message Message {
-//       string text = 1; // The resource content.
-//     }
+// ```text
+// service Messaging {
+//   rpc GetMessage(GetMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//         get: "/v1/{name=messages/*}"
+//     };
+//   }
+// }
+// message GetMessageRequest {
+//   string name = 1; // Mapped to URL path.
+// }
+// message Message {
+//   string text = 1; // The resource content.
+// }
+// ```
 //
 // This enables an HTTP REST to gRPC mapping as below:
 //
@@ -90,21 +92,23 @@ message Http {
 // automatically become HTTP query parameters if there is no HTTP request body.
 // For example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//             get:"/v1/messages/{message_id}"
-//         };
-//       }
-//     }
-//     message GetMessageRequest {
-//       message SubMessage {
-//         string subfield = 1;
-//       }
-//       string message_id = 1; // Mapped to URL path.
-//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
-//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
-//     }
+// ```text
+// service Messaging {
+//   rpc GetMessage(GetMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//         get:"/v1/messages/{message_id}"
+//     };
+//   }
+// }
+// message GetMessageRequest {
+//   message SubMessage {
+//     string subfield = 1;
+//   }
+//   string message_id = 1; // Mapped to URL path.
+//   int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//   SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+// }
+// ```
 //
 // This enables a HTTP JSON to RPC mapping as below:
 //
@@ -125,18 +129,20 @@ message Http {
 // specifies the mapping. Consider a REST update method on the
 // message resource collection:
 //
-//     service Messaging {
-//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//           patch: "/v1/messages/{message_id}"
-//           body: "message"
-//         };
-//       }
-//     }
-//     message UpdateMessageRequest {
-//       string message_id = 1; // mapped to the URL
-//       Message message = 2;   // mapped to the body
-//     }
+// ```text
+// service Messaging {
+//   rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//       patch: "/v1/messages/{message_id}"
+//       body: "message"
+//     };
+//   }
+// }
+// message UpdateMessageRequest {
+//   string message_id = 1; // mapped to the URL
+//   Message message = 2;   // mapped to the body
+// }
+// ```
 //
 // The following HTTP JSON to RPC mapping is enabled, where the
 // representation of the JSON in the request body is determined by
@@ -152,19 +158,20 @@ message Http {
 // request body.  This enables the following alternative definition of
 // the update method:
 //
-//     service Messaging {
-//       rpc UpdateMessage(Message) returns (Message) {
-//         option (google.api.http) = {
-//           patch: "/v1/messages/{message_id}"
-//           body: "*"
-//         };
-//       }
-//     }
-//     message Message {
-//       string message_id = 1;
-//       string text = 2;
-//     }
-//
+// ```text
+// service Messaging {
+//   rpc UpdateMessage(Message) returns (Message) {
+//     option (google.api.http) = {
+//       patch: "/v1/messages/{message_id}"
+//       body: "*"
+//     };
+//   }
+// }
+// message Message {
+//   string message_id = 1;
+//   string text = 2;
+// }
+// ```
 //
 // The following HTTP JSON to RPC mapping is enabled:
 //
@@ -182,20 +189,22 @@ message Http {
 // It is possible to define multiple HTTP methods for one RPC by using
 // the `additional_bindings` option. Example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//           get: "/v1/messages/{message_id}"
-//           additional_bindings {
-//             get: "/v1/users/{user_id}/messages/{message_id}"
-//           }
-//         };
+// ```proto
+// service Messaging {
+//   rpc GetMessage(GetMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//       get: "/v1/messages/{message_id}"
+//       additional_bindings {
+//         get: "/v1/users/{user_id}/messages/{message_id}"
 //       }
-//     }
-//     message GetMessageRequest {
-//       string message_id = 1;
-//       string user_id = 2;
-//     }
+//     };
+//   }
+// }
+// message GetMessageRequest {
+//   string message_id = 1;
+//   string user_id = 2;
+// }
+// ```
 //
 // This enables the following two alternative HTTP JSON to RPC mappings:
 //
@@ -223,12 +232,14 @@ message Http {
 //
 // ### Path template syntax
 //
-//     Template = "/" Segments [ Verb ] ;
-//     Segments = Segment { "/" Segment } ;
-//     Segment  = "*" | "**" | LITERAL | Variable ;
-//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
-//     FieldPath = IDENT { "." IDENT } ;
-//     Verb     = ":" LITERAL ;
+// ```text
+// Template = "/" Segments [ Verb ] ;
+// Segments = Segment { "/" Segment } ;
+// Segment  = "*" | "**" | LITERAL | Variable ;
+// Variable = "{" FieldPath [ "=" Segments ] "}" ;
+// FieldPath = IDENT { "." IDENT } ;
+// Verb     = ":" LITERAL ;
+// ```
 //
 // The syntax `*` matches a single URL path segment. The syntax `**` matches
 // zero or more URL path segments, which must be the last part of the URL path
@@ -277,11 +288,13 @@ message Http {
 //
 // Example:
 //
+// ```yaml
 //     http:
 //       rules:
 //         # Selects a gRPC method and applies HttpRule to it.
 //         - selector: example.v1.Messaging.GetMessage
 //           get: /v1/messages/{message_id}/{sub.subfield}
+// ```
 //
 // ## Special notes
 //

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -84,6 +84,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-scheduler",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -83,6 +83,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-service",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -133,6 +133,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-store",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -105,6 +105,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-util",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -86,6 +86,7 @@ rust_test_suite(
 rust_doc(
     name = "docs",
     crate = ":nativelink-worker",
+    visibility = ["//visibility:public"],
 )
 
 rust_doc_test(

--- a/tools/docs.nix
+++ b/tools/docs.nix
@@ -1,0 +1,20 @@
+{
+  writeShellScriptBin,
+  rust,
+  ...
+}:
+writeShellScriptBin "docs" ''
+  set -xeuo pipefail
+
+  ${rust}/bin/cargo doc --no-deps \
+      -p nativelink-config \
+      -p nativelink-error \
+      -p nativelink-macro \
+      -p nativelink-proto \
+      -p nativelink-scheduler \
+      -p nativelink-service \
+      -p nativelink-store \
+      -p nativelink-util \
+      -p nativelink-worker \
+      --open
+''


### PR DESCRIPTION
This commit adds a new `docs` command to the flake which can be used to build rustdocs. The setup is compatible with Cargo and Bazel.

Docs may also be tested via `bazel test docs`.

This commit doesn't publish the docs and doesn't fully surface all configuration. It provides some basic infrastructure as a starting point for future enhancments to autogenerated documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/980)
<!-- Reviewable:end -->
