### PR TITLE
Write Tekton image tag outputs to a ConfigMap

### DIFF
--- a/native-cli/components/embedded/kustomization.yaml
+++ b/native-cli/components/embedded/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - skopeo-check-hashlocked-url.yaml
   - nix2container-image-info.yaml
   - trigger.yaml
+  - update-image-tags.yaml
   # - nativelink-gateways.yaml  # Gateways are handled in Pulumi via the
                                 # NativeLinkGateways resource.

--- a/native-cli/components/embedded/rebuild-nativelink.yaml
+++ b/native-cli/components/embedded/rebuild-nativelink.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: rebuild-nativelink
@@ -163,3 +163,15 @@ spec:
         - input: "$(tasks.check-hashlocked-url.results.exists)"
           operator: notin
           values: ["true"]
+
+    - name: update-image-tags
+      taskRef:
+        name: update-image-tags
+      params:
+        - name: imageName
+          value: "$(tasks.get-image-info.results.imageName)"
+        - name: imageTag
+          value: "$(tasks.get-image-info.results.imageTag)"
+      runAfter:
+        - copy-verified-prebuilt-image
+        - copy-nix-built-image

--- a/native-cli/components/embedded/trigger.yaml
+++ b/native-cli/components/embedded/trigger.yaml
@@ -1,4 +1,34 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: configmap-updater
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-updater
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-updater-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: configmap-updater
+    namespace: default
+roleRef:
+  kind: Role
+  name: configmap-updater
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
@@ -29,6 +59,9 @@ spec:
       metadata:
         generateName: rebuild-nativelink-run-
       spec:
+        taskRunSpecs:
+          - pipelineTaskName: update-image-tags
+            taskServiceAccountName: configmap-updater
         pipelineRef:
           name: rebuild-nativelink
         workspaces:

--- a/native-cli/components/embedded/update-image-tags.yaml
+++ b/native-cli/components/embedded/update-image-tags.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: update-image-tags
+  labels:
+    app.kubernetes.io/versions: "0.1"
+spec:
+  description: >
+    Update or add image tags in a ConfigMap.
+
+    Note: This task requires running under a ServiceAccount that has permissions
+    to "get", "patch" and "create" configmaps.
+  params:
+    - name: imageName
+    - name: imageTag
+  steps:
+    - name: update-configmap
+      image: bitnami/kubectl
+      env:
+        - name: CM_NAME
+          value: "nativelink-image-tags"
+      script: |
+        #!/bin/bash
+        set -e
+
+        # Transform the key to a format that flux accepts. The transformation
+        # here looks like `nativelink-worker` -> `NATIVELINK_WORKER_TAG`.
+        TRANSFORMED_KEY=$(echo "$(params.imageName)" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_TAG
+
+        # Check if the ConfigMap exists
+        if kubectl get configmap $CM_NAME &>/dev/null; then
+          # ConfigMap exists, update it
+          kubectl patch configmap $CM_NAME --type=json -p='[{"op": "add", "path": "/data/'$TRANSFORMED_KEY'", "value": "$(params.imageTag)"}]'
+        else
+          # ConfigMap doesn't exist, create it
+          kubectl create configmap $CM_NAME --from-literal=$TRANSFORMED_KEY=$(params.imageTag)
+        fi


### PR DESCRIPTION
This allows watching the `nativelink-image-tags` configmap to detect changes to the images running in the cluster.

Preparation for the NativeLink operator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1100)
<!-- Reviewable:end -->
