### PR TITLE
Fix typos in code comments

### DIFF
--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -18,7 +18,7 @@ ARG OS_VERSION=22.04
 ARG OPT_LEVEL=opt
 # Additional bazel flags.
 ARG ADDITIONAL_BAZEL_FLAGS=
-# Bash arguments my be passed in here to install any additional dependencies
+# Bash arguments may be passed in here to install any additional dependencies
 # needed by the user. Useful if your worker needs specific dependencies installed.
 ARG ADDITIONAL_SETUP_WORKER_CMD=
 

--- a/integration_tests/simple_prometheus_test.sh
+++ b/integration_tests/simple_prometheus_test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a sanity check test to ensure we are caching test results.
+# This is a sanity check test to ensure prometheus metrics server is working.
 
 if [[ $UNDER_TEST_RUNNER -ne 1 ]]; then
   echo "This script should be run under run_integration_tests.sh"


### PR DESCRIPTION
# Description

Recently, I found out that there were 2 typos remaining in this project.

1. Here, `my` should be `may`.

https://github.com/TraceMachina/nativelink/blob/d37bd90a314890fe901235e0432d263faa66d221/deployment-examples/docker-compose/Dockerfile#L21

2. Here, the code comments for `simple_cache_test.sh` and `simple_prometheus_test.sh` are the same currently.
For `simple_prometheus_test.sh`, the comment should be changed.

https://github.com/TraceMachina/nativelink/blob/d37bd90a314890fe901235e0432d263faa66d221/integration_tests/simple_cache_test.sh#L16

https://github.com/TraceMachina/nativelink/blob/d37bd90a314890fe901235e0432d263faa66d221/integration_tests/simple_prometheus_test.sh#L16

Fixes #1189 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1190)
<!-- Reviewable:end -->
