### PR TITLE
Remove unnecessary sync trait bounds.

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -81,20 +81,18 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
     fn get_awaited_action_by_id(
         &self,
         client_operation_id: &ClientOperationId,
-    ) -> impl Future<Output = Result<Option<Self::Subscriber>, Error>> + Send + Sync;
+    ) -> impl Future<Output = Result<Option<Self::Subscriber>, Error>> + Send;
 
     /// Get all AwaitedActions. This call should be avoided as much as possible.
     fn get_all_awaited_actions(
         &self,
-    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send + Sync>
-           + Send
-           + Sync;
+    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send> + Send;
 
     /// Get the AwaitedAction by the operation id.
     fn get_by_operation_id(
         &self,
         operation_id: &OperationId,
-    ) -> impl Future<Output = Result<Option<Self::Subscriber>, Error>> + Send + Sync;
+    ) -> impl Future<Output = Result<Option<Self::Subscriber>, Error>> + Send;
 
     /// Get a range of AwaitedActions of a specific state in sorted order.
     fn get_range_of_actions(
@@ -103,15 +101,13 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
         start: Bound<SortedAwaitedAction>,
         end: Bound<SortedAwaitedAction>,
         desc: bool,
-    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send + Sync>
-           + Send
-           + Sync;
+    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send> + Send;
 
     /// Process a change changed AwaitedAction and notify any listeners.
     fn update_awaited_action(
         &self,
         new_awaited_action: AwaitedAction,
-    ) -> impl Future<Output = Result<(), Error>> + Send + Sync;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Add (or join) an action to the AwaitedActionDb and subscribe
     /// to changes.
@@ -119,5 +115,5 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
         &self,
         client_operation_id: ClientOperationId,
         action_info: Arc<ActionInfo>,
-    ) -> impl Future<Output = Result<Self::Subscriber, Error>> + Send + Sync;
+    ) -> impl Future<Output = Result<Self::Subscriber, Error>> + Send;
 }

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -937,7 +937,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync + 'static> Awaite
         start: Bound<SortedAwaitedAction>,
         end: Bound<SortedAwaitedAction>,
         desc: bool,
-    ) -> impl Stream<Item = Result<Self::Subscriber, Error>> + Send + Sync {
+    ) -> impl Stream<Item = Result<Self::Subscriber, Error>> + Send {
         ChunkedStream::new(start, end, move |start, end, mut output| async move {
             let inner = self.inner.lock().await;
             let mut done = true;


### PR DESCRIPTION
# Description
Removes unnecessary sync bounds from functions inside of the
AwaitedActionDb trait. These bounds interfere with implementations while
attempting to communicate to with the redis store.

towards #1182

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1227)
<!-- Reviewable:end -->
