### PR TITLE
Add documentation for api key setup in github actions

### DIFF
--- a/.github/styles/config/vocabularies/TraceMachina/accept.txt
+++ b/.github/styles/config/vocabularies/TraceMachina/accept.txt
@@ -52,3 +52,4 @@ proto
 quantiles
 Config
 Grafana
+GitHub

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -122,6 +122,10 @@ export default defineConfig({
               label: "Pants",
               link: "/nativelink-cloud/pants/",
             },
+            {
+              label: "API Keys in Production",
+              link: "/nativelink-cloud/api-key/",
+            },
           ],
         },
         {

--- a/docs/scripts/md_to_mdx.ts
+++ b/docs/scripts/md_to_mdx.ts
@@ -76,7 +76,7 @@ pagefind: ${pagefind}
 `;
 }
 
-export function transformGithubMarkdown(content: RootContent[]): RootContent[] {
+export function transformGitHubMarkdown(content: RootContent[]): RootContent[] {
   return content.flatMap((node) => {
     if (node.type === "blockquote") {
       const transformed = transformBlockquote(node as Blockquote);
@@ -227,7 +227,7 @@ export async function transformMarkdownToMdx(
   const tree = parseMarkdown(preprocessedMarkdown);
   const { title, content } = extractTitle(tree);
 
-  let transformedContent = transformGithubMarkdown(content);
+  let transformedContent = transformGitHubMarkdown(content);
   transformedContent = preserveInlineCode(transformedContent);
 
   const modifiedMarkdown = remark()

--- a/docs/src/content/docs/nativelink-cloud/api-key.mdx
+++ b/docs/src/content/docs/nativelink-cloud/api-key.mdx
@@ -1,0 +1,30 @@
+---
+title: "API Keys in Production"
+description: "How to use NativeLink Cloud API keys in production"
+pagefind: true
+---
+
+## GitHub Actions
+GitHub Repository Secrets is the recommended way
+to store your NativeLink Cloud API keys
+for use with GitHub Actions.
+
+[GitHub Repository Secrets Tutorial](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)
+
+They can be access via the secrets context i.e.
+```
+${{ secrets.YourSecretKeyName }}
+```
+
+:::note
+If your repository uses forks for pull requests (PRs), note that the secrets
+context isn't accessible from PRs originating from forks. To address this,
+we will soon introduce Read-Only keys.
+
+Read-Only keys can be used for PRs and stored in the vars context. For
+merge-to-main actions, use a Read/Write key stored in the secrets context.
+:::
+
+If you need info on setting up API keys for different CI environments, ask in
+the [Slack channel](https://nativelink.slack.com/join/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A#/shared-invite/email)
+or open an issue on our [GitHub](https://github.com/TraceMachina/nativelink).


### PR DESCRIPTION
# Description
Adds a section to the docs for production grade setups for API key secrets in different CI systems, specifically github actions to start.

:::note
Will pass vale pre-commit warning level before landing
:::

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1185)
<!-- Reviewable:end -->
