### PR TITLE
Remove all uses of salt and put under ActionUniqueQualifier

### DIFF
--- a/nativelink-scheduler/src/operation_state_manager.rs
+++ b/nativelink-scheduler/src/operation_state_manager.rs
@@ -22,8 +22,7 @@ use bitflags::bitflags;
 use futures::Stream;
 use nativelink_error::Error;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionInfoHashKey, ActionStage, ActionState, ClientOperationId, OperationId,
-    WorkerId,
+    ActionInfo, ActionStage, ActionState, ActionUniqueKey, ClientOperationId, OperationId, WorkerId,
 };
 use nativelink_util::common::DigestInfo;
 use tokio::sync::watch;
@@ -89,9 +88,10 @@ pub struct OperationFilter {
 
     // /// The operation must have it's last client update before this time.
     // NOTE: NOT PART OF ANY FILTERING!
+    // TODO!(cleanup)
     // pub last_client_update_before: Option<SystemTime>,
     /// The unique key for filtering specific action results.
-    pub unique_qualifier: Option<ActionInfoHashKey>,
+    pub unique_key: Option<ActionUniqueKey>,
 
     /// If the results should be ordered by priority and in which direction.
     pub order_by_priority_direction: Option<OrderDirection>,

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -94,7 +94,7 @@ impl ActionScheduler for PropertyModifierScheduler {
         mut action_info: ActionInfo,
     ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         let platform_property_manager = self
-            .get_platform_property_manager(&action_info.unique_qualifier.instance_name)
+            .get_platform_property_manager(action_info.unique_qualifier.instance_name())
             .await
             .err_tip(|| "In PropertyModifierScheduler::add_action")?;
         for modification in &self.modifications {

--- a/nativelink-scheduler/src/scheduler_state/completed_action.rs
+++ b/nativelink-scheduler/src/scheduler_state/completed_action.rs
@@ -17,7 +17,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use nativelink_util::action_messages::{ActionInfoHashKey, ActionState, OperationId};
+use nativelink_util::action_messages::{ActionState, ActionUniqueQualifier, OperationId};
 
 /// A completed action that has no listeners.
 pub struct CompletedAction {
@@ -49,9 +49,9 @@ impl Borrow<OperationId> for CompletedAction {
     }
 }
 
-impl Borrow<ActionInfoHashKey> for CompletedAction {
+impl Borrow<ActionUniqueQualifier> for CompletedAction {
     #[inline]
-    fn borrow(&self) -> &ActionInfoHashKey {
+    fn borrow(&self) -> &ActionUniqueQualifier {
         &self.state.id.unique_qualifier
     }
 }

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -291,7 +291,7 @@ impl MetricsComponent for Worker {
             vec![("worker_id".into(), format!("{}", self.id).into())],
         );
         for action_info in self.running_action_infos.values() {
-            let action_name = action_info.unique_qualifier.action_name().to_string();
+            let action_name = action_info.unique_qualifier.to_string();
             c.publish_with_labels(
                 "timeout",
                 &action_info.timeout,
@@ -314,12 +314,6 @@ impl MetricsComponent for Worker {
                 "insert_timestamp",
                 &action_info.insert_timestamp,
                 "When this action was created.",
-                vec![("digest".into(), action_name.clone().into())],
-            );
-            c.publish_with_labels(
-                "skip_cache_lookup",
-                &action_info.skip_cache_lookup,
-                "Weather this action should skip cache lookup.",
                 vec![("digest".into(), action_name.clone().into())],
             );
         }

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::collections::HashMap;
+use std::time::SystemTime;
 
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
@@ -22,30 +21,20 @@ use nativelink_proto::build::bazel::remote::execution::v2::ExecuteResponse;
 use nativelink_proto::google::longrunning::{operation, Operation};
 use nativelink_proto::google::rpc::Status;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ClientOperationId,
-    ExecutionMetadata, OperationId,
+    ActionResult, ActionStage, ActionState, ActionUniqueKey, ActionUniqueQualifier,
+    ClientOperationId, ExecutionMetadata, OperationId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::platform_properties::PlatformProperties;
 use pretty_assertions::assert_eq;
-
-const NOW_TIME: u64 = 10000;
-
-fn make_system_time(add_time: u64) -> SystemTime {
-    SystemTime::UNIX_EPOCH
-        .checked_add(Duration::from_secs(NOW_TIME + add_time))
-        .unwrap()
-}
 
 #[nativelink_test]
 async fn action_state_any_url_test() -> Result<(), Error> {
-    let unique_qualifier = ActionInfoHashKey {
+    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
         instance_name: "foo_instance".to_string(),
         digest_function: DigestHasherFunc::Sha256,
         digest: DigestInfo::new([1u8; 32], 5),
-        salt: 0,
-    };
+    });
     let client_id = ClientOperationId::new(unique_qualifier.clone());
     let operation_id = OperationId::new(unique_qualifier);
     let action_state = ActionState {
@@ -99,118 +88,6 @@ async fn execute_response_status_message_is_some_on_success_test() -> Result<(),
 
     // This was once discovered to be None, which is why this test exists.
     assert_eq!(execute_response.status, Some(Status::default()));
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn highest_priority_action_first() -> Result<(), Error> {
-    const INSTANCE_NAME: &str = "foobar_instance_name";
-
-    let high_priority_action = Arc::new(ActionInfo {
-        command_digest: DigestInfo::new([0u8; 32], 0),
-        input_root_digest: DigestInfo::new([0u8; 32], 0),
-        timeout: Duration::MAX,
-        platform_properties: PlatformProperties {
-            properties: HashMap::new(),
-        },
-        priority: 1000,
-        load_timestamp: SystemTime::UNIX_EPOCH,
-        insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([0u8; 32], 0),
-            salt: 0,
-        },
-        skip_cache_lookup: true,
-    });
-    let lowest_priority_action = Arc::new(ActionInfo {
-        command_digest: DigestInfo::new([0u8; 32], 0),
-        input_root_digest: DigestInfo::new([0u8; 32], 0),
-        timeout: Duration::MAX,
-        platform_properties: PlatformProperties {
-            properties: HashMap::new(),
-        },
-        priority: 0,
-        load_timestamp: SystemTime::UNIX_EPOCH,
-        insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([1u8; 32], 0),
-            salt: 0,
-        },
-        skip_cache_lookup: true,
-    });
-    let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
-    action_set.insert(lowest_priority_action.clone());
-    action_set.insert(high_priority_action.clone());
-
-    assert_eq!(
-        vec![high_priority_action, lowest_priority_action],
-        action_set
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<Arc<ActionInfo>>>()
-    );
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn equal_priority_earliest_first() -> Result<(), Error> {
-    const INSTANCE_NAME: &str = "foobar_instance_name";
-
-    let first_action = Arc::new(ActionInfo {
-        command_digest: DigestInfo::new([0u8; 32], 0),
-        input_root_digest: DigestInfo::new([0u8; 32], 0),
-        timeout: Duration::MAX,
-        platform_properties: PlatformProperties {
-            properties: HashMap::new(),
-        },
-        priority: 0,
-        load_timestamp: SystemTime::UNIX_EPOCH,
-        insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([0u8; 32], 0),
-            salt: 0,
-        },
-        skip_cache_lookup: true,
-    });
-    let current_action = Arc::new(ActionInfo {
-        command_digest: DigestInfo::new([0u8; 32], 0),
-        input_root_digest: DigestInfo::new([0u8; 32], 0),
-        timeout: Duration::MAX,
-        platform_properties: PlatformProperties {
-            properties: HashMap::new(),
-        },
-        priority: 0,
-        load_timestamp: SystemTime::UNIX_EPOCH,
-        insert_timestamp: make_system_time(0),
-        unique_qualifier: ActionInfoHashKey {
-            instance_name: INSTANCE_NAME.to_string(),
-            digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([1u8; 32], 0),
-            salt: 0,
-        },
-        skip_cache_lookup: true,
-    });
-    let mut action_set = BTreeSet::<Arc<ActionInfo>>::new();
-    action_set.insert(current_action.clone());
-    action_set.insert(first_action.clone());
-
-    assert_eq!(
-        vec![first_action, current_action],
-        action_set
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<Arc<ActionInfo>>>()
-    );
 
     Ok(())
 }

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -15,14 +15,17 @@
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use nativelink_util::action_messages::{ActionInfo, ActionInfoHashKey};
+use nativelink_util::action_messages::{ActionInfo, ActionUniqueKey, ActionUniqueQualifier};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::platform_properties::PlatformProperties;
 
 pub const INSTANCE_NAME: &str = "foobar_instance_name";
 
-pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
+pub fn make_base_action_info(
+    insert_timestamp: SystemTime,
+    action_digest: DigestInfo,
+) -> ActionInfo {
     ActionInfo {
         command_digest: DigestInfo::new([0u8; 32], 0),
         input_root_digest: DigestInfo::new([0u8; 32], 0),
@@ -33,12 +36,10 @@ pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
         priority: 0,
         load_timestamp: UNIX_EPOCH,
         insert_timestamp,
-        unique_qualifier: ActionInfoHashKey {
+        unique_qualifier: ActionUniqueQualifier::Cachable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
-            digest: DigestInfo::new([0u8; 32], 0),
-            salt: 0,
-        },
-        skip_cache_lookup: false,
+            digest: action_digest,
+        }),
     }
 }

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -37,7 +37,7 @@ use nativelink_scheduler::scheduler_state::workers::ApiWorkerScheduler;
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
 use nativelink_service::worker_api_server::{ConnectWorkerStream, NowFn, WorkerApiServer};
 use nativelink_util::action_messages::{
-    ActionInfo, ActionInfoHashKey, ActionStage, OperationId, WorkerId,
+    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier, OperationId, WorkerId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -374,12 +374,11 @@ pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error:
     let action_digest = DigestInfo::new([7u8; 32], 123);
     let instance_name = "instance_name".to_string();
 
-    let unique_qualifier = ActionInfoHashKey {
+    let unique_qualifier = ActionUniqueQualifier::Uncachable(ActionUniqueKey {
         instance_name: instance_name.clone(),
         digest_function: DigestHasherFunc::Sha256,
         digest: action_digest,
-        salt: 0,
-    };
+    });
     let action_info = Arc::new(ActionInfo {
         command_digest: DigestInfo::new([0u8; 32], 0),
         input_root_digest: DigestInfo::new([0u8; 32], 0),
@@ -391,7 +390,6 @@ pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error:
         load_timestamp: make_system_time(0),
         insert_timestamp: make_system_time(0),
         unique_qualifier,
-        skip_cache_lookup: true,
     });
     let expected_operation_id = OperationId::new(action_info.unique_qualifier.clone());
     test_context

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use blake3::Hasher as Blake3Hasher;
 use nativelink_error::{error_if, make_input_err, Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::{
     execution_stage, Action, ActionResult as ProtoActionResult, ExecuteOperationMetadata,
@@ -43,22 +40,22 @@ use crate::platform_properties::PlatformProperties;
 /// Default priority remote execution jobs will get when not provided.
 pub const DEFAULT_EXECUTION_PRIORITY: i32 = 0;
 
-pub type WorkerTimestamp = u64;
+/// Exit code sent if there is an internal error.
+pub const INTERNAL_ERROR_EXIT_CODE: i32 = -178;
 
+/// Holds an id that is unique to the client for a requested operation.
+/// Each client should be issued a unique id even if they are attached
+/// to the same underlying operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ClientOperationId(String);
 
 impl ClientOperationId {
-    pub fn new(unique_qualifier: ActionInfoHashKey) -> Self {
+    pub fn new(unique_qualifier: ActionUniqueQualifier) -> Self {
         Self(OperationId::new(unique_qualifier).to_string())
     }
 
     pub fn from_raw_string(name: String) -> Self {
         Self(name)
-    }
-
-    pub fn from_operation(operation: &Operation) -> Self {
-        Self(operation.name.clone())
     }
 
     pub fn into_string(self) -> String {
@@ -72,36 +69,45 @@ impl std::fmt::Display for ClientOperationId {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OperationId {
-    pub unique_qualifier: ActionInfoHashKey,
+    // TODO!(this should be for debugging only)
+    pub unique_qualifier: ActionUniqueQualifier,
     pub id: Uuid,
 }
 
-// TODO: Eventually we should make this it's own hash rather than delegate to ActionInfoHashKey.
+impl PartialEq for OperationId {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.eq(&other.id)
+    }
+}
+
+impl Eq for OperationId {}
+
+impl PartialOrd for OperationId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OperationId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
 impl Hash for OperationId {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ActionInfoHashKey::hash(&self.unique_qualifier, state)
+        self.id.hash(state)
     }
 }
 
 impl OperationId {
-    pub fn new(unique_qualifier: ActionInfoHashKey) -> Self {
+    pub fn new(unique_qualifier: ActionUniqueQualifier) -> Self {
         Self {
             id: uuid::Uuid::new_v4(),
             unique_qualifier,
         }
-    }
-
-    /// Utility function used to make a unique hash of the digest including the salt.
-    pub fn get_hash(&self) -> [u8; 32] {
-        self.unique_qualifier.get_hash()
-    }
-
-    /// Returns the salt used for cache busting/hashing.
-    #[inline]
-    pub fn action_name(&self) -> String {
-        self.unique_qualifier.action_name()
     }
 }
 
@@ -111,7 +117,7 @@ impl TryFrom<&str> for OperationId {
     /// Attempts to convert a string slice into an `OperationId`.
     ///
     /// The input string `value` is expected to be in the format:
-    /// `<instance_name>/<digest_function>/<digest_hash>-<digest_size>/<salt>/<id>`.
+    /// `<instance_name>/<digest_function>/<digest_hash>-<digest_size>/<cached>/<id>`.
     ///
     /// # Parameters
     ///
@@ -146,30 +152,41 @@ impl TryFrom<&str> for OperationId {
             .err_tip(|| format!("Invalid OperationId unique_qualifier / id fragment - {value}"))?;
         let (instance_name, rest) = unique_qualifier
             .split_once('/')
-            .err_tip(|| format!("Invalid ActionInfoHashKey instance name fragment - {value}"))?;
+            .err_tip(|| format!("Invalid UniqueQualifier instance name fragment - {value}"))?;
         let (digest_function, rest) = rest
             .split_once('/')
-            .err_tip(|| format!("Invalid ActionInfoHashKey digest function fragment - {value}"))?;
+            .err_tip(|| format!("Invalid UniqueQualifier digest function fragment - {value}"))?;
         let (digest_hash, rest) = rest
             .split_once('-')
-            .err_tip(|| format!("Invalid ActionInfoHashKey digest hash fragment - {value}"))?;
-        let (digest_size, salt) = rest
+            .err_tip(|| format!("Invalid UniqueQualifier digest hash fragment - {value}"))?;
+        let (digest_size, cachable) = rest
             .split_once('/')
-            .err_tip(|| format!("Invalid ActionInfoHashKey digest size fragment - {value}"))?;
+            .err_tip(|| format!("Invalid UniqueQualifier digest size fragment - {value}"))?;
         let digest = DigestInfo::try_new(
             digest_hash,
             digest_size
                 .parse::<u64>()
-                .err_tip(|| format!("Invalid ActionInfoHashKey size value fragment - {value}"))?,
+                .err_tip(|| format!("Invalid UniqueQualifier size value fragment - {value}"))?,
         )
         .err_tip(|| format!("Invalid DigestInfo digest hash - {value}"))?;
-        let salt = u64::from_str_radix(salt, 16)
-            .err_tip(|| format!("Invalid ActionInfoHashKey salt hex conversion - {value}"))?;
-        let unique_qualifier = ActionInfoHashKey {
+        let cachable = match cachable {
+            "0" => false,
+            "1" => true,
+            _ => {
+                return Err(make_input_err!(
+                    "Invalid UniqueQualifier cachable value fragment - {value}"
+                ));
+            }
+        };
+        let unique_key = ActionUniqueKey {
             instance_name: instance_name.to_string(),
             digest_function: digest_function.try_into()?,
             digest,
-            salt,
+        };
+        let unique_qualifier = if cachable {
+            ActionUniqueQualifier::Cachable(unique_key)
+        } else {
+            ActionUniqueQualifier::Uncachable(unique_key)
         };
         let id = Uuid::parse_str(id).map_err(|e| make_input_err!("Failed to parse {e} as uuid"))?;
         Ok(Self {
@@ -181,21 +198,13 @@ impl TryFrom<&str> for OperationId {
 
 impl std::fmt::Display for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "{}/{}",
-            self.unique_qualifier.action_name(),
-            self.id
-        ))
+        f.write_fmt(format_args!("{}/{}", self.unique_qualifier, self.id))
     }
 }
 
 impl std::fmt::Debug for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "{}:{}",
-            self.unique_qualifier.action_name(),
-            self.id
-        ))
+        std::fmt::Display::fmt(&self, f)
     }
 }
 
@@ -213,9 +222,7 @@ impl std::fmt::Display for WorkerId {
 
 impl std::fmt::Debug for WorkerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut buf = Uuid::encode_buffer();
-        let worker_id_str = self.0.hyphenated().encode_lower(&mut buf);
-        f.write_fmt(format_args!("{worker_id_str}"))
+        std::fmt::Display::fmt(&self, f)
     }
 }
 
@@ -224,58 +231,77 @@ impl TryFrom<String> for WorkerId {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         match Uuid::parse_str(&s) {
             Err(e) => Err(make_input_err!(
-                "Failed to convert string to WorkerId : {} : {:?}",
-                s,
-                e
+                "Failed to convert string to WorkerId : {s} : {e:?}",
             )),
             Ok(my_uuid) => Ok(WorkerId(my_uuid)),
         }
     }
 }
+
+/// Holds the information needed to uniquely identify an action
+/// and if it is cachable or not.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionUniqueQualifier {
+    /// The action is cachable.
+    Cachable(ActionUniqueKey),
+    /// The action is uncachable.
+    Uncachable(ActionUniqueKey),
+}
+
+impl ActionUniqueQualifier {
+    /// Get the instance_name of the action.
+    pub const fn instance_name(&self) -> &String {
+        match self {
+            Self::Cachable(action) => &action.instance_name,
+            Self::Uncachable(action) => &action.instance_name,
+        }
+    }
+
+    /// Get the digest function of the action.
+    pub const fn digest_function(&self) -> DigestHasherFunc {
+        match self {
+            Self::Cachable(action) => action.digest_function,
+            Self::Uncachable(action) => action.digest_function,
+        }
+    }
+
+    /// Get the digest of the action.
+    pub const fn digest(&self) -> DigestInfo {
+        match self {
+            Self::Cachable(action) => action.digest,
+            Self::Uncachable(action) => action.digest,
+        }
+    }
+}
+
+impl std::fmt::Display for ActionUniqueQualifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (cachable, unique_key) = match self {
+            Self::Cachable(action) => (true, action),
+            Self::Uncachable(action) => (false, action),
+        };
+        f.write_fmt(format_args!(
+            "{}/{}/{}-{}/{}",
+            unique_key.instance_name,
+            unique_key.digest_function,
+            unique_key.digest.hash_str(),
+            unique_key.digest.size_bytes,
+            // TODO!(maybe make this a different value?)
+            cachable as i32, // Convert to 0 or 1.
+        ))
+    }
+}
+
 /// This is a utility struct used to make it easier to match `ActionInfos` in a
 /// `HashMap` without needing to construct an entire `ActionInfo`.
-/// Since the hashing only needs the digest and salt we can just alias them here
-/// and point the original `ActionInfo` structs to reference these structs for
-/// it's hashing functions.
-#[derive(Debug, Clone, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct ActionInfoHashKey {
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ActionUniqueKey {
     /// Name of instance group this action belongs to.
     pub instance_name: String,
     /// The digest function this action expects.
     pub digest_function: DigestHasherFunc,
     /// Digest of the underlying `Action`.
     pub digest: DigestInfo,
-    /// Salt that can be filled with a random number to ensure no `ActionInfo` will be a match
-    /// to another `ActionInfo` in the scheduler. When caching is wanted this value is usually
-    /// zero.
-    pub salt: u64,
-}
-
-impl ActionInfoHashKey {
-    /// Utility function used to make a unique hash of the digest including the salt.
-    pub fn get_hash(&self) -> [u8; 32] {
-        Blake3Hasher::new()
-            .update(self.instance_name.as_bytes())
-            .update(&i32::from(self.digest_function.proto_digest_func()).to_le_bytes())
-            .update(&self.digest.packed_hash[..])
-            .update(&self.digest.size_bytes.to_le_bytes())
-            .update(&self.salt.to_le_bytes())
-            .finalize()
-            .into()
-    }
-
-    /// Returns the salt used for cache busting/hashing.
-    #[inline]
-    pub fn action_name(&self) -> String {
-        format!(
-            "{}/{}/{}-{}/{:X}",
-            self.instance_name,
-            self.digest_function,
-            self.digest.hash_str(),
-            self.digest.size_bytes,
-            self.salt
-        )
-    }
 }
 
 /// Information needed to execute an action. This struct is used over bazel's proto `Action`
@@ -299,47 +325,43 @@ pub struct ActionInfo {
     pub load_timestamp: SystemTime,
     /// When this action was created.
     pub insert_timestamp: SystemTime,
-
-    /// Info used to uniquely identify this ActionInfo. Normally the hash function would just
-    /// use the fields it needs and you wouldn't need to separate them, however we have a use
-    /// case where we sometimes want to lookup an entry in a HashMap, but we don't have the
-    /// info to construct an entire ActionInfo. In such case we construct only a ActionInfoHashKey
-    /// then use that object to lookup the entry in the map. The root problem is that HashMap
-    /// requires `ActionInfo :Borrow<ActionInfoHashKey>` in order for this to work, which means
-    /// we need to be able to return a &ActionInfoHashKey from ActionInfo, but since we cannot
-    /// return a temporary reference we must have an object tied to ActionInfo's lifetime and
-    /// return it's reference.
-    pub unique_qualifier: ActionInfoHashKey,
-
-    /// Whether to try looking up this action in the cache.
-    pub skip_cache_lookup: bool,
+    /// Info used to uniquely identify this ActionInfo and if it is cachable.
+    /// This is primarily used to join actions/operations together using this key.
+    pub unique_qualifier: ActionUniqueQualifier,
 }
 
 impl ActionInfo {
     #[inline]
     pub const fn instance_name(&self) -> &String {
-        &self.unique_qualifier.instance_name
+        self.unique_qualifier.instance_name()
     }
 
     /// Returns the underlying digest of the `Action`.
     #[inline]
-    pub const fn digest(&self) -> &DigestInfo {
-        &self.unique_qualifier.digest
+    pub const fn digest(&self) -> DigestInfo {
+        self.unique_qualifier.digest()
     }
 
-    /// Returns the salt used for cache busting/hashing.
-    #[inline]
-    pub const fn salt(&self) -> &u64 {
-        &self.unique_qualifier.salt
-    }
-
-    pub fn try_from_action_and_execute_request_with_salt(
+    pub fn try_from_action_and_execute_request(
         execute_request: ExecuteRequest,
         action: Action,
-        salt: u64,
         load_timestamp: SystemTime,
         queued_timestamp: SystemTime,
     ) -> Result<Self, Error> {
+        let unique_key = ActionUniqueKey {
+            instance_name: execute_request.instance_name,
+            digest_function: DigestHasherFunc::try_from(execute_request.digest_function)
+                .err_tip(|| format!("Could not find digest_function in try_from_action_and_execute_request {:?}", execute_request.digest_function))?,
+            digest: execute_request
+                .action_digest
+                .err_tip(|| "Expected action_digest to exist on ExecuteRequest")?
+                .try_into()?,
+        };
+        let unique_qualifier = if execute_request.skip_cache_lookup {
+            ActionUniqueQualifier::Uncachable(unique_key)
+        } else {
+            ActionUniqueQualifier::Cachable(unique_key)
+        };
         Ok(Self {
             command_digest: action
                 .command_digest
@@ -355,20 +377,13 @@ impl ActionInfo {
                 .try_into()
                 .map_err(|_| make_input_err!("Failed convert proto duration to system duration"))?,
             platform_properties: action.platform.unwrap_or_default().into(),
-            priority: execute_request.execution_policy.unwrap_or_default().priority,
+            priority: execute_request
+                .execution_policy
+                .unwrap_or_default()
+                .priority,
             load_timestamp,
             insert_timestamp: queued_timestamp,
-            unique_qualifier: ActionInfoHashKey {
-                instance_name: execute_request.instance_name,
-                digest_function: DigestHasherFunc::try_from(execute_request.digest_function)
-                    .err_tip(|| format!("Could not find digest_function in try_from_action_and_execute_request_with_salt {:?}", execute_request.digest_function))?,
-                digest: execute_request
-                    .action_digest
-                    .err_tip(|| "Expected action_digest to exist on ExecuteRequest")?
-                    .try_into()?,
-                salt,
-            },
-            skip_cache_lookup: execute_request.skip_cache_lookup,
+            unique_qualifier,
         })
     }
 }
@@ -376,91 +391,20 @@ impl ActionInfo {
 impl From<ActionInfo> for ExecuteRequest {
     fn from(val: ActionInfo) -> Self {
         let digest = val.digest().into();
+        let (skip_cache_lookup, unique_qualifier) = match val.unique_qualifier {
+            ActionUniqueQualifier::Cachable(unique_qualifier) => (false, unique_qualifier),
+            ActionUniqueQualifier::Uncachable(unique_qualifier) => (true, unique_qualifier),
+        };
         Self {
-            instance_name: val.unique_qualifier.instance_name,
+            instance_name: unique_qualifier.instance_name,
             action_digest: Some(digest),
-            skip_cache_lookup: true, // The worker should never cache lookup.
-            execution_policy: None,  // Not used in the worker.
+            skip_cache_lookup,
+            execution_policy: None,     // Not used in the worker.
             results_cache_policy: None, // Not used in the worker.
-            digest_function: val
-                .unique_qualifier
-                .digest_function
-                .proto_digest_func()
-                .into(),
+            digest_function: unique_qualifier.digest_function.proto_digest_func().into(),
         }
     }
 }
-
-// Note: Hashing, Eq, and Ord matching on this struct is unique. Normally these functions
-// must play well with each other, but in our case the following rules apply:
-// * Hash - Hashing must be unique on the exact command being run and must never match
-//          when do_not_cache is enabled, but must be consistent between identical data
-//          hashes.
-// * Eq   - Same as hash.
-// * Ord  - Used when sorting `ActionInfo` together. The only major sorting is priority and
-//          insert_timestamp, everything else is undefined, but must be deterministic.
-impl Hash for ActionInfo {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        ActionInfoHashKey::hash(&self.unique_qualifier, state);
-    }
-}
-
-impl PartialEq for ActionInfo {
-    fn eq(&self, other: &Self) -> bool {
-        ActionInfoHashKey::eq(&self.unique_qualifier, &other.unique_qualifier)
-    }
-}
-
-impl Eq for ActionInfo {}
-
-impl Ord for ActionInfo {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Want the highest priority on top, but the lowest insert_timestamp.
-        self.priority
-            .cmp(&other.priority)
-            .then_with(|| other.insert_timestamp.cmp(&self.insert_timestamp))
-            .then_with(|| self.salt().cmp(other.salt()))
-            .then_with(|| self.digest().size_bytes.cmp(&other.digest().size_bytes))
-            .then_with(|| self.digest().packed_hash.cmp(&other.digest().packed_hash))
-            .then_with(|| {
-                self.unique_qualifier
-                    .digest_function
-                    .cmp(&other.unique_qualifier.digest_function)
-            })
-    }
-}
-
-impl PartialOrd for ActionInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Borrow<ActionInfoHashKey> for Arc<ActionInfo> {
-    #[inline]
-    fn borrow(&self) -> &ActionInfoHashKey {
-        &self.unique_qualifier
-    }
-}
-
-impl Hash for ActionInfoHashKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Digest is unique, so hashing it is all we need.
-        self.digest_function.hash(state);
-        self.digest.hash(state);
-        self.salt.hash(state);
-    }
-}
-
-impl PartialEq for ActionInfoHashKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.digest == other.digest
-            && self.salt == other.salt
-            && self.digest_function == other.digest_function
-    }
-}
-
-impl Eq for ActionInfoHashKey {}
 
 /// Simple utility struct to determine if a string is representing a full path or
 /// just the name of the file.
