### PR TITLE
[Refactor] Moves worker logic back to SimpleScheduler

### DIFF
--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -42,7 +42,7 @@ pub trait ActionScheduler: Sync + Send + Unpin {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>>;
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error>;
 
     /// Cleans up the cache of recently completed actions.
     async fn clean_recently_completed_actions(&self);

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -222,11 +222,11 @@ impl ActionScheduler for CacheLookupScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         {
             let cache_check_actions = self.cache_check_actions.lock();
             if let Some(rx) = subscribe_to_existing_action(&cache_check_actions, unique_qualifier) {
-                return Some(rx);
+                return Ok(Some(rx));
             }
         }
         // Cache skipped may be in the upstream scheduler.

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -260,7 +260,7 @@ impl ActionScheduler for GrpcScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let request = WaitExecutionRequest {
             name: unique_qualifier.action_name(),
         };
@@ -279,14 +279,14 @@ impl ActionScheduler for GrpcScheduler {
             .and_then(|result_stream| Self::stream_state(result_stream.into_inner()))
             .await;
         match result_stream {
-            Ok(result_stream) => Some(result_stream),
+            Ok(result_stream) => Ok(Some(result_stream)),
             Err(err) => {
                 event!(
                     Level::WARN,
                     ?err,
                     "Error looking up action with upstream scheduler"
                 );
-                None
+                Ok(None)
             }
         }
     }

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -101,7 +101,7 @@ pub type ActionStateResultStream = Pin<Box<dyn Stream<Item = Arc<dyn ActionState
 pub trait ClientStateManager {
     /// Add a new action to the queue or joins an existing action.
     async fn add_action(
-        &mut self,
+        &self,
         action_info: ActionInfo,
     ) -> Result<Arc<dyn ActionStateResult>, Error>;
 
@@ -119,7 +119,7 @@ pub trait WorkerStateManager {
     /// did not change with a modified timestamp in order to prevent
     /// the operation from being considered stale and being rescheduled.
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: WorkerId,
         action_stage: Result<ActionStage, Error>,
@@ -136,7 +136,7 @@ pub trait MatchingEngineStateManager {
 
     /// Update that state of an operation.
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,

--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -98,7 +98,7 @@ pub struct OrderBy {
 pub type ActionStateResultStream = Pin<Box<dyn Stream<Item = Arc<dyn ActionStateResult>> + Send>>;
 
 #[async_trait]
-pub trait ClientStateManager {
+pub trait ClientStateManager: Sync + Send + 'static {
     /// Add a new action to the queue or joins an existing action.
     async fn add_action(
         &self,
@@ -113,7 +113,7 @@ pub trait ClientStateManager {
 }
 
 #[async_trait]
-pub trait WorkerStateManager {
+pub trait WorkerStateManager: Sync + Send + 'static {
     /// Update that state of an operation.
     /// The worker must also send periodic updates even if the state
     /// did not change with a modified timestamp in order to prevent
@@ -127,7 +127,7 @@ pub trait WorkerStateManager {
 }
 
 #[async_trait]
-pub trait MatchingEngineStateManager {
+pub trait MatchingEngineStateManager: Sync + Send + 'static {
     /// Returns a stream of operations that match the filter.
     async fn filter_operations(
         &self,

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -117,7 +117,7 @@ impl ActionScheduler for PropertyModifierScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         self.scheduler.find_existing_action(unique_qualifier).await
     }
 

--- a/nativelink-scheduler/src/redis_operation_state.rs
+++ b/nativelink-scheduler/src/redis_operation_state.rs
@@ -413,7 +413,7 @@ impl<T: ConnectionLike + Unpin + Clone + Send + Sync + 'static> RedisStateManage
 #[async_trait]
 impl ClientStateManager for RedisStateManager {
     async fn add_action(
-        &mut self,
+        &self,
         action_info: ActionInfo,
     ) -> Result<Arc<dyn ActionStateResult>, Error> {
         self.inner_add_action(action_info).await
@@ -430,7 +430,7 @@ impl ClientStateManager for RedisStateManager {
 #[async_trait]
 impl WorkerStateManager for RedisStateManager {
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: WorkerId,
         action_stage: Result<ActionStage, Error>,
@@ -450,7 +450,7 @@ impl MatchingEngineStateManager for RedisStateManager {
     }
 
     async fn update_operation(
-        &mut self,
+        &self,
         operation_id: OperationId,
         worker_id: Option<WorkerId>,
         action_stage: Result<ActionStage, Error>,

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -65,13 +65,16 @@ const DEFAULT_MAX_JOB_RETRIES: usize = 3;
 
 struct SimpleSchedulerImpl {
     /// The manager responsible for holding the state of actions and workers.
-    state_manager: StateManager,
+    state_manager: Arc<StateManager>,
     /// The duration that actions are kept in recently_completed_actions for.
     retain_completed_for: Duration,
     /// Timeout of how long to evict workers if no response in this given amount of time in seconds.
     worker_timeout_s: u64,
     /// Default times a job can retry before failing.
     max_job_retries: usize,
+    /// A `Workers` pool that contains all workers that are available to execute actions in a priority
+    /// order based on the allocation strategy.
+    workers: Workers,
     metrics: Arc<Metrics>,
 }
 
@@ -216,12 +219,13 @@ impl SimpleSchedulerImpl {
     /// Evicts the worker from the pool and puts items back into the queue if anything was being executed on it.
     fn immediate_evict_worker(
         inner_state: &mut MutexGuard<'_, StateManagerImpl>,
+        workers: &mut Workers,
         max_job_retries: usize,
         metrics: &Metrics,
         worker_id: &WorkerId,
         err: Error,
     ) {
-        if let Some(mut worker) = inner_state.workers.remove_worker(worker_id) {
+        if let Some(mut worker) = workers.remove_worker(worker_id) {
             metrics.workers_evicted.inc();
             // We don't care if we fail to send message to worker, this is only a best attempt.
             let _ = worker.notify_update(WorkerUpdate::Disconnect);
@@ -249,15 +253,75 @@ impl SimpleSchedulerImpl {
         worker_id: WorkerId,
         is_draining: bool,
     ) -> Result<(), Error> {
-        let mut inner_state = self.state_manager.inner.lock().await;
-        let worker = inner_state
+        let worker = self
             .workers
             .workers
             .get_mut(&worker_id)
             .err_tip(|| format!("Worker {worker_id} doesn't exist in the pool"))?;
         self.metrics.workers_drained.inc();
         worker.is_draining = is_draining;
-        inner_state.tasks_change_notify.notify_one();
+        self.state_manager
+            .inner
+            .lock()
+            .await
+            .tasks_change_notify
+            .notify_one();
+        Ok(())
+    }
+
+    /// Notifies the specified worker to run the given action and handles errors by evicting
+    /// the worker if the notification fails.
+    ///
+    /// # Note
+    ///
+    /// Intended utility function for matching engine.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the notification to the worker fails, and in that case,
+    /// the worker will be immediately evicted from the system.
+    ///
+    async fn worker_notify_run_action(
+        &mut self,
+        worker_id: WorkerId,
+        action_info: Arc<ActionInfo>,
+    ) -> Result<(), Error> {
+        if let Some(worker) = self.workers.workers.get_mut(&worker_id) {
+            let notify_worker_result =
+                worker.notify_update(WorkerUpdate::RunAction(action_info.clone()));
+
+            if notify_worker_result.is_err() {
+                event!(
+                    Level::WARN,
+                    ?worker_id,
+                    ?action_info,
+                    ?notify_worker_result,
+                    "Worker command failed, removing worker",
+                );
+
+                let err = make_err!(
+                    Code::Internal,
+                    "Worker command failed, removing worker {worker_id} -- {notify_worker_result:?}",
+                );
+
+                let max_job_retries = self.max_job_retries;
+                let metrics = self.metrics.clone();
+                // TODO(allada) This is to get around rust borrow checker with double mut borrows
+                // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+                // removed.
+                let state_manager = self.state_manager.clone();
+                let mut inner_state = state_manager.inner.lock().await;
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    &mut self.workers,
+                    max_job_retries,
+                    &metrics,
+                    &worker_id,
+                    err.clone(),
+                );
+                return Err(err);
+            }
+        }
         Ok(())
     }
 
@@ -320,13 +384,9 @@ impl SimpleSchedulerImpl {
                         continue;
                     };
 
-                    let maybe_worker_id: Option<WorkerId> = {
-                        let inner_state = self.state_manager.inner.lock().await;
-                        
-                        inner_state
-                            .workers
-                            .find_worker_for_action(&action_info.platform_properties)
-                    };
+                    let maybe_worker_id = self
+                        .workers
+                        .find_worker_for_action(&action_info.platform_properties);
 
                     let operation_id = state.id.clone();
                     let ret = <StateManager as MatchingEngineStateManager>::update_operation(
@@ -338,12 +398,43 @@ impl SimpleSchedulerImpl {
                     .await;
 
                     if let Err(e) = ret {
+                        if let Some(worker_id) = maybe_worker_id {
+                            let max_job_retries = self.max_job_retries;
+                            let metrics = self.metrics.clone();
+                            // TODO(allada) This is to get around rust borrow checker with double mut borrows
+                            // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+                            // removed.
+                            let state_manager = self.state_manager.clone();
+                            let mut inner_state = state_manager.inner.lock().await;
+                            SimpleSchedulerImpl::immediate_evict_worker(
+                                &mut inner_state,
+                                &mut self.workers,
+                                max_job_retries,
+                                &metrics,
+                                &worker_id,
+                                e.clone(),
+                            );
+                        }
+
                         event!(
                             Level::ERROR,
                             ?e,
                             "update operation failed for {}",
                             operation_id
                         );
+                    } else if let Some(worker_id) = maybe_worker_id {
+                        if let Err(err) = self
+                            .worker_notify_run_action(worker_id, action_info.clone())
+                            .await
+                        {
+                            event!(
+                                Level::ERROR,
+                                ?err,
+                                ?worker_id,
+                                ?action_info,
+                                "failed to run worker_notify_run_action in SimpleSchedulerImpl::do_try_match"
+                            );
+                        }
                     }
                 }
             }
@@ -359,14 +450,63 @@ impl SimpleSchedulerImpl {
         action_info_hash_key: ActionInfoHashKey,
         action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error> {
+        let worker = self.workers.workers.get_mut(worker_id).err_tip(|| {
+            format!("Worker {worker_id} does not exist in SimpleSchedulerImpl::update_action")
+        })?;
+        let action_info_res = worker
+            .running_action_infos
+            .get(&action_info_hash_key)
+            .err_tip(|| format!("Action {action_info_hash_key:?} should not be running on worker {worker_id} in SimpleSchedulerImpl::update_action"));
+        let action_info = match action_info_res {
+            Ok(action_info) => action_info.clone(),
+            Err(err) => {
+                let max_job_retries = self.max_job_retries;
+                let metrics = self.metrics.clone();
+                // TODO(allada) This is to get around rust borrow checker with double mut borrows
+                // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+                // removed.
+                let state_manager = self.state_manager.clone();
+                let mut inner_state = state_manager.inner.lock().await;
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    &mut self.workers,
+                    max_job_retries,
+                    &metrics,
+                    worker_id,
+                    err.clone(),
+                );
+                return Err(err);
+            }
+        };
+        let operation_id = OperationId::new(action_info_hash_key.clone());
+        let due_to_backpressure = action_stage
+            .as_ref()
+            .map_or_else(|e| e.code == Code::ResourceExhausted, |_| false);
         let update_operation_result = <StateManager as WorkerStateManager>::update_operation(
             &self.state_manager,
-            OperationId::new(action_info_hash_key.clone()),
+            operation_id.clone(),
             *worker_id,
-            action_stage,
+            action_stage.clone(),
         )
-        .await;
-        if let Err(e) = &update_operation_result {
+        .await
+        .err_tip(|| "in update_operation on SimpleSchedulerImpl::update_action");
+        if let Err(e) = update_operation_result {
+            let max_job_retries = self.max_job_retries;
+            let metrics = self.metrics.clone();
+            // TODO(allada) This is to get around rust borrow checker with double mut borrows
+            // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+            // removed.
+            let state_manager = self.state_manager.clone();
+            let mut inner_state = state_manager.inner.lock().await;
+            SimpleSchedulerImpl::immediate_evict_worker(
+                &mut inner_state,
+                &mut self.workers,
+                max_job_retries,
+                &metrics,
+                worker_id,
+                e.clone(),
+            );
+
             event!(
                 Level::ERROR,
                 ?action_info_hash_key,
@@ -374,8 +514,43 @@ impl SimpleSchedulerImpl {
                 ?e,
                 "Failed to update_operation on update_action"
             );
+            return Err(e);
         }
-        update_operation_result
+
+        match action_stage {
+            Ok(_) => worker.complete_action(&action_info),
+            Err(err) => {
+                // Clear this action from the current worker.
+                let was_paused = !worker.can_accept_work();
+                // This unpauses, but since we're completing with an error, don't
+                // unpause unless all actions have completed.
+                // Note: We need to run this before dealing with backpressure logic.
+                worker.complete_action(&action_info);
+                // Only pause if there's an action still waiting that will unpause.
+                if (was_paused || due_to_backpressure) && worker.has_actions() {
+                    worker.is_paused = true;
+                }
+
+                let max_job_retries = self.max_job_retries;
+                let metrics = self.metrics.clone();
+                // TODO(allada) This is to get around rust borrow checker with double mut borrows
+                // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+                // removed.
+                let state_manager = self.state_manager.clone();
+                let mut inner_state = state_manager.inner.lock().await;
+                // Re-queue the action or fail on max attempts.
+                SimpleSchedulerImpl::retry_action(
+                    &mut inner_state,
+                    max_job_retries,
+                    &metrics,
+                    &action_info,
+                    worker_id,
+                    err,
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -436,16 +611,14 @@ impl SimpleScheduler {
         }
 
         let tasks_change_notify = Arc::new(Notify::new());
-        let state_manager = StateManager::new(
+        let state_manager = Arc::new(StateManager::new(
             HashSet::new(),
             BTreeMap::new(),
-            Workers::new(scheduler_cfg.allocation_strategy),
             HashMap::new(),
             HashSet::new(),
             Arc::new(SchedulerMetrics::default()),
-            max_job_retries,
             tasks_change_notify.clone(),
-        );
+        ));
         let metrics = Arc::new(Metrics::default());
         let metrics_for_do_try_match = metrics.clone();
         let inner = Arc::new(Mutex::new(SimpleSchedulerImpl {
@@ -454,6 +627,7 @@ impl SimpleScheduler {
             worker_timeout_s,
             max_job_retries,
             metrics: metrics.clone(),
+            workers: Workers::new(scheduler_cfg.allocation_strategy),
         }));
         let weak_inner = Arc::downgrade(&inner);
         Self {
@@ -493,8 +667,7 @@ impl SimpleScheduler {
     #[must_use]
     pub async fn contains_worker_for_test(&self, worker_id: &WorkerId) -> bool {
         let inner_scheduler = self.get_inner_lock().await;
-        let inner_state = inner_scheduler.state_manager.inner.lock().await;
-        inner_state.workers.workers.contains(worker_id)
+        inner_scheduler.workers.workers.contains(worker_id)
     }
 
     /// A unit test function used to send the keep alive message to the worker from the server.
@@ -502,9 +675,8 @@ impl SimpleScheduler {
         &self,
         worker_id: &WorkerId,
     ) -> Result<(), Error> {
-        let inner_scheduler = self.get_inner_lock().await;
-        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
-        let worker = inner_state
+        let mut inner_scheduler = self.get_inner_lock().await;
+        let worker = inner_scheduler
             .workers
             .workers
             .get_mut(worker_id)
@@ -594,17 +766,22 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn add_worker(&self, worker: Worker) -> Result<(), Error> {
         let worker_id = worker.id;
-        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_scheduler = self.get_inner_lock().await;
         let max_job_retries = inner_scheduler.max_job_retries;
-        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        // TODO(allada) This is to get around rust borrow checker with double mut borrows
+        // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+        // removed.
+        let state_manager = inner_scheduler.state_manager.clone();
+        let mut inner_state = state_manager.inner.lock().await;
         self.metrics.add_worker.wrap(move || {
-            let res = inner_state
+            let res = inner_scheduler
                 .workers
                 .add_worker(worker)
                 .err_tip(|| "Error while adding worker, removing from pool");
             if let Err(err) = &res {
                 SimpleSchedulerImpl::immediate_evict_worker(
                     &mut inner_state,
+                    &mut inner_scheduler.workers,
                     max_job_retries,
                     &self.metrics,
                     &worker_id,
@@ -634,68 +811,82 @@ impl WorkerScheduler for SimpleScheduler {
         worker_id: &WorkerId,
         timestamp: WorkerTimestamp,
     ) -> Result<(), Error> {
-        let inner_scheduler = self.get_inner_lock().await;
-        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
-        inner_state
+        let mut inner_scheduler = self.get_inner_lock().await;
+        inner_scheduler
             .workers
             .refresh_lifetime(worker_id, timestamp)
             .err_tip(|| "Error refreshing lifetime in worker_keep_alive_received()")
     }
 
     async fn remove_worker(&self, worker_id: WorkerId) {
-        let inner_scheduler = self.get_inner_lock().await;
-        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        let mut inner_scheduler = self.get_inner_lock().await;
+        let max_job_retries = inner_scheduler.max_job_retries;
+        let metrics = inner_scheduler.metrics.clone();
+        // TODO(allada) This is to get around rust borrow checker with double mut borrows
+        // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+        // removed.
+        let state_manager = inner_scheduler.state_manager.clone();
+        let mut inner_state = state_manager.inner.lock().await;
         SimpleSchedulerImpl::immediate_evict_worker(
             &mut inner_state,
-            inner_scheduler.max_job_retries,
-            &inner_scheduler.metrics,
+            &mut inner_scheduler.workers,
+            max_job_retries,
+            &metrics,
             &worker_id,
             make_err!(Code::Internal, "Received request to remove worker"),
         );
     }
 
     async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error> {
-        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_scheduler = self.get_inner_lock().await;
         let worker_timeout_s = inner_scheduler.worker_timeout_s;
         let max_job_retries = inner_scheduler.max_job_retries;
         let metrics = inner_scheduler.metrics.clone();
-        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
-        self.metrics.remove_timedout_workers.wrap(move || {
-            // Items should be sorted based on last_update_timestamp, so we don't need to iterate the entire
-            // map most of the time.
-            let worker_ids_to_remove: Vec<WorkerId> = inner_state
-                .workers
-                .workers
-                .iter()
-                .rev()
-                .map_while(|(worker_id, worker)| {
-                    if worker.last_update_timestamp <= now_timestamp - worker_timeout_s {
-                        Some(*worker_id)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            for worker_id in &worker_ids_to_remove {
-                event!(
-                    Level::WARN,
-                    ?worker_id,
-                    "Worker timed out, removing from pool"
-                );
-                SimpleSchedulerImpl::immediate_evict_worker(
-                    &mut inner_state,
-                    max_job_retries,
-                    &metrics,
-                    worker_id,
-                    make_err!(
-                        Code::Internal,
-                        "Worker {worker_id} timed out, removing from pool"
-                    ),
-                );
-            }
+        self.metrics
+            .remove_timedout_workers
+            .wrap(async move {
+                // Items should be sorted based on last_update_timestamp, so we don't need to iterate the entire
+                // map most of the time.
+                let worker_ids_to_remove: Vec<WorkerId> = inner_scheduler
+                    .workers
+                    .workers
+                    .iter()
+                    .rev()
+                    .map_while(|(worker_id, worker)| {
+                        if worker.last_update_timestamp <= now_timestamp - worker_timeout_s {
+                            Some(*worker_id)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                // TODO(allada) This is to get around rust borrow checker with double mut borrows
+                // of a mutex lock. Once the scheduler is fully moved to state manager this can be
+                // removed.
+                let state_manager = inner_scheduler.state_manager.clone();
+                let mut inner_state = state_manager.inner.lock().await;
+                for worker_id in &worker_ids_to_remove {
+                    event!(
+                        Level::WARN,
+                        ?worker_id,
+                        "Worker timed out, removing from pool"
+                    );
+                    SimpleSchedulerImpl::immediate_evict_worker(
+                        &mut inner_state,
+                        &mut inner_scheduler.workers,
+                        max_job_retries,
+                        &metrics,
+                        worker_id,
+                        make_err!(
+                            Code::Internal,
+                            "Worker {worker_id} timed out, removing from pool"
+                        ),
+                    );
+                }
 
-            Ok(())
-        })
+                Ok(())
+            })
+            .await
     }
 
     async fn set_drain_worker(&self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error> {
@@ -724,7 +915,7 @@ impl MetricsComponent for SimpleScheduler {
             );
             c.publish(
                 "workers_total",
-                &inner_state.workers.workers.len(),
+                &inner_scheduler.workers.workers.len(),
                 "The number workers active.",
             );
             c.publish(
@@ -753,7 +944,7 @@ impl MetricsComponent for SimpleScheduler {
                 "The amount of times a job is allowed to retry from an internal error before it is dropped.",
             );
             let mut props = HashMap::<&String, u64>::new();
-            for (_worker_id, worker) in inner_state.workers.workers.iter() {
+            for (_worker_id, worker) in inner_scheduler.workers.workers.iter() {
                 c.publish_with_labels(
                     "workers",
                     worker,
@@ -806,7 +997,7 @@ struct Metrics {
     existing_actions_found: CounterWithTime,
     existing_actions_not_found: CounterWithTime,
     clean_recently_completed_actions: CounterWithTime,
-    remove_timedout_workers: FuncCounterWrapper,
+    remove_timedout_workers: AsyncCounterWrapper,
     update_action: AsyncCounterWrapper,
     update_action_with_internal_error: CounterWithTime,
     update_action_with_internal_error_no_action: CounterWithTime,

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -20,7 +20,7 @@ use std::time::{Instant, SystemTime};
 
 use async_lock::{Mutex, MutexGuard};
 use async_trait::async_trait;
-use futures::{Future, Stream};
+use futures::{Future, Stream, TryFutureExt};
 use hashbrown::{HashMap, HashSet};
 use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
@@ -46,7 +46,7 @@ use crate::operation_state_manager::{
 };
 use crate::platform_property_manager::PlatformPropertyManager;
 use crate::scheduler_state::metrics::Metrics as SchedulerMetrics;
-use crate::scheduler_state::state_manager::StateManager;
+use crate::scheduler_state::state_manager::{mutate_stage, StateManager, StateManagerImpl};
 use crate::scheduler_state::workers::Workers;
 use crate::worker::{Worker, WorkerTimestamp, WorkerUpdate};
 use crate::worker_scheduler::WorkerScheduler;
@@ -90,31 +90,36 @@ impl SimpleSchedulerImpl {
         add_action_result.as_receiver().await.cloned()
     }
 
-    fn clean_recently_completed_actions(&mut self) {
+    async fn clean_recently_completed_actions(&mut self) {
         let expiry_time = SystemTime::now()
             .checked_sub(self.retain_completed_for)
             .unwrap();
         self.state_manager
             .inner
+            .lock()
+            .await
             .recently_completed_actions
             .retain(|action| action.completed_time > expiry_time);
     }
 
-    fn find_recently_completed_action(
+    async fn find_recently_completed_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
-        self.state_manager
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
+        Ok(self
+            .state_manager
             .inner
+            .lock()
+            .await
             .recently_completed_actions
             .get(unique_qualifier)
-            .map(|action| watch::channel(action.state.clone()).1)
+            .map(|action| watch::channel(action.state.clone()).1))
     }
 
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let filter_result = <StateManager as ClientStateManager>::filter_operations(
             &self.state_manager,
             OperationFilter {
@@ -131,22 +136,36 @@ impl SimpleSchedulerImpl {
         )
         .await;
 
-        let mut stream = filter_result.ok()?;
+        let mut stream = filter_result
+            .err_tip(|| "In SimpleScheduler::find_existing_action getting filter result")?;
         if let Some(result) = stream.next().await {
-            result.as_receiver().await.ok().cloned()
+            Ok(Some(
+                result
+                    .as_receiver()
+                    .await
+                    .err_tip(|| "In SimpleScheduler::find_existing_action getting receiver")?
+                    .clone(),
+            ))
         } else {
-            None
+            Ok(None)
         }
     }
 
-    fn retry_action(&mut self, action_info: &Arc<ActionInfo>, worker_id: &WorkerId, err: Error) {
-        match self.state_manager.inner.active_actions.remove(action_info) {
+    fn retry_action(
+        inner_state: &mut MutexGuard<'_, StateManagerImpl>,
+        max_job_retries: usize,
+        metrics: &Metrics,
+        action_info: &Arc<ActionInfo>,
+        worker_id: &WorkerId,
+        err: Error,
+    ) {
+        match inner_state.active_actions.remove(action_info) {
             Some(running_action) => {
                 let mut awaited_action = running_action;
-                let send_result = if awaited_action.attempts >= self.max_job_retries {
-                    self.metrics.retry_action_max_attempts_reached.inc();
+                let send_result = if awaited_action.attempts >= max_job_retries {
+                    metrics.retry_action_max_attempts_reached.inc();
 
-                    StateManager::mutate_stage(&mut awaited_action, ActionStage::Completed(ActionResult {
+                    mutate_stage(&mut awaited_action, ActionStage::Completed(ActionResult {
                         execution_metadata: ExecutionMetadata {
                             worker: format!("{worker_id}"),
                             ..ExecutionMetadata::default()
@@ -160,22 +179,17 @@ impl SimpleSchedulerImpl {
                     // Do not put the action back in the queue here, as this action attempted to run too many
                     // times.
                 } else {
-                    self.metrics.retry_action.inc();
-                    let send_result =
-                        StateManager::mutate_stage(&mut awaited_action, ActionStage::Queued);
-                    self.state_manager
-                        .inner
-                        .queued_actions_set
-                        .insert(action_info.clone());
-                    self.state_manager
-                        .inner
+                    metrics.retry_action.inc();
+                    let send_result = mutate_stage(&mut awaited_action, ActionStage::Queued);
+                    inner_state.queued_actions_set.insert(action_info.clone());
+                    inner_state
                         .queued_actions
                         .insert(action_info.clone(), awaited_action);
                     send_result
                 };
 
                 if send_result.is_err() {
-                    self.metrics.retry_action_no_more_listeners.inc();
+                    metrics.retry_action_no_more_listeners.inc();
                     // Don't remove this task, instead we keep them around for a bit just in case
                     // the client disconnected and will reconnect and ask for same job to be executed
                     // again.
@@ -188,7 +202,7 @@ impl SimpleSchedulerImpl {
                 }
             }
             None => {
-                self.metrics.retry_action_but_action_missing.inc();
+                metrics.retry_action_but_action_missing.inc();
                 event!(
                     Level::ERROR,
                     ?action_info,
@@ -200,40 +214,50 @@ impl SimpleSchedulerImpl {
     }
 
     /// Evicts the worker from the pool and puts items back into the queue if anything was being executed on it.
-    fn immediate_evict_worker(&mut self, worker_id: &WorkerId, err: Error) {
-        if let Some(mut worker) = self.state_manager.inner.workers.remove_worker(worker_id) {
-            self.metrics.workers_evicted.inc();
+    fn immediate_evict_worker(
+        inner_state: &mut MutexGuard<'_, StateManagerImpl>,
+        max_job_retries: usize,
+        metrics: &Metrics,
+        worker_id: &WorkerId,
+        err: Error,
+    ) {
+        if let Some(mut worker) = inner_state.workers.remove_worker(worker_id) {
+            metrics.workers_evicted.inc();
             // We don't care if we fail to send message to worker, this is only a best attempt.
             let _ = worker.notify_update(WorkerUpdate::Disconnect);
             // We create a temporary Vec to avoid doubt about a possible code
             // path touching the worker.running_action_infos elsewhere.
             for action_info in worker.running_action_infos.drain() {
-                self.metrics.workers_evicted_with_running_action.inc();
-                self.retry_action(&action_info, worker_id, err.clone());
+                metrics.workers_evicted_with_running_action.inc();
+                SimpleSchedulerImpl::retry_action(
+                    inner_state,
+                    max_job_retries,
+                    metrics,
+                    &action_info,
+                    worker_id,
+                    err.clone(),
+                );
             }
         }
         // Note: Calling this many time is very cheap, it'll only trigger `do_try_match` once.
-        self.state_manager
-            .inner
-            .tasks_or_workers_change_notify
-            .notify_one();
+        inner_state.tasks_change_notify.notify_one();
     }
 
     /// Sets if the worker is draining or not.
-    fn set_drain_worker(&mut self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error> {
-        let worker = self
-            .state_manager
-            .inner
+    async fn set_drain_worker(
+        &mut self,
+        worker_id: WorkerId,
+        is_draining: bool,
+    ) -> Result<(), Error> {
+        let mut inner_state = self.state_manager.inner.lock().await;
+        let worker = inner_state
             .workers
             .workers
             .get_mut(&worker_id)
             .err_tip(|| format!("Worker {worker_id} doesn't exist in the pool"))?;
         self.metrics.workers_drained.inc();
         worker.is_draining = is_draining;
-        self.state_manager
-            .inner
-            .tasks_or_workers_change_notify
-            .notify_one();
+        inner_state.tasks_change_notify.notify_one();
         Ok(())
     }
 
@@ -297,15 +321,16 @@ impl SimpleSchedulerImpl {
                     };
 
                     let maybe_worker_id: Option<WorkerId> = {
-                        self.state_manager
-                            .inner
+                        let inner_state = self.state_manager.inner.lock().await;
+                        
+                        inner_state
                             .workers
                             .find_worker_for_action(&action_info.platform_properties)
                     };
 
                     let operation_id = state.id.clone();
                     let ret = <StateManager as MatchingEngineStateManager>::update_operation(
-                        &mut self.state_manager,
+                        &self.state_manager,
                         operation_id.clone(),
                         maybe_worker_id,
                         Ok(ActionStage::Executing),
@@ -335,7 +360,7 @@ impl SimpleSchedulerImpl {
         action_stage: Result<ActionStage, Error>,
     ) -> Result<(), Error> {
         let update_operation_result = <StateManager as WorkerStateManager>::update_operation(
-            &mut self.state_manager,
+            &self.state_manager,
             OperationId::new(action_info_hash_key.clone()),
             *worker_id,
             action_stage,
@@ -410,7 +435,7 @@ impl SimpleScheduler {
             max_job_retries = DEFAULT_MAX_JOB_RETRIES;
         }
 
-        let tasks_or_workers_change_notify = Arc::new(Notify::new());
+        let tasks_change_notify = Arc::new(Notify::new());
         let state_manager = StateManager::new(
             HashSet::new(),
             BTreeMap::new(),
@@ -419,7 +444,7 @@ impl SimpleScheduler {
             HashSet::new(),
             Arc::new(SchedulerMetrics::default()),
             max_job_retries,
-            tasks_or_workers_change_notify.clone(),
+            tasks_change_notify.clone(),
         );
         let metrics = Arc::new(Metrics::default());
         let metrics_for_do_try_match = metrics.clone();
@@ -439,7 +464,7 @@ impl SimpleScheduler {
                 async move {
                     // Break out of the loop only when the inner is dropped.
                     loop {
-                        tasks_or_workers_change_notify.notified().await;
+                        tasks_change_notify.notified().await;
                         match weak_inner.upgrade() {
                             // Note: According to `parking_lot` documentation, the default
                             // `Mutex` implementation is eventual fairness, so we don't
@@ -467,13 +492,9 @@ impl SimpleScheduler {
     /// Checks to see if the worker exists in the worker pool. Should only be used in unit tests.
     #[must_use]
     pub async fn contains_worker_for_test(&self, worker_id: &WorkerId) -> bool {
-        let inner = self.get_inner_lock().await;
-        inner
-            .state_manager
-            .inner
-            .workers
-            .workers
-            .contains(worker_id)
+        let inner_scheduler = self.get_inner_lock().await;
+        let inner_state = inner_scheduler.state_manager.inner.lock().await;
+        inner_state.workers.workers.contains(worker_id)
     }
 
     /// A unit test function used to send the keep alive message to the worker from the server.
@@ -481,10 +502,9 @@ impl SimpleScheduler {
         &self,
         worker_id: &WorkerId,
     ) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
-        let worker = inner
-            .state_manager
-            .inner
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        let worker = inner_state
             .workers
             .workers
             .get_mut(worker_id)
@@ -532,24 +552,32 @@ impl ActionScheduler for SimpleScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         let inner = self.get_inner_lock().await;
-        let result = inner
+        let maybe_receiver = inner
             .find_existing_action(unique_qualifier)
+            .and_then(|maybe_action| async {
+                if let Some(action) = maybe_action {
+                    Ok(Some(action))
+                } else {
+                    inner.find_recently_completed_action(unique_qualifier).await
+                }
+            })
             .await
-            .or_else(|| inner.find_recently_completed_action(unique_qualifier));
-        if result.is_some() {
+            .err_tip(|| "Error while finding existing action")?;
+        if maybe_receiver.is_some() {
             self.metrics.existing_actions_found.inc();
         } else {
             self.metrics.existing_actions_not_found.inc();
         }
-        result
+        Ok(maybe_receiver)
     }
 
     async fn clean_recently_completed_actions(&self) {
         self.get_inner_lock()
             .await
-            .clean_recently_completed_actions();
+            .clean_recently_completed_actions()
+            .await;
         self.metrics.clean_recently_completed_actions.inc()
     }
 
@@ -566,22 +594,24 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn add_worker(&self, worker: Worker) -> Result<(), Error> {
         let worker_id = worker.id;
-        let mut inner = self.get_inner_lock().await;
+        let inner_scheduler = self.get_inner_lock().await;
+        let max_job_retries = inner_scheduler.max_job_retries;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
         self.metrics.add_worker.wrap(move || {
-            let res = inner
-                .state_manager
-                .inner
+            let res = inner_state
                 .workers
                 .add_worker(worker)
                 .err_tip(|| "Error while adding worker, removing from pool");
             if let Err(err) = &res {
-                inner.immediate_evict_worker(&worker_id, err.clone());
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    max_job_retries,
+                    &self.metrics,
+                    &worker_id,
+                    err.clone(),
+                );
             }
-            inner
-                .state_manager
-                .inner
-                .tasks_or_workers_change_notify
-                .notify_one();
+            inner_state.tasks_change_notify.notify_one();
             res
         })
     }
@@ -604,37 +634,42 @@ impl WorkerScheduler for SimpleScheduler {
         worker_id: &WorkerId,
         timestamp: WorkerTimestamp,
     ) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
-        inner
-            .state_manager
-            .inner
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        inner_state
             .workers
             .refresh_lifetime(worker_id, timestamp)
             .err_tip(|| "Error refreshing lifetime in worker_keep_alive_received()")
     }
 
     async fn remove_worker(&self, worker_id: WorkerId) {
-        let mut inner = self.get_inner_lock().await;
-        inner.immediate_evict_worker(
+        let inner_scheduler = self.get_inner_lock().await;
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
+        SimpleSchedulerImpl::immediate_evict_worker(
+            &mut inner_state,
+            inner_scheduler.max_job_retries,
+            &inner_scheduler.metrics,
             &worker_id,
             make_err!(Code::Internal, "Received request to remove worker"),
         );
     }
 
     async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error> {
-        let mut inner = self.get_inner_lock().await;
+        let inner_scheduler = self.get_inner_lock().await;
+        let worker_timeout_s = inner_scheduler.worker_timeout_s;
+        let max_job_retries = inner_scheduler.max_job_retries;
+        let metrics = inner_scheduler.metrics.clone();
+        let mut inner_state = inner_scheduler.state_manager.inner.lock().await;
         self.metrics.remove_timedout_workers.wrap(move || {
             // Items should be sorted based on last_update_timestamp, so we don't need to iterate the entire
             // map most of the time.
-            let worker_ids_to_remove: Vec<WorkerId> = inner
-                .state_manager
-                .inner
+            let worker_ids_to_remove: Vec<WorkerId> = inner_state
                 .workers
                 .workers
                 .iter()
                 .rev()
                 .map_while(|(worker_id, worker)| {
-                    if worker.last_update_timestamp <= now_timestamp - inner.worker_timeout_s {
+                    if worker.last_update_timestamp <= now_timestamp - worker_timeout_s {
                         Some(*worker_id)
                     } else {
                         None
@@ -647,7 +682,10 @@ impl WorkerScheduler for SimpleScheduler {
                     ?worker_id,
                     "Worker timed out, removing from pool"
                 );
-                inner.immediate_evict_worker(
+                SimpleSchedulerImpl::immediate_evict_worker(
+                    &mut inner_state,
+                    max_job_retries,
+                    &metrics,
                     worker_id,
                     make_err!(
                         Code::Internal,
@@ -662,7 +700,7 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn set_drain_worker(&self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error> {
         let mut inner = self.get_inner_lock().await;
-        inner.set_drain_worker(worker_id, is_draining)
+        inner.set_drain_worker(worker_id, is_draining).await
     }
 
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {
@@ -676,45 +714,46 @@ impl MetricsComponent for SimpleScheduler {
         self.metrics.gather_metrics(c);
         {
             // We use the raw lock because we dont gather stats about gathering stats.
-            let inner = self.inner.lock_blocking();
-            inner.state_manager.inner.metrics.gather_metrics(c);
+            let inner_scheduler = self.inner.lock_blocking();
+            let inner_state = inner_scheduler.state_manager.inner.lock_blocking();
+            inner_state.metrics.gather_metrics(c);
             c.publish(
                 "queued_actions_total",
-                &inner.state_manager.inner.queued_actions.len(),
+                &inner_state.queued_actions.len(),
                 "The number actions in the queue.",
             );
             c.publish(
                 "workers_total",
-                &inner.state_manager.inner.workers.workers.len(),
+                &inner_state.workers.workers.len(),
                 "The number workers active.",
             );
             c.publish(
                 "active_actions_total",
-                &inner.state_manager.inner.active_actions.len(),
+                &inner_state.active_actions.len(),
                 "The number of running actions.",
             );
             c.publish(
                 "recently_completed_actions_total",
-                &inner.state_manager.inner.recently_completed_actions.len(),
+                &inner_state.recently_completed_actions.len(),
                 "The number of recently completed actions in the buffer.",
             );
             c.publish(
                 "retain_completed_for_seconds",
-                &inner.retain_completed_for,
+                &inner_scheduler.retain_completed_for,
                 "The duration completed actions are retained for.",
             );
             c.publish(
                 "worker_timeout_seconds",
-                &inner.worker_timeout_s,
+                &inner_scheduler.worker_timeout_s,
                 "The configured timeout if workers have not responded for a while.",
             );
             c.publish(
                 "max_job_retries",
-                &inner.max_job_retries,
+                &inner_scheduler.max_job_retries,
                 "The amount of times a job is allowed to retry from an internal error before it is dropped.",
             );
             let mut props = HashMap::<&String, u64>::new();
-            for (_worker_id, worker) in inner.state_manager.inner.workers.workers.iter() {
+            for (_worker_id, worker) in inner_state.workers.workers.iter() {
                 c.publish_with_labels(
                     "workers",
                     worker,
@@ -735,7 +774,7 @@ impl MetricsComponent for SimpleScheduler {
                     format!("Total sum of available properties for {property}"),
                 );
             }
-            for (_, active_action) in inner.state_manager.inner.active_actions.iter() {
+            for (_, active_action) in inner_state.active_actions.iter() {
                 let action_name = active_action
                     .action_info
                     .unique_qualifier

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -118,9 +118,9 @@ async fn find_existing_action_call_passed() -> Result<(), Error> {
     };
     let (actual_result, actual_action_name) = join!(
         context.cache_scheduler.find_existing_action(&action_name),
-        context.mock_scheduler.expect_find_existing_action(None),
+        context.mock_scheduler.expect_find_existing_action(Ok(None)),
     );
-    assert_eq!(true, actual_result.is_none());
+    assert_eq!(true, actual_result.unwrap().is_none());
     assert_eq!(action_name, actual_action_name);
     Ok(())
 }

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -251,9 +251,9 @@ async fn find_existing_action_call_passed() -> Result<(), Error> {
         context
             .modifier_scheduler
             .find_existing_action(&action_name),
-        context.mock_scheduler.expect_find_existing_action(None),
+        context.mock_scheduler.expect_find_existing_action(Ok(None)),
     );
-    assert_eq!(true, actual_result.is_none());
+    assert_eq!(true, actual_result.unwrap().is_none());
     assert_eq!(action_name, actual_action_name);
     Ok(())
 }

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -1003,6 +1003,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(client_rx.borrow_and_update().stage, ActionStage::Executing);
     }
+    let _ = setup_new_worker(&scheduler, rogue_worker_id, PlatformProperties::default()).await?;
 
     let action_info_hash_key = ActionInfoHashKey {
         instance_name: INSTANCE_NAME.to_string(),
@@ -1043,8 +1044,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         .await;
 
     {
-        const EXPECTED_ERR: &str =
-            "Got a result from a worker that should not be running the action";
+        const EXPECTED_ERR: &str = "should not be running on worker";
         // Our request should have sent an error back.
         assert!(
             update_action_result.is_err(),
@@ -1503,10 +1503,13 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
                     output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
                 },
                 server_logs: HashMap::default(),
-                error: Some(err.merge(make_err!(
-                    Code::Internal,
-                    "Job cancelled because it attempted to execute too many times and failed"
-                ))),
+                error: Some(
+                    err.append("in update_operation on SimpleSchedulerImpl::update_action")
+                        .merge(make_err!(
+                        Code::Internal,
+                        "Job cancelled because it attempted to execute too many times and failed"
+                    )),
+                ),
                 message: String::new(),
             }),
         };

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -179,7 +179,8 @@ async fn find_executing_action() -> Result<(), Error> {
     let mut client_rx = scheduler
         .find_existing_action(&unique_qualifier)
         .await
-        .err_tip(|| "Action not found")?;
+        .expect("Action not found")
+        .unwrap();
 
     {
         // Worker should have been sent an execute command.
@@ -955,7 +956,8 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
     let mut client_rx = scheduler
         .find_existing_action(&unique_qualifier)
         .await
-        .err_tip(|| "Action not found")?;
+        .unwrap()
+        .expect("Action not found");
     {
         // Client should get notification saying it has been completed.
         let action_state = client_rx.borrow_and_update();

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -31,7 +31,7 @@ enum ActionSchedulerCalls {
 enum ActionSchedulerReturns {
     GetPlatformPropertyManager(Result<Arc<PlatformPropertyManager>, Error>),
     AddAction(Result<watch::Receiver<Arc<ActionState>>, Error>),
-    FindExistingAction(Option<watch::Receiver<Arc<ActionState>>>),
+    FindExistingAction(Result<Option<watch::Receiver<Arc<ActionState>>>, Error>),
 }
 
 pub struct MockActionScheduler {
@@ -100,7 +100,7 @@ impl MockActionScheduler {
 
     pub async fn expect_find_existing_action(
         &self,
-        result: Option<watch::Receiver<Arc<ActionState>>>,
+        result: Result<Option<watch::Receiver<Arc<ActionState>>>, Error>,
     ) -> ActionInfoHashKey {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::FindExistingAction(req) = rx_call_lock
@@ -161,7 +161,7 @@ impl ActionScheduler for MockActionScheduler {
     async fn find_existing_action(
         &self,
         unique_qualifier: &ActionInfoHashKey,
-    ) -> Option<watch::Receiver<Arc<ActionState>>> {
+    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
         self.tx_call
             .send(ActionSchedulerCalls::FindExistingAction(
                 unique_qualifier.clone(),

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -253,6 +253,7 @@ impl ExecutionServer {
             .scheduler
             .find_existing_action(&operation_id.unique_qualifier)
             .await
+            .err_tip(|| "Error running find_existing_action in ExecutionServer::wait_execution")?
         else {
             return Err(Status::not_found("Failed to find existing task"));
         };


### PR DESCRIPTION
Worker logic should not be visible to StateManager just yet. In the
future this will likely change, but for this phase of the refactor
SimpleScheduler should own all information about workers.

towards: #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1065)
<!-- Reviewable:end -->
