### PR TITLE
Convert AwaitedAction to and from raw bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,8 @@ dependencies = [
  "prost",
  "rand",
  "scopeguard",
+ "serde",
+ "serde_json",
  "static_assertions",
  "tokio",
  "tokio-stream",

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -43,6 +43,8 @@ rust_library(
         "@crates//:parking_lot",
         "@crates//:rand",
         "@crates//:scopeguard",
+        "@crates//:serde",
+        "@crates//:serde_json",
         "@crates//:static_assertions",
         "@crates//:tokio",
         "@crates//:tokio-stream",

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -27,6 +27,8 @@ tokio = "1.38.0"
 tokio-stream = { version = "0.1.15", default-features = false }
 tonic = { version = "0.12.0", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
+serde = { version = "1.0.203", features = ["rc"] }
+serde_json = "1.0.120"
 static_assertions = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION

Makes AwaitedAction Serialize/Deserialize and adds ability to convert to
and from raw bytes. This will be used to communicate operation data to
and external data storage such as Redis through the store API.

Towards #1182

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1206)
<!-- Reviewable:end -->
