### PR TITLE
Allow WebSocket upgrades in devcluster Loadbalancer

### DIFF
--- a/native-cli/components/embedded/envoy.template.yaml
+++ b/native-cli/components/embedded/envoy.template.yaml
@@ -32,6 +32,8 @@ static_resources:
                         {{- end }}
                 http_filters:
                   - name: envoy.filters.http.router
+                upgrade_configs:
+                  - upgrade_type: websocket
     {{- end }}
   clusters:
     {{- range .InternalGateways }}


### PR DESCRIPTION
Some dashboards like Capacitor require this to properly stream Logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1098)
<!-- Reviewable:end -->
