### PR TITLE
Make bytestream limits configurable

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -139,9 +139,14 @@ pub struct ByteStreamConfig {
     /// According to <https://github.com/grpc/grpc.github.io/issues/371>
     /// 16KiB - 64KiB is optimal.
     ///
+    /// TODO(marcussorealheis) in the config tests, include a defined max_bytes_per_stream.
     /// Defaults: 64KiB
     #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
     pub max_bytes_per_stream: usize,
+
+    /// Used when the config specifies a maximum number of bytes to decode on each grpc stream chunk.
+    #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
+    pub max_decoding_message_size: usize,
 
     /// In the event a client disconnects while uploading a blob, we will hold
     /// the internal stream open for this many seconds before closing it.


### PR DESCRIPTION
# Description

I can imagine there are lots of use cases "where a simple rule can generate lots of stdout." @ltekieli pointed out this issue and shared a patch for how it could be fixed. I copied it and added a test to ensure that the configured limit is enforced.  

I may need to figure out how to document this change better. Please advise. 

Fixes #1070 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1076)
<!-- Reviewable:end -->
