### PR TITLE
Show a warning message if versions are mismatched in `Worker` <-> `Scheduler` communication

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -87,7 +87,15 @@ message SupportedProperties {
     /// The details on how to use this property can be found here:
     /// https://github.com/TraceMachina/nativelink/blob/3147265047544572e3483c985e4aab0f9fdded38/nativelink-config/src/cas_server.rs
     repeated build.bazel.remote.execution.v2.Platform.Property properties = 1;
-    reserved 2; // NextId.
+
+    /// Version of the worker.
+    ///
+    /// The scheduler should throw a warning if its version doesn't match with
+    /// the worker's version when the worker sends the initial request to the
+    /// scheduler.
+    string version = 2;
+
+    reserved 3; // NextId.
 }
 
 /// The result of an ExecutionRequest.
@@ -121,7 +129,15 @@ message ExecuteResult {
 message ConnectionResult {
     /// The internal ID given to the newly connected node.
     string worker_id = 1;
-    reserved 2; // NextId.
+
+    /// Version of the scheduler.
+    ///
+    /// The worker should throw a warning when its version doesn't match with the
+    /// scheduler version when it receives the result sent back from the scheduler
+    /// after the initial request.
+    string scheduler_version = 2;
+
+    reserved 3; // NextId.
 }
 
 /// Request to kill a running operation sent from the scheduler to a worker.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -48,6 +48,13 @@ pub struct SupportedProperties {
     pub properties: ::prost::alloc::vec::Vec<
         super::super::super::super::super::build::bazel::remote::execution::v2::platform::Property,
     >,
+    /// / Version of the worker.
+    /// /
+    /// / The scheduler should throw a warning if its version doesn't match with
+    /// / the worker's version when the worker sends the initial request to the
+    /// / scheduler.
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
 }
 /// / The result of an ExecutionRequest.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -93,6 +100,13 @@ pub struct ConnectionResult {
     /// / The internal ID given to the newly connected node.
     #[prost(string, tag = "1")]
     pub worker_id: ::prost::alloc::string::String,
+    /// / Version of the scheduler.
+    /// /
+    /// / The worker should throw a warning when its version doesn't match with the
+    /// / scheduler version when it receives the result sent back from the scheduler
+    /// / after the initial request.
+    #[prost(string, tag = "2")]
+    pub scheduler_version: ::prost::alloc::string::String,
 }
 /// / Request to kill a running operation sent from the scheduler to a worker.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -81,6 +81,9 @@ struct ApiWorkerSchedulerImpl {
     allocation_strategy: WorkerAllocationStrategy,
     /// A channel to notify the matching engine that the worker pool has changed.
     worker_change_notify: Arc<Notify>,
