### PR TITLE
Append buck2 toolchain with additional packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -269,10 +269,8 @@
         createWorker = pkgs.callPackage ./tools/create-worker.nix {inherit buildImage self;};
         buck2-toolchain = let
           buck2-nightly-rust-version = "2024-04-28";
-          buck2-nightly-rust =
-            if pkgs.stdenv.isDarwin
-            then pkgs.rust-bin.nightly.${buck2-nightly-rust-version}
-            else pkgs.pkgsMusl.rust-bin.nightly.${buck2-nightly-rust-version};
+          buck2-nightly-rust = pkgs.rust-bin.nightly.${buck2-nightly-rust-version};
+          buck2-rust = buck2-nightly-rust.default.override {extensions = ["rust-src"];};
         in
           pkgs.callPackage ./tools/create-worker-experimental.nix {
             inherit buildImage self;
@@ -280,12 +278,19 @@
             packagesForImage = [
               pkgs.coreutils
               pkgs.bash
-              pkgs.clang
               pkgs.go
               pkgs.diffutils
               pkgs.gnutar
               pkgs.gzip
-              buck2-nightly-rust.default
+              pkgs.python3Full
+              pkgs.unzip
+              pkgs.zstd
+              pkgs.cargo-bloat
+              pkgs.mold-wrapped
+              pkgs.reindeer
+              pkgs.lld_16
+              pkgs.clang_16
+              buck2-rust
             ];
           };
         siso-chromium = buildImage {

--- a/tools/create-worker-experimental.nix
+++ b/tools/create-worker-experimental.nix
@@ -82,7 +82,9 @@ in
       (buildEnv {
         name = "${imageName}-buildEnv";
         paths = packagesForImage;
-        pathsToLink = ["/bin"];
+        # Explicitly flatten out the paths to link as
+        # laid out in the packages.
+        pathsToLink = "/";
       })
     ];
 


### PR DESCRIPTION
# Description

Append buck2 toolchain with additional packages

A toolchain for buck2 depends on more than llvm and rust,
appending more packages for compiling buck2 using remote
execution on nativelink. This mirrors similar to what is
used in [buck2/flake.nix](https://github.com/facebook/buck2/blob/main/flake.nix)

`create-worker-experimental.nix` now flattens out the container
image layout to a standard unix filesystem layout. Using the
nix store layout requires client knowledge of toolchains and
a similar setup as rbe gen/local remote execution which isn't
available at the moment.

Fixes  https://github.com/TraceMachina/nativelink/issues/1263

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Build with nix and copy to local docker daemon. 
Run a docker shell and inspected environment.

```
nix run .#nativelink-worker-buck2-toolchain.copyToDockerDaemon
docker run --rm -it --entrypoint bash nativelink-worker-buck2-toolchain:<generated label>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1264)
<!-- Reviewable:end -->
