### PR TITLE
Add read only key instructions to docs

### DIFF
--- a/docs/src/content/docs/nativelink-cloud/api-key.mdx
+++ b/docs/src/content/docs/nativelink-cloud/api-key.mdx
@@ -12,19 +12,28 @@ for use with GitHub Actions.
 [GitHub Repository Secrets Tutorial](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)
 
 They can be access via the secrets context i.e.
-```
+```bash
 ${{ secrets.YourSecretKeyName }}
 ```
 
+### Read Only keys
 :::note
 If your repository uses forks for pull requests (PRs), note that the secrets
 context isn't accessible from PRs originating from forks. To address this,
-we will soon introduce Read-Only keys.
+we introduced Read-Only keys.
+:::
 
 Read-Only keys can be used for PRs and stored in the vars context. For
 merge-to-main actions, use a Read/Write key stored in the secrets context.
-:::
 
+For Read Only API Keys you need to set these two flags:
+
+```bash
+--nogenerate_json_trace_profile
+--remote_upload_local_results=false
+```
+
+## Third-Party Secrets Management
 If you need info on setting up API keys for different CI environments, ask in
 the [Slack channel](https://nativelink.slack.com/join/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A#/shared-invite/email)
 or open an issue on our [GitHub](https://github.com/TraceMachina/nativelink).


### PR DESCRIPTION
A separate sections for read-only keys has been created in the cloud API key docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1187)
<!-- Reviewable:end -->
