### PR TITLE
Increase timeout of pre-commit-checks CI pipeline

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   pre-commit-checks:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: >- # v4.1.1


### PR DESCRIPTION
This pipeline sometimes takes more than 10 mins to run due to nix cache slowness, so increase the timeout some.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1009)
<!-- Reviewable:end -->
