### PR TITLE
ExistenceCacheStore now only evicts based on insert

### DIFF
--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -50,6 +50,7 @@ nativelink-macro = { path = "../nativelink-macro" }
 redis-test = { version = "0.4.0", features = ["aio"] }
 pretty_assertions = "1.4.0"
 memory-stats = "1.2.0"
+mock_instant = "0.3.2"
 once_cell = "1.19.0"
 http = "1.1.0"
 aws-smithy-types = "1.2.0"
@@ -57,4 +58,3 @@ aws-sdk-s3 = { version = "1.41.0" }
 aws-smithy-runtime = { version = "1.6.2", features = ["test-util"] }
 aws-smithy-runtime-api = "1.7.1"
 serial_test = { version = "3.1.1", features = ["async"] }
-mock_instant = "0.3.2"

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -23,7 +24,8 @@ use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::evicting_map::{EvictingMap, LenEntry};
-use nativelink_util::health_utils::{default_health_status_indicator, HealthStatusIndicator};
+use nativelink_util::health_utils::{HealthStatus, HealthStatusIndicator};
+use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo};
 
 #[derive(Clone, Debug)]
@@ -42,24 +44,38 @@ impl LenEntry for ExistanceItem {
 }
 
 #[derive(MetricsComponent)]
-pub struct ExistenceCacheStore {
+pub struct ExistenceCacheStore<I: InstantWrapper> {
     #[metric(group = "inner_store")]
     inner_store: Store,
-    existence_cache: EvictingMap<DigestInfo, ExistanceItem, SystemTime>,
+    existence_cache: EvictingMap<DigestInfo, ExistanceItem, I>,
 }
 
-impl ExistenceCacheStore {
+impl ExistenceCacheStore<SystemTime> {
     pub fn new(config: &ExistenceCacheStoreConfig, inner_store: Store) -> Arc<Self> {
+        Self::new_with_time(config, inner_store, SystemTime::now())
+    }
+}
+
+impl<I: InstantWrapper> ExistenceCacheStore<I> {
+    pub fn new_with_time(
+        config: &ExistenceCacheStoreConfig,
+        inner_store: Store,
+        anchor_time: I,
+    ) -> Arc<Self> {
         let empty_policy = EvictionPolicy::default();
         let eviction_policy = config.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
             inner_store,
-            existence_cache: EvictingMap::new(eviction_policy, SystemTime::now()),
+            existence_cache: EvictingMap::new(eviction_policy, anchor_time),
         })
     }
 
     pub async fn exists_in_cache(&self, digest: &DigestInfo) -> bool {
-        self.existence_cache.size_for_key(digest).await.is_some()
+        let mut results = [None];
+        self.existence_cache
+            .sizes_for_keys([digest], &mut results[..], true /* peek */)
+            .await;
+        results[0].is_some()
     }
 
     pub async fn remove_from_cache(&self, digest: &DigestInfo) {
@@ -71,7 +87,9 @@ impl ExistenceCacheStore {
         keys: &[DigestInfo],
         results: &mut [Option<usize>],
     ) -> Result<(), Error> {
-        self.existence_cache.sizes_for_keys(keys, results).await;
+        self.existence_cache
+            .sizes_for_keys(keys, results, true /* peek */)
+            .await;
 
         let not_cached_keys: Vec<_> = keys
             .iter()
@@ -129,7 +147,7 @@ impl ExistenceCacheStore {
 }
 
 #[async_trait]
-impl StoreDriver for ExistenceCacheStore {
+impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
@@ -214,4 +232,13 @@ impl StoreDriver for ExistenceCacheStore {
     }
 }
 
-default_health_status_indicator!(ExistenceCacheStore);
+#[async_trait]
+impl<I: InstantWrapper> HealthStatusIndicator for ExistenceCacheStore<I> {
+    fn get_name(&self) -> &'static str {
+        "ExistenceCacheStore"
+    }
+
+    async fn check_health(&self, namespace: Cow<'static, str>) -> HealthStatus {
+        StoreDriver::check_health(Pin::new(self), namespace).await
+    }
+}

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -737,7 +737,9 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         // insert them into the cache. In theory it should be able to elide this conversion
         // but it seems to be a bit tricky to get right.
         let keys: Vec<_> = keys.iter().map(|v| v.borrow().into_digest()).collect();
-        self.evicting_map.sizes_for_keys(&keys, results).await;
+        self.evicting_map
+            .sizes_for_keys(&keys, results, false /* peek */)
+            .await;
         // We need to do a special pass to ensure our zero files exist.
         // If our results failed and the result was a zero file, we need to
         // create the file by spec.

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -182,7 +182,9 @@ impl StoreDriver for MemoryStore {
         // TODO(allada): This is a dirty hack to get around the lifetime issues with the
         // evicting map.
         let digests: Vec<_> = keys.iter().map(|key| key.borrow().into_owned()).collect();
-        self.evicting_map.sizes_for_keys(digests, results).await;
+        self.evicting_map
+            .sizes_for_keys(digests, results, false /* peek */)
+            .await;
         // We need to do a special pass to ensure our zero digest exist.
         keys.iter()
             .zip(results.iter_mut())

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -19,7 +19,7 @@ use mock_instant::{Instant as MockInstant, MockClock};
 
 /// Wrapper used to abstract away which underlying Instant impl we are using.
 /// This is needed for testing.
-pub trait InstantWrapper: Send + Sync + 'static {
+pub trait InstantWrapper: Send + Sync + Unpin + 'static {
     fn from_secs(secs: u64) -> Self;
     fn unix_timestamp(&self) -> u64;
     fn elapsed(&self) -> Duration;


### PR DESCRIPTION
To protect against a case where the parent layer store has items hot in cache and those items are frequently touched, we would never actually ask the underlying store for the data. This caused a problem because the underlying store might evict our item, then our parent ExistenceCacheStore would never let go of the item causing the node to be required to shutdown to clear it up.

This was a vary rare event, because most items have `.get()` eventually called on the digest, which refreshes the underlying store object.

closes #1199

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1203)
<!-- Reviewable:end -->
