### PR TITLE
Remove ActionScheduler and introduce KnownPlatformPropertyProvider

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 rust_library(
     name = "nativelink-scheduler",
     srcs = [
-        "src/action_scheduler.rs",
         "src/api_worker_scheduler.rs",
         "src/awaited_action_db/awaited_action.rs",
         "src/awaited_action_db/mod.rs",

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -23,7 +23,7 @@ use nativelink_metric::{
     group, MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
     RootMetricsComponent,
 };
-use nativelink_util::action_messages::{ActionInfo, ActionStage, OperationId, WorkerId};
+use nativelink_util::action_messages::{ActionStage, OperationId, WorkerId};
 use nativelink_util::operation_state_manager::WorkerStateManager;
 use nativelink_util::platform_properties::PlatformProperties;
 use tokio::sync::Notify;
@@ -31,7 +31,7 @@ use tonic::async_trait;
 use tracing::{event, Level};
 
 use crate::platform_property_manager::PlatformPropertyManager;
-use crate::worker::{Worker, WorkerTimestamp, WorkerUpdate};
+use crate::worker::{ActionInfoWithProps, Worker, WorkerTimestamp, WorkerUpdate};
 use crate::worker_scheduler::WorkerScheduler;
 
 struct Workers(LruCache<WorkerId, Worker>);
@@ -248,7 +248,7 @@ impl ApiWorkerSchedulerImpl {
         &mut self,
         worker_id: WorkerId,
         operation_id: OperationId,
-        action_info: Arc<ActionInfo>,
+        action_info: ActionInfoWithProps,
     ) -> Result<(), Error> {
         if let Some(worker) = self.workers.get_mut(&worker_id) {
             let notify_worker_result =
@@ -345,7 +345,7 @@ impl ApiWorkerScheduler {
         &self,
         worker_id: WorkerId,
         operation_id: OperationId,
-        action_info: Arc<ActionInfo>,
+        action_info: ActionInfoWithProps,
     ) -> Result<(), Error> {
         let mut inner = self.inner.lock().await;
         inner

--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -147,7 +147,7 @@ pub trait AwaitedActionSubscriber: Send + Sync + Sized + 'static {
 }
 
 /// A trait that defines the interface for an AwaitedActionDb.
-pub trait AwaitedActionDb: Send + Sync + MetricsComponent + 'static {
+pub trait AwaitedActionDb: Send + Sync + MetricsComponent + Unpin + 'static {
     type Subscriber: AwaitedActionSubscriber;
 
     /// Get the AwaitedAction by the client operation id.

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use nativelink_config::schedulers::SchedulerConfig;
 use nativelink_error::{Error, ResultExt};
 use nativelink_store::store_manager::StoreManager;
+use nativelink_util::operation_state_manager::ClientStateManager;
 
-use crate::action_scheduler::ActionScheduler;
 use crate::cache_lookup_scheduler::CacheLookupScheduler;
 use crate::grpc_scheduler::GrpcScheduler;
 use crate::property_modifier_scheduler::PropertyModifierScheduler;
@@ -26,7 +26,7 @@ use crate::simple_scheduler::SimpleScheduler;
 use crate::worker_scheduler::WorkerScheduler;
 
 pub type SchedulerFactoryResults = (
-    Option<Arc<dyn ActionScheduler>>,
+    Option<Arc<dyn ClientStateManager>>,
     Option<Arc<dyn WorkerScheduler>>,
 );
 

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod action_scheduler;
 pub mod api_worker_scheduler;
 mod awaited_action_db;
 pub mod cache_lookup_scheduler;

--- a/nativelink-scheduler/src/platform_property_manager.rs
+++ b/nativelink-scheduler/src/platform_property_manager.rs
@@ -19,7 +19,7 @@ use nativelink_error::{make_input_err, Code, Error, ResultExt};
 use nativelink_metric::{
     group, MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
 };
-use nativelink_util::platform_properties::PlatformPropertyValue;
+use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
 
 /// Helps manage known properties and conversion into `PlatformPropertyValue`.
 pub struct PlatformPropertyManager {
@@ -55,6 +55,20 @@ impl PlatformPropertyManager {
     #[must_use]
     pub const fn get_known_properties(&self) -> &HashMap<String, PropertyType> {
         &self.known_properties
+    }
+
+    /// Given a map of key-value pairs, returns a map of `PlatformPropertyValue` based on the
+    /// configuration passed into the `PlatformPropertyManager` constructor.
+    pub fn make_platform_properties(
+        &self,
+        properties: HashMap<String, String>,
+    ) -> Result<PlatformProperties, Error> {
+        let mut platform_properties = HashMap::with_capacity(properties.len());
+        for (key, value) in properties {
+            let prop_value = self.make_prop_value(&key, &value)?;
+            platform_properties.insert(key, prop_value);
+        }
+        Ok(PlatformProperties::new(platform_properties))
     }
 
     /// Given a specific key and value, returns the translated `PlatformPropertyValue`. This will

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -23,6 +23,7 @@ use nativelink_util::action_messages::{
     ActionInfo, ActionResult, ActionStage, ActionState, ActionUniqueQualifier, ExecutionMetadata,
     OperationId, WorkerId,
 };
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
     OperationFilter, OperationStageFlags, OrderDirection, WorkerStateManager,
@@ -428,6 +429,10 @@ impl<T: AwaitedActionDb> ClientStateManager for SimpleSchedulerStateManager<T> {
     ) -> Result<ActionStateResultStream<'a>, Error> {
         self.inner_filter_operations(filter, move |rx| Box::new(ClientActionStateResult::new(rx)))
             .await
+    }
+
+    fn as_known_platform_property_provider(&self) -> Option<&dyn KnownPlatformPropertyProvider> {
+        None
     }
 }
 

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
@@ -25,9 +24,7 @@ use futures::join;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
-use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::cache_lookup_scheduler::CacheLookupScheduler;
-use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::action_messages::{
     ActionResult, ActionStage, ActionState, ActionUniqueQualifier, OperationId,
@@ -41,7 +38,7 @@ use tokio::sync::watch;
 use tokio::{self};
 use tokio_stream::StreamExt;
 use utils::mock_scheduler::MockActionScheduler;
-use utils::scheduler_utils::{make_base_action_info, TokioWatchActionStateResult, INSTANCE_NAME};
+use utils::scheduler_utils::{make_base_action_info, TokioWatchActionStateResult};
 
 struct TestContext {
     mock_scheduler: Arc<MockActionScheduler>,
@@ -60,27 +57,6 @@ fn make_cache_scheduler() -> Result<TestContext, Error> {
         ac_store,
         cache_scheduler,
     })
-}
-
-#[nativelink_test]
-async fn platform_property_manager_call_passed() -> Result<(), Error> {
-    let context = make_cache_scheduler()?;
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
-    let instance_name = INSTANCE_NAME.to_string();
-    let (actual_manager, actual_instance_name) = join!(
-        context
-            .cache_scheduler
-            .get_platform_property_manager(&instance_name),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager.clone())),
-    );
-    assert_eq!(
-        Arc::as_ptr(&platform_property_manager),
-        Arc::as_ptr(&actual_manager?)
-    );
-    assert_eq!(instance_name, actual_instance_name);
-    Ok(())
 }
 
 #[nativelink_test]

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -22,16 +22,14 @@ mod utils {
 }
 
 use futures::{join, StreamExt};
-use nativelink_config::schedulers::{PlatformPropertyAddition, PropertyModification, PropertyType};
+use nativelink_config::schedulers::{PlatformPropertyAddition, PropertyModification};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
-use nativelink_scheduler::action_scheduler::ActionScheduler;
-use nativelink_scheduler::platform_property_manager::PlatformPropertyManager;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
 use nativelink_util::action_messages::{ActionStage, ActionState, OperationId};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
 use nativelink_util::operation_state_manager::{ClientStateManager, OperationFilter};
-use nativelink_util::platform_properties::PlatformPropertyValue;
 use pretty_assertions::assert_eq;
 use tokio::sync::watch;
 use utils::mock_scheduler::MockActionScheduler;
@@ -73,18 +71,11 @@ async fn add_action_adds_property() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-        name.clone(),
-        PropertyType::exact,
-    )])));
     let client_operation_id = OperationId::default();
