### PR TITLE
Remove `#[async_trait]` where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,6 @@ name = "nativelink-worker"
 version = "0.4.0"
 dependencies = [
  "async-lock",
- "async-trait",
  "bytes",
  "filetime",
  "formatx",

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use async_lock::RwLock;
-use async_trait::async_trait;
 use bytes::Bytes;
 use filetime::{set_file_atime, FileTime};
 use futures::executor::block_on;
@@ -72,7 +71,6 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> Debug for TestFileEntry<Hook
     }
 }
 
-#[async_trait]
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<Hooks> {
     fn create(data_size: u64, block_size: u64, encoded_file_path: RwLock<EncodedFilePath>) -> Self {
         Self {
@@ -141,7 +139,6 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
     }
 }
 
-#[async_trait]
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> LenEntry for TestFileEntry<Hooks> {
     fn len(&self) -> usize {
         self.inner.as_ref().unwrap().len()

--- a/nativelink-util/src/default_store_key_subscribe.rs
+++ b/nativelink-util/src/default_store_key_subscribe.rs
@@ -16,11 +16,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use futures::Future;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use tokio::sync::watch;
 use tokio::time::sleep;
-use tonic::async_trait;
 
 use crate::background_spawn;
 use crate::buf_channel::{make_buf_channel_pair, DropCloserWriteHalf};

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use mock_instant::{Instant as MockInstant, MockClock};
 use nativelink_config::stores::EvictionPolicy;
@@ -361,7 +360,6 @@ async fn unref_called_on_replace() -> Result<(), Error> {
         unref_called: AtomicBool,
     }
 
-    #[async_trait]
     impl LenEntry for MockEntry {
         fn len(&self) -> usize {
             // Note: We are not testing this functionality.

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -15,7 +15,6 @@ nativelink-store = { path = "../nativelink-store" }
 nativelink-scheduler = { path = "../nativelink-scheduler" }
 
 async-lock = "3.3.0"
-async-trait = "0.1.80"
 bytes = "1.6.0"
 filetime = "0.2.23"
 formatx = "0.2.2"

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_lock::Mutex;
-use async_trait::async_trait;
 use hyper::body::Sender as HyperSender;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_error::Error;
@@ -123,7 +122,6 @@ impl MockWorkerApiClient {
     }
 }
 
-#[async_trait]
 impl WorkerApiClientTrait for MockWorkerApiClient {
     async fn connect_worker(
         &mut self,

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use async_lock::Mutex;
-use async_trait::async_trait;
 use nativelink_error::{make_input_err, Error};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_util::action_messages::ActionResult;
@@ -126,7 +125,6 @@ impl MockRunningActionsManager {
     }
 }
 
-#[async_trait]
 impl RunningActionsManager for MockRunningActionsManager {
     type RunningAction = MockRunningAction;
 
@@ -345,7 +343,6 @@ impl MockRunningAction {
     }
 }
 
-#[async_trait]
 impl RunningAction for MockRunningAction {
     fn get_action_id(&self) -> &ActionId {
         unreachable!("not implemented for tests");


### PR DESCRIPTION
# Description

`async fn` and `-> impl Trait` is stable in traits. This uses it wherever possible. Due to trait bound requirements, all converted functions need `-> impl Future + Send`.

Due to compiler limitations, namely `dyn Trait` compatibility, it is not possible at this time to convert the remaining uses without creating concrete types and implementing `Future` by hand.

Fixes #620

## Type of change

Code simplification

## How Has This Been Tested?

`cargo check` passes as expected; `bazel test //...` succeeds as well.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1055)
<!-- Reviewable:end -->
