### PR TITLE
Move `update_action_with_internal_error` into `StateManager`

### DIFF
--- a/nativelink-scheduler/src/scheduler_state/metrics.rs
+++ b/nativelink-scheduler/src/scheduler_state/metrics.rs
@@ -22,6 +22,10 @@ pub(crate) struct Metrics {
     pub(crate) update_action_missing_action_result: CounterWithTime,
     pub(crate) update_action_from_wrong_worker: CounterWithTime,
     pub(crate) update_action_no_more_listeners: CounterWithTime,
+    pub(crate) update_action_with_internal_error: CounterWithTime,
+    pub(crate) update_action_with_internal_error_no_action: CounterWithTime,
+    pub(crate) update_action_with_internal_error_backpressure: CounterWithTime,
+    pub(crate) update_action_with_internal_error_from_wrong_worker: CounterWithTime,
     pub(crate) workers_evicted: CounterWithTime,
     pub(crate) workers_evicted_with_running_action: CounterWithTime,
     pub(crate) retry_action: CounterWithTime,
@@ -70,6 +74,31 @@ impl Metrics {
                 &self.update_action_no_more_listeners,
                 "Stats about errors when worker sends update_action() to scheduler. These errors are not complete, just the most common.",
                 vec![("result".into(), "no_more_listeners".into())],
+            );
+        }
+        {
+            c.publish(
+                "update_action_with_internal_error",
+                &self.update_action_with_internal_error,
+                "The number of times update_action_with_internal_error was triggered.",
+            );
+            c.publish_with_labels(
+                "update_action_with_internal_error_errors",
+                &self.update_action_with_internal_error_no_action,
+                "Stats about what errors caused update_action_with_internal_error() in scheduler.",
+                vec![("result".into(), "no_action".into())],
+            );
+            c.publish_with_labels(
+                "update_action_with_internal_error_errors",
+                &self.update_action_with_internal_error_backpressure,
+                "Stats about what errors caused update_action_with_internal_error() in scheduler.",
+                vec![("result".into(), "backpressure".into())],
+            );
+            c.publish_with_labels(
+                "update_action_with_internal_error_errors",
+                &self.update_action_with_internal_error_from_wrong_worker,
+                "Stats about what errors caused update_action_with_internal_error() in scheduler.",
+                vec![("result".into(), "from_wrong_worker".into())],
             );
         }
     }

--- a/nativelink-scheduler/src/worker_scheduler.rs
+++ b/nativelink-scheduler/src/worker_scheduler.rs
@@ -32,21 +32,12 @@ pub trait WorkerScheduler: Sync + Send + Unpin {
     /// Adds a worker to the scheduler and begin using it to execute actions (when able).
     async fn add_worker(&self, worker: Worker) -> Result<(), Error>;
 
-    /// Similar to `update_action()`, but called when there was an error that is not
-    /// related to the task, but rather the worker itself.
-    async fn update_action_with_internal_error(
-        &self,
-        worker_id: &WorkerId,
-        action_info_hash_key: ActionInfoHashKey,
-        err: Error,
-    );
-
     /// Updates the status of an action to the scheduler from the worker.
     async fn update_action(
         &self,
         worker_id: &WorkerId,
         action_info_hash_key: ActionInfoHashKey,
-        action_stage: ActionStage,
+        action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error>;
 
     /// Event for when the keep alive message was received from the worker.

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -841,7 +841,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
         .update_action(
             &worker_id,
             action_info_hash_key,
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
 
@@ -947,7 +947,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         .update_action(
             &worker_id,
             action_info_hash_key,
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
 
@@ -1036,7 +1036,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         .update_action(
             &rogue_worker_id,
             action_info_hash_key,
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await;
 
@@ -1161,7 +1161,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
                 digest: action_digest,
                 salt: 0,
             },
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
 
@@ -1278,7 +1278,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
                 digest: action_digest1,
                 salt: 0,
             },
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
 
@@ -1324,7 +1324,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
                 digest: action_digest2,
                 salt: 0,
             },
-            ActionStage::Completed(action_result.clone()),
+            Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
 
@@ -1436,11 +1436,11 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         digest: action_digest,
         salt: 0,
     };
-    scheduler
-        .update_action_with_internal_error(
+    let _ = scheduler
+        .update_action(
             &worker_id,
             action_info_hash_key.clone(),
-            make_err!(Code::Internal, "Some error"),
+            Err(make_err!(Code::Internal, "Some error")),
         )
         .await;
 
@@ -1470,8 +1470,8 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
 
     let err = make_err!(Code::Internal, "Some error");
     // Send internal error from worker again.
-    scheduler
-        .update_action_with_internal_error(&worker_id, action_info_hash_key, err.clone())
+    let _ = scheduler
+        .update_action(&worker_id, action_info_hash_key, Err(err.clone()))
         .await;
 
     {
@@ -1587,8 +1587,8 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
         assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
     }
 
-    scheduler
-        .update_action_with_internal_error(
+    let _ = scheduler
+        .update_action(
             &worker_id1,
             ActionInfoHashKey {
                 instance_name: INSTANCE_NAME.to_string(),
@@ -1596,7 +1596,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
                 digest: action_digest,
                 salt: 0,
             },
-            make_err!(Code::NotFound, "Some error"),
+            Err(make_err!(Code::NotFound, "Some error")),
         )
         .await;
 

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -221,14 +221,15 @@ impl WorkerApiServer {
                     .try_into()
                     .err_tip(|| "Failed to convert ExecuteResponse into an ActionStage")?;
                 self.scheduler
-                    .update_action(&worker_id, action_info_hash_key, action_stage)
+                    .update_action(&worker_id, action_info_hash_key, Ok(action_stage))
                     .await
                     .err_tip(|| format!("Failed to update_action {action_digest:?}"))?;
             }
             execute_result::Result::InternalError(e) => {
                 self.scheduler
-                    .update_action_with_internal_error(&worker_id, action_info_hash_key, e.into())
-                    .await;
+                    .update_action(&worker_id, action_info_hash_key, Err(e.into()))
+                    .await
+                    .err_tip(|| format!("Failed to update_action {action_digest:?}"))?;
             }
         }
         Ok(Response::new(()))


### PR DESCRIPTION
# Description

`worker_api_server.rs::WorkerApiServer::inner_execution_response` contains the failure case/flow for `action_stage: Result<ActionStage, Error>` in `WorkerStageManager::update_operation`.

As of now that implementation is not handled when let `action_stage = action_stage.expect("Unimplemented error in update_operation()");` is evaluated.

This ticket represents the need to refactor and consolidate that implementation into a single code path of update_action/update_operation.

Fixes https://github.com/TraceMachina/nativelink/issues/1054

## Type of change

Please delete options that aren't relevant.

- [x] Refactor

## Checklist

- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1053)
<!-- Reviewable:end -->
