### PR TITLE
Fix docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         mkdir -p ~/.cache && \
         cd deployment-examples/docker-compose && \
-        docker-compose up -d && \
+        (docker-compose up -d || docker compose up -d) && \
         cd ../../ && \
         docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
           bazel clean && \


### PR DESCRIPTION
Docker compose on github runners appears to have been updated, so we need to use the new-er command `docker compose` instead of `docker-compose`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1238)
<!-- Reviewable:end -->
