### PR TITLE
Update README.md for starting Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ curl -O \
 # to find the latest tag
 docker run \
     -v $(pwd)/basic_cas.json:/config \
-    -p 50051 \
+    -p 50051:50051 \
     ghcr.io/tracemachina/nativelink:v0.5.1 \
     config
 ```
@@ -77,7 +77,7 @@ Invoke-WebRequest `
 # Note: Adjust the path if the script is not run from the directory containing basic_cas.json
 docker run `
     -v ${PWD}/basic_cas.json:/config `
-    -p 50051 `
+    -p 50051:50051 `
     ghcr.io/tracemachina/nativelink:v0.5.1 `
     config
 ```


### PR DESCRIPTION
specify both ports to ensure easy setup

# Description

When I launch the docker container with just `-p 50051` then it shows up under `docker ps` as `0.0.0.0:32772->50051/tcp, :::32772->50051/tcp`, meaning I have to point my clients at `:32772` in order to use the remote cache. Using `-p 50051:50051` means the host port is fixed to 50051 too. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1255)
<!-- Reviewable:end -->
