### PR TITLE
Change encoding for items that are cachable

### DIFF
--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -71,7 +71,6 @@ impl std::fmt::Display for ClientOperationId {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct OperationId {
-    // TODO!(this should be for debugging only)
     pub unique_qualifier: ActionUniqueQualifier,
     pub id: Uuid,
 }
@@ -138,7 +137,7 @@ impl TryFrom<&str> for OperationId {
     ///
     /// ```no_run
     /// use nativelink_util::action_messages::OperationId;
-    /// let operation_id_str = "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52";
+    /// let operation_id_str = "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52";
     /// let operation_id = OperationId::try_from(operation_id_str);
     /// ```
     ///
@@ -170,8 +169,8 @@ impl TryFrom<&str> for OperationId {
         )
         .err_tip(|| format!("Invalid DigestInfo digest hash - {value}"))?;
         let cachable = match cachable {
-            "0" => false,
-            "1" => true,
+            "u" => false,
+            "c" => true,
             _ => {
                 return Err(make_input_err!(
                     "Invalid UniqueQualifier cachable value fragment - {value}"
@@ -286,8 +285,7 @@ impl std::fmt::Display for ActionUniqueQualifier {
             unique_key.digest_function,
             unique_key.digest.hash_str(),
             unique_key.digest.size_bytes,
-            // TODO!(maybe make this a different value?)
-            cachable as i32, // Convert to 0 or 1.
+            if cachable { 'c' } else { 'u' },
         ))
     }
 }

--- a/nativelink-util/tests/operation_id_tests.rs
+++ b/nativelink-util/tests/operation_id_tests.rs
@@ -21,10 +21,10 @@ use pretty_assertions::assert_eq;
 async fn parse_operation_id() -> Result<(), Error> {
     {
         // Check no cached.
-        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
+        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
         assert_eq!(
             operation_id.to_string(),
-            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
         assert_eq!(
             operation_id.id.to_string(),
             "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
@@ -32,10 +32,10 @@ async fn parse_operation_id() -> Result<(), Error> {
     }
     {
         // Check cached.
-        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/1/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
+        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/c/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
         assert_eq!(
             operation_id.to_string(),
-            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/1/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/c/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
         assert_eq!(
             operation_id.id.to_string(),
             "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
@@ -70,7 +70,7 @@ async fn parse_empty_failure() -> Result<(), Error> {
         "Invalid OperationId unique_qualifier / id fragment - main"
     );
 
-    let operation_id = OperationId::try_from("main/nohashfn/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    let operation_id = OperationId::try_from("main/nohashfn/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(
@@ -79,7 +79,7 @@ async fn parse_empty_failure() -> Result<(), Error> {
     );
 
     let operation_id =
-        OperationId::try_from("main/SHA256/badhash-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52")
+        OperationId::try_from("main/SHA256/badhash-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52")
             .err()
             .unwrap();
     assert_eq!(operation_id.messages.len(), 3);
@@ -88,23 +88,23 @@ async fn parse_empty_failure() -> Result<(), Error> {
     assert_eq!(operation_id.messages[1], "Invalid sha256 hash: badhash");
     assert_eq!(
         operation_id.messages[2],
-        "Invalid DigestInfo digest hash - main/SHA256/badhash-211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
+        "Invalid DigestInfo digest hash - main/SHA256/badhash-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
     );
 
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
     assert_eq!(operation_id.messages.len(), 2);
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(
         operation_id.messages[0],
         "cannot parse integer from empty string"
     );
-    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(operation_id.messages.len(), 2);
     assert_eq!(operation_id.messages[0], "invalid digit found in string");
-    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/0/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
     let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
     assert_eq!(operation_id.messages.len(), 1);
@@ -116,7 +116,7 @@ async fn parse_empty_failure() -> Result<(), Error> {
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier cachable value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
 
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0/baduuid").err().unwrap();
+    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/baduuid").err().unwrap();
     assert_eq!(operation_id.messages.len(), 1);
     assert_eq!(operation_id.code, Code::InvalidArgument);
     assert_eq!(operation_id.messages[0], "Failed to parse invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `u` at 4 as uuid");


### PR DESCRIPTION
Instead of `0` and `1` if something is cachable we use `c` and `u`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1136)
<!-- Reviewable:end -->
