### PR TITLE
Fix potential infinite loop in `RedisStore::update`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bazel-*
 target/
 .vscode/
+.zed
 .cache
 .terraform*
 .config

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -298,39 +298,79 @@ impl StoreDriver for RedisStore {
         // As a result of this, there will be a span of time where a key in Redis has only partial data. We want other
         // observers to notice atomic updates to keys, rather than partial updates, so we first write to a temporary key
         // and then rename that key once we're done appending data.
-        //
-        // TODO(caass): Remove potential for infinite loop (https://reviewable.io/reviews/TraceMachina/nativelink/1188#-O2pu9LV5ux4ILuT6MND)
-        'outer: loop {
-            let mut expecting_first_chunk = true;
-            let pipe = client.pipeline();
+        let mut is_first_chunk = true;
+        let mut eof_reached = false;
+        let mut pipe = client.pipeline();
 
-            while expecting_first_chunk || !reader.is_empty() {
-                let chunk = reader
-                    .recv()
-                    .await
-                    .err_tip(|| "Failed to reach chunk in update in redis store")?;
+        while !eof_reached {
+            pipe = client.pipeline();
+            let mut pipe_size = 0;
+            const MAX_PIPE_SIZE: usize = 5 * 1024 * 1024; // 5 MB
 
-                if chunk.is_empty() {
-                    if is_zero_digest(key.borrow()) {
-                        return Ok(());
-                    }
+            let chunk = reader
+                .recv()
+                .await
+                .err_tip(|| "Failed to reach chunk in update in redis store")?;
 
-                    // Reader sent empty chunk, we're done here.
-                    break 'outer;
-                }
+            if chunk.is_empty() {
+                // There are three cases where we receive an empty chunk:
+                // 1. The first chunk of a zero-digest key. We're required to treat all zero-digest keys as if they exist
+                //    and are empty per the RBE spec, so we can just return early as if we've pushed it -- any attempts to
+                //    read the value later will similarly avoid the network trip.
+                // 2. This is an empty first chunk of a non-zero-digest key. In this case, we _do_ need to push up an
+                //    empty key, but can skip the rest of the process around renaming since there's only the one operation.
+                // 3. This is the last chunk (EOF) of a regular key. In that case we can skip pushing this chunk.
+                //
+                // In all three cases, we're done pushing data and can move it from the temporary key to the final key.
+                if is_first_chunk && is_zero_digest(key.borrow()) {
+                    // Case 1, a zero-digest key.
+                    return Ok(());
+                } else if is_first_chunk {
+                    // Case 2, an empty non-zero-digest key.
+                    pipe.append::<(), _, _>(&temp_key, "")
+                        .await
+                        .err_tip(|| "While appending to temp key in RedisStore::update")?;
+                };
 
-                // Queue the append, but don't execute until we've received all the chunks.
-                pipe.append::<(), _, _>(&temp_key, chunk)
-                    .await
-                    .err_tip(|| "Failed to append to temp key in RedisStore::update")?;
-                expecting_first_chunk = false;
-
-                // Give other tasks a chance to run to populate the reader's
-                // buffer if possible.
-                tokio::task::yield_now().await;
+                // Note: setting `eof_reached = true` and calling `continue` is semantically equivalent to `break`.
+                // Since we need to use the `eof_reached` flag in the inner loop, we do the same here
+                // for consistency.
+                eof_reached = true;
+                continue;
+            } else {
+                // Not EOF, but we've now received our first chunk.
+                is_first_chunk = false;
             }
 
-            // Here the reader is empty but more data is expected.
+            // Queue the append, but don't execute until we've received all the chunks.
+            pipe_size += chunk.len();
+            pipe.append::<(), _, _>(&temp_key, chunk)
+                .await
+                .err_tip(|| "Failed to append to temp key in RedisStore::update")?;
+
+            // Opportunistically grab any other chunks already in the reader.
+            while let Some(chunk) = reader
+                .try_recv()
+                .transpose()
+                .err_tip(|| "Failed to reach chunk in update in redis store")?
+            {
+                if chunk.is_empty() {
+                    eof_reached = true;
+                    break;
+                } else {
+                    pipe_size += chunk.len();
+                    pipe.append::<(), _, _>(&temp_key, chunk)
+                        .await
+                        .err_tip(|| "Failed to append to temp key in RedisStore::update")?;
+                }
+
+                // Stop appending if the pipeline is already holding 5MB of data.
+                if pipe_size >= MAX_PIPE_SIZE {
+                    break;
+                }
+            }
+
+            // We've exhausted the reader (or hit the 5MB cap), but more data is expected.
             // Executing the queued commands appends the data we just received to the temp key.
             pipe.all::<()>()
                 .await
@@ -338,8 +378,10 @@ impl StoreDriver for RedisStore {
         }
 
         // Rename the temp key so that the data appears under the real key. Any data already present in the real key is lost.
-        client
-            .rename::<(), _, _>(&temp_key, final_key.as_ref())
+        pipe.rename::<(), _, _>(&temp_key, final_key.as_ref())
+            .await
+            .err_tip(|| "While queueing key rename in RedisStore::update()")?;
+        pipe.all::<()>()
             .await
             .err_tip(|| "While renaming key in RedisStore::update()")?;
 

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::panicking;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use fred::bytes_utils::string::Str;
 use fred::error::RedisError;
 use fred::mocks::{MockCommand, Mocks};
@@ -30,6 +31,7 @@ use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
 use pretty_assertions::assert_eq;
+use tokio::sync::watch;
 
 const VALID_HASH1: &str = "3031323334353637383961626364656630303030303030303030303030303030";
 const TEMP_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
@@ -42,32 +44,72 @@ fn make_temp_key(final_name: &str) -> String {
     format!("temp-{TEMP_UUID}-{{{final_name}}}")
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct MockRedisBackend {
     /// Commands we expect to encounter, and results we to return to the client.
     // Commands are pushed from the back and popped from the front.
     expected: Mutex<VecDeque<(MockCommand, Result<RedisValue, RedisError>)>>,
+
+    tx: watch::Sender<MockCommand>,
+    rx: watch::Receiver<MockCommand>,
+
+    failing: AtomicBool,
+}
+
+impl Default for MockRedisBackend {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MockRedisBackend {
     fn new() -> Self {
-        Self::default()
+        let (tx, rx) = watch::channel(MockCommand {
+            cmd: "".into(),
+            subcommand: None,
+            args: vec![],
+        });
+        Self {
+            expected: Mutex::default(),
+            tx,
+            rx,
+            failing: AtomicBool::new(false),
+        }
     }
 
     fn expect(&self, command: MockCommand, result: Result<RedisValue, RedisError>) -> &Self {
         self.expected.lock().unwrap().push_back((command, result));
         self
     }
+
+    async fn wait_for(&self, command: MockCommand) {
+        self.rx
+            .clone()
+            .wait_for(|cmd| *cmd == command)
+            .await
+            .expect("the channel isn't closed while the struct exists");
+    }
 }
 
 impl Mocks for MockRedisBackend {
     fn process_command(&self, actual: MockCommand) -> Result<RedisValue, RedisError> {
+        self.tx
+            .send(actual.clone())
+            .expect("the channel isn't closed while the struct exists");
+
         let Some((expected, result)) = self.expected.lock().unwrap().pop_front() else {
             // panic here -- this isn't a redis error, it's a test failure
+            self.failing.store(true, Ordering::Relaxed);
             panic!("Didn't expect any more commands, but received {actual:?}");
         };
 
-        assert_eq!(actual, expected);
+        if actual != expected {
+            self.failing.store(true, Ordering::Relaxed);
+            assert_eq!(
+                actual, expected,
+                "mismatched command, received (left) but expected (right)"
+            );
+        };
 
         result
     }
@@ -96,8 +138,8 @@ impl Mocks for MockRedisBackend {
 
 impl Drop for MockRedisBackend {
     fn drop(&mut self) {
-        if panicking() {
-            // We're already panicking, let's make debugging easier and let future devs solve problems one at a time.
+        if panicking() || self.failing.load(Ordering::Relaxed) {
+            // We're already failing, let's make debugging easier and let future devs solve problems one at a time.
             return;
         }
 
@@ -110,7 +152,7 @@ impl Drop for MockRedisBackend {
         assert_eq!(
             *expected,
             VecDeque::new(),
-            "Didn't receive all expected commands."
+            "Didn't receive all expected commands, expected (left)"
         );
 
         // Panicking isn't enough inside a tokio task, we need to `exit(1)`
@@ -186,9 +228,9 @@ async fn upload_and_get_data() -> Result<(), Error> {
         RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
     };
 
-    store.update_oneshot(digest, data.clone()).await?;
+    store.update_oneshot(digest, data.clone()).await.unwrap();
 
-    let result = store.has(digest).await?;
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -196,7 +238,8 @@ async fn upload_and_get_data() -> Result<(), Error> {
 
     let result = store
         .get_part_unchunked(digest, 0, Some(data.len()))
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(result, data, "Expected redis store to have updated value",);
 
@@ -266,9 +309,9 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
         )?
     };
 
-    store.update_oneshot(digest, data.clone()).await?;
+    store.update_oneshot(digest, data.clone()).await.unwrap();
 
-    let result = store.has(digest).await?;
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -276,7 +319,8 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
 
     let result = store
         .get_part_unchunked(digest, 0, Some(data.len()))
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(result, data, "Expected redis store to have updated value",);
 
@@ -294,11 +338,12 @@ async fn upload_empty_data() -> Result<(), Error> {
         None,
         mock_uuid_generator,
         String::new(),
-    )?;
+    )
+    .unwrap();
 
-    store.update_oneshot(digest, data).await?;
+    store.update_oneshot(digest, data).await.unwrap();
 
-    let result = store.has(digest).await?;
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -318,11 +363,12 @@ async fn upload_empty_data_with_prefix() -> Result<(), Error> {
         None,
         mock_uuid_generator,
         prefix.to_string(),
-    )?;
+    )
+    .unwrap();
 
-    store.update_oneshot(digest, data).await?;
+    store.update_oneshot(digest, data).await.unwrap();
 
-    let result = store.has(digest).await?;
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -407,9 +453,9 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
         RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
     };
 
-    store.update_oneshot(digest, data.clone()).await?;
+    store.update_oneshot(digest, data.clone()).await.unwrap();
 
-    let result = store.has(digest).await?;
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -417,7 +463,8 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
 
     let get_result: Bytes = store
         .get_part_unchunked(digest, 0, Some(data.clone().len()))
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(
         get_result,
@@ -430,9 +477,13 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
-    let data = Bytes::from(vec![0u8; 10 * 1024]);
-    let data_p1 = Bytes::from(vec![0u8; 6 * 1024]);
-    let data_p2 = Bytes::from(vec![0u8; 4 * 1024]);
+    let data_p1 = Bytes::from(vec![b'A'; 6 * 1024]);
+    let data_p2 = Bytes::from(vec![b'B'; 4 * 1024]);
+
+    let mut data = BytesMut::new();
+    data.extend_from_slice(&data_p1);
+    data.extend_from_slice(&data_p2);
+    let data = data.freeze();
 
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
     let packed_hash_hex = format!("{digest}");
@@ -441,14 +492,16 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
     let real_key = RedisValue::Bytes(packed_hash_hex.into());
 
     let mocks = Arc::new(MockRedisBackend::new());
+    let first_append = MockCommand {
+        cmd: Str::from_static("APPEND"),
+        subcommand: None,
+        args: vec![temp_key.clone(), data_p1.clone().into()],
+    };
+
     mocks
         // We expect multiple `"APPEND"`s as we send data in multiple chunks
         .expect(
-            MockCommand {
-                cmd: Str::from_static("APPEND"),
-                subcommand: None,
-                args: vec![temp_key.clone(), data_p1.clone().into()],
-            },
+            first_append.clone(),
             Ok(RedisValue::Array(vec![RedisValue::Null])),
         )
         .expect(
@@ -496,15 +549,27 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
     };
 
     let (mut tx, rx) = make_buf_channel_pair();
-    tx.send(data_p1).await?;
-    tokio::task::yield_now().await;
-    tx.send(data_p2).await?;
-    tx.send_eof()?;
-    store
-        .update(digest, rx, UploadSizeInfo::ExactSize(data.len()))
-        .await?;
 
-    let result = store.has(digest).await?;
+    tokio::try_join!(
+        async {
+            store
+                .update(digest, rx, UploadSizeInfo::ExactSize(data.len()))
+                .await
+                .unwrap();
+
+            Ok::<_, Error>(())
+        },
+        async {
+            tx.send(data_p1).await.unwrap();
+            mocks.wait_for(first_append).await;
+            tx.send(data_p2).await.unwrap();
+            tx.send_eof().unwrap();
+            Ok::<_, Error>(())
+        },
+    )
+    .unwrap();
+
+    let result = store.has(digest).await.unwrap();
     assert!(
         result.is_some(),
         "Expected redis store to have hash: {VALID_HASH1}",
@@ -512,7 +577,8 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
 
     let result = store
         .get_part_unchunked(digest, 0, Some(data.clone().len()))
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(result, data, "Expected redis store to have updated value",);
 
@@ -564,6 +630,37 @@ async fn zero_len_items_exist_check() -> Result<(), Error> {
 
     let result = store.get_part_unchunked(digest, 0, None).await;
     assert_eq!(result.unwrap_err().code, Code::NotFound);
+
+    Ok(())
+}
+
+// Prevent regressions to https://reviewable.io/reviews/TraceMachina/nativelink/1188#-O2pu9LV5ux4ILuT6MND
+#[nativelink_test]
+async fn dont_loop_forever_on_empty() -> Result<(), Error> {
+    let store = {
+        let mut builder = Builder::default_centralized();
+        builder.set_config(RedisConfig {
+            mocks: Some(Arc::new(MockRedisBackend::new()) as Arc<dyn Mocks>),
+            ..Default::default()
+        });
+
+        RedisStore::new_from_builder_and_parts(builder, None, mock_uuid_generator, String::new())?
+    };
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 2).unwrap();
+    let (tx, rx) = make_buf_channel_pair();
+
+    tokio::join!(
+        async {
+            store
+                .update(digest, rx, UploadSizeInfo::MaxSize(0))
+                .await
+                .unwrap_err();
+        },
+        async {
+            drop(tx);
+        },
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Description

There was a logic bug in our original implementation of the redis store that persisted across the rewrite to fred -- there could be an infinite loop in `RedisStore::update`. This PR fixes that.

See: https://reviewable.io/reviews/TraceMachina/nativelink/1188#-O2pu9LV5ux4ILuT6MND

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The test suite has been validated to pass and behave as expected.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1269)
<!-- Reviewable:end -->
