### PR TITLE
Decouple nativelink from toolchain containers

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [image, nativelink-worker-lre-cc]
+        image: [image, nativelink-worker-init, nativelink-worker-lre-cc]
     name: Publish ${{ matrix.image }}
     runs-on: large-ubuntu-22.04
     permissions:

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -66,6 +66,15 @@ jobs:
   #       uses: >- # v10
   #         DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
 
+  #     - name: Free disk space
+  #       uses: >- # v2.0.0
+  #         endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
+  #       with:
+  #         remove_android: true
+  #         remove_dotnet: true
+  #         remove_haskell: true
+  #         remove_tool_cache: false
+
   #     - name: Cache Nix derivations
   #       uses: >- # v4
   #         DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [image, nativelink-worker-lre-cc]
+        image: [image, nativelink-worker-init, nativelink-worker-lre-cc]
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/deployment-examples/chromium/01_operations.sh
+++ b/deployment-examples/chromium/01_operations.sh
@@ -1,19 +1,19 @@
-# This script configures a cluster with a few standard deployments.
+#!/usr/bin/env bash
 
-# TODO(aaronmondal): Add Grafana, OpenTelemetry and the various other standard
-#                    deployments one would expect in a cluster.
+# Trigger cluster-internal pipelines to build or fetch necessary images.
 
 set -xeuo pipefail
 
-SRC_ROOT=$(git rev-parse --show-toplevel)
-
-# The image for the scheduler and CAS.
 curl -v \
     -H 'content-Type: application/json' \
     -d '{"flakeOutput": "./src_root#image"}' \
     localhost:8082/eventlistener
 
-# Wrap it nativelink to turn it into a worker.
+curl -v \
+    -H 'content-Type: application/json' \
+    -d '{"flakeOutput": "./src_root#nativelink-worker-init"}' \
+    localhost:8082/eventlistener
+
 curl -v \
     -H 'content-Type: application/json' \
     -d '{"flakeOutput": "./src_root#nativelink-worker-siso-chromium"}' \
@@ -25,12 +25,12 @@ until kubectl get pipelinerun \
     sleep 0.1
 done
 
-printf 'Waiting for PipelineRuns to finish...
+printf "Waiting for PipelineRuns to finish...
 
-You may cancel this script now and use `tkn pr ls` and `tkn pr logs -f` to
+You may cancel this script now and use 'tkn pr ls' and 'tkn pr logs -f' to
 monitor the PipelineRun logs.
 
-'
+"
 
 kubectl wait \
     --for=condition=Succeeded \

--- a/deployment-examples/chromium/02_application.sh
+++ b/deployment-examples/chromium/02_application.sh
@@ -1,6 +1,6 @@
-# Get the nix derivation hash from the toolchain container, change the
-# `TOOLCHAIN_TAG` variable in the `worker.json.template` to that hash and apply
-# the configuration.
+#!/usr/bin/env bash
+
+# Prepare the Kustomization and apply it to the cluster.
 
 KUSTOMIZE_DIR=$(git rev-parse --show-toplevel)/deployment-examples/chromium
 
@@ -16,10 +16,12 @@ resources:
 EOF
 
 cd "$KUSTOMIZE_DIR" && kustomize edit set image \
