### PR TITLE
StateManager will now cleanup actions on client disconnect

### DIFF
--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -58,9 +58,6 @@ pub trait ActionScheduler: Sync + Send + Unpin {
         client_operation_id: &ClientOperationId,
     ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error>;
 
-    /// Cleans up the cache of recently completed actions.
-    async fn clean_recently_completed_actions(&self);
-
     /// Register the metrics for the action scheduler.
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {}
 }

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -284,6 +284,4 @@ impl ActionScheduler for CacheLookupScheduler {
             .find_by_client_operation_id(client_operation_id)
             .await
     }
-
-    async fn clean_recently_completed_actions(&self) {}
 }

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -313,6 +313,4 @@ impl ActionScheduler for GrpcScheduler {
             }
         }
     }
-
-    async fn clean_recently_completed_actions(&self) {}
 }

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -126,10 +126,6 @@ impl ActionScheduler for PropertyModifierScheduler {
             .await
     }
 
-    async fn clean_recently_completed_actions(&self) {
-        self.scheduler.clean_recently_completed_actions().await
-    }
-
     // Register metrics for the underlying ActionScheduler.
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         let scheduler_registry = registry.sub_registry_with_prefix("property_modifier");

--- a/nativelink-scheduler/src/scheduler_state/state_manager.rs
+++ b/nativelink-scheduler/src/scheduler_state/state_manager.rs
@@ -15,18 +15,23 @@
 use std::cmp;
 use std::collections::{BTreeSet, VecDeque};
 use std::ops::Bound;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
+use std::time::{Duration, SystemTime};
 
 use async_lock::Mutex;
 use async_trait::async_trait;
 use futures::stream::{self, unfold};
 use hashbrown::HashMap;
+use nativelink_config::stores::EvictionPolicy;
 use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ClientOperationId,
     ExecutionMetadata, OperationId, WorkerId,
 };
-use tokio::sync::Notify;
+use nativelink_util::evicting_map::{EvictingMap, LenEntry};
+use nativelink_util::task::JoinHandleDropGuard;
+use nativelink_util::{background_spawn, spawn};
+use tokio::sync::{watch, Notify};
 use tracing::{event, Level};
 
 use super::awaited_action::AwaitedActionSortKey;
