### PR TITLE
Remove installation test from devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -278,7 +278,6 @@
 
               # Additional tools from within our development environment.
               local-image-test
-              nativelink-is-executable-test
               generate-toolchains
               customClang
               native-cli


### PR DESCRIPTION
This test requires building `nativelink`. When `nativelink` is cached, this isn't noticeable, but when changing the Rust sources this causes long wait times for flake reloads. Remove it from the devShell to prevent such rebuilds. The test is still runnable and tested in CI via `nix run .#nativelink-is-executable-test`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1014)
<!-- Reviewable:end -->
