### PR TITLE
StateManager can now be notified of noone listeneing

### DIFF
--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -29,13 +29,10 @@ pub trait ActionListener: Sync + Send + Unpin {
     /// Returns the client operation id.
     fn client_operation_id(&self) -> &ClientOperationId;
 
-    /// Returns the current action state.
-    fn action_state(&self) -> Arc<ActionState>;
-
     /// Waits for the action state to change.
     fn changed(
         &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + Sync + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + '_>>;
 }
 
 /// ActionScheduler interface is responsible for interactions between the scheduler

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -116,13 +116,9 @@ impl ActionListener for CachedActionListener {
         &self.client_operation_id
     }
 
-    fn action_state(&self) -> Arc<ActionState> {
-        self.action_state.clone()
-    }
-
     fn changed(
         &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + Sync + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<ActionState>, Error>> + Send + '_>> {
         Box::pin(async { Ok(self.action_state.clone()) })
     }
 }

--- a/nativelink-scheduler/src/scheduler_state/client_action_state_result.rs
+++ b/nativelink-scheduler/src/scheduler_state/client_action_state_result.rs
@@ -47,6 +47,6 @@ impl ActionStateResult for ClientActionStateResult {
     }
 
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
-        unimplemented!()
+        todo!()
     }
 }

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -393,14 +393,14 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client2_action_listener.action_state();
+        let action_state = client1_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client2_action_listener.action_state();
+        let action_state = client2_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -165,7 +165,7 @@ pub struct ExecutionServer {
     instance_infos: HashMap<InstanceName, InstanceInfo>,
 }
 
-type ExecuteStream = Pin<Box<dyn Stream<Item = Result<Operation, Status>> + Send + Sync + 'static>>;
+type ExecuteStream = Pin<Box<dyn Stream<Item = Result<Operation, Status>> + Send + 'static>>;
 
 impl ExecutionServer {
     pub fn new(


### PR DESCRIPTION
ActionStateResult is now wired up to ActionListener allowing it to be notified of Drop calls. This will be used to do client operation id cleanups.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1093)
<!-- Reviewable:end -->
