### PR TITLE
Fix Tekton depedency order within Pulumi

### DIFF
--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -60,7 +60,6 @@ jobs:
     name: Remote / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    if: false
     steps:
       - name: Checkout
         uses: >- # v4.1.1

--- a/native-cli/components/tekton.go
+++ b/native-cli/components/tekton.go
@@ -64,7 +64,8 @@ func (component *TektonPipelines) Install(
 
 // The configuration for Tekton Triggers.
 type TektonTriggers struct {
-	Version string
+	Version      string
+	Dependencies []pulumi.Resource
 }
 
 // Install installs the Tekton Triggers release and interceptors on the cluster.
@@ -72,12 +73,19 @@ func (component *TektonTriggers) Install(
 	ctx *pulumi.Context,
 	name string,
 ) ([]pulumi.Resource, error) {
-	tektonTriggers, err := yaml.NewConfigFile(ctx, name, &yaml.ConfigFileArgs{
-		File: fmt.Sprintf(
-			"https://storage.googleapis.com/tekton-releases/triggers/previous/v%s/release.yaml",
-			component.Version,
+	tektonTriggers, err := yaml.NewConfigFile(
+		ctx,
+		name,
+		&yaml.ConfigFileArgs{
+			File: fmt.Sprintf(
+				"https://storage.googleapis.com/tekton-releases/triggers/previous/v%s/release.yaml",
+				component.Version,
+			),
+		},
+		pulumi.DependsOn(
+			component.Dependencies,
 		),
-	})
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errPulumi, err)
 	}
@@ -91,6 +99,9 @@ func (component *TektonTriggers) Install(
 				component.Version,
 			),
 		},
+		pulumi.DependsOn(
+			[]pulumi.Resource{tektonTriggers},
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errPulumi, err)
@@ -101,7 +112,8 @@ func (component *TektonTriggers) Install(
 
 // Configuration for the Tekton Dashboard.
 type TektonDashboard struct {
-	Version string
+	Version      string
+	Dependencies []pulumi.Resource
 }
 
 // Install installs the Tekton Dashboard on the cluster.
@@ -109,12 +121,19 @@ func (component *TektonDashboard) Install(
 	ctx *pulumi.Context,
 	name string,
 ) ([]pulumi.Resource, error) {
-	tektonDashboard, err := yaml.NewConfigFile(ctx, name, &yaml.ConfigFileArgs{
-		File: fmt.Sprintf(
-			"https://storage.googleapis.com/tekton-releases/dashboard/previous/v%s/release.yaml",
-			component.Version,
+	tektonDashboard, err := yaml.NewConfigFile(
+		ctx,
+		name,
+		&yaml.ConfigFileArgs{
+			File: fmt.Sprintf(
+				"https://storage.googleapis.com/tekton-releases/dashboard/previous/v%s/release.yaml",
+				component.Version,
+			),
+		},
+		pulumi.DependsOn(
+			component.Dependencies,
 		),
-	})
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errPulumi, err)
 	}

--- a/native-cli/programs/local.go
+++ b/native-cli/programs/local.go
@@ -71,7 +71,9 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 	tektonPipelines, err := components.AddComponent(
 		ctx,
 		"tekton-pipelines",
-		&components.TektonPipelines{Version: "0.58.0"},
+		&components.TektonPipelines{
+			Version: "0.58.0",
+		},
 	)
 	if err != nil {
 		log.Println(err)
@@ -81,7 +83,12 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 	tektonTriggers, err := components.AddComponent(
 		ctx,
 		"tekton-triggers",
-		&components.TektonTriggers{Version: "0.26.1"},
+		&components.TektonTriggers{
+			Version: "0.26.1",
+			Dependencies: slices.Concat(
+				tektonPipelines,
+			),
+		},
 	)
 	if err != nil {
 		log.Println(err)
@@ -91,7 +98,12 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 	components.Check(components.AddComponent(
 		ctx,
 		"tekton-dashboard",
-		&components.TektonDashboard{Version: "0.45.0"},
+		&components.TektonDashboard{
+			Version: "0.45.0",
+			Dependencies: slices.Concat(
+				tektonPipelines, tektonTriggers,
+			),
+		},
 	))
 
 	components.Check(components.AddComponent(


### PR DESCRIPTION
# Description

The `native up` command did not always finish successfully on macOS, prompting for a `pulumi refresh` instead.

By ordering the Tekton dependencies correctly in Pulumi using `dependsOn`, this issue should now be resolved.


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on MacOS

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1291)
<!-- Reviewable:end -->
