### PR TITLE
Add Capacitor dashboard to devcluster

### DIFF
--- a/native-cli/components/embedded/capacitor.yaml
+++ b/native-cli/components/embedded/capacitor.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: capacitor
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: oci://ghcr.io/gimlet-io/capacitor-manifests
+  ref:
+    semver: ">=0.1.0"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capacitor
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  wait: true
+  prune: true
+  path: "./"
+  sourceRef:
+    kind: OCIRepository
+    name: capacitor
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-to-capacitor
+  namespace: flux-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: onechart
+      app.kubernetes.io/instance: capacitor
+  ingress:
+  - fromEntities:
+    - ingress
+  - toPorts:
+    - ports:
+      - port: "9000"
+        protocol: TCP

--- a/native-cli/components/embedded/kustomization.yaml
+++ b/native-cli/components/embedded/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - nix2container-image-info.yaml
   - trigger.yaml
   - update-image-tags.yaml
+  - capacitor.yaml
   # - nativelink-gateways.yaml  # Gateways are handled in Pulumi via the
                                 # NativeLinkGateways resource.

--- a/native-cli/components/embedded/nativelink-gateways.yaml
+++ b/native-cli/components/embedded/nativelink-gateways.yaml
@@ -57,3 +57,15 @@ spec:
     - name: tkn-gateway
       protocol: HTTP
       port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: capacitor-gateway
+  namespace: flux-system
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: capacitor-gateway
+      protocol: HTTP
+      port: 80

--- a/native-cli/components/embedded/nativelink-routes.yaml
+++ b/native-cli/components/embedded/nativelink-routes.yaml
@@ -49,3 +49,20 @@ spec:
       backendRefs:
         - name: tekton-dashboard
           port: 9097
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: capacitor-route
+  namespace: flux-system
+spec:
+  parentRefs:
+    - sectionName: capacitor-gateway
+      name: capacitor-gateway
+  rules:
+    - matches:
+        - path:
+            value: /
+      backendRefs:
+        - name: capacitor
+          port: 9000

--- a/native-cli/components/loadbalancer.go
+++ b/native-cli/components/loadbalancer.go
@@ -310,6 +310,7 @@ func (component *Loadbalancer) Install(
 			"el-gateway":        false,
 			"hubble-gateway":    false,
 			"tkn-gateway":       false,
+			"capacitor-gateway": false,
 		},
 	), component.Gateways)
 	if err != nil {

--- a/native-cli/programs/local.go
+++ b/native-cli/programs/local.go
@@ -155,6 +155,17 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 		},
 	}
 
+	capacitorGateway := components.Gateway{
+		ExternalPort: 9000, //nolint:mnd
+		InternalPort: 9000, //nolint:mnd
+		Routes: []components.RouteConfig{
+			{
+				Prefix:  "/",
+				Cluster: "capacitor-gateway",
+			},
+		},
+	}
+
 	nativelinkGateway := components.Gateway{
 		ExternalPort: 8082, //nolint:mnd
 		InternalPort: 8089, //nolint:mnd
@@ -184,6 +195,7 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 		"kind-loadbalancer",
 		&components.Loadbalancer{
 			Gateways: []components.Gateway{
+				capacitorGateway,
 				nativelinkGateway,
 				hubbleGateway,
 				tknGateway,


### PR DESCRIPTION
This lets us view logs and deployment statuses of Kustomizations.

The new dashboard is available via `localhost:9000`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1115)
<!-- Reviewable:end -->
