### PR TITLE
Remove ClientOperationId and move all to OperationId

### DIFF
--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use futures::Future;
 use nativelink_error::Error;
 use nativelink_metric::RootMetricsComponent;
-use nativelink_util::action_messages::{ActionInfo, ActionState, ClientOperationId};
+use nativelink_util::action_messages::{ActionInfo, ActionState, OperationId};
 
 use crate::platform_property_manager::PlatformPropertyManager;
 
@@ -27,7 +27,7 @@ use crate::platform_property_manager::PlatformPropertyManager;
 /// that are interested in the state of an action.
 pub trait ActionListener: Sync + Send + Unpin {
     /// Returns the client operation id.
-    fn client_operation_id(&self) -> &ClientOperationId;
+    fn client_operation_id(&self) -> &OperationId;
 
     /// Waits for the action state to change.
     fn changed(
@@ -48,13 +48,13 @@ pub trait ActionScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static 
     /// Adds an action to the scheduler for remote execution.
     async fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         action_info: ActionInfo,
     ) -> Result<Pin<Box<dyn ActionListener>>, Error>;
 
     /// Find an existing action by its name.
     async fn find_by_client_operation_id(
         &self,
-        client_operation_id: &ClientOperationId,
+        client_operation_id: &OperationId,
     ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error>;
 }

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -86,7 +86,8 @@ impl AwaitedAction {
         );
         let state = Arc::new(ActionState {
             stage,
-            id: operation_id.clone(),
+            operation_id: operation_id.clone(),
+            action_digest: action_info.unique_qualifier.digest(),
         });
         Self {
             version: AwaitedActionVersion(0),

--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -20,7 +20,7 @@ pub use awaited_action::{AwaitedAction, AwaitedActionSortKey};
 use futures::{Future, Stream};
 use nativelink_error::Error;
 use nativelink_metric::MetricsComponent;
-use nativelink_util::action_messages::{ActionInfo, ClientOperationId, OperationId};
+use nativelink_util::action_messages::{ActionInfo, OperationId};
 
 mod awaited_action;
 
@@ -80,7 +80,7 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
     /// Get the AwaitedAction by the client operation id.
     fn get_awaited_action_by_id(
         &self,
-        client_operation_id: &ClientOperationId,
+        client_operation_id: &OperationId,
     ) -> impl Future<Output = Result<Option<Self::Subscriber>, Error>> + Send;
 
     /// Get all AwaitedActions. This call should be avoided as much as possible.
@@ -113,7 +113,7 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
     /// to changes.
     fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
     ) -> impl Future<Output = Result<Self::Subscriber, Error>> + Send;
 }

--- a/nativelink-scheduler/src/default_action_listener.rs
+++ b/nativelink-scheduler/src/default_action_listener.rs
@@ -17,20 +17,20 @@ use std::sync::Arc;
 
 use futures::Future;
 use nativelink_error::{make_err, Code, Error};
