### PR TITLE
Add list api to StoreApi and MemoryStore

### DIFF
--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -221,6 +221,10 @@ where
         state.btree = Some(state.lru.iter().map(|(k, _)| k).cloned().collect());
     }
 
+    /// Run the `handler` function on each key-value pair that matches the `prefix_range`
+    /// and return the number of items that were processed.
+    /// The `handler` function should return `true` to continue processing the next item
+    /// or `false` to stop processing.
     pub async fn range<F, Q>(&self, prefix_range: impl RangeBounds<Q>, mut handler: F) -> usize
     where
         F: FnMut(&K, &T) -> bool,


### PR DESCRIPTION
Adds the list() api to all stores, but unimplemented by default.

Implements list() api for MemoryStore.
    
towards: #995

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1003)
<!-- Reviewable:end -->
