### PR TITLE
Allow Tekton pipelines to be triggered by Flux Alerts

### DIFF
--- a/deployment-examples/chromium/01_operations.sh
+++ b/deployment-examples/chromium/01_operations.sh
@@ -6,17 +6,17 @@ set -xeuo pipefail
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#image"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#image"}}' \
     localhost:8082/eventlistener
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#nativelink-worker-init"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#nativelink-worker-init"}}' \
     localhost:8082/eventlistener
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#nativelink-worker-siso-chromium"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#nativelink-worker-siso-chromium"}}' \
     localhost:8082/eventlistener
 
 until kubectl get pipelinerun \

--- a/deployment-examples/kubernetes/01_operations.sh
+++ b/deployment-examples/kubernetes/01_operations.sh
@@ -6,17 +6,17 @@ set -xeuo pipefail
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#image"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#image"}}' \
     localhost:8082/eventlistener
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#nativelink-worker-init"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#nativelink-worker-init"}}' \
     localhost:8082/eventlistener
 
 curl -v \
     -H 'content-Type: application/json' \
-    -d '{"flakeOutput": "./src_root#nativelink-worker-lre-cc"}' \
+    -d '{"metadata": {"flakeOutput": "./src_root#nativelink-worker-lre-cc"}}' \
     localhost:8082/eventlistener
 
 until kubectl get pipelinerun \

--- a/native-cli/components/embedded/trigger.yaml
+++ b/native-cli/components/embedded/trigger.yaml
@@ -57,7 +57,7 @@ metadata:
 spec:
   params:
     - name: flakeOutput
-      value: "$(body.flakeOutput)"
+      value: "$(body.metadata.flakeOutput)"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The `eventMetadata` field in Flux Alerts is of the form:

```yaml
eventMetadata:
  key: value
```

When such an Alert triggers, the corresponding Provider will send a JSON like `{"metadata": {"key": "value"}}` to the Provider's address. This commit makes the Tekton Eventlistener compatible with this pattern.

Part of preparations for the NativeLink operator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1094)
<!-- Reviewable:end -->