-use nativelink_util::action_messages::{ActionState, ClientOperationId};
+use nativelink_util::action_messages::{ActionState, OperationId};
 use tokio::sync::watch;
 
 use crate::action_scheduler::ActionListener;
 
 /// Simple implementation of ActionListener using tokio's watch.
 pub struct DefaultActionListener {
-    client_operation_id: ClientOperationId,
+    client_operation_id: OperationId,
     action_state: watch::Receiver<Arc<ActionState>>,
 }
 
 impl DefaultActionListener {
     pub fn new(
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         mut action_state: watch::Receiver<Arc<ActionState>>,
     ) -> Self {
         action_state.mark_changed();
@@ -54,7 +54,7 @@ impl DefaultActionListener {
 }
 
 impl ActionListener for DefaultActionListener {
-    fn client_operation_id(&self) -> &ClientOperationId {
+    fn client_operation_id(&self) -> &OperationId {
         &self.client_operation_id
     }
 

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use nativelink_config::schedulers::{PropertyModification, PropertyType};
 use nativelink_error::{Error, ResultExt};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::action_messages::{ActionInfo, ClientOperationId};
+use nativelink_util::action_messages::{ActionInfo, OperationId};
 use parking_lot::Mutex;
 
 use crate::action_scheduler::{ActionListener, ActionScheduler};
@@ -93,7 +93,7 @@ impl ActionScheduler for PropertyModifierScheduler {
 
     async fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         mut action_info: ActionInfo,
     ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         let platform_property_manager = self
@@ -122,7 +122,7 @@ impl ActionScheduler for PropertyModifierScheduler {
 
     async fn find_by_client_operation_id(
         &self,
-        client_operation_id: &ClientOperationId,
+        client_operation_id: &OperationId,
     ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error> {
         self.scheduler
             .find_by_client_operation_id(client_operation_id)

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -20,8 +20,8 @@ use futures::{future, stream, StreamExt, TryStreamExt};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionResult, ActionStage, ActionState, ActionUniqueQualifier, ClientOperationId,
-    ExecutionMetadata, OperationId, WorkerId,
+    ActionInfo, ActionResult, ActionStage, ActionState, ActionUniqueQualifier, ExecutionMetadata,
+    OperationId, WorkerId,
 };
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
@@ -249,7 +249,8 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
             }
             awaited_action.set_state(Arc::new(ActionState {
                 stage,
-                id: operation_id.clone(),
+                operation_id: operation_id.clone(),
+                action_digest: awaited_action.action_info().digest(),
             }));
             awaited_action.increment_version();
 
@@ -285,7 +286,7 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
 
     async fn inner_add_operation(
         &self,
-        new_client_operation_id: ClientOperationId,
+        new_client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
     ) -> Result<T::Subscriber, Error> {
         let rx = self
@@ -411,7 +412,7 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
 impl<T: AwaitedActionDb> ClientStateManager for SimpleSchedulerStateManager<T> {
     async fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
     ) -> Result<Box<dyn ActionStateResult>, Error> {
         let sub = self

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -22,7 +22,7 @@ use nativelink_proto::google::longrunning::{operation, Operation};
 use nativelink_proto::google::rpc::Status;
 use nativelink_util::action_messages::{
     ActionResult, ActionStage, ActionState, ActionUniqueKey, ActionUniqueQualifier,
-    ClientOperationId, ExecutionMetadata, OperationId,
+    ExecutionMetadata, OperationId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -35,12 +35,14 @@ async fn action_state_any_url_test() -> Result<(), Error> {
         digest_function: DigestHasherFunc::Sha256,
         digest: DigestInfo::new([1u8; 32], 5),
     });
-    let client_id = ClientOperationId::new(unique_qualifier.clone());
-    let operation_id = OperationId::new(unique_qualifier);
+    let action_digest = unique_qualifier.digest();
+    let client_id = OperationId::default();
+    let operation_id = OperationId::default();
     let action_state = ActionState {
-        id: operation_id.clone(),
+        operation_id: operation_id.clone(),
         // Result is only populated if has_action_result.
         stage: ActionStage::Completed(ActionResult::default()),
+        action_digest,
     };
     let operation: Operation = action_state.as_operation(client_id);
 

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -32,12 +32,10 @@ use nativelink_scheduler::simple_scheduler::SimpleScheduler;
 use nativelink_scheduler::worker::Worker;
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
 use nativelink_util::action_messages::{
-    ActionResult, ActionStage, ActionState, ActionUniqueKey, ActionUniqueQualifier,
-    ClientOperationId, DirectoryInfo, ExecutionMetadata, FileInfo, NameOrPath, OperationId,
-    SymlinkInfo, WorkerId, INTERNAL_ERROR_EXIT_CODE,
+    ActionResult, ActionStage, ActionState, DirectoryInfo, ExecutionMetadata, FileInfo, NameOrPath,
+    OperationId, SymlinkInfo, WorkerId, INTERNAL_ERROR_EXIT_CODE,
 };
 use nativelink_util::common::DigestInfo;
-use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::instant_wrapper::MockInstantWrapped;
 use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
 use pretty_assertions::assert_eq;
@@ -136,7 +134,7 @@ async fn setup_action(
 ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
     let mut action_info = make_base_action_info(insert_timestamp, action_digest);
     action_info.platform_properties = platform_properties;
-    let client_id = ClientOperationId::new(action_info.unique_qualifier.clone());
+    let client_id = OperationId::default();
     let result = scheduler.add_action(client_id, action_info).await;
     tokio::task::yield_now().await; // Allow task<->worker matcher to run.
     result
@@ -190,8 +188,9 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Executing,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -254,8 +253,9 @@ async fn find_executing_action() -> Result<(), Error> {
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Executing,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -328,7 +328,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
             .expect("`update` should be set on UpdateForWorker");
         let (operation_id, rx_start_execute) = match update_for_worker {
             update_for_worker::Update::StartAction(start_execute) => (
-                OperationId::try_from(start_execute.operation_id.as_str()).unwrap(),
+                OperationId::from(start_execute.operation_id.as_str()),
                 start_execute,
             ),
             v => panic!("Expected StartAction, got : {v:?}"),
@@ -347,7 +347,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
             .expect("`update` should be set on UpdateForWorker");
         let (operation_id, rx_start_execute) = match update_for_worker {
             update_for_worker::Update::StartAction(start_execute) => (
-                OperationId::try_from(start_execute.operation_id.as_str()).unwrap(),
+                OperationId::from(start_execute.operation_id.as_str()),
                 start_execute,
             ),
             v => panic!("Expected StartAction, got : {v:?}"),
@@ -460,7 +460,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         // Other tests check full data. We only care if we got StartAction.
         let operation_id = match rx_from_worker.recv().await.unwrap().update {
             Some(update_for_worker::Update::StartAction(start_execute)) => {
-                OperationId::try_from(start_execute.operation_id.as_str()).unwrap()
+                OperationId::from(start_execute.operation_id)
             }
             v => panic!("Expected StartAction, got : {v:?}"),
         };
@@ -491,8 +491,9 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Queued,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -506,8 +507,9 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Executing,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -553,8 +555,9 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Queued,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -582,8 +585,9 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Executing,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -608,15 +612,11 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
-    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
-        instance_name: String::new(),
-        digest: DigestInfo::zero_digest(),
-        digest_function: DigestHasherFunc::Sha256,
-    });
-    let id = OperationId::new(unique_qualifier);
+    let operation_id = OperationId::default();
     let mut expected_action_state = ActionState {
-        id,
+        operation_id,
         stage: ActionStage::Queued,
+        action_digest,
     };
 
     let insert_timestamp1 = make_system_time(1);
@@ -641,7 +641,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         let action_state1 = client1_action_listener.changed().await.unwrap();
         let action_state2 = client2_action_listener.changed().await.unwrap();
         // Name is random so we set force it to be the same.
-        expected_action_state.id = action_state1.id.clone();
+        expected_action_state.operation_id = action_state1.operation_id.clone();
         assert_eq!(action_state1.as_ref(), &expected_action_state);
         assert_eq!(action_state2.as_ref(), &expected_action_state);
     }
@@ -731,8 +731,9 @@ async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(),
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Queued,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -800,7 +801,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
                 )),
             }
         );
-        OperationId::try_from(operation_id.as_str()).unwrap()
+        OperationId::from(operation_id)
     };
 
     {
@@ -809,8 +810,9 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         assert_eq!(
             action_state.as_ref(),
             &ActionState {
-                id: operation_id.clone(),
+                operation_id: operation_id.clone(),
                 stage: ActionStage::Executing,
+                action_digest: action_state.action_digest,
             }
         );
     }
@@ -841,8 +843,9 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         assert_eq!(
             action_state.as_ref(),
             &ActionState {
-                id: operation_id.clone(),
+                operation_id: operation_id.clone(),
                 stage: ActionStage::Executing,
+                action_digest: action_state.action_digest,
             }
         );
     }
@@ -939,7 +942,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
     scheduler
         .update_action(
             &worker_id,
-            &OperationId::try_from(operation_id.as_str())?,
+            &OperationId::from(operation_id),
             Ok(ActionStage::Completed(action_result.clone())),
         )
         .await?;
@@ -949,8 +952,9 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Completed(action_result),
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -992,7 +996,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
             v => panic!("Expected StartAction, got : {v:?}"),
         };
         // Other tests check full data. We only care if client thinks we are Executing.
-        OperationId::try_from(operation_id.as_str())?
+        OperationId::from(operation_id)
     };
 
     let action_result = ActionResult {
@@ -1051,8 +1055,9 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Completed(action_result),
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -1097,11 +1102,6 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
     }
     let _ = setup_new_worker(&scheduler, rogue_worker_id, PlatformProperties::default()).await?;
 
-    let action_info_hash_key = ActionUniqueQualifier::Cachable(ActionUniqueKey {
-        instance_name: INSTANCE_NAME.to_string(),
-        digest_function: DigestHasherFunc::Sha256,
-        digest: action_digest,
-    });
     let action_result = ActionResult {
         output_files: Vec::default(),
         output_folders: Vec::default(),
@@ -1129,7 +1129,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
     let update_action_result = scheduler
         .update_action(
             &rogue_worker_id,
-            &OperationId::new(action_info_hash_key),
+            &OperationId::default(),
             Ok(ActionStage::Completed(action_result.clone())),
         )
         .await;
@@ -1171,15 +1171,11 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
-    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
-        instance_name: String::new(),
-        digest: DigestInfo::zero_digest(),
-        digest_function: DigestHasherFunc::Sha256,
-    });
-    let id = OperationId::new(unique_qualifier);
+    let operation_id = OperationId::default();
     let mut expected_action_state = ActionState {
-        id,
+        operation_id,
         stage: ActionStage::Executing,
+        action_digest,
     };
 
     let insert_timestamp = make_system_time(1);
