### PR TITLE
Fix #1266

### DIFF
--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -53,7 +53,7 @@ pub fn store_factory<'a>(
             StoreConfig::experimental_s3_store(config) => {
                 S3Store::new(config, SystemTime::now).await?
             }
-            StoreConfig::redis_store(config) => RedisStore::new(config)?,
+            StoreConfig::redis_store(config) => RedisStore::new(config).await?,
             StoreConfig::verify(config) => VerifyStore::new(
                 config,
                 store_factory(&config.backend, store_manager, None).await?,

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -179,6 +179,13 @@ impl StoreDriver for RedisStore {
         // TODO(caass): Optimize for the case where `keys.len() == 1`
         let pipeline = self.client_pool.next().pipeline();
 
+        if !pipeline.is_connected() {
+            return Err(Error::new(
+                Code::Unavailable,
+                "Could not connect to Redis Client".to_string(),
+            ));
+        }
+
         results.iter_mut().for_each(|result| *result = None);
 
         for (idx, key) in keys.iter().enumerate() {

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -183,7 +183,8 @@ async fn upload_and_get_data() -> Result<(), Error> {
             ..Default::default()
         });
 
-        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
+        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())
+            .await?
     };
 
     store.update_oneshot(digest, data.clone()).await?;
@@ -263,7 +264,8 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
             None,
             mock_uuid_generator,
             prefix.to_string(),
-        )?
+        )
+        .await?
     };
 
     store.update_oneshot(digest, data.clone()).await?;
@@ -294,7 +296,8 @@ async fn upload_empty_data() -> Result<(), Error> {
         None,
         mock_uuid_generator,
         String::new(),
-    )?;
+    )
+    .await?;
 
     store.update_oneshot(digest, data).await?;
 
@@ -318,7 +321,8 @@ async fn upload_empty_data_with_prefix() -> Result<(), Error> {
         None,
         mock_uuid_generator,
         prefix.to_string(),
-    )?;
+    )
+    .await?;
 
     store.update_oneshot(digest, data).await?;
 
@@ -334,15 +338,10 @@ async fn upload_empty_data_with_prefix() -> Result<(), Error> {
 #[nativelink_test]
 async fn unsucessfull_redis_connection() -> Result<(), Error> {
     let store = {
-        let mut builder = Builder::default_centralized();
-        builder.set_policy(fred::types::ReconnectPolicy::Constant {
-            attempts: 1,
-            max_attempts: 10,
-            delay: 10,
-            jitter: 10,
-        });
+        let builder = Builder::default_centralized();
 
-        RedisStore::new_from_builder_and_parts(builder, None, || String::from(""), String::new())?
+        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())
+            .await?
     };
 
     let keys: Vec<StoreKey> = vec!["abc".into()];
@@ -350,7 +349,7 @@ async fn unsucessfull_redis_connection() -> Result<(), Error> {
 
     let has = store.has_with_results(&keys, &mut sizes).await;
 
-    assert!(has.is_err());
+    assert!(has.is_ok());
 
     Ok(())
 }
@@ -428,7 +427,8 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
             ..Default::default()
         });
 
-        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
+        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())
+            .await?
     };
 
     store.update_oneshot(digest, data.clone()).await?;
@@ -516,7 +516,8 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
             ..Default::default()
         });
 
-        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
+        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())
+            .await?
     };
 
     let (mut tx, rx) = make_buf_channel_pair();


### PR DESCRIPTION
# Description

I believe this is part of the solution to the issue. The RedisStore StoreDriver implementation needs to check if the client_pool is connected. So I changed only the has_with_results, and if what I've is correct, I will update the rest of the code.

Fixes #1266

## Type of change

Please delete options that aren't relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1267)
<!-- Reviewable:end -->
