### PR TITLE
Migrate much of the ActionScheduler API to ClientStateManager API

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -82,6 +82,7 @@ rust_test_suite(
         "@crates//:pretty_assertions",
         "@crates//:prost",
         "@crates//:tokio",
+        "@crates//:tokio-stream",
         "@crates//:uuid",
     ],
 )

--- a/nativelink-scheduler/src/action_scheduler.rs
+++ b/nativelink-scheduler/src/action_scheduler.rs
@@ -17,31 +17,19 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nativelink_error::Error;
 use nativelink_metric::RootMetricsComponent;
-use nativelink_util::action_messages::{ActionInfo, OperationId};
-use nativelink_util::operation_state_manager::ActionStateResult;
+use nativelink_util::operation_state_manager::ClientStateManager;
 
 use crate::platform_property_manager::PlatformPropertyManager;
 
 /// ActionScheduler interface is responsible for interactions between the scheduler
 /// and action related operations.
 #[async_trait]
-pub trait ActionScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static {
+pub trait ActionScheduler:
+    ClientStateManager + Sync + Send + Unpin + RootMetricsComponent + 'static
+{
     /// Returns the platform property manager.
     async fn get_platform_property_manager(
         &self,
         instance_name: &str,
     ) -> Result<Arc<PlatformPropertyManager>, Error>;
-
-    /// Adds an action to the scheduler for remote execution.
-    async fn add_action(
-        &self,
-        client_operation_id: OperationId,
-        action_info: ActionInfo,
-    ) -> Result<Box<dyn ActionStateResult>, Error>;
-
-    /// Find an existing action by its name.
-    async fn find_by_client_operation_id(
-        &self,
-        client_operation_id: &OperationId,
-    ) -> Result<Option<Box<dyn ActionStateResult>>, Error>;
 }

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -29,7 +29,9 @@ use nativelink_util::action_messages::{
 use nativelink_util::background_spawn;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::operation_state_manager::ActionStateResult;
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
+};
 use nativelink_util::store_trait::Store;
 use parking_lot::{Mutex, MutexGuard};
 use scopeguard::guard;
@@ -147,23 +149,11 @@ impl CacheLookupScheduler {
             inflight_cache_checks: Default::default(),
         })
     }
-}
 
