### PR TITLE
Fix typos in the documentation and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ please raise an issue so that we can clarify this document.
 
 ## Local development setup
 
-NativeLink ships almost all of it's tooling in a nix flake which is configured
+NativeLink ships almost all of its tooling in a nix flake which is configured
 via a [`flake.nix`](./flake.nix) file in the root of the repository. While it's
 possible to work on some parts of the codebase without this environment, it'll
 make your life much easier since it lets you reproduce most of CI locally.
@@ -390,7 +390,7 @@ bazel test doctests
 
 NativeLink largely follows the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).
 
-NativeLink implements it's documentation style guide via Vale. The pre-commit
+NativeLink implements its documentation style guide via Vale. The pre-commit
 hooks forbid errors but permit warnings and suggestions. To view all of Vale's
 suggestions invoke it directly:
 

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -87,7 +87,7 @@ pub struct SimpleScheduler {
     /// The property names here must match the property keys provided by the
     /// worker nodes when they join the pool. In other words, the workers will
     /// publish their capabilities to the scheduler when they join the worker
-    /// pool. If the worker fails to notify the scheduler of it's (for example)
+    /// pool. If the worker fails to notify the scheduler of its (for example)
     /// "cpu_arch", the scheduler will never send any jobs to it, if all jobs
     /// have the "cpu_arch" label. There is no special treatment of any platform
     /// property labels other and entirely driven by worker configs and this

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -246,7 +246,7 @@ impl ByteStreamServer {
         let (tx, rx) = make_buf_channel_pair();
         let store_update_fut = Box::pin(async move {
             // We need to wrap `Store::update()` in a another future because we need to capture
-            // `store` to ensure it's lifetime follows the future and not the caller.
+            // `store` to ensure its lifetime follows the future and not the caller.
             store
                 // Bytestream always uses digest size as the actual byte size.
                 .update(

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -989,7 +989,7 @@ async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens()
     // Delete may happen on another thread, so wait for it.
     FILE_DELETED_BARRIER.wait().await;
 
-    // Now it should have cleaned up it's temp files.
+    // Now it should have cleaned up its temp files.
     {
         // Ensure `temp_path` is empty.
         let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();

--- a/nativelink-util/src/fastcdc.rs
+++ b/nativelink-util/src/fastcdc.rs
@@ -30,7 +30,7 @@ impl State {
 /// normal conditions all the chunk boundaries will be identical except the ones near
 /// the mutations.
 ///
-/// This is not very useful on it's own, but is extremely useful because we can pair
+/// This is not very useful on its own, but is extremely useful because we can pair
 /// this together with a hash algorithm (like sha256) to then hash each chunk and
 /// then check to see if we already have the sha256 somewhere before attempting to
 /// upload the file. If the file does exist, we can skip the chunk and continue then

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -78,7 +78,7 @@ const SLASH_SIZE: usize = 1;
 //                 uploads/{uuid}/blobs/                                          {hash}/{size}
 //
 
-// Useful utility struct for converting bazel's (uri-like path) into it's parts.
+// Useful utility struct for converting bazel's (uri-like path) into its parts.
 #[derive(Debug, Default)]
 pub struct ResourceInfo<'a> {
     pub instance_name: Cow<'a, str>,


### PR DESCRIPTION
# Description

There are typos of misusing `it's` instead of `its` in the documentation and comments. Those typos can be found in the contribution documentation file and code comments of this project. No more typos like this exist after this commit.

More details can be found in the issue link below.

Fixes #1173 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1174)
<!-- Reviewable:end -->
