### PR TITLE
Add a config option to prefix keys in Redis stores

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -879,6 +879,15 @@ pub struct RedisStore {
     /// Default: 10
     #[serde(default)]
     pub connection_timeout_s: u64,
+
+    /// An optional prefix to prepend to all keys in this store.
+    ///
+    /// Setting this value can make it convenient to query or
+    /// organize your data according to the shared prefix.
+    ///
+    /// Default: (Empty String / No Prefix)
+    #[serde(default)]
+    pub key_prefix: String,
 }
 
 /// Retry configuration. This configuration is exponential and each iteration


### PR DESCRIPTION
# Description

Add a configuration option that allows for setting an optional prefix to all the keys used with a Redis store. I added some documentation to the `RedisStore` configuration struct, but I'm not sure if there's docs I should update elsewhere.

Fixes #977

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

I added duplicates of existing tests of the Redis store to use prefixes

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/981)
<!-- Reviewable:end -->
