### PR TITLE
[bug] Ensure OperationId is used at external protocol points

### DIFF
--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -74,6 +74,7 @@ rust_test_suite(
         "tests/fastcdc_test.rs",
         "tests/fs_test.rs",
         "tests/health_utils_test.rs",
+        "tests/operation_id_tests.rs",
         "tests/proto_stream_utils_test.rs",
         "tests/resource_info_test.rs",
         "tests/retry_test.rs",

--- a/nativelink-util/tests/operation_id_tests.rs
+++ b/nativelink-util/tests/operation_id_tests.rs
@@ -1,0 +1,130 @@
+// Copyright 2024 The Native Link Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nativelink_error::{Code, Error};
+use nativelink_macro::nativelink_test;
+use nativelink_util::action_messages::OperationId;
+use pretty_assertions::assert_eq;
+
+#[nativelink_test]
+async fn parse_operation_id() -> Result<(), Error> {
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
+    assert_eq!(
+        operation_id.to_string(),
+        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(
+        operation_id.action_name(),
+        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0"
+    );
+    assert_eq!(
+        operation_id.id.to_string(),
+        "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
+    );
+    assert_eq!(
+        hex::encode(operation_id.get_hash()),
+        "5a36f0db39e27667c4b91937cd29c1df8799ba468f2de6810c6865be05517644"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn parse_empty_failure() -> Result<(), Error> {
+    let operation_id = OperationId::try_from("").err().unwrap();
+    assert_eq!(operation_id.code, Code::Internal);
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(
+        operation_id.messages[0],
+        "Invalid OperationId unique_qualifier / id fragment - "
+    );
+
+    let operation_id = OperationId::try_from("/").err().unwrap();
+    assert_eq!(operation_id.code, Code::Internal);
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(
+        operation_id.messages[0],
+        "Invalid ActionInfoHashKey instance name fragment - /"
+    );
+
+    let operation_id = OperationId::try_from("main").err().unwrap();
+    assert_eq!(operation_id.code, Code::Internal);
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(
+        operation_id.messages[0],
+        "Invalid OperationId unique_qualifier / id fragment - main"
+    );
+
+    let operation_id = OperationId::try_from("main/nohashfn/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(
+        operation_id.messages[0],
+        "Unknown or unsupported digest function for string conversion: \"NOHASHFN\""
+    );
+
+    let operation_id =
+        OperationId::try_from("main/SHA256/badhash-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52")
+            .err()
+            .unwrap();
+    assert_eq!(operation_id.messages.len(), 3);
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages[0], "Odd number of digits");
+    assert_eq!(operation_id.messages[1], "Invalid sha256 hash: badhash");
+    assert_eq!(
+        operation_id.messages[2],
+        "Invalid DigestInfo digest hash - main/SHA256/badhash-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
+    );
+
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(
+        operation_id.messages[0],
+        "cannot parse integer from empty string"
+    );
+    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.messages[0], "invalid digit found in string");
+    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages[0], "invalid digit found in string");
+    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey salt hex conversion - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages[0], "invalid digit found in string");
+    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey salt hex conversion - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/baduuid").err().unwrap();
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(operation_id.code, Code::InvalidArgument);
+    assert_eq!(operation_id.messages[0], "Failed to parse invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `u` at 4 as uuid");
+
+    let operation_id = OperationId::try_from(
+        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0",
+    )
+    .err()
+    .unwrap();
+    assert_eq!(operation_id.messages.len(), 1);
+    assert_eq!(operation_id.code, Code::Internal);
+    assert_eq!(operation_id.messages[0], "Invalid ActionInfoHashKey digest size fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0");
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

Execution server was leaking out `ActionInfoHashKey`, remove leakage and ensure `OperationId` is used for external communications.

Added tests around both `OperationId` and `ActionInfoHashKey` parsing.

Fixes https://github.com/TraceMachina/nativelink/issues/1000

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new tests around key encoding.

## Checklist

- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1001)
<!-- Reviewable:end -->
