### PR TITLE
Remove MatchingEngineStateManager::remove_operation

### DIFF
--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -144,9 +144,4 @@ pub trait MatchingEngineStateManager: Sync + Send + 'static {
         operation_id: &OperationId,
         worker_id_or_reason_for_unsassign: Result<&WorkerId, Error>,
     ) -> Result<(), Error>;
-
-    /// Remove an operation from the state manager.
-    /// It is important to use this function to remove operations
-    /// that are no longer needed to prevent memory leaks.
-    async fn remove_operation(&self, operation_id: OperationId) -> Result<(), Error>;
 }

--- a/nativelink-scheduler/src/scheduler_state/state_manager.rs
+++ b/nativelink-scheduler/src/scheduler_state/state_manager.rs
@@ -999,8 +999,4 @@ impl MatchingEngineStateManager for StateManager {
         };
         inner.inner_update_operation(operation_id, maybe_worker_id, stage_result)
     }
-
-    async fn remove_operation(&self, _operation_id: OperationId) -> Result<(), Error> {
-        todo!()
-    }
 }


### PR DESCRIPTION
We don't actually need this API, since the StateManager can now own the output struct, which means it controls the Drop function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1119)
<!-- Reviewable:end -->
