### PR TITLE
Add "docs builds" Into CI Tests

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -95,6 +95,10 @@ DID_FAIL=0
 export NATIVELINK_DIR="$CACHE_DIR/nativelink"
 mkdir -p "$NATIVELINK_DIR"
 
+# Running "docs builds" as CI to ensure documentation doesn't break after merging
+echo "Running \"docs builds\" to ensure documentation doesn't break"
+docs builds
+
 for pattern in "${TEST_PATTERNS[@]}"; do
   find "$SELF_DIR/integration_tests/" -name "$pattern" -type f -print0 | while IFS= read -r -d $'\0' fullpath; do
     # Cleanup.


### PR DESCRIPTION
# Description

This commit tackles Issue #1082, where the goal is to run "docs builds" as a CI test to ensure documentation gets built properly.

I saw that .github/workflows/main.yml has a CI job / GithubAction called "integration-tests" that executes the commands contained in run_integration_tests.sh, a shell script. This shell script has the line "set -euo pipefail" which will cause the execution of this script to break whenever a command has a non-Zero exit code. 

I added the command "docs builds" to run_integration_tests.sh. In case "docs builds" fails, it will exit with a non-zero exit code and cause run_integration_tests.sh to terminate abruptly which would in turn fail the "integration-tests" job in main.yml. This addition should ensure that "docs builds" always runs before merging a PR.

Fixes # 1082

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Need some help here – I tested "docs builds" by temporarily creating files with invalid rust syntax to examine error codes. I've never worked on editing CI pipelines and was unsure about what further tests to conduct. I'm unsure if GitHub Actions will find the "docs" command, which builds off Rust's cargo doc. Any suggestions would be helpful :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1224)
<!-- Reviewable:end -->
