### PR TITLE
Make CAS and AC server not to use the same store

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -134,4 +134,5 @@ jobs:
 
       - name: Test nix run
         run: |
+          nix run -L .#nativelink-prevent-store-conflict-test
           nix run -L .#nativelink-is-executable-test

--- a/flake.nix
+++ b/flake.nix
@@ -215,6 +215,8 @@
 
         local-image-test = pkgs.callPackage ./tools/local-image-test.nix {};
 
+        nativelink-prevent-store-conflict-test = pkgs.callPackage ./tools/nativelink-prevent-store-conflict-test.nix {inherit nativelink;};
+
         nativelink-is-executable-test = pkgs.callPackage ./tools/nativelink-is-executable-test.nix {inherit nativelink;};
 
         rbe-configs-gen = pkgs.callPackage ./local-remote-execution/rbe-configs-gen.nix {};
@@ -357,6 +359,7 @@
               nativelink-debug
               nativelink-image
               nativelink-is-executable-test
+              nativelink-prevent-store-conflict-test
               nativelink-worker-init
               nativelink-x86_64-linux
               publish-ghcr

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -17,12 +17,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::{
-    action_messages::{ActionInfo, OperationId},
-    known_platform_property_provider::KnownPlatformPropertyProvider,
-    operation_state_manager::{
-        ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
-    },
+use nativelink_util::action_messages::{ActionInfo, OperationId};
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
 };
 use tokio::sync::{mpsc, Mutex};
 

--- a/tools/nativelink-prevent-store-conflict-test.nix
+++ b/tools/nativelink-prevent-store-conflict-test.nix
@@ -1,0 +1,72 @@
+{
+  nativelink,
+  writeShellScriptBin,
+}:
+writeShellScriptBin "prevent-store-conflict-test" ''
+  set -xuo pipefail
+
+  cat > store_conflict_test.json <<EOF
+  {
+    "stores": {
+      "FILESYSTEM_STORE": {
+        "compression": {
+          "compression_algorithm": {
+            "lz4": {}
+          },
+          "backend": {
+            "filesystem": {
+              "content_path": "~/.cache/nativelink/content_path-cas",
+              "temp_path": "~/.cache/nativelink/tmp_path-cas",
+              "eviction_policy": {
+                // 10gb.
+                "max_bytes": 10000000000,
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [{
+      "listener": {
+        "http": {
+          "socket_address": "0.0.0.0:50053"
+        }
+      },
+      "services": {
+        "cas": {
+          "main": {
+            "cas_store": "FILESYSTEM_STORE"
+          }
+        },
+        "ac": {
+          "main": {
+            "ac_store": "FILESYSTEM_STORE"
+          }
+        },
+        "capabilities": {},
+        "bytestream": {
+          "cas_stores": {
+            "main": "FILESYSTEM_STORE",
+          }
+        }
+      }
+    }]
+  }
+  EOF
+
+  nativelink_output="$(${nativelink}/bin/nativelink ./store_conflict_test.json 2>&1)"
+
+  rm ./store_conflict_test.json
+
+  print_error_output=$(cat <<EOF
+  Error: Error { code: InvalidArgument, messages: ["CAS and AC cannot use the same store 'FILESYSTEM_STORE' in the config"] }
+  EOF)
+
+  if [ "$nativelink_output" = "$print_error_output" ]; then
+    echo "The output of nativelink matches the print_error output."
+  else
+    echo 'The output of nativelink does not match the print_error output:'
+    diff <(echo "$nativelink_output") <(echo "$print_error_output") >&2
+    exit 1
+  fi
+''


### PR DESCRIPTION
# Description

When CAS and AC uses the same store, it might produce unexpected side-effects and wrong behaviors. To prevent system from such situation, it currently raises an error when CAS and AC uses the same store.

Fixes #768 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1175)
<!-- Reviewable:end -->
