### PR TITLE
[Bug] Add rt-tokio feature to aws-sdk-s3

### DIFF
--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -14,7 +14,9 @@ async-trait = "0.1.80"
 aws-config = { version = "1.5.4", default-features = false, features = [
   "rustls",
 ] }
-aws-sdk-s3 = { version = "1.41.0", default-features = false }
+aws-sdk-s3 = { version = "1.41.0", features = [
+  "rt-tokio",
+], default-features = false }
 aws-smithy-runtime = { version = "1.6.2" }
 bincode = "1.3.3"
 blake3 = { version = "1.5.2", default-features = false }


### PR DESCRIPTION
# Description

Feature `rt-tokio` had been transitively dependended on, durning refactors of `Cargo.toml` files it was accidentally dropped.

Fixes https://github.com/TraceMachina/nativelink/issues/1247

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Will be deployed to staging systems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1248)
<!-- Reviewable:end -->