@@ -1216,9 +1212,9 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         // Client should get notification saying it's being executed.
         let action_state = action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
-        expected_action_state.id = action_state.id.clone();
+        expected_action_state.operation_id = action_state.operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
-        action_state.id.clone()
+        action_state.operation_id.clone()
     };
 
     let action_result = ActionResult {
@@ -1279,7 +1275,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         expected_action_state.stage = ActionStage::Executing;
         let action_state = action_listener.changed().await.unwrap();
         // The name of the action changed (since it's a new action), so update it.
-        expected_action_state.id = action_state.id.clone();
+        expected_action_state.operation_id = action_state.operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
@@ -1333,7 +1329,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         assert_eq!(state_1.stage, ActionStage::Executing);
         // Second client should be in a queued state.
         assert_eq!(state_2.stage, ActionStage::Queued);
-        (state_1.id.clone(), state_2.id.clone())
+        (state_1.operation_id.clone(), state_2.operation_id.clone())
     };
 
     let action_result = ActionResult {
@@ -1373,13 +1369,12 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
     {
         // First action should now be completed.
         let action_state = client1_action_listener.changed().await.unwrap();
-        let mut expected_action_state = ActionState {
+        let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Completed(action_result.clone()),
+            action_digest: action_state.action_digest,
         };
-        // We now know the name of the action so populate it.
-        expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
@@ -1411,13 +1406,12 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
     {
         // Our second client should be notified it completed.
         let action_state = client2_action_listener.changed().await.unwrap();
-        let mut expected_action_state = ActionState {
+        let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Completed(action_result.clone()),
+            action_digest: action_state.action_digest,
         };
-        // We now know the name of the action so populate it.
-        expected_action_state.id.unique_qualifier = action_state.id.unique_qualifier.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
 
@@ -1519,7 +1513,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
             action_listener.changed().await.unwrap().stage,
             ActionStage::Executing
         );
-        OperationId::try_from(operation_id.as_str())?
+        OperationId::from(operation_id)
     };
 
     let _ = scheduler
@@ -1535,8 +1529,9 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Queued,
+            action_digest: action_state.action_digest,
         };
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -1568,7 +1563,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         let action_state = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
-            id: action_state.id.clone(),
+            operation_id: action_state.operation_id.clone(),
             stage: ActionStage::Completed(ActionResult {
                 output_files: Vec::default(),
                 output_folders: Vec::default(),
@@ -1593,6 +1588,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
                 error: Some(err.clone()),
                 message: String::new(),
             }),
