### PR TITLE
Fix error message typo in `nativelink.rs`

### DIFF
--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -436,7 +436,7 @@ async fn inner_main(
                             Some(service)
                         })
                     })
-                    .err_tip(|| "Could not create WorkerApi service")?,
+                    .err_tip(|| "Could not create BEP service")?,
             );
 
         let health_registry = health_registry_builder.lock().await.build();


### PR DESCRIPTION
# Description

Fix a small typo in the error message for the "experimental_bep" service inside src/bin/nativelink.rs

https://github.com/TraceMachina/nativelink/blob/7777938294047377cb4ce9f4d8649c45055596ed/src/bin/nativelink.rs#L415-L440



## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update


## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1259)
<!-- Reviewable:end -->
