### PR TITLE
Implement MatchingEngineStateManager

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -20,6 +20,7 @@ rust_library(
         "src/scheduler_state/awaited_action.rs",
         "src/scheduler_state/client_action_state_result.rs",
         "src/scheduler_state/completed_action.rs",
+        "src/scheduler_state/matching_engine_action_state_result.rs",
         "src/scheduler_state/metrics.rs",
         "src/scheduler_state/mod.rs",
         "src/scheduler_state/state_manager.rs",

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -136,7 +136,7 @@ pub trait MatchingEngineStateManager {
 
     /// Update that state of an operation.
     async fn update_operation(
-        &self,
+        &mut self,
         operation_id: OperationId,
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,

--- a/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
+++ b/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
@@ -1,0 +1,46 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nativelink_error::Error;
+use nativelink_util::action_messages::{ActionInfo, ActionState};
+use tokio::sync::watch;
+
+use crate::operation_state_manager::ActionStateResult;
+
+pub struct MatchingEngineActionStateResult {
+    pub action_info: Arc<ActionInfo>,
+}
+impl MatchingEngineActionStateResult {
+    pub(crate) fn new(action_info: Arc<ActionInfo>) -> Self {
+        Self { action_info }
+    }
+}
+
+#[async_trait]
+impl ActionStateResult for MatchingEngineActionStateResult {
+    async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
+        unimplemented!()
+    }
+
+    async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error> {
+        unimplemented!()
+    }
+
+    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
+        Ok(self.action_info.clone())
+    }
+}

--- a/nativelink-scheduler/src/scheduler_state/metrics.rs
+++ b/nativelink-scheduler/src/scheduler_state/metrics.rs
@@ -101,5 +101,43 @@ impl Metrics {
                 vec![("result".into(), "from_wrong_worker".into())],
             );
         }
+        {
+            c.publish(
+                "workers_evicted_total",
+                &self.workers_evicted,
+                "The number of workers evicted from scheduler.",
+            );
+            c.publish(
+                "workers_evicted_with_running_action",
+                &self.workers_evicted_with_running_action,
+                "The number of jobs cancelled because worker was evicted from scheduler.",
+            );
+        }
+        {
+            c.publish_with_labels(
+                "retry_action",
+                &self.retry_action,
+                "Stats about retry_action().",
+                vec![("result".into(), "success".into())],
+            );
+            c.publish_with_labels(
+                "retry_action",
+                &self.retry_action_max_attempts_reached,
+                "Stats about retry_action().",
+                vec![("result".into(), "max_attempts_reached".into())],
+            );
+            c.publish_with_labels(
+                "retry_action",
+                &self.retry_action_no_more_listeners,
+                "Stats about retry_action().",
+                vec![("result".into(), "no_more_listeners".into())],
+            );
+            c.publish_with_labels(
+                "retry_action",
+                &self.retry_action_but_action_missing,
+                "Stats about retry_action().",
+                vec![("result".into(), "action_missing".into())],
+            );
+        }
     }
 }

--- a/nativelink-scheduler/src/scheduler_state/mod.rs
+++ b/nativelink-scheduler/src/scheduler_state/mod.rs
@@ -15,6 +15,7 @@
 pub(crate) mod awaited_action;
 pub(crate) mod client_action_state_result;
 pub(crate) mod completed_action;
+pub(crate) mod matching_engine_action_state_result;
 pub(crate) mod metrics;
 pub(crate) mod state_manager;
 pub(crate) mod workers;

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
 use async_lock::{Mutex, MutexGuard};
 use async_trait::async_trait;
-use futures::Future;
+use futures::{Future, Stream};
 use hashbrown::{HashMap, HashSet};
 use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
@@ -40,9 +41,11 @@ use tracing::{event, Level};
 
 use crate::action_scheduler::ActionScheduler;
 use crate::operation_state_manager::{
-    ClientStateManager, OperationFilter, OperationStageFlags, WorkerStateManager,
+    ActionStateResult, ClientStateManager, MatchingEngineStateManager, OperationFilter,
+    OperationStageFlags, WorkerStateManager,
 };
 use crate::platform_property_manager::PlatformPropertyManager;
+use crate::scheduler_state::awaited_action::AwaitedAction;
 use crate::scheduler_state::metrics::Metrics as SchedulerMetrics;
 use crate::scheduler_state::state_manager::StateManager;
 use crate::scheduler_state::workers::Workers;
