### PR TITLE
Add BEP to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,10 @@ jobs:
         bazel test \
           --remote_cache=${{ secrets.NATIVELINK_COM_REMOTE_CACHE_URL }} \
           --remote_header=${{ secrets.NATIVELINK_COM_API_HEADER }} \
+          --bes_backend=${{ secrets.NATIVELINK_COM_BES_URL }} \
+          --bes_header=${{ secrets.NATIVELINK_COM_API_HEADER }} \
+          --bes_results_url=${{ secrets.NATIVELINK_COM_BES_RESULTS_URL }} \
+          --remote_header=x-nativelink-project=nativelink-ci \
           //...
 
   docker-compose-compiles-nativelink:


### PR DESCRIPTION
# Description
Adds BEP to CI workflow using shared Trace Machina account BEP headers associated with it's shared CAS from the quickstart.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1124)
<!-- Reviewable:end -->