-    nativelink=localhost:5001/nativelink:$(\
-        nix eval .#image.imageTag --raw) \
-    nativelink-worker-chromium=localhost:5001/nativelink-worker-siso-chromium:$(\
-        nix eval .#nativelink-worker-siso-chromium.imageTag --raw)
+    nativelink=localhost:5001/nativelink:"$(\
+        nix eval .#image.imageTag --raw)" \
+    nativelink-worker-init=localhost:5001/nativelink-worker-init:"$(\
+        nix eval .#nativelink-worker-init.imageTag --raw)" \
+    nativelink-worker-chromium=localhost:5001/nativelink-worker-siso-chromium:"$(\
+        nix eval .#nativelink-worker-siso-chromium.imageTag --raw)"
 
 kubectl apply -k "$KUSTOMIZE_DIR"
 

--- a/deployment-examples/chromium/03_build_chrome_tests.sh
+++ b/deployment-examples/chromium/03_build_chrome_tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 function fetch_chromium() {

--- a/deployment-examples/chromium/04_delete_application.sh
+++ b/deployment-examples/chromium/04_delete_application.sh
@@ -1,7 +1,6 @@
-# Get the nix derivation hash from the toolchain container, change the
-# `TOOLCHAIN_TAG` variable in the `worker.json.template` to that hash and delete
-# the configuration.
+#!/usr/bin/env bash
 
-KUSTOMIZE_DIR=$(git rev-parse --show-toplevel)/deployment-examples/chromium
+# Delete the Kustomization but leave the rest of the cluster intact.
 
-kubectl delete -k "$KUSTOMIZE_DIR"
+kubectl delete -k \
+    "$(git rev-parse --show-toplevel)/deployment-examples/chromium"

--- a/deployment-examples/chromium/worker-chromium.yaml
+++ b/deployment-examples/chromium/worker-chromium.yaml
@@ -13,6 +13,15 @@ spec:
       labels:
         app: nativelink-worker-chromium
     spec:
+      initContainers:
+        - name: nativelink-worker-init
+          # This image will be edited by kustomize.
+          image: nativelink-worker-init
+          args: ["/shared/nativelink"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+
       containers:
         - name: nativelink-worker-chromium
           # This image will be edited by kustomize.
@@ -28,9 +37,11 @@ spec:
             - name: worker-config
               mountPath: /worker.json
               subPath: worker.json
-          command: ["/bin/nativelink"]
+          command: ["/shared/nativelink"]
           args: ["/worker.json"]
       volumes:
+        - name: shared
+          emptyDir: {}
         - name: worker-config
           configMap:
             name: worker

--- a/deployment-examples/kubernetes/01_operations.sh
+++ b/deployment-examples/kubernetes/01_operations.sh
@@ -1,15 +1,17 @@
-# This script configures a cluster with a few standard deployments.
+#!/usr/bin/env bash
 
-# TODO(aaronmondal): Add Grafana, OpenTelemetry and the various other standard
-#                    deployments one would expect in a cluster.
+# Trigger cluster-internal pipelines to build or fetch necessary images.
 
 set -xeuo pipefail
-
-SRC_ROOT=$(git rev-parse --show-toplevel)
 
 curl -v \
     -H 'content-Type: application/json' \
     -d '{"flakeOutput": "./src_root#image"}' \
+    localhost:8082/eventlistener
+
+curl -v \
+    -H 'content-Type: application/json' \
+    -d '{"flakeOutput": "./src_root#nativelink-worker-init"}' \
     localhost:8082/eventlistener
 
 curl -v \
@@ -23,12 +25,12 @@ until kubectl get pipelinerun \
     sleep 0.1
 done
 
-printf 'Waiting for PipelineRuns to finish...
+printf "Waiting for PipelineRuns to finish...
 
-You may cancel this script now and use `tkn pr ls` and `tkn pr logs -f` to
+You may cancel this script now and use 'tkn pr ls' and 'tkn pr logs -f' to
 monitor the PipelineRun logs.
 
-'
+"
 
 kubectl wait \
     --for=condition=Succeeded \

--- a/deployment-examples/kubernetes/02_application.sh
+++ b/deployment-examples/kubernetes/02_application.sh
@@ -1,6 +1,6 @@
-# Get the nix derivation hash from the toolchain container, change the
-# `TOOLCHAIN_TAG` variable in the `worker.json.template` to that hash and apply
-# the configuration.
+#!/usr/bin/env bash
+
+# Prepare the Kustomization and apply it to the cluster.
 
 KUSTOMIZE_DIR=$(git rev-parse --show-toplevel)/deployment-examples/kubernetes
 
@@ -18,10 +18,12 @@ resources:
 EOF
 
 cd "$KUSTOMIZE_DIR" && kustomize edit set image \
-    nativelink=localhost:5001/nativelink:$(\
-        nix eval .#image.imageTag --raw) \
-    nativelink-worker-lre-cc=localhost:5001/nativelink-worker-lre-cc:$(\
-        nix eval .#nativelink-worker-lre-cc.imageTag --raw) \
+    nativelink=localhost:5001/nativelink:"$(\
+        nix eval .#image.imageTag --raw)" \
+    nativelink-worker-init=localhost:5001/nativelink-worker-init:"$(\
+        nix eval .#nativelink-worker-init.imageTag --raw)" \
+    nativelink-worker-lre-cc=localhost:5001/nativelink-worker-lre-cc:"$(\
+        nix eval .#nativelink-worker-lre-cc.imageTag --raw)"
 
 # TODO(aaronmondal): Fix java and add this:
 #   nativelink-worker-lre-java=localhost:5001/nativelink-worker-lre-java:$(\

--- a/deployment-examples/kubernetes/03_delete_application.sh
+++ b/deployment-examples/kubernetes/03_delete_application.sh
@@ -1,7 +1,6 @@
-# Get the nix derivation hash from the toolchain container, change the
-# `TOOLCHAIN_TAG` variable in the `worker.json.template` to that hash and delete
-# the configuration.
+#!/usr/bin/env bash
 
-KUSTOMIZE_DIR=$(git rev-parse --show-toplevel)/deployment-examples/kubernetes
+# Delete the Kustomization but leave the rest of the cluster intact.
 
-kubectl delete -k "$KUSTOMIZE_DIR"
+kubectl delete -k \
+    "$(git rev-parse --show-toplevel)/deployment-examples/kubernetes"

--- a/deployment-examples/kubernetes/worker-lre-cc.yaml
+++ b/deployment-examples/kubernetes/worker-lre-cc.yaml
@@ -14,30 +14,39 @@ spec:
         app: nativelink-worker-lre-cc
     spec:
       initContainers:
-      - name: setup-entrypoint
-        image: nixpkgs/nix-flakes:latest
-        command: ["/bin/sh", "-c"]
-        # The kind setup mounts the nativelink repository into the kind nodes at
-        # `/mnt/src_root`. This ensures that the tags between the worker configs
-        # and bazel toolchains match when this setup is run in CI.
-        #
-        # WARNING: The platform is *not* necessarily the container that is
-        # actually deployed here. The generator container in this example was
-        # `rbe-autogen-lre-cc:<sometag>` and the platform was modified
-        # after the fact to be `lre-cc:<sometag>`. The deployed container
-        # we use as worker is
-        # `nativelink-worker-lre-cc:<some_potentially_other_tag>` which is a
-        # completely separate extension of the `lre-cc` base image.
-        args:
-          - |
-            NATIVELINK_WORKER_PLATFORM=docker://lre-cc:$(nix eval /mnt/src_root#lre-cc.imageTag --raw) &&
-            printf '#!/bin/sh\nexport NATIVELINK_WORKER_PLATFORM=%s\nexec "$@"' "$NATIVELINK_WORKER_PLATFORM" > /entrypoint/entrypoint.sh &&
-            chmod +x /entrypoint/entrypoint.sh
-        volumeMounts:
-          - name: entrypoint
-            mountPath: /entrypoint
-          - name: mnt
-            mountPath: /mnt
+        - name: setup-entrypoint
+          image: nixpkgs/nix-flakes:latest
+          command: ["/bin/sh", "-c"]
+          # The kind setup mounts the nativelink repository into the kind nodes
+          # at `/mnt/src_root`. This ensures that the tags between the worker
+          # configs and bazel toolchains match when this setup is run in CI.
+          #
+          # WARNING: The platform is *not* necessarily the container that is
+          # actually deployed here. The generator container in this example was
+          # `rbe-autogen-lre-cc:<sometag>` and the platform was modified
+          # after the fact to be `lre-cc:<sometag>`. The deployed container
+          # we use as worker is
+          # `nativelink-worker-lre-cc:<some_potentially_other_tag>` which is a
+          # completely separate extension of the `lre-cc` base image.
+          args:
+            - |
+              NATIVELINK_WORKER_PLATFORM=docker://lre-cc:$(nix eval /mnt/src_root#lre-cc.imageTag --raw) &&
+              printf '#!/bin/sh\nexport NATIVELINK_WORKER_PLATFORM=%s\nexec "$@"' "$NATIVELINK_WORKER_PLATFORM" > /entrypoint/entrypoint.sh &&
+              chmod +x /entrypoint/entrypoint.sh
+          volumeMounts:
+            - name: entrypoint
+              mountPath: /entrypoint
+            - name: mnt
+              mountPath: /mnt
+
+        - name: nativelink-worker-init
+          # This image will be edited by kustomize.
+          image: nativelink-worker-init
+          args: ["/shared/nativelink"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+
       containers:
         - name: nativelink-worker-lre-cc
           # This image will be edited by kustomize.
@@ -55,9 +64,13 @@ spec:
               subPath: worker.json
             - name: entrypoint
               mountPath: /entrypoint
+            - name: shared
+              mountPath: /shared
           command: ["/entrypoint/entrypoint.sh"]
-          args: ["/bin/nativelink", "/worker.json"]
+          args: ["/shared/nativelink", "/worker.json"]
       volumes:
+        - name: shared
+          emptyDir: {}
         - name: entrypoint
           emptyDir: {}
         - name: worker-config

--- a/tools/create-worker.nix
+++ b/tools/create-worker.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  nativelink,
   buildImage,
   self,
   ...
@@ -82,7 +81,7 @@ in
         mkEnvSymlink
         (pkgs.buildEnv {
           name = "${image.imageName}-buildEnv";
-          paths = [nativelink pkgs.coreutils pkgs.bash];
+          paths = [pkgs.coreutils pkgs.bash];
           pathsToLink = ["/bin"];
         })
       ];
@@ -92,10 +91,10 @@ in
         mkTmpPerms
       ];
 
-      # Override the final image tag with the one from the base image. This way
-      # the nativelink executable doesn't influence this tag and and changes to
-      # its codebase don't invalidate existing toolchain containers.
-      tag = null;
+      # Override the final image tag with the one from the base image to make
+      # the relationship between the toolchain and the worker extension more
+      # obvious.
+      tag = image.imageTag;
 
       config = {
         User = user;

--- a/tools/nativelink-worker-init.nix
+++ b/tools/nativelink-worker-init.nix
@@ -1,0 +1,42 @@
+{
+  buildImage,
+  self,
+  lib,
+  pkgsMusl,
+  nativelink-image,
+}:
+# This image copies a bundled `nativelink` executable to a specified location.
+#
+# Toolchain containers shouldn't have the `nativelink` executable built-in since
+# it would make it hard to update toolchain dependencies and nativelink
+# independently.
+#
+# Instead, use this image as initContainer to populate a shared volume in a
+# Deployment. Then mount that volume into the toolchain container and set the
+# Deployment's entrypoint to the mounted `nativelink` executable.
+let
+  copyToDestination = pkgsMusl.writeShellScriptBin "copyToDestination" ''
+    cp -Lv /bin/nativelink "$@"
+  '';
+in
+  buildImage {
+    name = "nativelink-worker-init";
+    # Workers should use the same version of NativeLink as the scheduler and cas
+    # deployments. Use the same tag for the init image so that users don't need to
+    # manage multiple tags.
+    fromImage = nativelink-image;
+    tag = nativelink-image.imageTag;
+    copyToRoot = [pkgsMusl.coreutils];
+    config = {
+      Entrypoint = [(lib.getExe' copyToDestination "copyToDestination")];
+      Labels = {
+        "org.opencontainers.image.description" = "Init container to prepare NativeLink workers.";
+        "org.opencontainers.image.documentation" = "https://github.com/TraceMachina/nativelink";
+        "org.opencontainers.image.licenses" = "Apache-2.0";
+        "org.opencontainers.image.revision" = "${self.rev or self.dirtyRev or "dirty"}";
+        "org.opencontainers.image.source" = "https://github.com/TraceMachina/nativelink";
+        "org.opencontainers.image.title" = "NativeLink worker init";
+        "org.opencontainers.image.vendor" = "Trace Machina, Inc.";
+      };
+    };
+  }


### PR DESCRIPTION
Changes to `nativelink` no longer require rebuilding toolchain containers and vice versa.

The `nativelink` executable has been removed from the `createWorker` function. Instead, users should mount the `nativelink` executable into a toolchain container during deployment. This makes deployments more generic and provides out-of-the-box compatibility with any arbitrary toolchain container.

Introduce a new `nativelink-worker-init` image, a thin wrapper around the `nativelink` container that copies the bundled `nativelink` executable to specified location. This can be used in worker deployments to populate temporary volumes with the `nativelink` executable. The new setup significantly improves setup times (observerd 90%+) for LRE-style deployments as workflows can fetch the `nativelink-init` container instead of rebuilding the executable from scratch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1013)
<!-- Reviewable:end -->