@@ -37,6 +42,10 @@ use crate::operation_state_manager::{
 use crate::scheduler_state::awaited_action::AwaitedAction;
 use crate::scheduler_state::client_action_state_result::ClientActionStateResult;
 use crate::scheduler_state::matching_engine_action_state_result::MatchingEngineActionStateResult;
+
+/// How often the owning database will have the AwaitedAction touched
+/// to keep it from being evicted.
+const KEEPALIVE_DURATION: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone)]
 struct SortedAwaitedAction {
@@ -76,10 +85,81 @@ struct SortedAwaitedActions {
     completed_from_cache: BTreeSet<SortedAwaitedAction>,
 }
 
-#[derive(Default)]
+#[derive(Debug)]
+struct ClientAwaitedAction {
+    /// A weak reference to the owning StateManagerImpl.
+    state_manager_impl: Weak<Mutex<StateManagerImpl>>,
+
+    /// The client operation id that is listening to the action.
+    // Note: This is an Option because it is taken when the
+    // ClientAwaitedAction is dropped, but will never actually be
+    // None except during the drop.
+    client_operation_id: Option<ClientOperationId>,
+
+    /// The awaited action that the client is listening to.
+    awaited_action: Arc<AwaitedAction>,
+}
+
+impl ClientAwaitedAction {
+    fn new(
+        state_manager_impl: Weak<Mutex<StateManagerImpl>>,
+        client_operation_id: Option<ClientOperationId>,
+        awaited_action: Arc<AwaitedAction>,
+    ) -> Self {
+        awaited_action.inc_listening_clients();
+        Self {
+            state_manager_impl,
+            client_operation_id,
+            awaited_action,
+        }
+    }
+}
+
+impl Drop for ClientAwaitedAction {
+    fn drop(&mut self) {
+        let Some(inner) = self.state_manager_impl.upgrade() else {
+            return; // Nothing to do, since the StateManagerImpl is already dropped.
+        };
+        let client_operation_id = self
+            .client_operation_id
+            .take()
+            .expect("Operation Id should be present");
+        let awaited_action = self.awaited_action.clone();
+
+        // We must spawn the cleanup in the background so we can use await.
+        background_spawn!("client_awaited_action_drop", async move {
+            let mut inner = inner.lock().await;
+            awaited_action.dec_listening_clients();
+            inner
+                .on_client_struct_dropped(&client_operation_id, awaited_action)
+                .await;
+        });
+    }
+}
+
+/// Trait to be able to use the [`EvictingMap`] with [`ClientAwaitedAction`].
+/// Note: We only use [`EvictingMap`] for a time based evictiong, which is
+/// why the implementation has fixed default values in it.
+impl LenEntry for ClientAwaitedAction {
+    #[inline]
+    fn len(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// The database for storing the state of all actions.
+/// IMPORTANT: Any time an item is removed from
+/// [`AwaitedActionDb::client_operation_to_awaited_action`], it must
+/// also remove the entries from all the other maps.
 pub struct AwaitedActionDb {
     /// A lookup table to lookup the state of an action by its client operation id.
-    client_operation_to_awaited_action: HashMap<ClientOperationId, Arc<AwaitedAction>>,
+    client_operation_to_awaited_action:
+        EvictingMap<ClientOperationId, Arc<ClientAwaitedAction>, SystemTime>,
 
     /// A lookup table to lookup the state of an action by its worker operation id.
     operation_id_to_awaited_action: HashMap<OperationId, Arc<AwaitedAction>>,
@@ -96,16 +176,104 @@ pub struct AwaitedActionDb {
 
 #[allow(clippy::mutable_key_type)]
 impl AwaitedActionDb {
-    fn get_by_client_operation_id(
+    /// Refreshes/Updates the time to live of the [`ClientOperationId`] in
+    /// the [`EvictingMap`] by touching the key.
+    async fn refresh_client_operation_id(&self, client_operation_id: &ClientOperationId) -> bool {
+        self.client_operation_to_awaited_action
+            .size_for_key(client_operation_id)
+            .await
+            .is_some()
+    }
+
+    async fn get_by_client_operation_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> Option<&Arc<AwaitedAction>> {
+    ) -> Option<Arc<ClientAwaitedAction>> {
         self.client_operation_to_awaited_action
             .get(client_operation_id)
+            .await
+    }
+
+    /// Removes the client operation id from the database and cleanup entry from other maps.
+    /// Returns `true` if the client operation id was found and removed.
+    async fn remove_client_operation_id(
+        &mut self,
+        client_operation_id: &ClientOperationId,
+        awaited_action: Arc<AwaitedAction>,
+    ) -> bool {
+        let did_remove = self
+            .client_operation_to_awaited_action
+            .remove(client_operation_id)
+            .await;
+        if !did_remove {
+            // Note: This might be very noisy, but we will leave it in for now to help
+            // with debugging. In the event it is too noisy we can downgrade the level.
+            event!(
+                Level::ERROR,
+                ?client_operation_id,
+                ?awaited_action,
+                "Client operation id not found in StateManager::remove_client_operation_id"
+            );
+        }
+        if awaited_action.get_listening_clients() != 0 {
+            // We still have other clients listening to this action.
+            return did_remove;
+        }
+
+        let operation_id = awaited_action.get_operation_id();
+
+        // Cleanup operation_id_to_awaited_action.
+        if self
+            .operation_id_to_awaited_action
+            .remove(&operation_id)
+            .is_none()
+        {
+            event!(
+                Level::ERROR,
+                ?client_operation_id,
+                ?operation_id,
+                ?awaited_action,
+                "operation_id_to_awaited_action and client_operation_to_awaited_action are out of sync",
+            );
+        }
+
+        // Cleanup action_info_hash_key_to_awaited_action.
+        let action_info = awaited_action.get_action_info();
+        let maybe_awaited_action = self
+            .action_info_hash_key_to_awaited_action
+            .remove(&action_info.unique_qualifier);
+        if maybe_awaited_action.is_none() {
+            event!(
+                Level::ERROR,
+                ?operation_id,
+                ?awaited_action,
+                "action_info_hash_key_to_awaited_action and operation_id_to_awaited_action are out of sync",
+            );
+        }
+
+        // Cleanup sorted_awaited_action.
+        let sort_info = awaited_action.get_sort_info();
+        let sort_key = sort_info.get_previous_sort_key();
+        let sort_map_for_state =
+            self.get_sort_map_for_state(&awaited_action.get_current_state().stage);
+        drop(sort_info);
+        let maybe_sorted_awaited_action = sort_map_for_state.take(&SortedAwaitedAction {
+            sort_key,
+            awaited_action,
+        });
+        if maybe_sorted_awaited_action.is_none() {
+            event!(
+                Level::ERROR,
+                ?operation_id,
+                ?sort_key,
+                "sorted_action_info_hash_keys and action_info_hash_key_to_awaited_action are out of sync",
+            );
+        }
+        did_remove
     }
 
     fn get_all_awaited_actions(&self) -> impl Iterator<Item = &Arc<AwaitedAction>> {
-        self.client_operation_to_awaited_action.values()
+        self.operation_id_to_awaited_action.values()
     }
 
     fn get_by_operation_id(&self, operation_id: &OperationId) -> Option<&Arc<AwaitedAction>> {
@@ -220,18 +388,23 @@ impl AwaitedActionDb {
         has_listeners
     }
 
-    fn subscribe_or_add_action(
+    async fn subscribe_or_add_action(
         &mut self,
-        new_client_operation_id: ClientOperationId,
+        state_manager_impl: &Weak<Mutex<StateManagerImpl>>,
+        client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Arc<ClientActionStateResult> {
+    ) -> watch::Receiver<Arc<ActionState>> {
         // Check to see if the action is already known and subscribe if it is.
-        let action_info = match self.try_subscribe(
-            &new_client_operation_id,
-            &action_info.unique_qualifier,
-            action_info.priority,
-            action_info.skip_cache_lookup,
-        ) {
+        let subscription_result = self
+            .try_subscribe(
+                state_manager_impl,
+                &client_operation_id,
+                &action_info.unique_qualifier,
+                action_info.priority,
+                action_info.skip_cache_lookup,
+            )
+            .await;
+        let action_info = match subscription_result {
             Ok(subscription) => return subscription,
             Err(_) => Arc::new(action_info),
         };
@@ -240,7 +413,15 @@ impl AwaitedActionDb {
             AwaitedAction::new_with_subscription(action_info.clone());
         let awaited_action = Arc::new(awaited_action);
         self.client_operation_to_awaited_action
-            .insert(new_client_operation_id, awaited_action.clone());
+            .insert(
+                client_operation_id.clone(),
+                Arc::new(ClientAwaitedAction::new(
+                    state_manager_impl.clone(),
+                    Some(client_operation_id),
+                    awaited_action.clone(),
+                )),
+            )
+            .await;
         self.action_info_hash_key_to_awaited_action
             .insert(action_info.unique_qualifier.clone(), awaited_action.clone());
         self.operation_id_to_awaited_action
@@ -253,16 +434,17 @@ impl AwaitedActionDb {
                 awaited_action,
             },
         );
-        Arc::new(ClientActionStateResult::new(subscription))
+        subscription
     }
 
-    fn try_subscribe(
+    async fn try_subscribe(
         &mut self,
+        state_manager_impl: &Weak<Mutex<StateManagerImpl>>,
         client_operation_id: &ClientOperationId,
         unique_qualifier: &ActionInfoHashKey,
         priority: i32,
         skip_cache_lookup: bool,
-    ) -> Result<Arc<ClientActionStateResult>, Error> {
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         if skip_cache_lookup {
             return Err(make_err!(
                 Code::InvalidArgument,
@@ -310,9 +492,17 @@ impl AwaitedActionDb {
         let subscription = awaited_action.subscribe();
 
         self.client_operation_to_awaited_action
-            .insert(client_operation_id.clone(), awaited_action);
+            .insert(
+                client_operation_id.clone(),
+                Arc::new(ClientAwaitedAction {
+                    state_manager_impl: state_manager_impl.clone(),
+                    client_operation_id: Some(client_operation_id.clone()),
+                    awaited_action,
+                }),
+            )
+            .await;
 
-        Ok(Arc::new(ClientActionStateResult::new(subscription)))
+        Ok(subscription)
     }
 }
 
@@ -322,27 +512,39 @@ pub struct StateManager {
 }
 
 impl StateManager {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(tasks_change_notify: Arc<Notify>, max_job_retries: usize) -> Self {
+    pub fn new(
+        config: &EvictionPolicy,
+        tasks_change_notify: Arc<Notify>,
+        max_job_retries: usize,
+    ) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(StateManagerImpl {
-                action_db: AwaitedActionDb::default(),
-                tasks_change_notify,
-                max_job_retries,
-            })),
+            inner: Arc::new_cyclic(move |weak_self| {
+                Mutex::new(StateManagerImpl {
+                    weak_self: weak_self.clone(),
+                    action_db: AwaitedActionDb {
+                        client_operation_to_awaited_action: EvictingMap::new(
+                            config,
+                            SystemTime::now(),
+                        ),
+                        operation_id_to_awaited_action: HashMap::new(),
+                        action_info_hash_key_to_awaited_action: HashMap::new(),
+                        sorted_action_info_hash_keys: SortedAwaitedActions::default(),
+                    },
+                    tasks_change_notify,
+                    max_job_retries,
+                })
+            }),
         }
     }
 
-    async fn inner_filter_operations(
+    async fn inner_filter_operations<F>(
         &self,
         filter: &OperationFilter,
-    ) -> Result<ActionStateResultStream, Error> {
-        fn to_action_state_result(
-            awaited_action: Arc<AwaitedAction>,
-        ) -> Arc<dyn ActionStateResult> {
-            Arc::new(MatchingEngineActionStateResult::new(awaited_action))
-        }
-
+        to_action_state_result: F,
+    ) -> Result<ActionStateResultStream, Error>
+    where
+        F: Fn(Arc<AwaitedAction>) -> Arc<dyn ActionStateResult> + Send + Sync + 'static,
+    {
         fn get_tree_for_stage(
             action_db: &AwaitedActionDb,
             stage: OperationStageFlags,
@@ -375,11 +577,13 @@ impl StateManager {
             return Ok(inner
                 .action_db
                 .get_by_client_operation_id(client_operation_id)
-                .filter(|awaited_action| filter_check(awaited_action.as_ref(), filter))
-                .cloned()
-                .map(|awaited_action| -> ActionStateResultStream {
+                .await
+                .filter(|client_awaited_action| {
+                    filter_check(client_awaited_action.awaited_action.as_ref(), filter)
+                })
+                .map(|client_awaited_action| -> ActionStateResultStream {
                     Box::pin(stream::once(async move {
-                        to_action_state_result(awaited_action)
+                        to_action_state_result(client_awaited_action.awaited_action.clone())
                     }))
                 })
                 .unwrap_or_else(|| Box::pin(stream::empty())));
@@ -412,17 +616,21 @@ impl StateManager {
 
         drop(inner);
 
-        struct State {
+        struct State<
+            F: Fn(Arc<AwaitedAction>) -> Arc<dyn ActionStateResult> + Send + Sync + 'static,
+        > {
             inner: Arc<Mutex<StateManagerImpl>>,
             filter: OperationFilter,
             buffer: VecDeque<SortedAwaitedAction>,
             start_key: Bound<SortedAwaitedAction>,
+            to_action_state_result: F,
         }
         let state = State {
             inner: self.inner.clone(),
             filter: filter.clone(),
             buffer: VecDeque::new(),
             start_key: Bound::Unbounded,
+            to_action_state_result,
         };
 
         const STREAM_BUFF_SIZE: usize = 64;
@@ -433,7 +641,7 @@ impl StateManager {
                     state.start_key = Bound::Excluded(sorted_awaited_action.clone());
                 }
                 return Some((
-                    to_action_state_result(sorted_awaited_action.awaited_action),
+                    (state.to_action_state_result)(sorted_awaited_action.awaited_action),
                     state,
                 ));
             }
@@ -465,7 +673,7 @@ impl StateManager {
                 state.start_key = Bound::Excluded(sorted_awaited_action.clone());
             }
             Some((
-                to_action_state_result(sorted_awaited_action.awaited_action),
+                (state.to_action_state_result)(sorted_awaited_action.awaited_action),
                 state,
             ))
         })))
@@ -476,12 +684,14 @@ impl StateManager {
 /// includes the actions that are queued, active, and recently completed. It also includes the
 /// workers that are available to execute actions based on allocation strategy.
 pub(crate) struct StateManagerImpl {
-    pub(crate) action_db: AwaitedActionDb,
+    weak_self: Weak<Mutex<StateManagerImpl>>,
+
+    action_db: AwaitedActionDb,
 
     /// Notify task<->worker matching engine that work needs to be done.
-    pub(crate) tasks_change_notify: Arc<Notify>,
+    tasks_change_notify: Arc<Notify>,
 
-    pub(crate) max_job_retries: usize,
+    max_job_retries: usize,
 }
 
 fn filter_check(awaited_action: &AwaitedAction, filter: &OperationFilter) -> bool {
@@ -649,35 +859,105 @@ impl StateManagerImpl {
         Ok(())
     }
 
-    fn inner_add_operation(
+    async fn inner_add_operation(
         &mut self,
         new_client_operation_id: ClientOperationId,
         action_info: ActionInfo,
-    ) -> Result<Arc<dyn ActionStateResult>, Error> {
-        let subscription = self
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+        let rx = self
             .action_db
-            .subscribe_or_add_action(new_client_operation_id, action_info);
+            .subscribe_or_add_action(&self.weak_self, new_client_operation_id, action_info)
+            .await;
         self.tasks_change_notify.notify_one();
-        Ok(subscription)
+        Ok(rx)
     }
+
+    /// Called when the client struct is dropped. This will remove the client operation id
+    /// from the database and cleanup the entry from other maps.
+    /// This is not called a client disconnects, but rather when the EvictionMap drops the
+    /// struct.
+    async fn on_client_struct_dropped(
+        &mut self,
+        client_operation_id: &ClientOperationId,
+        awaited_action: Arc<AwaitedAction>,
+    ) {
+        let did_remove_operation_id = self
+            .action_db
+            .remove_client_operation_id(client_operation_id, awaited_action)
+            .await;
+        if !did_remove_operation_id {
+            event!(
+                Level::ERROR,
+                ?client_operation_id,
+                "Client operation id not found in StateManager::on_client_struct_dropped"
+            );
+        }
+    }
+}
+
+/// Utility struct to create a background task that keeps the client operation id alive.
+fn make_client_keepalive_spawn(
+    client_operation_id: ClientOperationId,
+    inner_weak: Weak<Mutex<StateManagerImpl>>,
+) -> JoinHandleDropGuard<()> {
+    spawn!("client_action_state_result_keepalive", async move {
+        loop {
+            tokio::time::sleep(KEEPALIVE_DURATION).await;
+            let Some(inner) = inner_weak.upgrade() else {
+                return; // Nothing to do.
+            };
+            let inner = inner.lock().await;
+            let refresh_success = inner
+                .action_db
+                .refresh_client_operation_id(&client_operation_id)
+                .await;
+            if !refresh_success {
+                event! {
+                    Level::ERROR,
+                    ?client_operation_id,
+                    "Client operation id not found in StateManager::add_action keepalive"
+                };
+            }
+        }
+    })
 }
 
 #[async_trait]
 impl ClientStateManager for StateManager {
     async fn add_action(
         &self,
-        new_client_operation_id: ClientOperationId,
+        client_operation_id: ClientOperationId,
         action_info: ActionInfo,
     ) -> Result<Arc<dyn ActionStateResult>, Error> {
         let mut inner = self.inner.lock().await;
-        inner.inner_add_operation(new_client_operation_id, action_info)
+        let rx = inner
+            .inner_add_operation(client_operation_id.clone(), action_info)
+            .await?;
+
+        let inner_weak = Arc::downgrade(&self.inner);
+        Ok(Arc::new(ClientActionStateResult::new(
+            rx,
+            Some(make_client_keepalive_spawn(client_operation_id, inner_weak)),
+        )))
     }
 
     async fn filter_operations(
         &self,
         filter: &OperationFilter,
     ) -> Result<ActionStateResultStream, Error> {
-        self.inner_filter_operations(filter).await
+        let maybe_client_operation_id = filter.client_operation_id.clone();
+        let inner_weak = Arc::downgrade(&self.inner);
+        self.inner_filter_operations(filter, move |awaited_action| {
+            Arc::new(ClientActionStateResult::new(
+                awaited_action.subscribe(),
+                maybe_client_operation_id
+                    .as_ref()
+                    .map(|client_operation_id| {
+                        make_client_keepalive_spawn(client_operation_id.clone(), inner_weak.clone())
+                    }),
+            ))
+        })
+        .await
     }
 }
 
@@ -700,7 +980,10 @@ impl MatchingEngineStateManager for StateManager {
         &self,
         filter: &OperationFilter,
     ) -> Result<ActionStateResultStream, Error> {
-        self.inner_filter_operations(filter).await
+        self.inner_filter_operations(filter, |awaited_action| {
+            Arc::new(MatchingEngineActionStateResult::new(awaited_action))
+        })
+        .await
     }
 
     async fn assign_operation(

--- a/nativelink-scheduler/src/scheduler_state/workers.rs
+++ b/nativelink-scheduler/src/scheduler_state/workers.rs
@@ -162,17 +162,14 @@ impl ApiWorkerSchedulerImpl {
                 .await
                 .err_tip(|| "in update_operation on SimpleScheduler::update_action");
             if let Err(err) = update_operation_res {
-                let result = Result::<(), _>::Err(err.clone())
-                    .merge(self.immediate_evict_worker(worker_id, err).await);
-
                 event!(
                     Level::ERROR,
                     ?operation_id,
                     ?worker_id,
-                    ?result,
+                    ?err,
                     "Failed to update_operation on update_action"
                 );
-                return result;
+                return Err(err);
             }
         }
 

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{Future, Stream};
+use nativelink_config::stores::EvictionPolicy;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_util::action_messages::{
     ActionInfo, ActionStage, ActionState, ClientOperationId, OperationId, WorkerId,
@@ -51,6 +52,10 @@ const DEFAULT_RETAIN_COMPLETED_FOR_S: u64 = 60;
 /// Default times a job can retry before failing.
 /// If this changes, remember to change the documentation in the config.
 const DEFAULT_MAX_JOB_RETRIES: usize = 3;
+
+/// Default time in seconds before a client is evicted.
+// TODO!(make this a config and documented)
+const CLIENT_EVICTION_SECONDS: u32 = 300; // 5 mins
 
 struct SimpleSchedulerActionListener {
     client_operation_id: ClientOperationId,
@@ -147,19 +152,6 @@ impl SimpleScheduler {
             client_operation_id,
             add_action_result,
         )))
-    }
-
-    async fn clean_recently_completed_actions(&self) {
-        todo!();
-        // let expiry_time = SystemTime::now()
-        //     .checked_sub(self.retain_completed_for)
-        //     .unwrap();
-        // self.state_manager
-        //     .inner
-        //     .lock()
-        //     .await
-        //     .recently_completed_actions
-        //     .retain(|action| action.completed_time > expiry_time);
     }
 
     async fn find_by_client_operation_id(
@@ -317,6 +309,10 @@ impl SimpleScheduler {
 
         let tasks_or_worker_change_notify = Arc::new(Notify::new());
         let state_manager = Arc::new(StateManager::new(
+            &EvictionPolicy {
+                max_seconds: CLIENT_EVICTION_SECONDS,
+                ..Default::default()
+            },
             tasks_or_worker_change_notify.clone(),
             max_job_retries,
         ));
@@ -393,10 +389,6 @@ impl ActionScheduler for SimpleScheduler {
                 format!("Error while finding action with client id: {client_operation_id:?}")
             })?;
         Ok(maybe_receiver)
-    }
-
-    async fn clean_recently_completed_actions(&self) {
-        self.clean_recently_completed_actions().await;
     }
 
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {}

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -182,6 +182,4 @@ impl ActionScheduler for MockActionScheduler {
             _ => panic!("Expected find_by_client_operation_id return value"),
         }
     }
-
-    async fn clean_recently_completed_actions(&self) {}
 }

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -45,7 +45,7 @@ pub const DEFAULT_EXECUTION_PRIORITY: i32 = 0;
 
 pub type WorkerTimestamp = u64;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ClientOperationId(String);
 
 impl ClientOperationId {
@@ -72,7 +72,7 @@ impl std::fmt::Display for ClientOperationId {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct OperationId {
     pub unique_qualifier: ActionInfoHashKey,
     pub id: Uuid,
@@ -237,7 +237,7 @@ impl TryFrom<String> for WorkerId {
 /// Since the hashing only needs the digest and salt we can just alias them here
 /// and point the original `ActionInfo` structs to reference these structs for
 /// it's hashing functions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ActionInfoHashKey {
     /// Name of instance group this action belongs to.
     pub instance_name: String,


### PR DESCRIPTION
StateManager will now properly remove items from the maps if the client disconnects after a set amount of time. Currently these values are hard codded, but will be easy to transition them to use config variables once we design it out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1107)
<!-- Reviewable:end -->
