### PR TITLE
ClientAwaitedAction now uses a channel to notify drops happened

### DIFF
--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -227,7 +227,6 @@ impl ActionScheduler for CacheLookupScheduler {
             .await;
             match maybe_action_result {
                 Ok(action_result) => {
-                    println!("{action_result:?}");
                     let maybe_pending_txs = {
                         let mut inflight_cache_checks = inflight_cache_checks.lock();
                         // We are ready to resolve the in-flight actions. We remove the

--- a/nativelink-scheduler/src/scheduler_state/awaited_action.rs
+++ b/nativelink-scheduler/src/scheduler_state/awaited_action.rs
@@ -68,7 +68,7 @@ pub struct AwaitedAction {
     action_info: Arc<ActionInfo>,
 
     // The unique identifier of the operation.
-    // TODO(operation_id should be stored here).
+    // TODO!(operation_id should be stored here).
     // operation_id: OperationId,
     /// The data that is used to sort the action in the queue.
     /// The first item in the tuple is the current priority,


### PR DESCRIPTION
Instead of using Weak references and custom spawns, we now use
a channel to notify receivers that cleanups are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1130)
<!-- Reviewable:end -->