@@ -754,9 +698,6 @@ impl TryFrom<ExecutedActionMetadata> for ExecutionMetadata {
         })
     }
 }
-
-/// Exit code sent if there is an internal error.
-pub const INTERNAL_ERROR_EXIT_CODE: i32 = -178;
 
 /// Represents the results of an execution.
 /// This struct must be 100% compatible with `ActionResult` in `remote_execution.proto`.
@@ -1143,15 +1084,6 @@ pub struct ActionState {
 }
 
 impl ActionState {
-    #[inline]
-    pub fn unique_qualifier(&self) -> &ActionInfoHashKey {
-        &self.id.unique_qualifier
-    }
-    #[inline]
-    pub fn action_digest(&self) -> &DigestInfo {
-        &self.id.unique_qualifier.digest
-    }
-
     pub fn try_from_operation(
         operation: Operation,
         operation_id: OperationId,
@@ -1210,7 +1142,7 @@ impl ActionState {
         } else {
             None
         };
-        let digest = Some(self.id.unique_qualifier.digest.into());
+        let digest = Some(self.id.unique_qualifier.digest().into());
 
         let metadata = ExecuteOperationMetadata {
             stage,

--- a/nativelink-util/tests/operation_id_tests.rs
+++ b/nativelink-util/tests/operation_id_tests.rs
@@ -19,22 +19,28 @@ use pretty_assertions::assert_eq;
 
 #[nativelink_test]
 async fn parse_operation_id() -> Result<(), Error> {
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
-    assert_eq!(
-        operation_id.to_string(),
-        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-    assert_eq!(
-        operation_id.action_name(),
-        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0"
-    );
-    assert_eq!(
-        operation_id.id.to_string(),
-        "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
-    );
-    assert_eq!(
-        hex::encode(operation_id.get_hash()),
-        "5a36f0db39e27667c4b91937cd29c1df8799ba468f2de6810c6865be05517644"
-    );
+    {
+        // Check no cached.
+        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
+        assert_eq!(
+            operation_id.to_string(),
+            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+        assert_eq!(
+            operation_id.id.to_string(),
+            "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
+        );
+    }
+    {
+        // Check cached.
+        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/1/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
+        assert_eq!(
+            operation_id.to_string(),
+            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/1/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+        assert_eq!(
+            operation_id.id.to_string(),
+            "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
+        );
+    }
     Ok(())
 }
 
@@ -53,7 +59,7 @@ async fn parse_empty_failure() -> Result<(), Error> {
     assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(
         operation_id.messages[0],
-        "Invalid ActionInfoHashKey instance name fragment - /"
+        "Invalid UniqueQualifier instance name fragment - /"
     );
 
     let operation_id = OperationId::try_from("main").err().unwrap();
@@ -92,25 +98,23 @@ async fn parse_empty_failure() -> Result<(), Error> {
         operation_id.messages[0],
         "cannot parse integer from empty string"
     );
-    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
     let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(operation_id.messages.len(), 2);
     assert_eq!(operation_id.messages[0], "invalid digit found in string");
-    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
     let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "invalid digit found in string");
-    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey salt hex conversion - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier cachable value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
     let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 2);
+    assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "invalid digit found in string");
-    assert_eq!(operation_id.messages[1], "Invalid ActionInfoHashKey salt hex conversion - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier cachable value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
     let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/baduuid").err().unwrap();
     assert_eq!(operation_id.messages.len(), 1);
@@ -124,7 +128,7 @@ async fn parse_empty_failure() -> Result<(), Error> {
     .unwrap();
     assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(operation_id.code, Code::Internal);
-    assert_eq!(operation_id.messages[0], "Invalid ActionInfoHashKey digest size fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0");
+    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier digest size fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0");
 
     Ok(())
 }

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1033,7 +1033,7 @@ impl RunningActionImpl {
             )
         };
         let cas_store = self.running_actions_manager.cas_store.as_ref();
-        let hasher = self.action_info.unique_qualifier.digest_function;
+        let hasher = self.action_info.unique_qualifier.digest_function();
         enum OutputType {
             None,
             File(FileInfo),
@@ -1731,10 +1731,9 @@ impl RunningActionsManagerImpl {
                 get_and_decode_digest::<Action>(self.cas_store.as_ref(), action_digest.into())
                     .await
                     .err_tip(|| "During start_action")?;
-            let action_info = ActionInfo::try_from_action_and_execute_request_with_salt(
+            let action_info = ActionInfo::try_from_action_and_execute_request(
                 execute_request,
                 action,
-                0, // TODO: salt is no longer needed.
                 load_start_timestamp,
                 queued_timestamp,
             )

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -42,7 +42,8 @@ use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::filesystem_store::FilesystemStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ExecutionMetadata, OperationId,
+    ActionInfo, ActionResult, ActionStage, ActionUniqueKey, ActionUniqueQualifier,
+    ExecutionMetadata, OperationId,
 };
 use nativelink_util::common::{encode_stream_proto, fs, DigestInfo};
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -230,13 +231,11 @@ async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
+        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Blake3,
             digest: action_digest,
-            salt: 0,
-        },
-        skip_cache_lookup: true,
+        }),
     };
 
     {
@@ -314,13 +313,11 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
+        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
-            salt: 0,
-        },
-        skip_cache_lookup: true,
+        }),
     };
 
     {
@@ -578,13 +575,11 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
+        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
-            salt: 0,
-        },
-        skip_cache_lookup: true,
+        }),
     };
 
     {
@@ -630,8 +625,6 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
 
 #[nativelink_test]
 async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Error>> {
-    const SALT: u64 = 1000;
-
     let mut test_context = setup_local_worker(HashMap::new()).await;
 
     let streaming_response = test_context.maybe_streaming_response.take().unwrap();
@@ -667,13 +660,11 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionInfoHashKey {
+        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Blake3,
             digest: action_digest,
-            salt: SALT,
-        },
-        skip_cache_lookup: true,
+        }),
     };
 
     let operation_id = OperationId::new(action_info.unique_qualifier.clone());

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -42,11 +42,10 @@ use nativelink_store::ac_utils::{get_and_decode_digest, serialize_and_upload_mes
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::filesystem_store::FilesystemStore;
 use nativelink_store::memory_store::MemoryStore;
-use nativelink_util::action_messages::{ActionInfoHashKey, OperationId};
-#[cfg_attr(target_family = "windows", allow(unused_imports))]
 use nativelink_util::action_messages::{
-    ActionResult, DirectoryInfo, ExecutionMetadata, FileInfo, NameOrPath, SymlinkInfo,
+    ActionResult, DirectoryInfo, ExecutionMetadata, FileInfo, NameOrPath,
 };
+use nativelink_util::action_messages::{ActionUniqueKey, ActionUniqueQualifier, OperationId};
 use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::store_trait::{Store, StoreLike};
@@ -143,7 +142,7 @@ fn increment_clock(time: &mut SystemTime) -> SystemTime {
 }
 
 fn make_operation_id(execute_request: &ExecuteRequest) -> OperationId {
-    let unique_qualifier = ActionInfoHashKey {
+    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
         instance_name: execute_request.instance_name.clone(),
         digest_function: execute_request.digest_function.try_into().unwrap(),
         digest: execute_request
@@ -152,8 +151,7 @@ fn make_operation_id(execute_request: &ExecuteRequest) -> OperationId {
             .unwrap()
             .try_into()
             .unwrap(),
-        salt: 0,
-    };
+    });
     OperationId::new(unique_qualifier)
 }
 


### PR DESCRIPTION
We no longer need `salt` as part of the action key, because we now put the key as an value in an enum in ActionUniqueQualifier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1126)
<!-- Reviewable:end -->
