### PR TITLE
Support cluster mode when using Redis as a store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
 name = "crc32c"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,11 +2560,14 @@ dependencies = [
  "async-trait",
  "bytes",
  "combine",
+ "crc16",
  "futures",
  "futures-util",
  "itoa",
+ "log",
  "percent-encoding",
  "pin-project-lite",
+ "rand",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -864,7 +864,6 @@ pub struct RedisStore {
     /// The hostname or IP address of the Redis server.
     /// Ex: ["redis://username:password@redis-server-url:6380/99"]
     /// 99 Represents database ID, 6380 represents the port.
-    // Note: This is currently one address but supports multile for clusters.
     #[serde(deserialize_with = "convert_vec_string_with_shellexpand")]
     pub addresses: Vec<String>,
 
@@ -888,6 +887,26 @@ pub struct RedisStore {
     /// Default: (Empty String / No Prefix)
     #[serde(default)]
     pub key_prefix: String,
+
+    /// Set the mode Redis is operating in.
+    ///
+    /// Available options are "cluster" for
+    /// [cluster mode](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/),
+    /// "sentinel" for [sentinel mode](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/),
+    /// or "standard" if Redis is operating in neither cluster nor sentinel mode.
+    ///
+    /// Default: standard,
+    #[serde(default)]
+    pub mode: RedisMode,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RedisMode {
+    Cluster,
+    Sentinel,
+    #[default]
+    Standard,
 }
 
 /// Retry configuration. This configuration is exponential and each iteration

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -29,7 +29,12 @@ lz4_flex = "0.11.3"
 parking_lot = "0.12.2"
 prost = "0.12.4"
 rand = "0.8.5"
-redis = { version = "0.25.3", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"] }
+redis = { version = "0.25.3", features = [
+  "tokio-comp",
+  "tokio-rustls-comp",
+  "connection-manager",
+  "cluster-async",
+] }
 serde = "1.0.201"
 sha2 = "0.10.8"
 shellexpand = "3.1.0"
@@ -50,7 +55,7 @@ memory-stats = "1.1.0"
 once_cell = "1.19.0"
 http = "1.1.0"
 aws-smithy-types = "1.1.9"
-aws-sdk-s3 = { version = "1.28.0"  }
+aws-sdk-s3 = { version = "1.28.0" }
 aws-smithy-runtime = { version = "1.5.0", features = ["test-util"] }
 aws-smithy-runtime-api = "1.6.0"
 serial_test = { version = "3.1.1", features = ["async"] }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::cell::OnceCell;
+use std::cell::{OnceCell, UnsafeCell};
+use std::fmt::Display;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 
-use arc_cell::ArcCell;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::future::{BoxFuture, FutureExt, Shared};
+use futures::future::{ErrInto, FutureExt, Shared};
+use futures::stream::FuturesOrdered;
+use futures::{Future, TryFutureExt, TryStreamExt};
+use nativelink_config::stores::RedisMode;
 use nativelink_error::{error_if, make_err, Code, Error, ResultExt};
 use nativelink_util::background_spawn;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -28,21 +31,219 @@ use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthS
 use nativelink_util::metrics_utils::{Collector, CollectorState, MetricsComponent, Registry};
 use nativelink_util::store_trait::{StoreDriver, StoreKey, UploadSizeInfo};
 use redis::aio::{ConnectionLike, ConnectionManager};
+use redis::cluster_async::ClusterConnection;
 use redis::{AsyncCommands, ToRedisArgs};
+use tokio::task::JoinHandle;
 
 use crate::cas_utils::is_zero_digest;
 
 const READ_CHUNK_SIZE: isize = 64 * 1024;
 
-/// Holds a connection result or a future that resolves to a connection.
-/// This is a utility to allow us to start a connection but not block on it.
-pub enum LazyConnection<T: ConnectionLike + Unpin + Clone + Send + Sync> {
-    Connection(Result<T, Error>),
-    Future(Shared<BoxFuture<'static, Result<T, Error>>>),
+/// A wrapper type containing the different Redis clients we support.
+//
+// Typically we would use `dyn ConnectionLike` instead of creating a wrapper type, but these clients are cheaply
+// cloneable; you're meant to clone a client in order to get mutable access.
+// [`Clone`] has a [`Sized`] bound, which means that any supertrait we constructed with a `Clone` bound
+// wouldn't be object safe -- in short, this won't compile:
+//
+// ```compile_fail
+// trait CloneableConnectionHandle: ConnectionLike + Clone {}
+//
+// impl <C: ConnectionLike + Clone> CloneableConnectionHandle for C {}
+// ```
+#[derive(Clone)]
+pub enum ConnectionKind {
+    Cluster(ClusterConnection),
+    Single(ConnectionManager),
 }
 
-pub struct RedisStore<T: ConnectionLike + Unpin + Clone + Send + Sync = ConnectionManager> {
-    lazy_conn: ArcCell<LazyConnection<T>>,
+impl From<ClusterConnection> for ConnectionKind {
+    fn from(value: ClusterConnection) -> Self {
+        Self::Cluster(value)
+    }
+}
+
+impl From<ConnectionManager> for ConnectionKind {
+    fn from(value: ConnectionManager) -> Self {
+        Self::Single(value)
+    }
+}
+
+// delegate to the inner impl's
+impl ConnectionLike for ConnectionKind {
+    fn req_packed_command<'a>(
+        &'a mut self,
+        cmd: &'a redis::Cmd,
+    ) -> redis::RedisFuture<'a, redis::Value> {
+        match self {
+            ConnectionKind::Cluster(inner) => inner.req_packed_command(cmd),
+            ConnectionKind::Single(inner) => inner.req_packed_command(cmd),
+        }
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a redis::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> redis::RedisFuture<'a, Vec<redis::Value>> {
+        match self {
+            ConnectionKind::Cluster(inner) => inner.req_packed_commands(cmd, offset, count),
+            ConnectionKind::Single(inner) => inner.req_packed_commands(cmd, offset, count),
+        }
+    }
+
+    fn get_db(&self) -> i64 {
+        match self {
+            ConnectionKind::Cluster(inner) => inner.get_db(),
+            ConnectionKind::Single(inner) => inner.get_db(),
+        }
+    }
+}
+
+/// Type alias for a [`Shared`] [`JoinHandle`] that has had its [`JoinError`](`tokio::task::JoinError`) mapped to an [`Error`]
+type RedisConnectionFuture<C> = Shared<ErrInto<JoinHandle<Result<C, Error>>, Error>>;
+
+/// Represents the possible states of a Redis connection.
+enum ConnectionState<C> {
+    /// Contains a future that must be polled to connect to Redis
+    Connecting(RedisConnectionFuture<C>),
+
+    /// Contains a connection that was made successfully
+    Connected(C),
+
+    /// Contains an error that occurred while connecting
+    Errored(Error),
+}
+
+/// Represents a connection to Redis.
+pub struct BackgroundConnection<C> {
+    /// Synchronization primitive used for tracking if `self.state` has been changed from `ConnectionState::Connecting`
+    /// to `ConnectionState::Error` or `ConnectionState::Connected`. Once it's been changed exactly once,
+    /// [`Once::is_completed`] will return `true`.
+    once: Once,
+
+    /// Contains the current state of the connection.
+    // Invariant: the state must be mutated exactly once.
+    state: UnsafeCell<ConnectionState<C>>,
+}
+
+impl BackgroundConnection<ConnectionKind> {
+    /// Connect to a single Redis instance.
+    ///
+    /// ## Errors
+    ///
+    /// Some cursory checks are performed on the given connection info that can fail before a connection is established.
+    /// Errors that occur during the connection process are surfaced when the connection is first used.
+    pub fn single<T: redis::IntoConnectionInfo>(params: T) -> Result<Self, Error> {
+        let client = redis::Client::open(params).map_err(from_redis_err)?;
+        let init = async move { client.get_connection_manager().await };
+        Ok(Self::with_initializer(init))
+    }
+
+    /// Connect to multiple Redis instances configured in cluster mode
+    ///
+    /// ## Errors
+    ///
+    /// Some cursory checks are performed on the given connection info that can fail before a connection is established.
+    /// Errors that occur during the connection are surfaced when the connection is first used.
+    pub fn cluster<T: redis::IntoConnectionInfo>(
+        params: impl IntoIterator<Item = T>,
+    ) -> Result<Self, Error> {
+        let client = redis::cluster::ClusterClient::new(params).map_err(from_redis_err)?;
+        let init = async move { client.get_async_connection().await };
+        Ok(Self::with_initializer(init))
+    }
+}
+
+impl<C: Clone + Send + 'static> BackgroundConnection<C> {
+    /// Initialize a new connection by spawning a background task to run the provided future to completion.
+    ///
+    /// Outside of testing, you will probably want to use [`BackgroundConnection::single`] or [`BackgroundConnection::cluster`].
+    pub fn with_initializer<Fut, T, E>(init: Fut) -> Self
+    where
+        Fut: Future<Output = Result<T, E>> + Send + 'static,
+        C: From<T>,
+        T: Send + 'static,
+        Error: From<E>,
+        E: Send + 'static,
+    {
+        let handle = background_spawn!("redis_initial_connection", init.err_into().ok_into());
+        let state = ConnectionState::Connecting(handle.err_into().shared());
+        Self {
+            once: Once::new(),
+            state: UnsafeCell::new(state),
+        }
+    }
+
+    /// Retrieve the underlying connection. If the connection hasn't been established yet, the current task will
+    /// wait until the connection has been made.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if there was an issue establishing a connection to Redis.
+    async fn get(&self) -> Result<C, Error> {
+        // Safety: we don't mutate state here, so normal borrowck rules are followed and the invariant is upheld
+        let state_ref = unsafe { &*self.state.get() };
+        let connection_future = match state_ref {
+            ConnectionState::Connecting(handle) => Shared::clone(handle),
+            ConnectionState::Connected(connection) => return Ok(connection.clone()),
+            ConnectionState::Errored(error) => return Err(error.clone()),
+        };
+
+        let connection_result = connection_future.await.and_then(|conn| conn);
+        self.once.call_once(|| {
+            // Safety: This part is `unsafe` because we break borrowck's rules of aliasing XOR mutability;
+            // calling `LazyConnection::get` takes `&self`, but now we're going to take `&mut self.state`.
+            // This means that if multiple tasks call `LazyConnection::get` at once, they could potentially
+            // attempt to mutate `self.state` simultaneously, which is `unsafe` -- it's a data race.
+            //
+            // The synchronization primitive we're using here to manually enforce borrowck's rules is [`Once`],
+            // which allows for executing closures exactly once. We use this guarantee to ensure that we only
+            // mutate `self.state` exactly once, despite having multiple tasks awaiting the same connection.
+            //
+            // Put another way: we only mutate state exactly once, inside this closure (exclusive). Outside of
+            // the closure, multiple tasks can read state simultaneously (aliasing).
+            //
+            // More specifically, the `Once` can be in one of three states:
+            //
+            // 1. Uninitialized
+            //  In this state, borrowck rules are followed because nobody has attempted to mutate `self.state` yet.
+            // 2. Initializing
+            //  In this state, borrowck rules are followed because exactly one thread has exclusive mutable access
+            //  to `self.state`, while all other threads block -- i.e. they will not read or write state.
+            // 3. Initialized
+            //  In this state, borrowck rules are followed because this closure will never get called.
+            //
+            // Put a third way: we've essentially recreated a `RwLock` that always prioritizes writes, and only allows
+            // one write. The invariant is upheld.
+            let state_mut = unsafe { &mut *self.state.get() };
+            *state_mut = match connection_result.clone() {
+                Ok(connection) => ConnectionState::Connected(connection),
+                Err(error) => ConnectionState::Errored(error),
+            };
+        });
+
+        connection_result
+    }
+}
+
+// Safety: We don't hold any raw pointers or `!Send` types except `UnsafeCell`.
+// Why do we need `C: Send`?
+// Task A creates a `BackgroundConnection` and shares it with task B,
+// which mutates the cell, which is then destroyed by A.
+// That is, destructor observes a sent value.
+unsafe impl<C: Sync + Send> Send for BackgroundConnection<C> {}
+
+// Safety: We ensure that exactly one task will mutate state exactly once.
+unsafe impl<C: Sync> Sync for BackgroundConnection<C> {}
+
+/// A [`StoreDriver`] implementation that uses Redis as a backing store.
+pub struct RedisStore<C: ConnectionLike + Clone = ConnectionKind> {
+    /// The connection to the underlying Redis instance(s).
+    connection: BackgroundConnection<C>,
+
+    /// A function used to generate names for temporary keys.
     temp_name_generator_fn: fn() -> String,
 
     /// A common prefix to append to all keys before they are sent to Redis.
@@ -51,40 +252,40 @@ pub struct RedisStore<T: ConnectionLike + Unpin + Clone + Send + Sync = Connecti
     key_prefix: String,
 }
 
-impl RedisStore {
-    pub fn new(
-        config: &nativelink_config::stores::RedisStore,
-    ) -> Result<Arc<RedisStore<ConnectionManager>>, Error> {
-        // Note: Currently only one connection is supported.
-        error_if!(
-            config.addresses.len() != 1,
-            "Only one address is supported for Redis store"
-        );
-
-        let address = config.addresses[0].clone();
-        let conn_fut = async move {
-            redis::Client::open(address)
-                .map_err(from_redis_err)?
-                .get_connection_manager()
-                .await
-                .map_err(from_redis_err)
-        }
-        .boxed()
-        .shared();
-
-        let conn_fut_clone = conn_fut.clone();
-        // Start connecting to redis, but don't block our construction on it.
-        background_spawn!("redis_initial_connection", async move {
-            if let Err(e) = conn_fut_clone.await {
-                make_err!(Code::Unavailable, "Failed to connect to Redis: {:?}", e);
-            }
-        });
-
-        let lazy_conn = LazyConnection::Future(conn_fut);
+impl RedisStore<ConnectionKind> {
+    pub fn new(config: &nativelink_config::stores::RedisStore) -> Result<Arc<Self>, Error> {
+        if config.addresses.is_empty() {
+            return Err(Error::new(
+                Code::InvalidArgument,
+                "At least one address must be specified to connect to Redis".to_string(),
+            ));
+        };
+        let connection =
+            match config.mode {
+                RedisMode::Cluster => {
+                    let addrs = config.addresses.iter().map(String::as_str);
+                    BackgroundConnection::cluster(addrs)?
+                }
+                RedisMode::Standard if config.addresses.len() > 1 => return Err(Error::new(
+                    Code::InvalidArgument,
+                    "Attempted to connect to multiple addresses without setting `cluster = true`"
+                        .to_string(),
+                )),
+                RedisMode::Standard => {
+                    let addr = config.addresses[0].as_str();
+                    BackgroundConnection::single(addr)?
+                }
+                RedisMode::Sentinel => {
+                    return Err(Error::new(
+                        Code::Unimplemented,
+                        "Sentinel mode is currently not supported.".to_string(),
+                    ))
+                }
+            };
 
         Ok(Arc::new(
             RedisStore::new_with_conn_and_name_generator_and_prefix(
-                lazy_conn,
+                connection,
                 || uuid::Uuid::new_v4().to_string(),
                 config.key_prefix.clone(),
             ),
@@ -92,42 +293,39 @@ impl RedisStore {
     }
 }
 
-impl<T: ConnectionLike + Unpin + Clone + Send + Sync> RedisStore<T> {
+impl<C: ConnectionLike + Clone + Send + 'static> RedisStore<C> {
+    #[inline]
     pub fn new_with_conn_and_name_generator(
-        lazy_conn: LazyConnection<T>,
+        connection: BackgroundConnection<C>,
         temp_name_generator_fn: fn() -> String,
-    ) -> RedisStore<T> {
+    ) -> Self {
         RedisStore::new_with_conn_and_name_generator_and_prefix(
-            lazy_conn,
+            connection,
             temp_name_generator_fn,
             String::new(),
         )
     }
 
+    #[inline]
     pub fn new_with_conn_and_name_generator_and_prefix(
-        lazy_conn: LazyConnection<T>,
+        connection: BackgroundConnection<C>,
         temp_name_generator_fn: fn() -> String,
         key_prefix: String,
-    ) -> RedisStore<T> {
+    ) -> Self {
         RedisStore {
-            lazy_conn: ArcCell::new(Arc::new(lazy_conn)),
+            connection,
             temp_name_generator_fn,
             key_prefix,
         }
     }
 
-    async fn get_conn(&self) -> Result<T, Error> {
-        let result = match self.lazy_conn.get().as_ref() {
-            LazyConnection::Connection(conn_result) => return conn_result.clone(),
-            LazyConnection::Future(fut) => fut.clone().await,
-        };
-        self.lazy_conn
-            .set(Arc::new(LazyConnection::Connection(result.clone())));
-        result
+    #[inline]
+    async fn get_conn(&self) -> Result<C, Error> {
+        self.connection.get().await
     }
 
     /// Encode a [`StoreKey`] so it can be sent to Redis.
-    fn encode_key(&self, key: StoreKey) -> impl ToRedisArgs {
+    fn encode_key<'a>(&self, key: StoreKey<'a>) -> impl ToRedisArgs + Display + Send + Sync + 'a {
         // TODO(caass): Once https://github.com/redis-rs/redis-rs/pull/1219 makes it into a release,
         // this can be changed to
         // ```rust
@@ -140,7 +338,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync> RedisStore<T> {
         //   Cow::Owned(encoded_key)
         // }
         //```
-        // to avoid an allocation
+        // and the return type changed to `Cow<'a, str>`
         let key_body = key.as_str();
 
         let mut encoded_key = String::with_capacity(self.key_prefix.len() + key_body.len());
@@ -152,7 +350,10 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync> RedisStore<T> {
 }
 
 #[async_trait]
-impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for RedisStore<T> {
+impl<C> StoreDriver for RedisStore<C>
+where
+    C: ConnectionLike + Clone + Send + Sync + Unpin + 'static,
+{
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
@@ -162,25 +363,32 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for 
             results[0] = Some(0);
             return Ok(());
         }
-        let mut conn = self.get_conn().await?;
-
-        let mut pipe = redis::pipe();
-        pipe.atomic();
 
         let mut zero_digest_indexes = Vec::new();
-        keys.iter().enumerate().for_each(|(index, key)| {
-            if is_zero_digest(key.borrow()) {
-                zero_digest_indexes.push(index);
-            }
 
-            pipe.strlen(self.encode_key(key.borrow()));
-        });
+        let queries =
+            keys.iter()
+                .enumerate()
+                .map(|(index, key)| {
+                    if is_zero_digest(key.borrow()) {
+                        zero_digest_indexes.push(index);
+                    }
+                    let encoded_key = self.encode_key(key.borrow());
 
-        let digest_sizes = pipe
-            .query_async::<_, Vec<usize>>(&mut conn)
-            .await
-            .map_err(from_redis_err)
-            .err_tip(|| "Error: Could not call pipeline in has_with_results")?;
+                    async {
+                        let mut conn = self.get_conn().await.err_tip(|| {
+                            "Error: Could not get connection handle in has_with_results"
+                        })?;
+
+                        conn.strlen::<_, usize>(encoded_key)
+                            .await
+                            .map_err(from_redis_err)
+                            .err_tip(|| "Error: Could not call strlen in has_with_results")
+                    }
+                })
+                .collect::<FuturesOrdered<_>>();
+
+        let digest_sizes = queries.try_collect::<Vec<_>>().await?;
 
         error_if!(
             digest_sizes.len() != results.len(),
@@ -208,7 +416,27 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for 
         _upload_size: UploadSizeInfo,
     ) -> Result<(), Error> {
         let temp_key = OnceCell::new();
-        let make_temp_name = || format!("temp-{}", (self.temp_name_generator_fn)());
+        let final_key = self.encode_key(key.borrow());
+
+        // While the name generation function can be supplied by the user, we need to have the curly
+        // braces in place in order to manage redis' hashing behavior and make sure that the temporary
+        // key name and the final key name are directed to the same cluster node. See
+        // https://redis.io/blog/redis-clustering-best-practices-with-keys/
+        //
+        // The TL;DR is that if we're in cluster mode and the names hash differently, we can't use request
+        // pipelining. By using these braces, we tell redis to only hash the part of the temporary key that's
+        // identical to the final key -- so they will always hash to the same node.
+        //
+        // TODO(caass): the stabilization PR for [`LazyCell`](`std::cell::LazyCell`) has been merged into rust-lang,
+        // so in the next stable release we can use LazyCell::new(|| { ... }) instead.
+        let make_temp_name = || {
+            format!(
+                "temp-{}-{{{}}}",
+                (self.temp_name_generator_fn)(),
+                &final_key
+            )
+        };
+
         let mut conn = self.get_conn().await?;
         let mut pipe = redis::pipe();
         pipe.atomic();
@@ -227,7 +455,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for 
                         return Ok(());
                     }
                     if force_recv {
-                        conn.append(self.encode_key(key.borrow()), &chunk[..])
+                        conn.append(&final_key, &chunk[..])
                             .await
                             .map_err(from_redis_err)
                             .err_tip(|| "In RedisStore::update() single chunk")?;
@@ -254,7 +482,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for 
 
         pipe.cmd("RENAME")
             .arg(temp_key.get_or_init(make_temp_name))
-            .arg(self.encode_key(key));
+            .arg(final_key);
         pipe.query_async(&mut conn)
             .await
             .map_err(from_redis_err)
@@ -368,13 +596,17 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> StoreDriver for 
     }
 }
 
-impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> MetricsComponent for RedisStore<T> {
+impl<C> MetricsComponent for RedisStore<C>
+where
+    C: ConnectionLike + Clone + Send + 'static,
+{
     fn gather_metrics(&self, _c: &mut CollectorState) {}
 }
 
 #[async_trait]
-impl<T: ConnectionLike + ConnectionLike + Unpin + Clone + Send + Sync + 'static>
-    HealthStatusIndicator for RedisStore<T>
+impl<C> HealthStatusIndicator for RedisStore<C>
+where
+    C: ConnectionLike + Clone + Send + Sync + Unpin + 'static,
 {
     fn get_name(&self) -> &'static str {
         "RedisStore"


### PR DESCRIPTION
# Description

This PR brings support for using Redis in cluster mode as a store.

Fixes #869

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Notably, no new tests have been added. Since we currently use a mock to test our redis support, we don't have infrastructure in place to test against a live redis cluster.

I'd like to add some tests that spin up a redis cluster and assert that everything works ok in cluster mode, but it's a non-trivial amount of work. I'd like for them to run using the rust test harness, so likely that'd mean grouping them under a cargo feature (like, "slow-tests") and using testcontainers to create a redis cluster.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/998)
<!-- Reviewable:end -->