@@ -117,9 +120,9 @@ impl SimpleSchedulerImpl {
         &self,
         unique_qualifier: &ActionInfoHashKey,
     ) -> Option<watch::Receiver<Arc<ActionState>>> {
-        let filter_result = self
-            .state_manager
-            .filter_operations(OperationFilter {
+        let filter_result = <StateManager as ClientStateManager>::filter_operations(
+            &self.state_manager,
+            OperationFilter {
                 stages: OperationStageFlags::Any,
                 operation_id: None,
                 worker_id: None,
@@ -129,8 +132,9 @@ impl SimpleSchedulerImpl {
                 last_client_update_before: None,
                 unique_qualifier: Some(unique_qualifier.clone()),
                 order_by: None,
-            })
-            .await;
+            },
+        )
+        .await;
 
         let mut stream = filter_result.ok()?;
         if let Some(result) = stream.next().await {
@@ -146,7 +150,8 @@ impl SimpleSchedulerImpl {
                 let mut awaited_action = running_action;
                 let send_result = if awaited_action.attempts >= self.max_job_retries {
                     self.metrics.retry_action_max_attempts_reached.inc();
-                    Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Completed(ActionResult {
+
+                    StateManager::mutate_stage(&mut awaited_action, ActionStage::Completed(ActionResult {
                         execution_metadata: ExecutionMetadata {
                             worker: format!("{worker_id}"),
                             ..ExecutionMetadata::default()
@@ -156,18 +161,13 @@ impl SimpleSchedulerImpl {
                             "Job cancelled because it attempted to execute too many times and failed"
                         ))),
                         ..ActionResult::default()
-                    });
-                    awaited_action
-                        .notify_channel
-                        .send(awaited_action.current_state.clone())
+                    }))
                     // Do not put the action back in the queue here, as this action attempted to run too many
                     // times.
                 } else {
                     self.metrics.retry_action.inc();
-                    Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Queued;
-                    let send_result = awaited_action
-                        .notify_channel
-                        .send(awaited_action.current_state.clone());
+                    let send_result =
+                        StateManager::mutate_stage(&mut awaited_action, ActionStage::Queued);
                     self.state_manager
                         .inner
                         .queued_actions_set
@@ -242,6 +242,27 @@ impl SimpleSchedulerImpl {
         Ok(())
     }
 
+    async fn get_queued_operations(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Arc<dyn ActionStateResult + 'static>> + Send>>, Error>
+    {
+        <StateManager as MatchingEngineStateManager>::filter_operations(
+            &self.state_manager,
+            OperationFilter {
+                stages: OperationStageFlags::Queued,
+                operation_id: None,
+                worker_id: None,
+                action_digest: None,
+                worker_update_before: None,
+                completed_before: None,
+                last_client_update_before: None,
+                unique_qualifier: None,
+                order_by: None,
+            },
+        )
+        .await
+    }
+
     // TODO(blaise.bruer) This is an O(n*m) (aka n^2) algorithm. In theory we can create a map
     // of capabilities of each worker and then try and match the actions to the worker using
     // the map lookup (ie. map reduce).
@@ -251,98 +272,67 @@ impl SimpleSchedulerImpl {
         // to add `drain_filter`, which would in theory solve this problem, but because we need
         // to iterate the items in reverse it becomes more difficult (and it is currently an
         // unstable feature [see: https://github.com/rust-lang/rust/issues/70530]).
-        let action_infos: Vec<Arc<ActionInfo>> = self
-            .state_manager
-            .inner
-            .queued_actions
-            .keys()
-            .rev()
-            .cloned()
-            .collect();
-        for action_info in action_infos {
-            let Some(awaited_action) = self
-                .state_manager
-                .inner
-                .queued_actions
-                .get(action_info.as_ref())
-            else {
-                event!(
-                    Level::ERROR,
-                    ?action_info,
-                    "queued_actions out of sync with itself"
-                );
-                continue;
-            };
-            let Some(worker) = self
-                .state_manager
-                .inner
-                .workers
-                .find_worker_for_action_mut(awaited_action)
-            else {
-                // No worker found, check the next action to see if there's a
-                // matching one for that.
-                continue;
-            };
-            let worker_id = worker.id;
 
-            // Try to notify our worker of the new action to run, if it fails remove the worker from the
-            // pool and try to find another worker.
-            let notify_worker_result =
-                worker.notify_update(WorkerUpdate::RunAction(action_info.clone()));
-            if notify_worker_result.is_err() {
-                // Remove worker, as it is no longer receiving messages and let it try to find another worker.
-                event!(
-                    Level::WARN,
-                    ?worker_id,
-                    ?action_info,
-                    ?notify_worker_result,
-                    "Worker command failed, removing worker",
-                );
-                self.immediate_evict_worker(
-                    &worker_id,
-                    make_err!(
-                        Code::Internal,
-                        "Worker command failed, removing worker {worker_id} -- {notify_worker_result:?}",
-                    ),
-                );
-                return;
-            }
+        let action_state_results = self.get_queued_operations().await;
 
-            // At this point everything looks good, so remove it from the queue and add it to active actions.
-            let (action_info, mut awaited_action) = self
-                .state_manager
-                .inner
-                .queued_actions
-                .remove_entry(action_info.as_ref())
-                .unwrap();
-            assert!(
-                self.state_manager
-                    .inner
-                    .queued_actions_set
-                    .remove(&action_info),
-                "queued_actions_set should always have same keys as queued_actions"
-            );
-            Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Executing;
-            awaited_action.worker_id = Some(worker_id);
-            let send_result = awaited_action
-                .notify_channel
-                .send(awaited_action.current_state.clone());
-            if send_result.is_err() {
-                // Don't remove this task, instead we keep them around for a bit just in case
-                // the client disconnected and will reconnect and ask for same job to be executed
-                // again.
-                event!(
-                    Level::WARN,
-                    ?action_info,
-                    ?worker_id,
-                    "Action has no more listeners during do_try_match()"
-                );
+        match action_state_results {
+            Ok(mut stream) => {
+                while let Some(action_state_result) = stream.next().await {
+                    let action_state_result = action_state_result.as_action_info().await;
+                    let Ok(action_info) = action_state_result else {
+                        let _ = action_state_result.inspect_err(|err| {
+                            event!(
+                                Level::ERROR,
+                                ?err,
+                                "Failed to get action_info from action_state_results stream"
+                            );
+                        });
+                        continue;
+                    };
+
+                    let Some(awaited_action): Option<&AwaitedAction> = self
+                        .state_manager
+                        .inner
+                        .queued_actions
+                        .get(action_info.as_ref())
+                    else {
+                        event!(
+                            Level::ERROR,
+                            ?action_info,
+                            "queued_actions out of sync with itself"
+                        );
+                        continue;
+                    };
+
+                    let maybe_worker_id: Option<WorkerId> = {
+                        self.state_manager
+                            .inner
+                            .workers
+                            .find_worker_for_action(awaited_action)
+                    };
+
+                    let operation_id = awaited_action.current_state.id.clone();
+                    let ret = <StateManager as MatchingEngineStateManager>::update_operation(
+                        &mut self.state_manager,
+                        operation_id.clone(),
+                        maybe_worker_id,
+                        Ok(ActionStage::Executing),
+                    )
+                    .await;
+
+                    if let Err(e) = ret {
+                        event!(
+                            Level::ERROR,
+                            ?e,
+                            "update operation failed for {}",
+                            operation_id
+                        );
+                    }
+                }
             }
-            awaited_action.attempts += 1;
-            self.state_manager
-                .inner
-                .active_actions
-                .insert(action_info, awaited_action);
+            Err(e) => {
+                event!(Level::ERROR, ?e, "stream error in do_try_match");
+            }
         }
     }
 
@@ -352,38 +342,23 @@ impl SimpleSchedulerImpl {
         action_info_hash_key: ActionInfoHashKey,
         action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error> {
-        let update_operation_result = self
-            .state_manager
-            .update_operation(
-                OperationId::new(action_info_hash_key.clone()),
-                *worker_id,
-                action_stage,
-            )
-            .await;
-        // Note: Calling this many time is very cheap, it'll only trigger `do_try_match` once.
-        match update_operation_result {
-            Ok(_) => {
-                self.state_manager
-                    .inner
-                    .tasks_or_workers_change_notify
-                    .notify_one();
-                Ok(())
-            }
-            Err(e) => {
-                event!(
-                    Level::ERROR,
-                    ?action_info_hash_key,
-                    ?worker_id,
-                    ?e,
-                    "Failed to update_operation on update_action"
-                );
-                self.state_manager
-                    .inner
-                    .tasks_or_workers_change_notify
-                    .notify_one();
-                Err(e)
-            }
+        let update_operation_result = <StateManager as WorkerStateManager>::update_operation(
+            &mut self.state_manager,
+            OperationId::new(action_info_hash_key.clone()),
+            *worker_id,
+            action_stage,
+        )
+        .await;
+        if let Err(e) = &update_operation_result {
+            event!(
+                Level::ERROR,
+                ?action_info_hash_key,
+                ?worker_id,
+                ?e,
+                "Failed to update_operation on update_action"
+            );
         }
+        update_operation_result
     }
 }
 


### PR DESCRIPTION
# Description

Implement MatchingEngineStateManager

Implement `MatchingEngineStateManager` for `StateManager`. This hides implementation
logic for `do_try_match()` behind `MatchingEngineStateManager` on `filter_operations` and
`update_operation`. `tasks_or_workers_change_notify` has been moved into the `StateManager`.

Fixes https://github.com/TraceMachina/nativelink/issues/1043

## Type of change

Please delete options that aren't relevant.

- [x] Refactor


## How Has This Been Tested?

```
bazel test //...
```

## Checklist

- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1041)
<!-- Reviewable:end -->
