### PR TITLE
Fix `docs` build warning from `nativelink-config`

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -937,7 +937,7 @@ pub enum RedisMode {
 
 /// Retry configuration. This configuration is exponential and each iteration
 /// a jitter as a percentage is applied of the calculated delay. For example:
-/// ```rust,ignore
+/// ```haskell
 /// Retry{
 ///   max_retries: 7,
 ///   delay: 0.1,
@@ -970,7 +970,7 @@ pub struct Retry {
 
     /// Amount of jitter to add as a percentage in decimal form. This will
     /// change the formula like:
-    /// ```rust,ignore
+    /// ```haskell
     /// random(
     ///    (2 ^ {attempt_number}) * {delay} * (1 - (jitter / 2)),
     ///    (2 ^ {attempt_number}) * {delay} * (1 + (jitter / 2)),


### PR DESCRIPTION
# Description

Fix the build warning in the docs caused by the `,ignore` flag

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1270)
<!-- Reviewable:end -->
