### PR TITLE
Declare version explicitly for `clap` library in `nativelink.rs`

### DIFF
--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -19,11 +19,9 @@ use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
-use nativelink_util::{
-    action_messages::{ActionInfo, OperationId},
-    operation_state_manager::{
-        ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
-    },
+use nativelink_util::action_messages::{ActionInfo, OperationId};
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
 };
 use tokio::sync::{mpsc, Mutex};
 

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -96,7 +96,7 @@ const METRICS_DISABLE_ENV: &str = "NATIVELINK_DISABLE_METRICS";
 #[derive(Parser, Debug)]
 #[clap(
     author = "Trace Machina, Inc. <nativelink@tracemachina.com>",
-    version,
+    version = "0.5.1",
     about,
     long_about = None
 )]


### PR DESCRIPTION
# Description

Currently, the `--version` command doesn't work when the application is built with `Bazel`. The reason is because `Bazel` doesn't set the `CARGO_PKG_VERSION` environment variable natively. Solution is to declare `version` explicitly in `nativelink.rs`.
More details can be found in the issue below.

Fixes #1257 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1258)
<!-- Reviewable:end -->
