### PR TITLE
Include ActionState to MatchingEngineActionStateResult

### DIFF
--- a/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
+++ b/nativelink-scheduler/src/scheduler_state/matching_engine_action_state_result.rs
@@ -22,22 +22,29 @@ use tokio::sync::watch;
 use crate::operation_state_manager::ActionStateResult;
 
 pub struct MatchingEngineActionStateResult {
-    pub action_info: Arc<ActionInfo>,
+    action_info: Arc<ActionInfo>,
+    action_state: watch::Receiver<Arc<ActionState>>,
 }
 impl MatchingEngineActionStateResult {
-    pub(crate) fn new(action_info: Arc<ActionInfo>) -> Self {
-        Self { action_info }
+    pub(crate) fn new(
+        action_info: Arc<ActionInfo>,
+        action_state: watch::Receiver<Arc<ActionState>>,
+    ) -> Self {
+        Self {
+            action_info,
+            action_state,
+        }
     }
 }
 
 #[async_trait]
 impl ActionStateResult for MatchingEngineActionStateResult {
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
-        unimplemented!()
+        Ok(self.action_state.borrow().clone())
     }
 
     async fn as_receiver(&self) -> Result<&'_ watch::Receiver<Arc<ActionState>>, Error> {
-        unimplemented!()
+        Ok(&self.action_state)
     }
 
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {


### PR DESCRIPTION
# Description

Refactoring to include the `awaited_action` watch channel `notify_channel: watch::Sender<Arc<ActionState>>` to be provided via `MatchingEngineActionStateResult`. This aids the matching engine's need for access to `OperationId`.

Fixes https://github.com/TraceMachina/nativelink/issues/1063

## Type of change

Please delete options that aren't relevant.

- [x] Refactor

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1064)
<!-- Reviewable:end -->
