### PR TITLE
ActionScheduler will now use ActionListener instead of tokio::watch

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
     srcs = [
         "src/action_scheduler.rs",
         "src/cache_lookup_scheduler.rs",
+        "src/default_action_listener.rs",
         "src/default_scheduler_factory.rs",
         "src/grpc_scheduler.rs",
         "src/lib.rs",

--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -12,15 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::Future;
 use nativelink_error::Error;
 use nativelink_util::action_messages::{ActionInfo, ActionState, ClientOperationId};
 use nativelink_util::metrics_utils::Registry;
-use tokio::sync::watch;
 
 use crate::platform_property_manager::PlatformPropertyManager;
+
+/// ActionListener interface is responsible for interfacing with clients
+/// that are interested in the state of an action.
+pub trait ActionListener: Sync + Send + Unpin {
+    /// Returns the client operation id.
+    fn client_operation_id(&self) -> &ClientOperationId;
+
+    /// Returns the current action state.
+    fn action_state(&self) -> Arc<ActionState>;
+
+    /// Waits for the action state to change.
+    fn changed(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + Sync + '_>>;
+}
 
 /// ActionScheduler interface is responsible for interactions between the scheduler
 /// and action related operations.
@@ -37,13 +53,13 @@ pub trait ActionScheduler: Sync + Send + Unpin {
         &self,
         client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Result<(ClientOperationId, watch::Receiver<Arc<ActionState>>), Error>;
+    ) -> Result<Pin<Box<dyn ActionListener>>, Error>;
 
     /// Find an existing action by its name.
     async fn find_by_client_operation_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error>;
+    ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error>;
 
     /// Cleans up the cache of recently completed actions.
     async fn clean_recently_completed_actions(&self);

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -13,21 +13,19 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::future::Shared as SharedFuture;
-use futures::stream::StreamExt;
-use futures::FutureExt;
-use nativelink_error::{make_err, Code, Error};
+use futures::Future;
+use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::{
     ActionResult as ProtoActionResult, GetActionResultRequest,
 };
 use nativelink_store::ac_utils::get_and_decode_digest;
 use nativelink_store::grpc_store::GrpcStore;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ClientOperationId,
-    OperationId,
+    ActionInfo, ActionInfoHashKey, ActionStage, ActionState, ClientOperationId, OperationId,
 };
 use nativelink_util::background_spawn;
 use nativelink_util::common::DigestInfo;
@@ -35,28 +33,22 @@ use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::{Store, StoreLike};
 use parking_lot::{Mutex, MutexGuard};
 use scopeguard::guard;
-use tokio::select;
-use tokio::sync::{oneshot, watch};
-use tokio_stream::wrappers::WatchStream;
+use tokio::sync::oneshot;
 use tonic::Request;
 use tracing::{event, Level};
 
-use crate::action_scheduler::ActionScheduler;
+use crate::action_scheduler::{ActionListener, ActionScheduler};
 use crate::platform_property_manager::PlatformPropertyManager;
-
-/// A future containing the resolved `ClientOperationId` once it is figured out.
-/// This future may be cloned and will always yield the same value once resolved.
-type ClientOperationIdFuture = SharedFuture<oneshot::Receiver<ClientOperationId>>;
 
 /// Actions that are having their cache checked or failed cache lookup and are
 /// being forwarded upstream.  Missing the skip_cache_check actions which are
 /// forwarded directly.
 type CheckActions = HashMap<
     ActionInfoHashKey,
-    (
-        SharedFuture<oneshot::Receiver<ClientOperationId>>,
-        watch::Receiver<Arc<ActionState>>,
-    ),
+    Vec<(
+        ClientOperationId,
+        oneshot::Sender<Result<Pin<Box<dyn ActionListener>>, Error>>,
+    )>,
 >;
 
 pub struct CacheLookupScheduler {
@@ -67,7 +59,7 @@ pub struct CacheLookupScheduler {
     /// in the action cache.
     action_scheduler: Arc<dyn ActionScheduler>,
     /// Actions that are currently performing a CacheCheck.
-    cache_check_actions: Arc<Mutex<CheckActions>>,
+    inflight_cache_checks: Arc<Mutex<CheckActions>>,
 }
 
 async fn get_action_from_store(
@@ -98,17 +90,41 @@ async fn get_action_from_store(
     }
 }
 
+/// Future for when ActionListeners are known.
+type ActionListenerOneshot = oneshot::Receiver<Result<Pin<Box<dyn ActionListener>>, Error>>;
+
 fn subscribe_to_existing_action(
-    cache_check_actions: &MutexGuard<CheckActions>,
+    inflight_cache_checks: &mut MutexGuard<CheckActions>,
     unique_qualifier: &ActionInfoHashKey,
-) -> Option<(ClientOperationIdFuture, watch::Receiver<Arc<ActionState>>)> {
-    cache_check_actions
-        .get(unique_qualifier)
-        .map(|(client_operation_id_rx, rx)| {
-            let mut rx = rx.clone();
-            rx.mark_changed();
-            (client_operation_id_rx.clone(), rx)
+    client_operation_id: &ClientOperationId,
+) -> Option<ActionListenerOneshot> {
+    inflight_cache_checks
+        .get_mut(unique_qualifier)
+        .map(|oneshots| {
+            let (tx, rx) = oneshot::channel();
+            oneshots.push((client_operation_id.clone(), tx));
+            rx
         })
+}
+struct CachedActionListener {
+    client_operation_id: ClientOperationId,
+    action_state: Arc<ActionState>,
+}
+
+impl ActionListener for CachedActionListener {
+    fn client_operation_id(&self) -> &ClientOperationId {
+        &self.client_operation_id
+    }
+
+    fn action_state(&self) -> Arc<ActionState> {
+        self.action_state.clone()
+    }
+
+    fn changed(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + Sync + '_>> {
+        Box::pin(async { Ok(self.action_state.clone()) })
+    }
 }
 
 impl CacheLookupScheduler {
@@ -116,7 +132,7 @@ impl CacheLookupScheduler {
         Ok(Self {
             ac_store,
             action_scheduler,
-            cache_check_actions: Default::default(),
+            inflight_cache_checks: Default::default(),
         })
     }
 }
@@ -136,7 +152,7 @@ impl ActionScheduler for CacheLookupScheduler {
         &self,
         client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Result<(ClientOperationId, watch::Receiver<Arc<ActionState>>), Error> {
+    ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         if action_info.skip_cache_lookup {
             // Cache lookup skipped, forward to the upstream.
             return self
@@ -144,77 +160,85 @@ impl ActionScheduler for CacheLookupScheduler {
                 .add_action(client_operation_id, action_info)
                 .await;
         }
-        let mut current_state = Arc::new(ActionState {
-            id: OperationId::new(action_info.unique_qualifier.clone()),
-            stage: ActionStage::CacheCheck,
-        });
         let cache_check_result = {
             // Check this isn't a duplicate request first.
-            let mut cache_check_actions = self.cache_check_actions.lock();
-            let current_state = current_state.clone();
+            let mut inflight_cache_checks = self.inflight_cache_checks.lock();
             let unique_qualifier = action_info.unique_qualifier.clone();
-            subscribe_to_existing_action(&cache_check_actions, &unique_qualifier).ok_or_else(
-                move || {
-                    let (client_operation_id_tx, client_operation_id_rx) = oneshot::channel();
-                    let client_operation_id_rx = client_operation_id_rx.shared();
-                    let (tx, rx) = watch::channel(current_state);
-                    cache_check_actions.insert(
-                        unique_qualifier.clone(),
-                        (client_operation_id_rx.clone(), rx),
-                    );
-                    // In the event we loose the reference to our `scope_guard`, it will remove
-                    // the action from the cache_check_actions map.
-                    let cache_check_actions = self.cache_check_actions.clone();
-                    (
-                        client_operation_id_tx,
-                        client_operation_id_rx,
-                        tx,
-                        guard((), move |_| {
-                            cache_check_actions.lock().remove(&unique_qualifier);
-                        }),
-                    )
-                },
+            subscribe_to_existing_action(
+                &mut inflight_cache_checks,
+                &unique_qualifier,
+                &client_operation_id,
             )
+            .ok_or_else(move || {
+                let (action_listener_tx, action_listener_rx) = oneshot::channel();
+                inflight_cache_checks.insert(
+                    unique_qualifier.clone(),
+                    vec![(client_operation_id, action_listener_tx)],
+                );
+                // In the event we loose the reference to our `scope_guard`, it will remove
+                // the action from the inflight_cache_checks map.
+                let inflight_cache_checks = self.inflight_cache_checks.clone();
+                (
+                    action_listener_rx,
+                    guard((), move |_| {
+                        inflight_cache_checks.lock().remove(&unique_qualifier);
+                    }),
+                )
+            })
         };
-        let (client_operation_id_tx, client_operation_id_rx, tx, scope_guard) =
-            match cache_check_result {
-                Ok((client_operation_id_tx, rx)) => {
-                    let client_operation_id = client_operation_id_tx.await.map_err(|_| {
-                        make_err!(
-                            Code::Internal,
-                            "Client operation id tx hung up in CacheLookupScheduler::add_action"
-                        )
-                    })?;
-                    return Ok((client_operation_id, rx));
-                }
-                Err(client_tx_and_scope_guard) => client_tx_and_scope_guard,
-            };
-        let rx = tx.subscribe();
+        let (action_listener_rx, scope_guard) = match cache_check_result {
+            Ok(action_listener_fut) => {
+                let action_listener = action_listener_fut.await.map_err(|_| {
+                    make_err!(
+                        Code::Internal,
+                        "ActionListener tx hung up in CacheLookupScheduler::add_action"
+                    )
+                })?;
+                return action_listener;
+            }
+            Err(client_tx_and_scope_guard) => client_tx_and_scope_guard,
+        };
 
         let ac_store = self.ac_store.clone();
         let action_scheduler = self.action_scheduler.clone();
-        let client_operation_id_clone = client_operation_id.clone();
+        let inflight_cache_checks = self.inflight_cache_checks.clone();
         // We need this spawn because we are returning a stream and this spawn will populate the stream's data.
         background_spawn!("cache_lookup_scheduler_add_action", async move {
-            // If our spawn ever dies, we will remove the action from the cache_check_actions map.
+            // If our spawn ever dies, we will remove the action from the inflight_cache_checks map.
             let _scope_guard = scope_guard;
 
             // Perform cache check.
-            let action_digest = current_state.action_digest();
-            let instance_name = action_info.instance_name().clone();
+            let instance_name = action_info.unique_qualifier.instance_name.clone();
             if let Some(action_result) = get_action_from_store(
                 &ac_store,
-                *action_digest,
+                action_info.unique_qualifier.digest,
                 instance_name,
-                current_state.id.unique_qualifier.digest_function,
+                action_info.unique_qualifier.digest_function,
             )
             .await
             {
-                match ac_store.has(*action_digest).await {
+                match ac_store.has(action_info.unique_qualifier.digest).await {
                     Ok(Some(_)) => {
-                        Arc::make_mut(&mut current_state).stage =
-                            ActionStage::CompletedFromCache(action_result);
-                        let _ = tx.send(current_state);
+                        let maybe_pending_txs = {
+                            let mut inflight_cache_checks = inflight_cache_checks.lock();
+                            // We are ready to resolve the in-flight actions. We remove the
+                            // in-flight actions from the map.
+                            inflight_cache_checks.remove(&action_info.unique_qualifier)
+                        };
+                        let Some(pending_txs) = maybe_pending_txs else {
+                            return; // Nobody is waiting for this action anymore.
+                        };
+                        let action_state = Arc::new(ActionState {
+                            id: OperationId::new(action_info.unique_qualifier.clone()),
+                            stage: ActionStage::CompletedFromCache(action_result),
+                        });
+                        for (client_operation_id, pending_tx) in pending_txs {
+                            // Ignore errors here, as the other end may have hung up.
+                            let _ = pending_tx.send(Ok(Box::pin(CachedActionListener {
+                                client_operation_id,
+                                action_state: action_state.clone(),
+                            })));
+                        }
                         return;
                     }
                     Err(err) => {
@@ -227,52 +251,39 @@ impl ActionScheduler for CacheLookupScheduler {
                     _ => {}
                 }
             }
-            // Not in cache, forward to upstream and proxy state.
-            match action_scheduler
-                .add_action(client_operation_id_clone, action_info)
-                .await
-            {
-                Ok((new_client_operation_id, rx)) => {
-                    // It's ok if the other end hung up, just keep going just
-                    // in case they come back.
-                    let _ = client_operation_id_tx.send(new_client_operation_id);
-                    let mut watch_stream = WatchStream::new(rx);
-                    loop {
-                        select!(
-                            Some(action_state) = watch_stream.next() => {
-                                if tx.send(action_state).is_err() {
-                                    break;
-                                }
-                            }
-                            _ = tx.closed() => {
-                                break;
-                            }
-                        )
-                    }
-                }
-                Err(err) => {
-                    Arc::make_mut(&mut current_state).stage =
-                        ActionStage::Completed(ActionResult {
-                            error: Some(err),
-                            ..Default::default()
-                        });
-                    let _ = tx.send(current_state);
-                }
+
+            let maybe_pending_txs = {
+                let mut inflight_cache_checks = inflight_cache_checks.lock();
+                inflight_cache_checks.remove(&action_info.unique_qualifier)
+            };
+            let Some(pending_txs) = maybe_pending_txs else {
+                return; // Noone is waiting for this action anymore.
+            };
+
+            for (client_operation_id, pending_tx) in pending_txs {
+                // Ignore errors here, as the other end may have hung up.
+                let _ = pending_tx.send(
+                    action_scheduler
+                        .add_action(client_operation_id, action_info.clone())
+                        .await,
+                );
             }
         });
-        let client_operation_id = client_operation_id_rx.await.map_err(|_| {
-            make_err!(
-                Code::Internal,
-                "Client operation id tx hung up in CacheLookupScheduler::add_action"
-            )
-        })?;
-        Ok((client_operation_id, rx))
+        action_listener_rx
+            .await
+            .map_err(|_| {
+                make_err!(
+                    Code::Internal,
+                    "ActionListener tx hung up in CacheLookupScheduler::add_action"
+                )
+            })?
+            .err_tip(|| "In CacheLookupScheduler::add_action")
     }
 
     async fn find_by_client_operation_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
+    ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error> {
         self.action_scheduler
             .find_by_client_operation_id(client_operation_id)
             .await

--- a/nativelink-scheduler/src/default_action_listener.rs
+++ b/nativelink-scheduler/src/default_action_listener.rs
@@ -1,0 +1,80 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::Future;
+use nativelink_error::{make_err, Code, Error};
+use nativelink_util::action_messages::{ActionState, ClientOperationId};
+use tokio::sync::watch;
+
+use crate::action_scheduler::ActionListener;
+
+/// Simple implementation of ActionListener using tokio's watch.
+pub struct DefaultActionListener {
+    client_operation_id: ClientOperationId,
+    action_state: watch::Receiver<Arc<ActionState>>,
+}
+
+impl DefaultActionListener {
+    pub fn new(
+        client_operation_id: ClientOperationId,
+        mut action_state: watch::Receiver<Arc<ActionState>>,
+    ) -> Self {
+        action_state.mark_changed();
+        Self {
+            client_operation_id,
+            action_state,
+        }
+    }
+}
+
+impl ActionListener for DefaultActionListener {
+    fn client_operation_id(&self) -> &ClientOperationId {
+        &self.client_operation_id
+    }
+
+    fn action_state(&self) -> Arc<ActionState> {
+        self.action_state.borrow().clone()
+    }
+
+    fn changed(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + Sync + '_>> {
+        Box::pin(async move {
+            self.action_state.changed().await.map_or_else(
+                |e| {
+                    Err(make_err!(
+                        Code::Internal,
+                        "Sender of ActionState went away unexpectedly - {e:?}"
+                    ))
+                },
+                |()| Ok(self.action_state.borrow_and_update().clone()),
+            )
+        })
+    }
+}
+
+impl Clone for DefaultActionListener {
+    /// Clones the current action state and marks the receiver as changed.
+    fn clone(&self) -> Self {
+        let mut action_state = self.action_state.clone();
+        action_state.mark_changed();
+        Self {
+            client_operation_id: self.client_operation_id.clone(),
+            action_state,
+        }
+    }
+}

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod action_scheduler;
 pub mod cache_lookup_scheduler;
+pub mod default_action_listener;
 pub mod default_scheduler_factory;
 pub mod grpc_scheduler;
 pub mod operation_state_manager;

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -19,17 +19,18 @@ use async_trait::async_trait;
 use futures::{Future, Stream};
 use nativelink_error::{Error, ResultExt};
 use nativelink_util::action_messages::{
-    ActionInfo, ActionStage, ActionState, ClientOperationId, OperationId, WorkerId,
+    ActionInfo, ActionStage, ClientOperationId, OperationId, WorkerId,
 };
 use nativelink_util::metrics_utils::Registry;
 use nativelink_util::spawn;
 use nativelink_util::task::JoinHandleDropGuard;
-use tokio::sync::{watch, Notify};
+use tokio::sync::Notify;
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
 use tracing::{event, Level};
 
-use crate::action_scheduler::ActionScheduler;
+use crate::action_scheduler::{ActionListener, ActionScheduler};
+use crate::default_action_listener::DefaultActionListener;
 use crate::operation_state_manager::{
     ActionStateResult, ClientStateManager, MatchingEngineStateManager, OperationFilter,
     OperationStageFlags,
@@ -83,7 +84,7 @@ impl SimpleScheduler {
         &self,
         client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Result<(ClientOperationId, watch::Receiver<Arc<ActionState>>), Error> {
+    ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         let add_action_result = self
             .client_state_manager
             .add_action(client_operation_id.clone(), action_info)
@@ -91,7 +92,12 @@ impl SimpleScheduler {
         add_action_result
             .as_receiver()
             .await
-            .map(move |receiver| (client_operation_id, receiver.into_owned()))
+            .map(move |receiver| -> Pin<Box<dyn ActionListener>> {
+                Box::pin(DefaultActionListener::new(
+                    client_operation_id,
+                    receiver.into_owned(),
+                ))
+            })
     }
 
     async fn clean_recently_completed_actions(&self) {
@@ -110,7 +116,7 @@ impl SimpleScheduler {
     async fn find_by_client_operation_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
+    ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error> {
         let filter_result = self
             .client_state_manager
             .filter_operations(&OperationFilter {
@@ -124,13 +130,14 @@ impl SimpleScheduler {
         let Some(result) = stream.next().await else {
             return Ok(None);
         };
-        Ok(Some(
+        Ok(Some(Box::pin(DefaultActionListener::new(
+            client_operation_id.clone(),
             result
                 .as_receiver()
                 .await
                 .err_tip(|| "In SimpleScheduler::find_by_client_operation_id getting receiver")?
                 .into_owned(),
-        ))
+        ))))
     }
 
     async fn get_queued_operations(
@@ -326,14 +333,14 @@ impl ActionScheduler for SimpleScheduler {
         &self,
         client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Result<(ClientOperationId, watch::Receiver<Arc<ActionState>>), Error> {
+    ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         self.add_action(client_operation_id, action_info).await
     }
 
     async fn find_by_client_operation_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> Result<Option<watch::Receiver<Arc<ActionState>>>, Error> {
+    ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error> {
         let maybe_receiver = self
             .find_by_client_operation_id(client_operation_id)
             .await

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -27,6 +27,7 @@ use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::cache_lookup_scheduler::CacheLookupScheduler;
+use nativelink_scheduler::default_action_listener::DefaultActionListener;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::action_messages::{
@@ -105,7 +106,10 @@ async fn add_action_handles_skip_cache() -> Result<(), Error> {
             .add_action(client_operation_id.clone(), skip_cache_action),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id, forward_watch_channel_rx)))
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id,
+                forward_watch_channel_rx
+            ))))
     );
     Ok(())
 }

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -26,6 +26,7 @@ use nativelink_config::schedulers::{PlatformPropertyAddition, PropertyModificati
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_scheduler::action_scheduler::ActionScheduler;
+use nativelink_scheduler::default_action_listener::DefaultActionListener;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
 use nativelink_util::action_messages::{
@@ -88,7 +89,10 @@ async fn add_action_adds_property() -> Result<(), Error> {
             .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id.clone(), forward_watch_channel_rx))),
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id.clone(),
+                forward_watch_channel_rx
+            )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
@@ -132,7 +136,10 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
             .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id.clone(), forward_watch_channel_rx))),
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id.clone(),
+                forward_watch_channel_rx
+            )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
@@ -173,7 +180,10 @@ async fn add_action_property_added_after_remove() -> Result<(), Error> {
             .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id.clone(), forward_watch_channel_rx))),
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id.clone(),
+                forward_watch_channel_rx
+            )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
@@ -214,7 +224,10 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
             .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id.clone(), forward_watch_channel_rx))),
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id.clone(),
+                forward_watch_channel_rx
+            )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
@@ -250,7 +263,10 @@ async fn add_action_property_remove() -> Result<(), Error> {
             .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
-            .expect_add_action(Ok((client_operation_id.clone(), forward_watch_channel_rx))),
+            .expect_add_action(Ok(Box::pin(DefaultActionListener::new(
+                client_operation_id.clone(),
+                forward_watch_channel_rx
+            )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(


### PR DESCRIPTION
This will enable the underlying scheduler to intercept the Drop call allowing easier cleanups of actively listened actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1091)
<!-- Reviewable:end -->