-    let (_, _, (passed_client_operation_id, action_info)) = join!(
+    let (_, (passed_client_operation_id, action_info)) = join!(
         context
             .modifier_scheduler
             .add_action(client_operation_id.clone(), action_info.clone()),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
             .expect_add_action(Ok(Box::new(TokioWatchActionStateResult::new(
@@ -95,8 +86,8 @@ async fn add_action_adds_property() -> Result<(), Error> {
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
-        HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
-        action_info.platform_properties.properties
+        HashMap::from([(name, value)]),
+        action_info.platform_properties
     );
     Ok(())
 }
@@ -116,8 +107,7 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
         .clone();
     action_info
         .platform_properties
-        .properties
-        .insert(name.clone(), PlatformPropertyValue::Unknown(original_value));
+        .insert(name.clone(), original_value);
     let action_info = Arc::new(action_info);
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
@@ -125,18 +115,11 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-        name.clone(),
-        PropertyType::exact,
-    )])));
     let client_operation_id = OperationId::default();
-    let (_, _, (passed_client_operation_id, action_info)) = join!(
+    let (_, (passed_client_operation_id, action_info)) = join!(
         context
             .modifier_scheduler
             .add_action(client_operation_id.clone(), action_info.clone()),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
             .expect_add_action(Ok(Box::new(TokioWatchActionStateResult::new(
@@ -147,8 +130,8 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
-        HashMap::from([(name, PlatformPropertyValue::Exact(replaced_value))]),
-        action_info.platform_properties.properties
+        HashMap::from([(name, replaced_value)]),
+        action_info.platform_properties
     );
     Ok(())
 }
@@ -171,18 +154,11 @@ async fn add_action_property_added_after_remove() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-        name.clone(),
-        PropertyType::exact,
-    )])));
     let client_operation_id = OperationId::default();
