### PR TITLE
Significantly reduce Bazel test time

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,11 +16,12 @@
 startup --digest_function=blake3
 common --enable_platform_specific_config
 
+# Don't use legacy toolchain resolution.
+common --incompatible_enable_cc_toolchain_resolution
+common --incompatible_enable_proto_toolchain_resolution
+
 # Don't leak PATH and LD_LIBRARY_PATH into the build.
 build --incompatible_strict_action_env
-
-# Don't use legacy toolchain resolution.
-build --incompatible_enable_cc_toolchain_resolution
 
 # Don't use legacy repository rules.
 build --incompatible_disable_native_repo_rules

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -85,7 +85,14 @@ rust_analyzer = use_extension(
 )
 rust_analyzer.rust_analyzer_dependencies()
 
-bazel_dep(name = "protobuf", version = "27.2")
+bazel_dep(name = "protobuf", version = "27.2", repo_name = "com_google_protobuf")
+bazel_dep(name = "toolchains_protoc", version = "0.3.1")
+
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "v27.1",
+)
 
 # Local remote execution.
 bazel_dep(name = "local-remote-execution", version = "0.0.0")

--- a/nativelink-proto/BUILD.bazel
+++ b/nativelink-proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@rules_rust//rust:defs.bzl",
     "rust_binary",
@@ -27,6 +28,42 @@ rust_binary(
     ],
 )
 
+# TODO(aaronmondal): The config settings we create here don't follow good
+#                    practices and are purely created this way to work around a
+#                    suboptimal naming scheme in toolchains_protoc. Don't use
+#                    this outside of getting protoc. Consider upstreaming a
+#                    naming scheme fix.
+PLATFORM_OS_ARCH = [
+    ("linux", "aarch64"),
+    ("linux", "x86_64"),
+    ("macos", "aarch64"),
+    ("macos", "x86_64"),
+    ("windows", "aarch64"),
+    ("windows", "x86_64"),
+]
+
+[
+    selects.config_setting_group(
+        name = "{}_{}".format(
+            os.replace("macos", "osx"),
+            arch.replace("aarch64", "aarch_64"),
+        ),
+        match_all = [
+            "@platforms//cpu:{}".format(arch),
+            "@platforms//os:{}".format(os),
+        ],
+    )
+    for (os, arch) in PLATFORM_OS_ARCH
+]
+
+PLATFORM_NAMES = [
+    "{}_{}".format(
+        os.replace("macos", "osx"),
+        arch.replace("aarch64", "aarch_64"),
+    )
+    for (os, arch) in PLATFORM_OS_ARCH
+]
+
 genrule(
     name = "gen_rs_protos",
     srcs = [
@@ -51,20 +88,27 @@ genrule(
         "google/rpc/status.proto",
     ],
     outs = ["{}.pb.rs".format(name) for name in PROTO_NAMES],
-    cmd = '''
+    cmd = select({
+        platform: '''
         set -e
-        export PROTOC=$(execpath @protobuf//:protoc)
+        export PROTOC=$(execpath @@toolchains_protoc~~protoc~toolchains_protoc_hub.{}//:bin/protoc)
 
         $(execpath :gen_protos_tool) $(SRCS) -o $(RULEDIR)
 
         for file in $(RULEDIR)/*.rs; do
-            mv -- "$$file" "$${file%.rs}.pb.rs"
+            mv -- "$$file" "$${{file%.rs}}.pb.rs"
         done
-        ''',
+        '''.format(platform)
+        for platform in PLATFORM_NAMES
+    }),
     tools = [
         ":gen_protos_tool",
-        "@protobuf//:protoc",
-    ],
+    ] + select({
+        platform: [
+            "@@toolchains_protoc~~protoc~toolchains_protoc_hub.{}//:bin/protoc".format(platform),
+        ]
+        for platform in PLATFORM_NAMES
+    }),
 )
 
 py_binary(

--- a/nativelink-proto/google/bytestream/bytestream.proto
+++ b/nativelink-proto/google/bytestream/bytestream.proto
@@ -16,9 +16,6 @@ syntax = "proto3";
 
 package google.bytestream;
 
-import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
-
 option go_package = "google.golang.org/genproto/googleapis/bytestream;bytestream";
 option java_outer_classname = "ByteStreamProto";
 option java_package = "com.google.bytestream";


### PR DESCRIPTION
This massive compile time improvement comes from a few evil platform tricks to fetch a precompiled protoc. This saves 713 compile actions.

Observed speedups for clean builds are between 20% and 50%.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1210)
<!-- Reviewable:end -->
