### PR TITLE
S3 store can ignore `.has()` requests based on LastModified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ dependencies = [
  "hyper-rustls",
  "lz4_flex",
  "memory-stats",
+ "mock_instant",
  "nativelink-config",
  "nativelink-error",
  "nativelink-macro",

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -743,6 +743,20 @@ pub struct S3Store {
     #[serde(default)]
     pub retry: Retry,
 
+    /// If the number of seconds since the `last_modified` time of the object
+    /// is greater than this value, the object will not be considered
+    /// "existing". This allows for external tools to delete objects that
+    /// have not been uploaded in a long time. If a client receives a NotFound
+    /// the client should re-upload the object.
+    ///
+    /// There should be sufficient buffer time between how long the expiration
+    /// configuration of the external tool is and this value. Keeping items
+    /// around for a few days is generally a good idea.
+    ///
+    /// Default: 0. Zero means never consider an object expired.
+    #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
+    pub consider_expired_after_s: u32,
+
     /// The maximum buffer size to retain in case of a retryable error
     /// during upload. Setting this to zero will disable upload buffering;
     /// this means that in the event of a failure during upload, the entire

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -117,6 +117,7 @@ rust_test_suite(
         "@crates//:http-body",
         "@crates//:hyper",
         "@crates//:memory-stats",
+        "@crates//:mock_instant",
         "@crates//:once_cell",
         "@crates//:parking_lot",
         "@crates//:pretty_assertions",

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -59,3 +59,4 @@ aws-sdk-s3 = { version = "1.28.0" }
 aws-smithy-runtime = { version = "1.5.0", features = ["test-util"] }
 aws-smithy-runtime-api = "1.6.0"
 serial_test = { version = "3.1.1", features = ["async"] }
+mock_instant = "0.3.2"

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -14,6 +14,7 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use futures::stream::FuturesOrdered;
 use futures::{Future, TryStreamExt};
@@ -49,7 +50,9 @@ pub fn store_factory<'a>(
     Box::pin(async move {
         let store: Arc<dyn StoreDriver> = match backend {
             StoreConfig::memory(config) => MemoryStore::new(config),
-            StoreConfig::experimental_s3_store(config) => S3Store::new(config).await?,
+            StoreConfig::experimental_s3_store(config) => {
+                S3Store::new(config, SystemTime::now).await?
+            }
             StoreConfig::redis_store(config) => RedisStore::new(config)?,
             StoreConfig::verify(config) => VerifyStore::new(
                 config,

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -15,7 +15,7 @@
 use std::future::Future;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use mock_instant::Instant as MockInstant;
+use mock_instant::{Instant as MockInstant, MockClock};
 
 /// Wrapper used to abstract away which underlying Instant impl we are using.
 /// This is needed for testing.
@@ -65,7 +65,7 @@ impl InstantWrapper for MockInstantWrapped {
     }
 
     fn unix_timestamp(&self) -> u64 {
-        100
+        MockClock::time().as_secs()
     }
 
     fn elapsed(&self) -> Duration {


### PR DESCRIPTION
This feature enables users to setup s3 buckets to evict items after some N amount of time and NativeLink will ignore items that are older than some age. As long as NatliveLink's ignore time is shorter than the eviction time (plus some buffer), clients will upload the artifact again instead of assuming it exists.

closes: #35

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1205)
<!-- Reviewable:end -->