-    let (_, _, (passed_client_operation_id, action_info)) = join!(
+    let (_, (passed_client_operation_id, action_info)) = join!(
         context
             .modifier_scheduler
             .add_action(client_operation_id.clone(), action_info.clone()),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
             .expect_add_action(Ok(Box::new(TokioWatchActionStateResult::new(
@@ -193,8 +169,8 @@ async fn add_action_property_added_after_remove() -> Result<(), Error> {
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
     assert_eq!(
-        HashMap::from([(name, PlatformPropertyValue::Exact(value))]),
-        action_info.platform_properties.properties
+        HashMap::from([(name, value)]),
+        action_info.platform_properties
     );
     Ok(())
 }
@@ -217,18 +193,15 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-        name,
-        PropertyType::exact,
-    )])));
+    // let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
+    //     name,
+    //     PropertyType::exact,
+    // )])));
     let client_operation_id = OperationId::default();
-    let (_, _, (passed_client_operation_id, action_info)) = join!(
+    let (_, (passed_client_operation_id, action_info)) = join!(
         context
             .modifier_scheduler
             .add_action(client_operation_id.clone(), action_info.clone()),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
             .expect_add_action(Ok(Box::new(TokioWatchActionStateResult::new(
@@ -238,10 +211,7 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
             )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
-    assert_eq!(
-        HashMap::from([]),
-        action_info.platform_properties.properties
-    );
+    assert_eq!(HashMap::from([]), action_info.platform_properties);
     Ok(())
 }
 
@@ -253,10 +223,7 @@ async fn add_action_property_remove() -> Result<(), Error> {
     let mut action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest())
         .as_ref()
         .clone();
-    action_info
-        .platform_properties
-        .properties
-        .insert(name, PlatformPropertyValue::Unknown(value));
+    action_info.platform_properties.insert(name, value);
     let action_info = Arc::new(action_info);
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
@@ -264,15 +231,12 @@ async fn add_action_property_remove() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
+    // let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
     let client_operation_id = OperationId::default();
-    let (_, _, (passed_client_operation_id, action_info)) = join!(
+    let (_, (passed_client_operation_id, action_info)) = join!(
         context
             .modifier_scheduler
             .add_action(client_operation_id.clone(), action_info.clone()),
-        context
-            .mock_scheduler
-            .expect_get_platform_property_manager(Ok(platform_property_manager)),
         context
             .mock_scheduler
             .expect_add_action(Ok(Box::new(TokioWatchActionStateResult::new(
@@ -282,10 +246,7 @@ async fn add_action_property_remove() -> Result<(), Error> {
             )))),
     );
     assert_eq!(client_operation_id, passed_client_operation_id);
-    assert_eq!(
-        HashMap::from([]),
-        action_info.platform_properties.properties
-    );
+    assert_eq!(HashMap::from([]), action_info.platform_properties);
     Ok(())
 }
 
@@ -319,19 +280,15 @@ async fn find_by_client_operation_id_call_passed() -> Result<(), Error> {
 async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
     let name = "name".to_string();
     let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
-    let scheduler_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
-    let get_property_manager_fut = context
+    let known_properties = Vec::new();
+    let instance_name_fut = context
         .mock_scheduler
-        .expect_get_platform_property_manager(Ok(scheduler_property_manager));
-    let property_manager_fut = context
+        .expect_get_known_properties(Ok(known_properties));
+    let known_props_fut = context
         .modifier_scheduler
-        .get_platform_property_manager(INSTANCE_NAME);
-    let (actual_instance_name, property_manager) =
-        join!(get_property_manager_fut, property_manager_fut);
-    assert_eq!(
-        HashMap::<_, _>::from_iter([(name, PropertyType::priority)]),
-        *property_manager?.get_known_properties()
-    );
+        .get_known_properties(INSTANCE_NAME);
+    let (actual_instance_name, known_props) = join!(instance_name_fut, known_props_fut);
+    assert_eq!(Ok(vec![name]), known_props);
     assert_eq!(actual_instance_name, INSTANCE_NAME);
     Ok(())
 }
@@ -340,20 +297,14 @@ async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
 async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
     let name = "name".to_string();
     let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
-    let scheduler_property_manager =
-        Arc::new(PlatformPropertyManager::new(HashMap::<_, _>::from_iter([
-            (name.clone(), PropertyType::exact),
-        ])));
-    let get_property_manager_fut = context
+    let known_properties = vec![name.clone()];
+    let instance_name_fut = context
         .mock_scheduler
-        .expect_get_platform_property_manager(Ok(scheduler_property_manager));
-    let property_manager_fut = context
+        .expect_get_known_properties(Ok(known_properties));
+    let known_props_fut = context
         .modifier_scheduler
-        .get_platform_property_manager(INSTANCE_NAME);
-    let (_, property_manager) = join!(get_property_manager_fut, property_manager_fut);
-    assert_eq!(
-        HashMap::<_, _>::from_iter([(name, PropertyType::exact)]),
-        *property_manager?.get_known_properties()
-    );
+        .get_known_properties(INSTANCE_NAME);
+    let (_, known_props) = join!(instance_name_fut, known_props_fut);
+    assert_eq!(Ok(vec![name]), known_props);
     Ok(())
 }

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -24,7 +24,6 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::operation_state_manager::ActionStateResult;
-use nativelink_util::platform_properties::PlatformProperties;
 use tokio::sync::watch;
 
 pub const INSTANCE_NAME: &str = "foobar_instance_name";
@@ -37,9 +36,7 @@ pub fn make_base_action_info(
         command_digest: DigestInfo::new([0u8; 32], 0),
         input_root_digest: DigestInfo::new([0u8; 32], 0),
         timeout: Duration::MAX,
-        platform_properties: PlatformProperties {
-            properties: HashMap::new(),
-        },
+        platform_properties: HashMap::new(),
         priority: 0,
         load_timestamp: UNIX_EPOCH,
         insert_timestamp,

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -22,6 +22,7 @@ rust_library(
         "src/fs.rs",
         "src/health_utils.rs",
         "src/instant_wrapper.rs",
+        "src/known_platform_property_provider.rs",
         "src/lib.rs",
         "src/metrics_utils.rs",
         "src/operation_state_manager.rs",

--- a/nativelink-util/src/known_platform_property_provider.rs
+++ b/nativelink-util/src/known_platform_property_provider.rs
@@ -12,24 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use nativelink_error::Error;
 use nativelink_metric::RootMetricsComponent;
-use nativelink_util::operation_state_manager::ClientStateManager;
 
-use crate::platform_property_manager::PlatformPropertyManager;
+use crate::operation_state_manager::ClientStateManager;
 
-/// ActionScheduler interface is responsible for interactions between the scheduler
-/// and action related operations.
+/// KnownPlatformPropertyProvider interface is responsible for retrieving
+/// a list of known platform properties.
+// TODO(https://github.com/rust-lang/rust/issues/65991) When this lands we can
+// move this to the nativelink-scheduler crate.
 #[async_trait]
-pub trait ActionScheduler:
+pub trait KnownPlatformPropertyProvider:
     ClientStateManager + Sync + Send + Unpin + RootMetricsComponent + 'static
 {
-    /// Returns the platform property manager.
-    async fn get_platform_property_manager(
-        &self,
-        instance_name: &str,
-    ) -> Result<Arc<PlatformPropertyManager>, Error>;
+    // / Returns the platform property manager.
+    async fn get_known_properties(&self, instance_name: &str) -> Result<Vec<String>, Error>;
 }

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -25,6 +25,7 @@ pub mod fastcdc;
 pub mod fs;
 pub mod health_utils;
 pub mod instant_wrapper;
+pub mod known_platform_property_provider;
 pub mod metrics_utils;
 pub mod operation_state_manager;
 pub mod origin_context;

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -806,9 +806,8 @@ impl RunningActionImpl {
                     EnvironmentSource::property(property) => self
                         .action_info
                         .platform_properties
-                        .properties
                         .get(property)
-                        .map_or_else(|| Cow::Borrowed(""), |v| v.as_str()),
+                        .map_or_else(|| Cow::Borrowed(""), |v| Cow::Borrowed(v.as_str())),
                     EnvironmentSource::value(value) => Cow::Borrowed(value.as_str()),
                     EnvironmentSource::timeout_millis => {
                         Cow::Owned(requested_timeout.as_millis().to_string())

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -48,7 +48,6 @@ use nativelink_util::action_messages::{
 };
 use nativelink_util::common::{encode_stream_proto, fs, DigestInfo};
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::store_trait::Store;
 use nativelink_worker::local_worker::new_local_worker;
 use pretty_assertions::assert_eq;
@@ -228,7 +227,7 @@ async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::
         command_digest: DigestInfo::new([1u8; 32], 10),
         input_root_digest: DigestInfo::new([2u8; 32], 10),
         timeout: Duration::from_secs(1),
-        platform_properties: PlatformProperties::default(),
+        platform_properties: HashMap::new(),
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
@@ -244,7 +243,7 @@ async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::
         tx_stream
             .send(Frame::data(encode_stream_proto(&UpdateForWorker {
                 update: Some(Update::StartAction(StartExecute {
-                    execute_request: Some(action_info.into()),
+                    execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
                 })),
@@ -310,7 +309,7 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
         command_digest: DigestInfo::new([1u8; 32], 10),
         input_root_digest: DigestInfo::new([2u8; 32], 10),
         timeout: Duration::from_secs(1),
-        platform_properties: PlatformProperties::default(),
+        platform_properties: HashMap::new(),
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
@@ -326,7 +325,7 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
         tx_stream
             .send(Frame::data(encode_stream_proto(&UpdateForWorker {
                 update: Some(Update::StartAction(StartExecute {
-                    execute_request: Some(action_info.into()),
+                    execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
                 })),
@@ -572,7 +571,7 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
         command_digest: DigestInfo::new([1u8; 32], 10),
         input_root_digest: DigestInfo::new([2u8; 32], 10),
         timeout: Duration::from_secs(1),
-        platform_properties: PlatformProperties::default(),
+        platform_properties: HashMap::new(),
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
@@ -588,7 +587,7 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
         tx_stream
             .send(Frame::data(encode_stream_proto(&UpdateForWorker {
                 update: Some(Update::StartAction(StartExecute {
-                    execute_request: Some(action_info.into()),
+                    execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
                 })),
@@ -657,7 +656,7 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         command_digest: DigestInfo::new([1u8; 32], 10),
         input_root_digest: DigestInfo::new([2u8; 32], 10),
         timeout: Duration::from_secs(1),
-        platform_properties: PlatformProperties::default(),
+        platform_properties: HashMap::new(),
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
@@ -674,7 +673,7 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         tx_stream
             .send(Frame::data(encode_stream_proto(&UpdateForWorker {
                 update: Some(Update::StartAction(StartExecute {
-                    execute_request: Some(action_info.clone().into()),
+                    execute_request: Some((&action_info).into()),
                     operation_id: operation_id.to_string(),
                     queued_timestamp: None,
                 })),

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -35,7 +35,6 @@ use nativelink_metric::{
     MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent, RootMetricsComponent,
 };
 use nativelink_metric_collector::{otel_export, MetricsCollectorLayer};
-use nativelink_scheduler::action_scheduler::ActionScheduler;
 use nativelink_scheduler::default_scheduler_factory::scheduler_factory;
 use nativelink_service::ac_server::AcServer;
 use nativelink_service::bep_server::BepServer;
@@ -52,6 +51,7 @@ use nativelink_util::common::fs::{set_idle_file_descriptor_timeout, set_open_fil
 use nativelink_util::digest_hasher::{set_default_digest_hasher_func, DigestHasherFunc};
 use nativelink_util::health_utils::HealthRegistryBuilder;
 use nativelink_util::metrics_utils::{set_metrics_enabled_for_this_thread, Counter};
+use nativelink_util::operation_state_manager::ClientStateManager;
 use nativelink_util::origin_context::OriginContext;
 use nativelink_util::store_trait::{
     set_default_digest_size_health_check, DEFAULT_DIGEST_SIZE_HEALTH_CHECK_CFG,
@@ -122,7 +122,7 @@ struct RootMetrics {
     // TODO(allada) To prevent output from being too verbose we only
     // print the action_schedulers.
     #[metric(group = "action_schedulers")]
-    schedulers: HashMap<String, Arc<dyn ActionScheduler>>,
+    schedulers: HashMap<String, Arc<dyn ClientStateManager>>,
 }
 
 impl RootMetricsComponent for RootMetrics {}


### PR DESCRIPTION
We want to phase out ActionScheduler in favor of ClientStateManager. In doing so, we need to have a way to let CapabilitiesServer know about platform properties; if we do this, it'd be a breaking change. Instead of causing a breaking change, we instead are going to make the provided scheduler allow the capabilities service query the optionally provided property provider interface and if it does not exist throw a warning and have it return an empty set (most RBE clients ignore this field anyway).

towards #1213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1260)
<!-- Reviewable:end -->
