### PR TITLE
Add CI test to run on nativelink.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,29 @@ on:
 permissions: read-all
 
 jobs:
+  nativelink-dot-com-build-test:
+    runs-on: ubuntu-22.04
+    environment: production
+    steps:
+    - name: Checkout
+      uses: >- # v4.1.1
+        actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - name: Setup Bazelisk
+      uses: >- # v0.8.1
+        bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+      with:
+        bazelisk-cache: true
+    - name: Run Bazel tests
+      shell: bash
+      run: |
+        bazel test \
+          --remote_cache=grpcs://cas-demofs2.build-faster.nativelink.net \
+          --remote_executor=grpcs://scheduler-demofs2.build-faster.nativelink.net \
+          --remote_instance_name=main \
+          --remote_default_exec_properties=cpu_count=1 \
+          --remote_header=x-nativelink-api-key=${{ secrets.NATIVELINK_COM_API_KEY }} \
+          //...
+
   docker-compose-compiles-nativelink:
     # The type of runner that the job will run on.
     runs-on: large-ubuntu-22.04


### PR DESCRIPTION
The main branch will now run on nativelink.com's CI in addition to other tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1005)
<!-- Reviewable:end -->
