### PR TITLE
Unbreak LRE Remote workflow

### DIFF
--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -48,78 +48,77 @@ jobs:
            --verbose_failures \
            @local-remote-execution//examples:hello_lre"
 
-  # TODO(nativelink#986) Re-enable once LRE is no longer flaky.
-  # remote:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [large-ubuntu-22.04]
-  #   name: Remote / ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   timeout-minutes: 45
-  #   steps:
-  #     - name: Checkout
-  #       uses: >- # v4.1.1
-  #         actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+  remote:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [large-ubuntu-22.04]
+    name: Remote / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-  #     - name: Install Nix
-  #       uses: >- # v10
-  #         DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
+      - name: Install Nix
+        uses: >- # v10
+          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
 
-  #     - name: Free disk space
-  #       uses: >- # v2.0.0
-  #         endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-  #       with:
-  #         remove_android: true
-  #         remove_dotnet: true
-  #         remove_haskell: true
-  #         remove_tool_cache: false
+      - name: Free disk space
+        uses: >- # v2.0.0
+          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: false
 
-  #     - name: Cache Nix derivations
-  #       uses: >- # v4
-  #         DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Cache Nix derivations
+        uses: >- # v4
+          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
 
-  #     - name: Start Kubernetes cluster (Infra)
-  #       run: >
-  #         nix run .#native up
+      - name: Start Kubernetes cluster (Infra)
+        run: >
+          nix run .#native up
 
-  #     - name: Start Kubernetes cluster (Operations)
-  #       run: >
-  #         nix develop --impure --command
-  #         bash -c "./deployment-examples/kubernetes/01_operations.sh"
+      - name: Start Kubernetes cluster (Operations)
+        run: >
+          nix develop --impure --command
+          bash -c "./deployment-examples/kubernetes/01_operations.sh"
 
-  #     - name: Start Kubernetes cluster (Application)
-  #       run: >
-  #         nix develop --impure --command
-  #         bash -c "./deployment-examples/kubernetes/02_application.sh"
+      - name: Start Kubernetes cluster (Application)
+        run: >
+          nix develop --impure --command
+          bash -c "./deployment-examples/kubernetes/02_application.sh"
 
-  #     - name: Get gateway IPs
-  #       id: gateway-ips
-  #       run: |
-  #         echo "cache_ip=$(kubectl get gtw cache-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
-  #         echo "scheduler_ip=$(kubectl get gtw scheduler-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
+      - name: Get gateway IPs
+        id: gateway-ips
+        run: |
+          echo "cache_ip=$(kubectl get gtw cache-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
+          echo "scheduler_ip=$(kubectl get gtw scheduler-gateway -o=jsonpath='{.status.addresses[0].value}')" >> "$GITHUB_ENV"
 
-  #     - name: Print cluster state
-  #       run: |
-  #         kubectl get svc -A
-  #         kubectl get pod -A
-  #         kubectl get svc -A
-  #         kubectl get deployments -A
-  #         kubectl describe gtw
-  #         echo "cas"
-  #         kubectl logs -l app=nativelink-cas
-  #         echo "scheduler"
-  #         kubectl logs -l app=nativelink-scheduler
-  #         echo "worker"
-  #         kubectl logs -l app=nativelink-worker
+      - name: Print cluster state
+        run: |
+          kubectl get svc -A
+          kubectl get pod -A
+          kubectl get svc -A
+          kubectl get deployments -A
+          kubectl describe gtw
+          echo "cas"
+          kubectl logs -l app=nativelink-cas
+          echo "scheduler"
+          kubectl logs -l app=nativelink-scheduler
+          echo "worker"
+          kubectl logs -l app=nativelink-worker
 
-  #     - name: Build hello_lre with LRE toolchain.
-  #       run: >
-  #         nix develop --impure --command
-  #         bash -c "bazel run \
-  #           --config=lre \
-  #           --remote_instance_name=main \
-  #           --remote_cache=grpc://$cache_ip \
-  #           --remote_executor=grpc://$scheduler_ip \
-  #           --verbose_failures \
-  #           @local-remote-execution//examples:hello_lre"
+      - name: Build hello_lre with LRE toolchain.
+        run: >
+          nix develop --impure --command
+          bash -c "bazel run \
+            --config=lre \
+            --remote_instance_name=main \
+            --remote_cache=grpc://$cache_ip \
+            --remote_executor=grpc://$scheduler_ip \
+            --verbose_failures \
+            @local-remote-execution//examples:hello_lre"

--- a/deployment-examples/kubernetes/worker-lre-cc.yaml
+++ b/deployment-examples/kubernetes/worker-lre-cc.yaml
@@ -30,6 +30,7 @@ spec:
           # completely separate extension of the `lre-cc` base image.
           args:
             - |
+              git config --global --add safe.directory "*"
               NATIVELINK_WORKER_PLATFORM=docker://lre-cc:$(nix eval /mnt/src_root#lre-cc.imageTag --raw) &&
               printf '#!/bin/sh\nexport NATIVELINK_WORKER_PLATFORM=%s\nexec "$@"' "$NATIVELINK_WORKER_PLATFORM" > /entrypoint/entrypoint.sh &&
               chmod +x /entrypoint/entrypoint.sh

--- a/deployment-examples/kubernetes/worker-lre-java.yaml
+++ b/deployment-examples/kubernetes/worker-lre-java.yaml
@@ -30,6 +30,7 @@ spec:
         # completely separate extension of the `lre-java` base image.
         args:
           - |
+            git config --global --add safe.directory "*"
             NATIVELINK_WORKER_PLATFORM=docker://lre-java:$(nix eval /mnt/src_root#lre-java.imageTag --raw) &&
             printf '#!/bin/sh\nexport NATIVELINK_WORKER_PLATFORM=%s\nexec "$@"' "$NATIVELINK_WORKER_PLATFORM" > /entrypoint/entrypoint.sh &&
             chmod +x /entrypoint/entrypoint.sh

--- a/native-cli/components/embedded/nix2container-copyto.yaml
+++ b/native-cli/components/embedded/nix2container-copyto.yaml
@@ -83,6 +83,10 @@ spec:
         NIX_SOCKET="unix:///workspace/nix-store/nix/var/nix/daemon-socket/socket"
         NIX_ROOT="/workspace/nix-store"
 
+        # Not ideal, but will have to do until we implement more elaborate git
+        # repo syncing schemes.
+        git config --global --add safe.directory "*"
+
         nix run \
           --store "${NIX_SOCKET}?root=${NIX_ROOT}" \
           --option sandbox "${ENABLE_NIX_SANDBOX}" \

--- a/native-cli/components/embedded/nix2container-image-info.yaml
+++ b/native-cli/components/embedded/nix2container-image-info.yaml
@@ -67,6 +67,10 @@ spec:
 
         echo "NIX_STORE_OPTS: '$NIX_STORE_OPTS'"
 
+        # Not ideal, but will have to do until we implement more elaborate git
+        # repo syncing schemes.
+        git config --global --add safe.directory "*"
+
         IMAGE_NAME=$(nix eval $NIX_STORE_OPTS "${FLAKE_OUTPUT}".imageName --raw)
         IMAGE_TAG=$(nix eval $NIX_STORE_OPTS "${FLAKE_OUTPUT}".imageTag --raw)
 


### PR DESCRIPTION
The failures were caused by "ambiguous directory permission" errors from git. Locally this was hard to notice because local permissions might've been different and the infra is set up in a way that it reuses previous images.

Long-term we should implement a proper mechanism to make the git repo available to cluster-internal Tekton steps.

Fixes #986

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1058)
<!-- Reviewable:end -->