+            action_digest: action_state.action_digest,
         };
         let mut received_state = action_state.as_ref().clone();
         if let ActionStage::Completed(stage) = &mut received_state.stage {
@@ -1688,7 +1684,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
             action_listener.changed().await.unwrap().stage,
             ActionStage::Executing
         );
-        OperationId::try_from(operation_id.as_str())?
+        OperationId::from(operation_id)
     };
 
     let _ = scheduler
@@ -1769,7 +1765,7 @@ async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
         // evicting map. So we constantly ask for some other client
         // to trigger eviction logic.
         scheduler
-            .find_by_client_operation_id(&ClientOperationId::from_raw_string(
+            .find_by_client_operation_id(&OperationId::from_raw_string(
                 "dummy_client_id".to_string(),
             ))
             .await

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -20,14 +20,14 @@ use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_scheduler::action_scheduler::{ActionListener, ActionScheduler};
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
-use nativelink_util::action_messages::{ActionInfo, ClientOperationId};
+use nativelink_util::action_messages::{ActionInfo, OperationId};
 use tokio::sync::{mpsc, Mutex};
 
 #[allow(clippy::large_enum_variant)]
 enum ActionSchedulerCalls {
     GetPlatformPropertyManager(String),
-    AddAction((ClientOperationId, ActionInfo)),
-    FindExistingAction(ClientOperationId),
+    AddAction((OperationId, ActionInfo)),
+    FindExistingAction(OperationId),
 }
 
 enum ActionSchedulerReturns {
@@ -85,7 +85,7 @@ impl MockActionScheduler {
     pub async fn expect_add_action(
         &self,
         result: Result<Pin<Box<dyn ActionListener>>, Error>,
-    ) -> (ClientOperationId, ActionInfo) {
+    ) -> (OperationId, ActionInfo) {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::AddAction(req) = rx_call_lock
             .recv()
@@ -104,7 +104,7 @@ impl MockActionScheduler {
     pub async fn expect_find_by_client_operation_id(
         &self,
         result: Result<Option<Pin<Box<dyn ActionListener>>>, Error>,
-    ) -> ClientOperationId {
+    ) -> OperationId {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::FindExistingAction(req) = rx_call_lock
             .recv()
@@ -145,7 +145,7 @@ impl ActionScheduler for MockActionScheduler {
 
     async fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         action_info: ActionInfo,
     ) -> Result<Pin<Box<dyn ActionListener>>, Error> {
         self.tx_call
@@ -167,7 +167,7 @@ impl ActionScheduler for MockActionScheduler {
 
     async fn find_by_client_operation_id(
         &self,
-        client_operation_id: &ClientOperationId,
+        client_operation_id: &OperationId,
     ) -> Result<Option<Pin<Box<dyn ActionListener>>>, Error> {
         self.tx_call
             .send(ActionSchedulerCalls::FindExistingAction(

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -32,8 +32,7 @@ use nativelink_scheduler::action_scheduler::{ActionListener, ActionScheduler};
 use nativelink_store::ac_utils::get_and_decode_digest;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::action_messages::{
-    ActionInfo, ActionUniqueKey, ActionUniqueQualifier, ClientOperationId,
-    DEFAULT_EXECUTION_PRIORITY,
+    ActionInfo, ActionUniqueKey, ActionUniqueQualifier, OperationId, DEFAULT_EXECUTION_PRIORITY,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::{make_ctx_for_hash_func, DigestHasherFunc};
@@ -44,19 +43,19 @@ use tracing::{error_span, event, instrument, Level};
 
 type InstanceInfoName = String;
 
-struct NativelinkClientOperationId {
+struct NativelinkOperationId {
     instance_name: InstanceInfoName,
-    client_operation_id: ClientOperationId,
+    client_operation_id: OperationId,
 }
 
-impl NativelinkClientOperationId {
+impl NativelinkOperationId {
     fn from_name(name: &str) -> Result<Self, Error> {
         let (instance_name, name) = name
             .split_once('/')
             .err_tip(|| "Expected instance_name and name to be separated by '/'")?;
         Ok(Self {
             instance_name: instance_name.to_string(),
-            client_operation_id: ClientOperationId::from_raw_string(name.to_string()),
+            client_operation_id: OperationId::from_raw_string(name.to_string()),
         })
     }
 
@@ -206,7 +205,7 @@ impl ExecutionServer {
     }
 
     fn to_execute_stream(
-        nl_client_operation_id: NativelinkClientOperationId,
+        nl_client_operation_id: NativelinkOperationId,
         action_listener: Pin<Box<dyn ActionListener>>,
     ) -> Response<ExecuteStream> {
         let client_operation_id_string = nl_client_operation_id.into_string();
@@ -219,9 +218,8 @@ impl ExecutionServer {
                     match action_listener.changed().await {
                         Ok(action_update) => {
                             event!(Level::INFO, ?action_update, "Execute Resp Stream");
-                            let client_operation_id = ClientOperationId::from_raw_string(
-                                client_operation_id_string.clone(),
-                            );
+                            let client_operation_id =
+                                OperationId::from_raw_string(client_operation_id_string.clone());
                             // If the action is finished we won't be sending any more updates.
                             let maybe_action_listener = if action_update.stage.is_finished() {
                                 None
@@ -284,15 +282,12 @@ impl ExecutionServer {
 
         let action_listener = instance_info
             .scheduler
-            .add_action(
-                ClientOperationId::new(action_info.unique_qualifier.clone()),
-                action_info,
-            )
+            .add_action(OperationId::default(), action_info)
             .await
             .err_tip(|| "Failed to schedule task")?;
 
         Ok(Self::to_execute_stream(
-            NativelinkClientOperationId {
+            NativelinkOperationId {
                 instance_name,
                 client_operation_id: action_listener.client_operation_id().clone(),
             },
@@ -305,7 +300,7 @@ impl ExecutionServer {
         request: Request<WaitExecutionRequest>,
     ) -> Result<Response<ExecuteStream>, Status> {
         let (instance_name, client_operation_id) =
-            NativelinkClientOperationId::from_name(&request.into_inner().name)
+            NativelinkOperationId::from_name(&request.into_inner().name)
                 .map(|v| (v.instance_name, v.client_operation_id))
                 .err_tip(|| "Failed to parse operation_id in ExecutionServer::wait_execution")?;
         let Some(instance_info) = self.instance_infos.get(&instance_name) else {
@@ -322,7 +317,7 @@ impl ExecutionServer {
             return Err(Status::not_found("Failed to find existing task"));
         };
         Ok(Self::to_execute_stream(
-            NativelinkClientOperationId {
+            NativelinkOperationId {
                 instance_name,
                 client_operation_id,
             },

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -199,10 +199,7 @@ impl WorkerApiServer {
         execute_result: ExecuteResult,
     ) -> Result<Response<()>, Error> {
         let worker_id: WorkerId = execute_result.worker_id.try_into()?;
-        let operation_id =
-            OperationId::try_from(execute_result.operation_id.as_str()).err_tip(|| {
-                "Failed to convert operation_id in WorkerApiServer::inner_execution_response"
-            })?;
+        let operation_id = OperationId::from(execute_result.operation_id);
 
         match execute_result
             .result

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -393,7 +393,7 @@ pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error:
         insert_timestamp: make_system_time(0),
         unique_qualifier,
     });
-    let expected_operation_id = OperationId::new(action_info.unique_qualifier.clone());
+    let expected_operation_id = OperationId::default();
     test_context
         .scheduler
         .worker_notify_run_action(

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -113,6 +113,7 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tokio-util",
         "@crates//:tonic",
+        "@crates//:uuid",
     ],
 )
 

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -23,7 +23,7 @@ use nativelink_error::Error;
 use nativelink_metric::MetricsComponent;
 
 use crate::action_messages::{
-    ActionInfo, ActionStage, ActionState, ActionUniqueKey, ClientOperationId, OperationId, WorkerId,
+    ActionInfo, ActionStage, ActionState, ActionUniqueKey, OperationId, WorkerId,
 };
 use crate::common::DigestInfo;
 
@@ -69,7 +69,7 @@ pub struct OperationFilter {
     pub stages: OperationStageFlags,
 
     /// The client operation id.
-    pub client_operation_id: Option<ClientOperationId>,
+    pub client_operation_id: Option<OperationId>,
 
     /// The operation id.
     pub operation_id: Option<OperationId>,
@@ -101,7 +101,7 @@ pub trait ClientStateManager: Sync + Send + MetricsComponent {
     /// Add a new action to the queue or joins an existing action.
     async fn add_action(
         &self,
-        client_operation_id: ClientOperationId,
+        client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
     ) -> Result<Box<dyn ActionStateResult>, Error>;
 

--- a/nativelink-util/tests/operation_id_tests.rs
+++ b/nativelink-util/tests/operation_id_tests.rs
@@ -12,123 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nativelink_error::{Code, Error};
+use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_util::action_messages::OperationId;
 use pretty_assertions::assert_eq;
+use uuid::Uuid;
 
 #[nativelink_test]
 async fn parse_operation_id() -> Result<(), Error> {
-    {
-        // Check no cached.
-        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
-        assert_eq!(
-            operation_id.to_string(),
-            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-        assert_eq!(
-            operation_id.id.to_string(),
-            "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
-        );
-    }
-    {
-        // Check cached.
-        let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/c/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap();
-        assert_eq!(
-            operation_id.to_string(),
-            "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/c/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-        assert_eq!(
-            operation_id.id.to_string(),
-            "19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
-        );
-    }
+    let operation_id = OperationId::from("19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
+    assert_eq!(
+        operation_id,
+        OperationId::Uuid(Uuid::parse_str("19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").unwrap())
+    );
     Ok(())
 }
 
 #[nativelink_test]
 async fn parse_empty_failure() -> Result<(), Error> {
-    let operation_id = OperationId::try_from("").err().unwrap();
-    assert_eq!(operation_id.code, Code::Internal);
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(
-        operation_id.messages[0],
-        "Invalid OperationId unique_qualifier / id fragment - "
-    );
-
-    let operation_id = OperationId::try_from("/").err().unwrap();
-    assert_eq!(operation_id.code, Code::Internal);
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(
-        operation_id.messages[0],
-        "Invalid UniqueQualifier instance name fragment - /"
-    );
-
-    let operation_id = OperationId::try_from("main").err().unwrap();
-    assert_eq!(operation_id.code, Code::Internal);
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(
-        operation_id.messages[0],
-        "Invalid OperationId unique_qualifier / id fragment - main"
-    );
-
-    let operation_id = OperationId::try_from("main/nohashfn/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(
-        operation_id.messages[0],
-        "Unknown or unsupported digest function for string conversion: \"NOHASHFN\""
-    );
-
-    let operation_id =
-        OperationId::try_from("main/SHA256/badhash-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52")
-            .err()
-            .unwrap();
-    assert_eq!(operation_id.messages.len(), 3);
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "Odd number of digits");
-    assert_eq!(operation_id.messages[1], "Invalid sha256 hash: badhash");
-    assert_eq!(
-        operation_id.messages[2],
-        "Invalid DigestInfo digest hash - main/SHA256/badhash-211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52"
-    );
-
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 2);
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(
-        operation_id.messages[0],
-        "cannot parse integer from empty string"
-    );
-    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages.len(), 2);
-    assert_eq!(operation_id.messages[0], "invalid digit found in string");
-    assert_eq!(operation_id.messages[1], "Invalid UniqueQualifier size value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f--211/u/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier cachable value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/x/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier cachable value fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/-10/19b16cf8-a1ad-4948-aaac-b6f4eb7fca52");
-
-    let operation_id = OperationId::try_from("main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/u/baduuid").err().unwrap();
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(operation_id.code, Code::InvalidArgument);
-    assert_eq!(operation_id.messages[0], "Failed to parse invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `u` at 4 as uuid");
-
-    let operation_id = OperationId::try_from(
-        "main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0",
-    )
-    .err()
-    .unwrap();
-    assert_eq!(operation_id.messages.len(), 1);
-    assert_eq!(operation_id.code, Code::Internal);
-    assert_eq!(operation_id.messages[0], "Invalid UniqueQualifier digest size fragment - main/SHA256/4a0885a39d5ba8da3123c02ff56b73196a8b23fd3c835e1446e74a3a3ff4313f-211/0");
+    {
+        let operation_id = OperationId::from("");
+        assert_eq!(operation_id, OperationId::String(String::new()));
+    }
+    {
+        let operation_id = OperationId::from("foobar");
+        assert_eq!(operation_id, OperationId::String("foobar".to_string()));
+    }
 
     Ok(())
 }

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -211,22 +211,8 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                             self.metrics.keep_alives_received.inc();
                         }
                         Update::KillOperationRequest(kill_operation_request) => {
-                            let operation_id_res = kill_operation_request
-                                .operation_id
-                                .as_str()
-                                .try_into();
-                            let operation_id = match operation_id_res {
-                                Ok(operation_id) => operation_id,
-                                Err(err) => {
-                                    event!(
-                                        Level::ERROR,
-                                        ?kill_operation_request,
-                                        ?err,
-                                        "Failed to convert string to operation_id"
-                                    );
-                                    continue;
-                                }
-                            };
+                            let operation_id = kill_operation_request
+                                .operation_id.into();
                             if let Err(err) = self.running_actions_manager.kill_operation(&operation_id).await {
                                 event!(
                                     Level::ERROR,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1704,7 +1704,7 @@ impl RunningActionsManagerImpl {
         operation_id: &'a OperationId,
     ) -> impl Future<Output = Result<String, Error>> + 'a {
         self.metrics.make_action_directory.wrap(async move {
-            let action_directory = format!("{}/{}", self.root_action_directory, operation_id.id);
+            let action_directory = format!("{}/{}", self.root_action_directory, operation_id);
             fs::create_dir(&action_directory)
                 .await
                 .err_tip(|| format!("Error creating action directory {action_directory}"))?;
@@ -1791,11 +1791,8 @@ impl RunningActionsManager for RunningActionsManagerImpl {
                     .queued_timestamp
                     .and_then(|time| time.try_into().ok())
                     .unwrap_or(SystemTime::UNIX_EPOCH);
-                let operation_id: OperationId = start_execute
-                    .operation_id
-                    .as_str()
-                    .try_into()
-                    .err_tip(|| "Could not convert to operation_id in RunningActionsManager::create_and_add_action")?;
+                let operation_id = start_execute
+                    .operation_id.as_str().into();
                 let action_info = self.create_action_info(start_execute, queued_timestamp).await?;
                 event!(
                     Level::INFO,

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -668,7 +668,7 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         }),
     };
 
-    let operation_id = OperationId::new(action_info.unique_qualifier.clone());
+    let operation_id = OperationId::default();
     {
         // Send execution request.
         tx_stream

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -45,8 +45,7 @@ use nativelink_store::memory_store::MemoryStore;
 #[cfg_attr(target_family = "windows", allow(unused_imports))]
 use nativelink_util::action_messages::SymlinkInfo;
 use nativelink_util::action_messages::{
-    ActionResult, ActionUniqueKey, ActionUniqueQualifier, DirectoryInfo, ExecutionMetadata,
-    FileInfo, NameOrPath, OperationId,
+    ActionResult, DirectoryInfo, ExecutionMetadata, FileInfo, NameOrPath, OperationId,
 };
 use nativelink_util::common::{fs, DigestInfo};
 use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
@@ -141,20 +140,6 @@ fn increment_clock(time: &mut SystemTime) -> SystemTime {
     let previous_time = *time;
     *time = previous_time.checked_add(Duration::from_secs(1)).unwrap();
     previous_time
-}
-
-fn make_operation_id(execute_request: &ExecuteRequest) -> OperationId {
-    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
-        instance_name: execute_request.instance_name.clone(),
-        digest_function: execute_request.digest_function.try_into().unwrap(),
-        digest: execute_request
-            .action_digest
-            .clone()
-            .unwrap()
-            .try_into()
-            .unwrap(),
-    });
-    OperationId::new(unique_qualifier)
 }
 
 #[nativelink_test]
@@ -506,7 +491,7 @@ async fn ensure_output_files_full_directories_are_created_no_working_directory_t
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action = running_actions_manager
             .create_and_add_action(
@@ -623,7 +608,7 @@ async fn ensure_output_files_full_directories_are_created_test(
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action = running_actions_manager
             .create_and_add_action(
@@ -756,7 +741,7 @@ async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
             digest_function: ProtoDigestFunction::Blake3.into(),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -928,7 +913,7 @@ async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Er
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -1084,7 +1069,7 @@ async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>>
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -1279,7 +1264,7 @@ async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Erro
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -1409,7 +1394,7 @@ async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .clone()
@@ -1555,7 +1540,7 @@ exit 0
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .clone()
@@ -1722,7 +1707,7 @@ exit 0
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .clone()
@@ -1862,7 +1847,7 @@ exit 1
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .clone()
@@ -2377,7 +2362,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         running_actions_manager
             .create_and_add_action(
@@ -2457,7 +2442,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         running_actions_manager
             .create_and_add_action(
@@ -2537,7 +2522,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let result = running_actions_manager
             .create_and_add_action(
@@ -2660,7 +2645,7 @@ async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let execute_results_fut = running_actions_manager
         .create_and_add_action(
@@ -2779,7 +2764,7 @@ async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::err
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let (cleanup_tx, cleanup_rx) = oneshot::channel();
     let cleanup_was_requested = AtomicBool::new(false);
@@ -2931,7 +2916,7 @@ async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -3020,7 +3005,7 @@ async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::erro
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .create_and_add_action(
@@ -3154,7 +3139,7 @@ async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
             action_digest: Some(action_digest.into()),
             ..Default::default()
         };
-        let operation_id = make_operation_id(&execute_request).to_string();
+        let operation_id = OperationId::default().to_string();
 
         let running_action_impl = running_actions_manager
             .create_and_add_action(
@@ -3327,7 +3312,7 @@ async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn
         action_digest: Some(action_digest.into()),
         ..Default::default()
     };
-    let operation_id = make_operation_id(&execute_request).to_string();
+    let operation_id = OperationId::default().to_string();
 
     let running_action_impl = running_actions_manager
         .clone()


### PR DESCRIPTION
This is in prep to support generic layering of workers & schedulers. We can no longer know if the source is a client or just an up-stream-component, so we need to fall back to just using OperationId.

towards #1213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1214)
<!-- Reviewable:end -->
