### PR TITLE
Add `workspace.members` to root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,16 @@
 [workspace]
 resolver = "2"
+members = [
+  "nativelink-config",
+  "nativelink-error",
+  "nativelink-macro",
+  "nativelink-proto",
+  "nativelink-scheduler",
+  "nativelink-service",
+  "nativelink-store",
+  "nativelink-util",
+  "nativelink-worker",
+]
 
 [package]
 name = "nativelink"


### PR DESCRIPTION
# Description

Without this set, Rust Analyzer has trouble picking up changes to tests.
This should make it understand our crate structure better.


## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

By seeing if rust-analyzer picks up changes to tests now.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1018)
<!-- Reviewable:end -->
