### PR TITLE
Fix overflowing mermaid diagrams in docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -63,7 +63,7 @@ export default defineConfig({
     sitemap(),
     starlight({
       components: {
-        PagekFrame: "./src/components/PageFrame.astro",
+        PageFrame: "./src/components/PageFrame.astro",
       },
       logo: {
         light: "/src/assets/logo-light.svg",


### PR DESCRIPTION
Turns out I added this already and it just didn't work because of a typo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1133)
<!-- Reviewable:end -->
