### PR TITLE
[Refactor] Move scheduler state behind mutex

### DIFF
--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -42,7 +42,7 @@ pub trait ActionScheduler: Sync + Send + Unpin {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>>;
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error>;
 
     /// Cleans up the cache of recently completed actions.
     async fn clean_recently_completed_actions(&self);

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -222,11 +222,11 @@ impl ActionScheduler for CacheLookupScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         {
             let cache_check_actions = self.cache_check_actions.lock();
             if let Some(rx) = subscribe_to_existing_action(&cache_check_actions, unique_qualifier) {
-                return Some(rx);
+                return Ok(Some(rx));
             }
         }
         // Cache skipped may be in the upstream scheduler.

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -260,7 +260,7 @@ impl ActionScheduler for GrpcScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let request = WaitExecutionRequest {
             name: unique_qualifier.action_name(),
         };
@@ -279,14 +279,14 @@ impl ActionScheduler for GrpcScheduler {
             .and_then(|result_stream| Self::stream_state(result_stream.into_inner()))
             .await;
         match result_stream {
-            Ok(result_stream) => Some(result_stream),
+            Ok(result_stream) => Ok(Some(result_stream)),
             Err(err) => {
                 event!(
                     Level::WARN,
                     ?err,
                     "Error looking up action with upstream scheduler"
                 );
-                None
+                Ok(None)
             }
         }
     }

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -101,7 +101,7 @@ pub type ActionStateResultStream = Pin<Box<dyn Stream<Item = Arc<dyn ActionState
 pub trait ClientStateManager {
     /// Add a new action to the queue or joins an existing action.
     async fn add_action(
-        &mut self,
+        &self,
         action_info: ActionInfo,
     ) -> Result<Arc<dyn ActionStateResult>, Error>;
 
@@ -119,7 +119,7 @@ pub trait WorkerStateManager {
     /// did not change with a modified timestamp in order to prevent
     /// the operation from being considered stale and being rescheduled.
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: WorkerId,
         action_stage: Result<ActionStage, Error>,
@@ -136,7 +136,7 @@ pub trait MatchingEngineStateManager {
 
     /// Update that state of an operation.
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -117,7 +117,7 @@ impl ActionScheduler for PropertyModifierScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         self.scheduler.find_existing_action(unique_qualifier).await
     }
 

--- a/nativelink-scheduler/src/redis_operation_state.rs
+++ b/nativelink-scheduler/src/redis_operation_state.rs
@@ -413,7 +413,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> RedisStateManage
 #[async_trait]
 impl ClientStateManager for RedisStateManager {
     async fn add_action(
-        &mut self,
+        &self,
         action_info: ActionInfo,
     ) -> Result<Arc<dyn ActionStateResult>, Error> {
         self.inner_add_action(action_info).await
@@ -430,7 +430,7 @@ impl ClientStateManager for RedisStateManager {
 #[async_trait]
 impl WorkerStateManager for RedisStateManager {
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: WorkerId,
         action_stage: Result<ActionStage, Error>,
@@ -450,7 +450,7 @@ impl MatchingEngineStateManager for RedisStateManager {
     }
 
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,

--- a/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
+++ b/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
@@ -22,22 +22,29 @@ use tokio::sync::watch;
 use crate::operation_state_manager::ActionStateResult;
 
 pub struct MatchingEngineActionStateResult {
-    pub action_info: Arc<ActionInfo>,
+    action_info: Arc<ActionInfo>,
+    action_state: watch::Receiver<Arc<ActionState>>,
 }
 impl MatchingEngineActionStateResult {
-    pub(crate) fn new(action_info: Arc<ActionInfo>) -> Self {
-        Self { action_info }
+    pub(crate) fn new(
+        action_info: Arc<ActionInfo>,
+        action_state: watch::Receiver<Arc<ActionState>>,
+    ) -> Self {
+        Self {
+            action_info,
+            action_state,
+        }
     }
 }
 
 #[async_trait]
 impl ActionStateResult for MatchingEngineActionStateResult {
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
-        unimplemented!()
+        Ok(self.action_state.borrow().clone())
     }
 
     async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error> {
-        unimplemented!()
+        Ok(&self.action_state)
     }
 
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -20,7 +20,7 @@ use std::time::{Instant, SystemTime};
 
 use async_lock::{Mutex, MutexGuard};
 use async_trait::async_trait;
-use futures::{Future, Stream};
+use futures::{Future, Stream, TryFutureExt};
 use hashbrown::{HashMap, HashSet};
 use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
@@ -47,7 +47,7 @@ use crate::operation_state_manager::{
 use crate::platform_property_manager::PlatformPropertyManager;
 use crate::scheduler_state::awaited_action::AwaitedAction;
 use crate::scheduler_state::metrics::Metrics as SchedulerMetrics;
-use crate::scheduler_state::state_manager::StateManager;
+use crate::scheduler_state::state_manager::{mutate_stage, StateManager, StateManagerImpl};
 use crate::scheduler_state::workers::Workers;
 use crate::worker::{Worker, WorkerTimestamp, WorkerUpdate};
 use crate::worker_scheduler::WorkerScheduler;
@@ -91,31 +91,36 @@ impl SimpleSchedulerImpl {
         add_action_result.as_receiver().await.cloned()
     }
 
-    fn clean_recently_completed_actions(&mut self) {
+    async fn clean_recently_completed_actions(&mut self) {
         let expiry_time = SystemTime::now()
             .checked_sub(self.retain_completed_for)
             .unwrap();
         self.state_manager
             .inner
+            .lock()
+            .await
             .recently_completed_actions
             .retain(|action| action.completed_time > expiry_time);
     }
 
-    fn find_recently_completed_action(
+    async fn find_recently_completed_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
-        self.state_manager
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
+        Ok(self
+            .state_manager
             .inner
+            .lock()
+            .await
             .recently_completed_actions
             .get(unique_qualifier)
-            .map(|action| watch::channel(action.state.clone()).1)
+            .map(|action| watch::channel(action.state.clone()).1))
     }
 
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let filter_result = <StateManager as ClientStateManager>::filter_operations(
             &self.state_manager,
             OperationFilter {
@@ -132,22 +137,36 @@ impl SimpleSchedulerImpl {
         )
         .await;
 
-        let mut stream = filter_result.ok()?;
+        let mut stream = filter_result
+            .err_tip(|| "In SimpleScheduler::find_existing_action getting filter result")?;
         if let Some(result) = stream.next().await {
-            result.as_receiver().await.ok().cloned()
+            Ok(Some(
+                result
+                    .as_receiver()
+                    .await
+                    .err_tip(|| "In SimpleScheduler::find_existing_action getting receiver")?
+                    .clone(),
+            ))
         } else {
-            None
+            Ok(None)
         }
     }
 
-    fn retry_action(&mut self, action_info: &Arc<ActionInfo>, worker_id: &WorkerId, err: Error) {
-        match self.state_manager.inner.active_actions.remove(action_info) {
+    fn retry_action(
+        inner_state: &mut MutexGuard<'_, StateManagerImpl>,
+        max_job_retries: usize,
+        metrics: &Metrics,
+        action_info: &Arc<ActionInfo>,
+        worker_id: &WorkerId,
+        err: Error,
+    ) {
+        match inner_state.active_actions.remove(action_info) {
             Some(running_action) => {
                 let mut awaited_action = running_action;
-                let send_result = if awaited_action.attempts >= self.max_job_retries {
-                    self.metrics.retry_action_max_attempts_reached.inc();
+                let send_result = if awaited_action.attempts >= max_job_retries {
+                    metrics.retry_action_max_attempts_reached.inc();
 
-                    StateManager::mutate_stage(&mut awaited_action, ActionStage::Completed(ActionResult {
+                    mutate_stage(&mut awaited_action, ActionStage::Completed(ActionResult {
                         execution_metadata: ExecutionMetadata {
                             worker: format!("{worker_id}"),
                             ..ExecutionMetadata::default()
@@ -161,22 +180,17 @@ impl SimpleSchedulerImpl {
                     // Do not put the action back in the queue here, as this action attempted to run too many
                     // times.
                 } else {
-                    self.metrics.retry_action.inc();
-                    let send_result =
-                        StateManager::mutate_stage(&mut awaited_action, ActionStage::Queued);
-                    self.state_manager
-                        .inner
-                        .queued_actions_set
-                        .insert(action_info.clone());
-                    self.state_manager
-                        .inner
+                    metrics.retry_action.inc();
+                    let send_result = mutate_stage(&mut awaited_action, ActionStage::Queued);
+                    inner_state.queued_actions_set.insert(action_info.clone());
+                    inner_state
                         .queued_actions
                         .insert(action_info.clone(), awaited_action);
                     send_result
                 };
 
                 if send_result.is_err() {
-                    self.metrics.retry_action_no_more_listeners.inc();
+                    metrics.retry_action_no_more_listeners.inc();
                     // Don't remove this task, instead we keep them around for a bit just in case
                     // the client disconnected and will reconnect and ask for same job to be executed
                     // again.
@@ -189,7 +203,7 @@ impl SimpleSchedulerImpl {
                 }
             }
             None => {
-                self.metrics.retry_action_but_action_missing.inc();
+                metrics.retry_action_but_action_missing.inc();
                 event!(
                     Level::ERROR,
                     ?action_info,
@@ -201,40 +215,50 @@ impl SimpleSchedulerImpl {
     }
 
     /// Evicts the worker from the pool and puts items back into the queue if anything was being executed on it.
-    fn immediate_evict_worker(&mut self, worker_id: &WorkerId, err: Error) {
-        if let Some(mut worker) = self.state_manager.inner.workers.remove_worker(worker_id) {
-            self.metrics.workers_evicted.inc();
+    fn immediate_evict_worker(
+        inner_state: &mut MutexGuard<'_, StateManagerImpl>,
+        max_job_retries: usize,
+        metrics: &Metrics,
+        worker_id: &WorkerId,
+        err: Error,
+    ) {
+        if let Some(mut worker) = inner_state.workers.remove_worker(worker_id) {
+            metrics.workers_evicted.inc();
             // We don't care if we fail to send message to worker, this is only a best attempt.
             let _ = worker.notify_update(WorkerUpdate::Disconnect);
             // We create a temporary Vec to avoid doubt about a possible code
             // path touching the worker.running_action_infos elsewhere.
             for action_info in worker.running_action_infos.drain() {
-                self.metrics.workers_evicted_with_running_action.inc();
-                self.retry_action(&action_info, worker_id, err.clone());
+                metrics.workers_evicted_with_running_action.inc();
+                SimpleSchedulerImpl::retry_action(
+                    inner_state,
+                    max_job_retries,
+                    metrics,
+                    &action_info,
+                    worker_id,
+                    err.clone(),
+                );
             }
         }
         // Note: Calling this many time is very cheap, it'll only trigger `do_try_match` once.
-        self.state_manager
-            .inner
-            .tasks_or_workers_change_notify
-            .notify_one();
+        inner_state.tasks_change_notify.notify_one();
     }
 
     /// Sets if the worker is draining or not.
-    fn set_drain_worker(&mut self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error> {
-        let worker = self
-            .state_manager
-            .inner
+    async fn set_drain_worker(
+        &mut self,
+        worker_id: WorkerId,
+        is_draining: bool,
+    ) -> Result<(), Error> {
+        let mut inner_state = self.state_manager.inner.lock().await;
+        let worker = inner_state
             .workers
             .workers
             .get_mut(&worker_id)
             .err_tip(|| format!("Worker {worker_id} doesn't exist in the pool"))?;
         self.metrics.workers_drained.inc();
         worker.is_draining = is_draining;
-        self.state_manager
-            .inner
-            .tasks_or_workers_change_notify
-            .notify_one();
+        inner_state.tasks_change_notify.notify_one();
         Ok(())
     }
 
@@ -286,30 +310,27 @@ impl SimpleSchedulerImpl {
                         continue;
                     };
 
-                    let Some(awaited_action): Option<&AwaitedAction> = self
-                        .state_manager
-                        .inner
-                        .queued_actions
-                        .get(action_info.as_ref())
-                    else {
-                        event!(
-                            Level::ERROR,
-                            ?action_info,
-                            "queued_actions out of sync with itself"
-                        );
-                        continue;
+                    let (operation_id, maybe_worker_id) = {
+                        let inner_state = self.state_manager.inner.lock().await;
+                        let Some(awaited_action): Option<&AwaitedAction> =
+                            inner_state.queued_actions.get(action_info.as_ref())
+                        else {
+                            event!(
+                                Level::ERROR,
+                                ?action_info,
+                                "queued_actions out of sync with itself"
+                            );
+                            continue;
+                        };
+
+                        (
+                            awaited_action.current_state.id.clone(),
+                            inner_state.workers.find_worker_for_action(awaited_action),
+                        )
                     };
 
-                    let maybe_worker_id: Option<WorkerId> = {
-                        self.state_manager
-                            .inner
-                            .workers
-                            .find_worker_for_action(awaited_action)
-                    };
-
-                    let operation_id = awaited_action.current_state.id.clone();
                     let ret = <StateManager as MatchingEngineStateManager>::update_operation(
-                        &mut self.state_manager,
+                        &self.state_manager,
                         operation_id.clone(),
                         maybe_worker_id,
                         Ok(ActionStage::Executing),
@@ -339,7 +360,7 @@ impl SimpleSchedulerImpl {
         action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error> {
         let update_operation_result = <StateManager as WorkerStateManager>::update_operation(
-            &mut self.state_manager,
+            &self.state_manager,
             OperationId::new(action_info_hash_key.clone()),
             *worker_id,
             action_stage,
@@ -414,7 +435,7 @@ impl SimpleScheduler {
             max_job_retries = DEFAULT_MAX_JOB_RETRIES;
         }
 
-        let tasks_or_workers_change_notify = Arc::new(Notify::new());
+        let tasks_change_notify = Arc::new(Notify::new());
         let state_manager = StateManager::new(
             HashSet::new(),
             BTreeMap::new(),
@@ -423,7 +444,7 @@ impl SimpleScheduler {
             HashSet::new(),
             Arc::new(SchedulerMetrics::default()),
             max_job_retries,
-            tasks_or_workers_change_notify.clone(),
+            tasks_change_notify.clone(),
         );
         let metrics = Arc::new(Metrics::default());
         let metrics_for_do_try_match = metrics.clone();
@@ -443,7 +464,7 @@ impl SimpleScheduler {
                 async move {
                     // Break out of the loop only when the inner is dropped.
                     loop {
-                        tasks_or_workers_change_notify.notified().await;
+                        tasks_change_notify.notified().await;
                         match weak_inner.upgrade() {
                             // Note: According to `parking_lot` documentation, the default
                             // `Mutex` implementation is eventual fairness, so we don't
@@ -471,13 +492,9 @@ impl SimpleScheduler {
     /// Checks to see if the worker exists in the worker pool. Should only be used in unit tests.
     #[must_use]
     pub async fn contains_worker_for_test(&self, worker_id: &WorkerId) -> bool {
-        let inner = self.get_inner_lock().await;
-        inner
-            .state_manager
-            .inner
-            .workers
-            .workers
-            .contains(worker_id)
+        let inner_scheduler = self.get_inner_lock().await;
+        let inner_state = inner_scheduler.state_manager.inner.lock().await;
+        inner_state.workers.workers.contains(worker_id)
     }
 
     /// A unit test function used to send the keep alive message to the worker from the server.
@@ -485,10 +502,9 @@ impl SimpleScheduler {
         &self,
         worker_id: &WorkerId,
     ) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
-        let worker = inner
-            .state_manager
-            .inner
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        let worker = inner_state
             .workers
             .workers
             .get_mut(worker_id)
@@ -536,24 +552,32 @@ impl ActionScheduler for SimpleScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let inner = self.get_inner_lock().await;
-        let result = inner
+        let maybe_receiver = inner
             .find_existing_action(unique_qualifier)
+            .and_then(|maybe_action| async {
+                if let Some(action) = maybe_action {
+                    Ok(Some(action))
+                } else {
+                    inner.find_recently_completed_action(unique_qualifier).await
+                }
+            })
             .await
-            .or_else(|| inner.find_recently_completed_action(unique_qualifier));
-        if result.is_some() {
+            .err_tip(|| "Error while finding existing action")?;
+        if maybe_receiver.is_some() {
             self.metrics.existing_actions_found.inc();
         } else {
             self.metrics.existing_actions_not_found.inc();
         }
-        result
+        Ok(maybe_receiver)
     }
 
     async fn clean_recently_completed_actions(&self) {
         self.get_inner_lock()
             .await
-            .clean_recently_completed_actions();
+            .clean_recently_completed_actions()
+            .await;
         self.metrics.clean_recently_completed_actions.inc()
     }
 
@@ -570,22 +594,24 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn add_worker(&self, worker: Worker) -> Result<(), Error> {
         let worker_id = worker.id;
-        let mut inner = self.get_inner_lock().await;
+        let inner_scheduler = self.get_inner_lock().await;
+        let max_job_retries = inner_scheduler.max_job_retries;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
         self.metrics.add_worker.wrap(move || {
-            let res = inner
-                .state_manager
-                .inner
+            let res = inner_state
                 .workers
                 .add_worker(worker)
                 .err_tip(|| "Error while adding worker, removing from pool");
             if let Err(err) = &res {
-                inner.immediate_evict_worker(&worker_id, err.clone());
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    max_job_retries,
+                    &self.metrics,
+                    &worker_id,
+                    err.clone(),
+                );
             }
-            inner
-                .state_manager
-                .inner
-                .tasks_or_workers_change_notify
-                .notify_one();
+            inner_state.tasks_change_notify.notify_one();
             res
         })
     }
@@ -608,37 +634,42 @@ impl WorkerScheduler for SimpleScheduler {
         worker_id: &WorkerId,
         timestamp: WorkerTimestamp,
     ) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
-        inner
-            .state_manager
-            .inner
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        inner_state
             .workers
             .refresh_lifetime(worker_id, timestamp)
             .err_tip(|| "Error refreshing lifetime in worker_keep_alive_received()")
     }
 
     async fn remove_worker(&self, worker_id: WorkerId) {
-        let mut inner = self.get_inner_lock().await;
-        inner.immediate_evict_worker(
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        SimpleSchedulerImpl::immediate_evict_worker(
+            &mut inner_state,
+            inner_scheduler.max_job_retries,
+            &inner_scheduler.metrics,
             &worker_id,
             make_err!(Code::Internal, "Received request to remove worker"),
         );
     }
 
     async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
+        let inner_scheduler = self.get_inner_lock().await;
+        let worker_timeout_s = inner_scheduler.worker_timeout_s;
+        let max_job_retries = inner_scheduler.max_job_retries;
+        let metrics = inner_scheduler.metrics.clone();
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
         self.metrics.remove_timedout_workers.wrap(move || {
             // Items should be sorted based on last_update_timestamp, so we don't need to iterate the entire
             // map most of the time.
-            let worker_ids_to_remove: Vec<WorkerId> = inner
-                .state_manager
-                .inner
+            let worker_ids_to_remove: Vec<WorkerId> = inner_state
                 .workers
                 .workers
                 .iter()
                 .rev()
                 .map_while(|(worker_id, worker)| {
-                    if worker.last_update_timestamp <= now_timestamp - inner.worker_timeout_s {
+                    if worker.last_update_timestamp <= now_timestamp - worker_timeout_s {
                         Some(*worker_id)
                     } else {
                         None
@@ -651,7 +682,10 @@ impl WorkerScheduler for SimpleScheduler {
                     ?worker_id,
                     "Worker timed out, removing from pool"
                 );
-                inner.immediate_evict_worker(
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    max_job_retries,
+                    &metrics,
                     worker_id,
                     make_err!(
                         Code::Internal,
@@ -666,7 +700,7 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn set_drain_worker(&self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error> {
         let mut inner = self.get_inner_lock().await;
-        inner.set_drain_worker(worker_id, is_draining)
+        inner.set_drain_worker(worker_id, is_draining).await
     }
 
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {
@@ -680,45 +714,46 @@ impl MetricsComponent for SimpleScheduler {
         self.metrics.gather_metrics(c);
         {
             // We use the raw lock because we dont gather stats about gathering stats.
-            let inner = self.inner.lock_blocking();
-            inner.state_manager.inner.metrics.gather_metrics(c);
+            let inner_scheduler = self.inner.lock_blocking();
+            let inner_state = inner_scheduler.state_manager.inner.lock_blocking();
+            inner_state.metrics.gather_metrics(c);
             c.publish(
                 "queued_actions_total",
-                &inner.state_manager.inner.queued_actions.len(),
+                &inner_state.queued_actions.len(),
                 "The number actions in the queue.",
             );
             c.publish(
                 "workers_total",
-                &inner.state_manager.inner.workers.workers.len(),
+                &inner_state.workers.workers.len(),
                 "The number workers active.",
             );
             c.publish(
                 "active_actions_total",
-                &inner.state_manager.inner.active_actions.len(),
+                &inner_state.active_actions.len(),
                 "The number of running actions.",
             );
             c.publish(
                 "recently_completed_actions_total",
-                &inner.state_manager.inner.recently_completed_actions.len(),
+                &inner_state.recently_completed_actions.len(),
                 "The number of recently completed actions in the buffer.",
             );
             c.publish(
                 "retain_completed_for_seconds",
-                &inner.retain_completed_for,
+                &inner_scheduler.retain_completed_for,
                 "The duration completed actions are retained for.",
             );
             c.publish(
                 "worker_timeout_seconds",
-                &inner.worker_timeout_s,
+                &inner_scheduler.worker_timeout_s,
                 "The configured timeout if workers have not responded for a while.",
             );
             c.publish(
                 "max_job_retries",
-                &inner.max_job_retries,
+                &inner_scheduler.max_job_retries,
                 "The amount of times a job is allowed to retry from an internal error before it is dropped.",
             );
             let mut props = HashMap::<&String, u64>::new();
-            for (_worker_id, worker) in inner.state_manager.inner.workers.workers.iter() {
+            for (_worker_id, worker) in inner_state.workers.workers.iter() {
                 c.publish_with_labels(
                     "workers",
                     worker,
@@ -739,7 +774,7 @@ impl MetricsComponent for SimpleScheduler {
                     format!("Total sum of available properties for {property}"),
                 );
             }
-            for (_, active_action) in inner.state_manager.inner.active_actions.iter() {
+            for (_, active_action) in inner_state.active_actions.iter() {
                 let action_name = active_action
                     .action_info
                     .unique_qualifier

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -118,9 +118,9 @@ async fn find_existing_action_call_passed() -> Result<(), Error> {
     };
     let (actual_result, actual_action_name) = join!(
         context.cache_scheduler.find_existing_action(&action_name),
-        context.mock_scheduler.expect_find_existing_action(None),
+        context.mock_scheduler.expect_find_existing_action(Ok(None)),
     );
-    assert_eq!(true, actual_result.is_none());
+    assert_eq!(true, actual_result.unwrap().is_none());
     assert_eq!(action_name, actual_action_name);
     Ok(())
 }

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -251,9 +251,9 @@ async fn find_existing_action_call_passed() -> Result<(), Error> {
         context
             .modifier_scheduler
             .find_existing_action(&action_name),
-        context.mock_scheduler.expect_find_existing_action(None),
+        context.mock_scheduler.expect_find_existing_action(Ok(None)),
     );
-    assert_eq!(true, actual_result.is_none());
+    assert_eq!(true, actual_result.unwrap().is_none());
     assert_eq!(action_name, actual_action_name);
     Ok(())
 }

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -179,7 +179,8 @@ async fn find_executing_action() -> Result<(), Error> {
     let mut client_rx = scheduler
         .find_existing_action(&unique_qualifier)
         .await
-        .err_tip(|| "Action not found")?;
+        .expect("Action not found")
+        .unwrap();
 
     {
         // Worker should have been sent an execute command.
@@ -955,7 +956,8 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
     let mut client_rx = scheduler
         .find_existing_action(&unique_qualifier)
         .await
-        .err_tip(|| "Action not found")?;
+        .unwrap()
+        .expect("Action not found");
     {
         // Client should get notification saying it has been completed.
         let action_state = client_rx.borrow_and_update();

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -31,7 +31,7 @@ enum ActionSchedulerCalls {
 enum ActionSchedulerReturns {
     GetPlatformPropertyManager(Result<Arc<PlatformPropertyManager>, Error>),
     AddAction(Result<watch::Receiver<Arc<ActionState>>, Error>),
-    FindExistingAction(Option<watch::Receiver<Arc<ActionState>>>),
+    FindExistingAction(Result<Option<watch::Receiver<Arc<ActionState>>>, Error>),
 }
 
 pub struct MockActionScheduler {
@@ -100,7 +100,7 @@ impl MockActionScheduler {
 
     pub async fn expect_find_existing_action(
         &self,
-        result: Option<watch::Receiver<Arc<ActionState>>>,
+        result: Result<Option<watch::Receiver<Arc<ActionState>>>, Error>,
     ) -> ActionInfoHashKey {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::FindExistingAction(req) = rx_call_lock
@@ -161,7 +161,7 @@ impl ActionScheduler for MockActionScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         self.tx_call
             .send(ActionSchedulerCalls::FindExistingAction(
                 unique_qualifier.clone(),

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -253,6 +253,7 @@ impl ExecutionServer {
             .scheduler
             .find_existing_action(&operation_id.unique_qualifier)
             .await
+            .err_tip(|| "Error running find_existing_action in ExecutionServer::wait_execution")?
         else {
             return Err(Status::not_found("Failed to find existing task"));
         };


### PR DESCRIPTION
In prep to support a distributed/redis scheduler, prepare the state interface to no longer take mutable references.

This is a partial PR and should be landed immediately with follow up PRs that will remove many of the locking in the SimpleScheduler.

towards: #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1062)
<!-- Reviewable:end -->