-#[async_trait]
-impl ActionScheduler for CacheLookupScheduler {
-    async fn get_platform_property_manager(
-        &self,
-        instance_name: &str,
-    ) -> Result<Arc<PlatformPropertyManager>, Error> {
-        self.action_scheduler
-            .get_platform_property_manager(instance_name)
-            .await
-    }
-
-    async fn add_action(
+    async fn inner_add_action(
         &self,
         client_operation_id: OperationId,
-        action_info: ActionInfo,
+        action_info: Arc<ActionInfo>,
     ) -> Result<Box<dyn ActionStateResult>, Error> {
         let unique_key = match &action_info.unique_qualifier {
             ActionUniqueQualifier::Cachable(unique_key) => unique_key.clone(),
@@ -320,13 +310,45 @@ impl ActionScheduler for CacheLookupScheduler {
             .err_tip(|| "In CacheLookupScheduler::add_action")
     }
 
-    async fn find_by_client_operation_id(
+    async fn inner_filter_operations(
         &self,
-        client_operation_id: &OperationId,
-    ) -> Result<Option<Box<dyn ActionStateResult>>, Error> {
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
         self.action_scheduler
-            .find_by_client_operation_id(client_operation_id)
+            .filter_operations(filter)
             .await
+            .err_tip(|| "In CacheLookupScheduler::filter_operations")
+    }
+}
+
+#[async_trait]
+impl ActionScheduler for CacheLookupScheduler {
+    async fn get_platform_property_manager(
+        &self,
+        instance_name: &str,
+    ) -> Result<Arc<PlatformPropertyManager>, Error> {
+        self.action_scheduler
+            .get_platform_property_manager(instance_name)
+            .await
+    }
+}
+
+#[async_trait]
+impl ClientStateManager for CacheLookupScheduler {
+    async fn add_action(
+        &self,
+        client_operation_id: OperationId,
+        action_info: Arc<ActionInfo>,
+    ) -> Result<Box<dyn ActionStateResult>, Error> {
+        self.inner_add_action(client_operation_id, action_info)
+            .await
+    }
+
+    async fn filter_operations(
+        &self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.inner_filter_operations(filter).await
     }
 }
 

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -139,7 +139,7 @@ impl SimpleScheduler {
     /// for execution based on priority and other metrics.
     /// All further updates to the action will be provided through the returned
     /// value.
-    async fn add_action(
+    async fn inner_add_action(
         &self,
         client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
@@ -155,25 +155,14 @@ impl SimpleScheduler {
         )))
     }
 
-    async fn find_by_client_operation_id(
+    async fn inner_filter_operations(
         &self,
-        client_operation_id: &OperationId,
-    ) -> Result<Option<Box<dyn ActionStateResult>>, Error> {
-        let filter = OperationFilter {
-            client_operation_id: Some(client_operation_id.clone()),
-            ..Default::default()
-        };
-        let filter_result = self.client_state_manager.filter_operations(filter).await;
-
-        let mut stream = filter_result
-            .err_tip(|| "In SimpleScheduler::find_by_client_operation_id getting filter result")?;
-        let Some(action_state_result) = stream.next().await else {
-            return Ok(None);
-        };
-        Ok(Some(Box::new(SimpleSchedulerActionStateResult::new(
-            client_operation_id.clone(),
-            action_state_result,
-        ))))
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream, Error> {
+        self.client_state_manager
+            .filter_operations(filter)
+            .await
+            .err_tip(|| "In SimpleScheduler::find_by_client_operation_id getting filter result")
     }
 
     async fn get_queued_operations(&self) -> Result<ActionStateResultStream, Error> {
@@ -370,34 +359,31 @@ impl SimpleScheduler {
 }
 
 #[async_trait]
+impl ClientStateManager for SimpleScheduler {
+    async fn add_action(
+        &self,
+        client_operation_id: OperationId,
+        action_info: Arc<ActionInfo>,
+    ) -> Result<Box<dyn ActionStateResult>, Error> {
+        self.inner_add_action(client_operation_id, action_info)
+            .await
+    }
+
+    async fn filter_operations<'a>(
+        &'a self,
+        filter: OperationFilter,
+    ) -> Result<ActionStateResultStream<'a>, Error> {
+        self.inner_filter_operations(filter).await
+    }
+}
+
+#[async_trait]
 impl ActionScheduler for SimpleScheduler {
     async fn get_platform_property_manager(
         &self,
         _instance_name: &str,
     ) -> Result<Arc<PlatformPropertyManager>, Error> {
         Ok(self.platform_property_manager.clone())
-    }
-
-    async fn add_action(
-        &self,
-        client_operation_id: OperationId,
-        action_info: ActionInfo,
-    ) -> Result<Box<dyn ActionStateResult>, Error> {
-        self.add_action(client_operation_id, Arc::new(action_info))
-            .await
-    }
-
-    async fn find_by_client_operation_id(
-        &self,
-        client_operation_id: &OperationId,
-    ) -> Result<Option<Box<dyn ActionStateResult>>, Error> {
-        let maybe_receiver = self
-            .find_by_client_operation_id(client_operation_id)
-            .await
-            .err_tip(|| {
-                format!("Error while finding action with client id: {client_operation_id:?}")
-            })?;
-        Ok(maybe_receiver)
     }
 }
 

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -32,8 +32,8 @@ pub const INSTANCE_NAME: &str = "foobar_instance_name";
 pub fn make_base_action_info(
     insert_timestamp: SystemTime,
     action_digest: DigestInfo,
-) -> ActionInfo {
-    ActionInfo {
+) -> Arc<ActionInfo> {
+    Arc::new(ActionInfo {
         command_digest: DigestInfo::new([0u8; 32], 0),
         input_root_digest: DigestInfo::new([0u8; 32], 0),
         timeout: Duration::MAX,
@@ -48,7 +48,7 @@ pub fn make_base_action_info(
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
         }),
-    }
+    })
 }
 
 pub struct TokioWatchActionStateResult {

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -106,10 +106,10 @@ pub trait ClientStateManager: Sync + Send + MetricsComponent {
     ) -> Result<Box<dyn ActionStateResult>, Error>;
 
     /// Returns a stream of operations that match the filter.
-    async fn filter_operations<'a>(
-        &'a self,
+    async fn filter_operations(
+        &self,
         filter: OperationFilter,
-    ) -> Result<ActionStateResultStream<'a>, Error>;
+    ) -> Result<ActionStateResultStream, Error>;
 }
 
 #[async_trait]


### PR DESCRIPTION
Mostly a cosmetic change to move the compatible parts of
ActionSchedulers to use ClientStateManager API instead and implement all
related requirements to existing schedulers.

towards #1213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1241)
<!-- Reviewable:end -->
