### PR TITLE
Add Int as StoreKey type

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -176,6 +176,12 @@ impl TryFrom<&[u8]> for AwaitedAction {
 #[repr(transparent)]
 pub struct AwaitedActionSortKey(u64);
 
+impl AwaitedActionSortKey {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
 impl MetricsComponent for AwaitedActionSortKey {
     fn publish(
         &self,

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -127,6 +127,12 @@ impl ShardStore {
                 let key_u64 = hasher.finish();
                 (key_u64 >> 32) as u32 // We only need the top 32 bits.
             }
+            StoreKey::Int(i) => {
+                let mut hasher = DefaultHasher::new();
+                hasher.write(&i.to_be_bytes());
+                let key_u64 = hasher.finish();
+                (key_u64 >> 32) as u32 // We only need the top 32 bits.
+            }
         };
         self.weights_and_stores
             .binary_search_by_key(&key, |item| item.weight)


### PR DESCRIPTION
# Description
Adding Int as StoreKey type enables using index based bounds on list calls. This is useful when communicating with some backends such as redis, and can enable further optimizations in the future.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1226)
<!-- Reviewable:end -->
