### PR TITLE
Fix Cargo.toml files when using cargo test on specific packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ nativelink-util = { path = "nativelink-util" }
 nativelink-worker = { path = "nativelink-worker" }
 nativelink-metric = { path = "nativelink-metric" }
 nativelink-metric-collector = { path = "nativelink-metric-collector" }
-async-lock = { version = "3.4.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 axum = { version = "0.7.5", default-features = false }
 clap = { version = "4.5.9", features = ["derive"] }
 futures = { version = "0.3.30", default-features = false }
@@ -54,11 +54,11 @@ parking_lot = "0.12.3"
 rustls-pemfile = { version = "2.1.2", default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
 serde_json5 = "0.1.0"
-tokio = { version = "1.38.0", features = ["rt-multi-thread", "signal"] }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
 tokio-rustls = { version = "0.25.0", default-features = false, features = [
   "ring",
 ] }
-tonic = { version = "0.12.0", default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 tower = { version = "0.4.13", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 opentelemetry_sdk = { version = "0.23.0", default-features = false }
@@ -69,6 +69,7 @@ opentelemetry-prometheus = "0.16.0"
 serde_json = "1.0.120"
 
 [workspace.cargo-features-manager.keep]
+async-lock = ["std"]
 aws-sdk-s3 = ["rt-tokio"]
 aws-smithy-runtime = ["test-util"]
 # This causes blake3 to detect SIMD capabilities at runtime.
@@ -76,5 +77,8 @@ blake3 = ["std"]
 pretty_assertions = ["std"]
 redis-test = ["aio"]
 serial_test = ["async"]
-tokio = ["signal"]
+tokio = ["fs", "rt-multi-thread", "signal", "io-util"]
+tokio-stream = ["fs"]
 tonic-build = ["prost"]
+tonic = ["transport", "tls"]
+uuid = ["v4", "serde"]

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -17,5 +17,5 @@ hex = { version = "0.4.3", default-features = false }
 prost = { version = "0.13.1", default-features = false }
 prost-types = { version = "0.13.1", default-features = false }
 serde = { version = "1.0.204", default-features = false }
-tokio = { version = "1.38.0" }
-tonic = { version = "0.12.0", default-features = false }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }
-async-lock = { version = "3.3.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 parking_lot = "0.12.2"
 tracing = { version = "0.1.40", default-features = false }
-tokio = "1.37.0"
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 [dependencies]
 prost = { version = "0.13.1", default-features = false }
 prost-types = { version = "0.13.1", default-features = false }
-tonic = { version = "0.12.0", default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 
 [dev-dependencies]
 prost-build = { version = "0.13.1", default-features = false }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -13,19 +13,19 @@ nativelink-metric = { path = "../nativelink-metric" }
 # TODO(aaronmondal): This should not be a dependency. Move the corresponding
 #                    files somewhere else.
 nativelink-store = { path = "../nativelink-store" }
-async-lock = { version = "3.4.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 async-trait = "0.1.81"
 prost = { version = "0.13.1", default-features = false }
-uuid = { version = "1.10.0", default-features = false }
+uuid = { version = "1.8.0", default-features = false, features = ["v4", "serde"] }
 futures = { version = "0.3.30", default-features = false }
 lru = { version = "0.12.3", default-features = false }
 mock_instant = "0.3.2"
 parking_lot = "0.12.2"
 rand = { version = "0.8.5", default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
-tokio = "1.38.0"
-tokio-stream = { version = "0.1.15", default-features = false }
-tonic = { version = "0.12.0", default-features = false }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio-stream = { version = "0.1.15", features = ["fs"], default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 serde = { version = "1.0.203", features = ["rc"] }
 serde_json = "1.0.120"

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -19,19 +19,19 @@ hyper = { version = "1.4.1" }
 serde_json5 = "0.1.0"
 parking_lot = "0.12.3"
 prost = { version = "0.13.1", default-features = false }
-tokio = "1.38.0"
-tokio-stream = { version = "0.1.15", default-features = false }
-tonic = { version = "0.12.0", default-features = false }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio-stream = { version = "0.1.15", features = ["fs"], default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 tower = { version = "0.4.13", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
-uuid = { version = "1.10.0", default-features = false }
+uuid = { version = "1.8.0", default-features = false, features = ["v4", "serde"] }
 
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }
 nativelink-metric = { path = "../nativelink-metric" }
 
 async-trait = "0.1.80"
-async-lock = { version = "3.3.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 hyper = "1.4.1"
 hyper-util = "0.1.6"
 maplit = "1.0.2"

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -9,7 +9,7 @@ nativelink-config = { path = "../nativelink-config" }
 nativelink-util = { path = "../nativelink-util" }
 nativelink-proto = { path = "../nativelink-proto" }
 nativelink-metric = { path = "../nativelink-metric" }
-async-lock = { version = "3.3.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 async-trait = "0.1.80"
 aws-config = { version = "1.5.4", default-features = false, features = [
   "rustls",
@@ -43,12 +43,12 @@ parking_lot = "0.12.3"
 prost = { version = "0.13.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.204", default-features = false }
-tokio = "1.38.0"
-tokio-stream = { version = "0.1.15", default-features = false }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio-stream = { version = "0.1.15", features = ["fs"], default-features = false }
 tokio-util = { version = "0.7.11" }
-tonic = { version = "0.12.0", default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 tracing = { version = "0.1.40", default-features = false }
-uuid = { version = "1.10.0", default-features = false }
+uuid = { version = "1.8.0", default-features = false, features = ["v4", "serde"] }
 
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -11,7 +11,7 @@ nativelink-config = { path = "../nativelink-config" }
 nativelink-error = { path = "../nativelink-error" }
 nativelink-proto = { path = "../nativelink-proto" }
 nativelink-metric = { path = "../nativelink-metric" }
-async-lock = { version = "3.3.0", default-features = false }
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 async-trait = "0.1.80"
 bitflags = "2.5.0"
 blake3 = { version = "1.5.1", features = ["mmap"] }
@@ -34,13 +34,13 @@ prost-types = { version = "0.13.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.204", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
-tokio = "1.38.0"
-tokio-stream = { version = "0.1.15", default-features = false }
+tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio-stream = { version = "0.1.15", features = ["fs"], default-features = false }
 tokio-util = { version = "0.7.11" }
-tonic = { version = "0.12.0", default-features = false }
+tonic = { version = "0.12.0", features = ["transport", "tls"], default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = ["ansi", "env-filter", "json"], default-features = false }
-uuid = { version = "1.8.0", default-features = false, features = ["serde"] }
+uuid = { version = "1.8.0", default-features = false, features = ["v4", "serde"] }
 mock_instant = "0.3.2"
 
 [dev-dependencies]

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -10,7 +10,7 @@ nativelink-config = { path = "../nativelink-config" }
 nativelink-util = { path = "../nativelink-util" }
 nativelink-store = { path = "../nativelink-store" }
 nativelink-metric = { path = "../nativelink-metric" }
-async-lock = "3.4.0"
+async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 bytes = { version = "1.6.1", default-features = false }
 filetime = "0.2.23"
 formatx = "0.2.2"
@@ -22,11 +22,11 @@ scopeguard = { version = "1.2.0", default-features = false }
 serde = { version = "1.0.204", default-features = false }
 serde_json5 = "0.1.0"
 shlex = { version = "1.3.0", default-features = false }
-tokio = { version = "1.38.0", features = ["process"] }
+tokio = { version = "1.38.0", features = ["process", "fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["fs"] }
-tonic = { version = "0.12.0", features = ["gzip", "tls"], default-features = false }
+tonic = { version = "0.12.0", features = ["gzip", "tls", "transport"], default-features = false }
 tracing = { version = "0.1.40", default-features = false }
-uuid = { version = "1.10.0", default-features = false, features = ["v4"] }
+uuid = { version = "1.10.0", default-features = false, features = ["v4", "serde"] }
 
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }


### PR DESCRIPTION
During the pruning of features we disabled a bit too many features and cargo would complain if compiled from the parent package, but to a sub-package because certain packages needed features enabled but only for those tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1236)
<!-- Reviewable:end -->
