### PR TITLE
Introduce NL_LOG to control logging format

### DIFF
--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -30,7 +30,7 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-util = { version = "0.7.11" }
 tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

`NL_LOG` envionment variable is used to control the logging format that `tracing_subscriber` emits out. We currently want to allow for better ingestion of formatted logs in json.

`NL_LOG` can be configured with `pretty`, `json`, or `compact`. See [Format](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Format.html) for more detail on console logging format configurations for tracing_subscriber.

Fixes https://github.com/TraceMachina/nativelink/issues/1153

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Run from console to see the different log formats

**Default**

```
$ cargo run --bin nativelink -- nativelink-config/examples/basic_cas.json
     Running `target/debug/nativelink nativelink-config/examples/basic_cas.json`
  2024-07-13T05:38:08.874357Z  WARN nativelink: Ready, listening on 0.0.0.0:50051
    at src/bin/nativelink.rs:677

  2024-07-13T05:38:08.874826Z  WARN nativelink: Ready, listening on 0.0.0.0:50061
    at src/bin/nativelink.rs:677

  2024-07-13T05:38:08.879914Z  WARN nativelink_worker::local_worker: Worker registered with scheduler, worker_id: 8e0703dc-73c3-428f-a3c4-6dbebaafd0f7
    at nativelink-worker/src/local_worker.rs:558
    in nativelink::worker with name: "worker_0"
```


**Json**

```
$ NL_LOG=json cargo run --bin nativelink -- nativelink-config/examples/basic_cas.json
     Running `target/debug/nativelink nativelink-config/examples/basic_cas.json`
{"timestamp":"2024-07-13T05:38:25.159897Z","level":"WARN","fields":{"message":"Ready, listening on 0.0.0.0:50051"},"target":"nativelink"}
{"timestamp":"2024-07-13T05:38:25.160350Z","level":"WARN","fields":{"message":"Ready, listening on 0.0.0.0:50061"},"target":"nativelink"}
{"timestamp":"2024-07-13T05:38:25.164892Z","level":"WARN","fields":{"message":"Worker registered with scheduler","worker_id":"73cf46ea-c58c-480a-bf4f-bd792ced4f1d"},"target":"nativelink_worker::local_worker","span":{"name":"\"worker_0\"","name":"worker"},"spans":[{"name":"\"worker_0\"","name":"worker"}]}
```

**compact**

```
$ NL_LOG=compact cargo run --bin nativelink -- nativelink-config/examples/basic_cas.json
     Running `target/debug/nativelink nativelink-config/examples/basic_cas.json`
2024-07-13T05:38:34.098568Z  WARN nativelink: Ready, listening on 0.0.0.0:50051
2024-07-13T05:38:34.099017Z  WARN nativelink: Ready, listening on 0.0.0.0:50061
2024-07-13T05:38:34.104507Z  WARN worker: nativelink_worker::local_worker: Worker registered with scheduler worker_id=bf440d8a-8dab-4fe1-8683-1e40469b87c2 name="worker_0"
```

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1154)
<!-- Reviewable:end -->
