### PR TITLE
Remove nativelink-proto as build dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,7 +18,6 @@ rust_binary(
         "//nativelink-error",
         "//nativelink-metric",
         "//nativelink-metric-collector",
-        "//nativelink-proto",
         "//nativelink-scheduler",
         "//nativelink-service",
         "//nativelink-store",


### PR DESCRIPTION
# Description
This package was already removed from Cargo.toml and should be removed from BUILD.bazel to keep in sync.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ensured that code generation using nativelink-proto through bazel still works and exists as a target

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1209)
<!-- Reviewable:end -->