+
+    /// The version of the scheduler.
+    version: String,
 }
 
 impl ApiWorkerSchedulerImpl {
@@ -117,7 +120,7 @@ impl ApiWorkerSchedulerImpl {
         // the multi-threaded runtime works.
         let worker = self.workers.peek_mut(&worker_id).unwrap();
         let res = worker
-            .send_initial_connection_result()
+            .send_initial_connection_result(self.version.clone())
             .err_tip(|| "Failed to send initial connection result to worker");
         if let Err(err) = &res {
             event!(
@@ -328,6 +331,7 @@ impl ApiWorkerScheduler {
         allocation_strategy: WorkerAllocationStrategy,
         worker_change_notify: Arc<Notify>,
         worker_timeout_s: u64,
+        version: String,
     ) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(ApiWorkerSchedulerImpl {
@@ -335,6 +339,7 @@ impl ApiWorkerScheduler {
                 worker_state_manager,
                 allocation_strategy,
                 worker_change_notify,
+                version,
             }),
             platform_property_manager,
             worker_timeout_s,

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -269,9 +269,11 @@ impl SimpleScheduler {
 impl SimpleScheduler {
     pub fn new(
         scheduler_cfg: &nativelink_config::schedulers::SimpleScheduler,
+        version: String,
     ) -> (Arc<Self>, Arc<dyn WorkerScheduler>) {
         Self::new_with_callback(
             scheduler_cfg,
+            version,
             || {
                 // The cost of running `do_try_match()` is very high, but constant
                 // in relation to the number of changes that have happened. This
@@ -294,6 +296,7 @@ impl SimpleScheduler {
         NowFn: Fn() -> I + Clone + Send + Sync + 'static,
     >(
         scheduler_cfg: &nativelink_config::schedulers::SimpleScheduler,
+        version: String,
         on_matching_engine_run: F,
         now_fn: NowFn,
     ) -> (Arc<Self>, Arc<dyn WorkerScheduler>) {
@@ -338,6 +341,7 @@ impl SimpleScheduler {
             scheduler_cfg.allocation_strategy,
             tasks_or_worker_change_notify.clone(),
             worker_timeout_s,
+            version,
         );
 
         let worker_scheduler_clone = worker_scheduler.clone();

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -144,11 +144,12 @@ impl Worker {
 
     /// Sends the initial connection information to the worker. This generally is just meta info.
     /// This should only be sent once and should always be the first item in the stream.
-    pub fn send_initial_connection_result(&mut self) -> Result<(), Error> {
+    pub fn send_initial_connection_result(&mut self, version: String) -> Result<(), Error> {
         send_msg_to_worker(
             &mut self.tx,
             update_for_worker::Update::ConnectionResult(ConnectionResult {
                 worker_id: self.id.to_string(),
+                scheduler_version: version,
             }),
         )
         .err_tip(|| format!("Failed to send ConnectionResult to worker : {}", self.id))

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -49,6 +49,8 @@ mod utils {
     pub(crate) mod scheduler_utils;
 }
 
+const APP_VERSION: &str = "0.1.2";
+
 fn update_eq(expected: UpdateForWorker, actual: UpdateForWorker, ignore_id: bool) -> bool {
     let Some(expected_update) = expected.update else {
         return actual.update.is_none();
@@ -97,6 +99,7 @@ async fn verify_initial_connection_message(
         update: Some(update_for_worker::Update::ConnectionResult(
             ConnectionResult {
                 worker_id: worker_id.to_string(),
+                scheduler_version: APP_VERSION.to_string(),
             },
         )),
     };
@@ -150,6 +153,7 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -202,6 +206,7 @@ async fn find_executing_action() -> Result<(), Error> {
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -275,6 +280,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -443,6 +449,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -522,6 +529,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
             supported_platform_properties: Some(prop_defs),
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -606,6 +614,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -698,6 +707,7 @@ async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(),
     let worker_id: WorkerId = WorkerId(Uuid::new_v4());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -736,6 +746,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -851,6 +862,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -943,6 +955,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1052,6 +1065,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1141,6 +1155,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1275,6 +1290,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
             supported_platform_properties: Some(supported_props),
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1426,6 +1442,7 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
             supported_platform_properties: Some(supported_props),
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1486,6 +1503,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
             max_job_retries: 1,
             ..Default::default()
         },
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1624,6 +1642,7 @@ async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
     // DropChecker.
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         move || {
             // This will ensure dropping happens if this function is ever dropped.
             let _drop_checker = drop_checker.clone();
@@ -1650,6 +1669,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
 
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );
@@ -1715,6 +1735,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
 async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &nativelink_config::schedulers::SimpleScheduler::default(),
+        APP_VERSION.to_string(),
         || async move {},
         MockInstantWrapped::default,
     );

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -17,12 +17,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::{
-    action_messages::{ActionInfo, OperationId},
-    known_platform_property_provider::KnownPlatformPropertyProvider,
-    operation_state_manager::{
-        ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
-    },
+use nativelink_util::action_messages::{ActionInfo, OperationId};
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
 };
 use tokio::sync::{mpsc, Mutex};
 

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -51,6 +51,7 @@ use tonic::Request;
 
 const BASE_NOW_S: u64 = 10;
 const BASE_WORKER_TIMEOUT_S: u64 = 100;
+const APP_VERSION: &str = "0.1.2";
 
 #[derive(Debug)]
 enum WorkerStateManagerCalls {
@@ -147,6 +148,7 @@ async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestCont
         WorkerAllocationStrategy::default(),
         tasks_or_worker_change_notify,
         worker_timeout,
+        APP_VERSION.to_string(),
     );
 
     let mut schedulers: HashMap<String, Arc<dyn WorkerScheduler>> = HashMap::new();
@@ -156,6 +158,7 @@ async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestCont
             scheduler: SCHEDULER_NAME.to_string(),
         },
         &schedulers,
+        APP_VERSION.to_string(),
         now_fn,
     )
     .err_tip(|| "Error creating WorkerApiServer")?;

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -28,6 +28,7 @@ use tracing::{event, Level};
 
 pub async fn make_supported_properties<S: BuildHasher>(
     worker_properties: &HashMap<String, WorkerProperty, S>,
+    version: String,
 ) -> Result<SupportedProperties, Error> {
     let mut futures = vec![];
     for (property_name, worker_property) in worker_properties {
@@ -99,5 +100,6 @@ pub async fn make_supported_properties<S: BuildHasher>(
 
     Ok(SupportedProperties {
         properties: try_join_all(futures).await?.into_iter().flatten().collect(),
+        version,
     })
 }

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -181,7 +181,10 @@ pub fn setup_grpc_stream() -> (
     (tx, Response::new(stream))
 }
 
-pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConfig) -> TestContext {
+pub async fn setup_local_worker_with_config(
+    local_worker_config: LocalWorkerConfig,
+    version: String,
+) -> TestContext {
     let mock_worker_api_client = MockWorkerApiClient::new();
     let mock_worker_api_client_clone = mock_worker_api_client.clone();
     let actions_manager = Arc::new(MockRunningActionsManager::new());
@@ -193,6 +196,7 @@ pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConf
             Box::pin(async move { Ok(mock_worker_api_client) })
         }),
         Box::new(move |_| Box::pin(async move { /* No sleep */ })),
+        version,
     );
     let drop_guard = spawn!("local_worker_spawn", async move { worker.run().await });
 
@@ -210,6 +214,7 @@ pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConf
 
 pub async fn setup_local_worker(
     platform_properties: HashMap<String, WorkerProperty>,
+    version: String,
 ) -> TestContext {
     const ARBITRARY_LARGE_TIMEOUT: f32 = 10000.;
     let local_worker_config = LocalWorkerConfig {
@@ -220,7 +225,7 @@ pub async fn setup_local_worker(
         },
         ..Default::default()
     };
-    setup_local_worker_with_config(local_worker_config).await
+    setup_local_worker_with_config(local_worker_config, version).await
 }
 
 pub struct TestContext {


### PR DESCRIPTION
# Description

When `Worker` is connecting to the `Scheduler`, both sides should express which version of NativeLink they are using in the metadata and if they are not matched, they should throw a warning. WorkerAPI protobuf is updated to include version information for both `Worker` and `Scheduler` in the initial request and the response to that initial request. `CARGO_PKG_VERSION` environment varaible is used to get the current NativeLink version - which is how `clap` library gets version by itself. Notice that `CARGO_PKG_VERSION` environment variable is only set when the NativeLink is built with `cargo` not `bazel`.
Tests are updated to include version information for both `Worker` and `Scheduler`.


Fixes #1253

## Type of change

Please delete options that aren't relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1265)
<!-- Reviewable:end -->
