### PR TITLE
Fix invalid links in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ please raise an issue so that we can clarify this document.
 ## Local development setup
 
 NativeLink ships almost all of its tooling in a nix flake which is configured
-via a [`flake.nix`](./flake.nix) file in the root of the repository. While it's
+via a [`flake.nix`](https://github.com/tracemachina/nativelink/tree/main/flake.nix) file in the root of the repository. While it's
 possible to work on some parts of the codebase without this environment, it'll
 make your life much easier since it lets you reproduce most of CI locally.
 
@@ -468,4 +468,4 @@ most automatically generated changelogs provide.
 ## Conduct
 
 NativeLink Code of Conduct is available in the
-[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) file.
+[CODE_OF_CONDUCT](https://github.com/tracemachina/nativelink/tree/main/CODE_OF_CONDUCT.md) file.

--- a/docs/src/content/docs/contribute/nix.mdx
+++ b/docs/src/content/docs/contribute/nix.mdx
@@ -10,7 +10,7 @@ You'll need a recent version of Nix with flakes enabled, for instance installed
 via the [next-gen nix installer](https://github.com/NixOS/experimental-nix-installer).
 
 This build doesn't require cloning the repository, but you need to provide a
-configuration file, for instance the one at [`https://github.com/TraceMachina/nativelink/blob/main/nativelink-config/examples/basic_cas.json`](./nativelink-config/examples/basic_cas.json).
+configuration file, for instance the one at [`https://github.com/TraceMachina/nativelink/blob/main/nativelink-config/examples/basic_cas.json`](https://github.com/tracemachina/nativelink/tree/main/nativelink-config/examples/basic_cas.json).
 
 The following command builds and runs NativeLink in release (optimized) mode:
 

--- a/docs/src/content/docs/faq/lre.mdx
+++ b/docs/src/content/docs/faq/lre.mdx
@@ -11,4 +11,4 @@ custom toolchain configurations. This system aims to be transparent, fully
 hermetic, and reproducible across machines with the same system architecture.
 
 For more detailed information about Local Remote Execution (LRE), please
-visit our [LRE Documentation](../explanations/lre/).
+visit our [LRE Documentation](https://docs.nativelink.com/explanations/lre/).

--- a/docs/src/content/docs/faq/remote-execution.mdx
+++ b/docs/src/content/docs/faq/remote-execution.mdx
@@ -19,7 +19,7 @@ a development team are working in the same environment, reducing the
  reducing redundant work and further speeding up the development process.
 
 For more information on how to get started with remote execution in NativeLink,
-please refer to our [NativeLink On-Prem Guide](../introduction/on-prem.mdx).
+please refer to our [NativeLink On-Prem Guide](https://docs.nativelink.com/introduction/on-prem).
 
 For more detailed information about remote execution, you can visit the below links:
 [Bazel Remote Execution Documentation](https://bazel.build/remote/rbe).

--- a/docs/src/content/docs/introduction/contributors.mdx
+++ b/docs/src/content/docs/introduction/contributors.mdx
@@ -6,7 +6,7 @@ pagefind: true
 Open source is at the heart of NativeLink.
 We're always immensely grateful for the contributions from our community!
 
-For more details on how to contribute, please refer to our [Contribution Guide](./guides/contributing.mdx).
+For more details on how to contribute, please refer to our [Contribution Guide](https://docs.nativelink.com/contribute/guidelines).
 
 ## Have additional questions?
 

--- a/local-remote-execution/README.md
+++ b/local-remote-execution/README.md
@@ -167,7 +167,7 @@ build:lre --extra_toolchains=@local-remote-execution//generated-cc/config:cc-too
 ```
 
 The `@local-remote-execution` Bazel module contains the Bazel-side configuration
-of the LRE toolchain. If you view [`generated-cc/cc/BUILD`](./generated-cc/cc/BUILD)
+of the LRE toolchain. If you view [`generated-cc/cc/BUILD`](https://github.com/tracemachina/nativelink/tree/main/local-remote-execution/generated-cc/cc/BUILD)
 you should find the same `/nix/store/...` paths as in the `lre.bazelrc` file.
 
 Now import the LRE toolchains in your `MODULE.bazel` to make the
@@ -192,7 +192,7 @@ Let's use NativeLink's Kubernetes example to verify that the setup worked.
 ## 🚢 Testing with local K8s
 
 Start the cluster and set up NativeLink in an LRE configuration. For details on
-this refer to the [Kubernetes example](../deployment-examples/kubernetes):
+this refer to the [Kubernetes example](https://github.com/tracemachina/nativelink/tree/main/deployment-examples/kubernetes):
 
 > [!TIP]
 > NativeLink's `native` CLI tool is self-contained and can be imported into
@@ -345,7 +345,7 @@ Instead, their container environments are used and passed through transforming
 functions that take a container schematic as input and generate some other
 output.
 
-The first transform is the [`createWorker`](../tools/create-worker.nix) wrapper
+The first transform is the [`createWorker`](https://github.com/tracemachina/nativelink/tree/main/tools/create-worker.nix) wrapper
 which converts an arbitrary OCI image to a NativeLink worker:
 
 ```mermaid

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -2,7 +2,7 @@
 
 NativeLink uses a JSON file as the configuration format.
 
-To view the available fields please refer to the [configuration reference](../../reference/nativelink-config).
+To view the available fields please refer to the [configuration reference](https://github.com/tracemachina/nativelink/tree/main/nativelink-config/src).
 
 ## Examples
 


### PR DESCRIPTION

# Description

Relative links in markdown files produce 404 error when it's deployed on the documentation site. Reviewed all relative links in markdown files and fixed them all. This commit doesn't include any CIs to prevent from 404 errors permanently ( maybe that's what to do next from here ), but it's a hotfix for currently not available links in the documentation website which are actually hurting user experience.

Fixes #1242 

( Not a perfect fix for the issue, just a hotfix to solve the user-interfacing problems only )

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

It's been tested by deploying the documentation website locally.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1256)
<!-- Reviewable:end -->
