### PR TITLE
Change remote cache URLs from secrets to vars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,11 @@ jobs:
       shell: bash
       run: |
         bazel test \
-          --remote_cache=${{ secrets.NATIVELINK_COM_REMOTE_CACHE_URL }} \
+          --remote_cache=${{ vars.NATIVELINK_COM_REMOTE_CACHE_URL }} \
           --remote_header=${{ secrets.NATIVELINK_COM_API_HEADER }} \
-          --bes_backend=${{ secrets.NATIVELINK_COM_BES_URL }} \
+          --bes_backend=${{ vars.NATIVELINK_COM_BES_URL }} \
           --bes_header=${{ secrets.NATIVELINK_COM_API_HEADER }} \
-          --bes_results_url=${{ secrets.NATIVELINK_COM_BES_RESULTS_URL }} \
+          --bes_results_url=${{ vars.NATIVELINK_COM_BES_RESULTS_URL }} \
           --remote_header=x-nativelink-project=nativelink-ci \
           //...
 


### PR DESCRIPTION
# Description

Changes using the url variables for the NativeLink Cloud from secrets to vars

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1143)
<!-- Reviewable:end -->
