### PR TITLE
Fixed the docs and removed errant TODO

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -139,12 +139,13 @@ pub struct ByteStreamConfig {
     /// According to <https://github.com/grpc/grpc.github.io/issues/371>
     /// 16KiB - 64KiB is optimal.
     ///
-    /// TODO(marcussorealheis) in the config tests, include a defined max_bytes_per_stream.
+    ///
     /// Defaults: 64KiB
     #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
     pub max_bytes_per_stream: usize,
 
-    /// Used when the config specifies a maximum number of bytes to decode on each grpc stream chunk.
+    /// Maximum number of bytes to decode on each grpc stream chunk.
+    /// Defaults: 4 MiB
     #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
     pub max_decoding_message_size: usize,
 


### PR DESCRIPTION
# Description

Removes a TODO from our docs. 

Fixes #1084 

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1085)
<!-- Reviewable:end -->
