### PR TITLE
Disable some workflows on PRs that only change docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
 
 permissions: read-all
 

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 permissions: read-all
 

--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 permissions: read-all
 

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 permissions: read-all
 


### PR DESCRIPTION
This is a bit risky and we might want to reenable some of these, but let's see how this goes. Reasoning for the disabled workflows:

- `main.yaml`: This is independent of docs
- `native-bazel.yaml`: Dev-only workflow and covered by nix workflows.
- `native-cargo.yaml`: Dev-only workflow and covered by nix workflows.
- `sanitizers.yaml`: Independent of the docs.

This change deliberately doesn't touch the Nix workflows as parts of the development tooling used by doc workflows relies on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1148)
<!-- Reviewable:end -->
