### PR TITLE
Fix nix2container skopeo patch hash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,16 +126,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1720642556,
-        "narHash": "sha256-qsnqk13UmREKmRT7c8hEnz26X3GFFyIQrqx4EaRc1Is=",
+        "lastModified": 1724912665,
+        "narHash": "sha256-29cabSYFmIIfIR29ReoJsrvC95gtxmzQeEnFRlcLdH0=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "3853e5caf9ad24103b13aa6e0e8bcebb47649fe4",
+        "rev": "80e34774e5904aae7a3542bc3b70dab1fe048587",
         "type": "github"
       },
       "original": {
         "owner": "nlewo",
         "repo": "nix2container",
+        "rev": "80e34774e5904aae7a3542bc3b70dab1fe048587",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nix2container = {
-      url = "github:nlewo/nix2container";
+      # TODO(aaronmondal): Remove this once it lands in nix2container main.
+      url = "github:nlewo/nix2container/80e34774e5904aae7a3542bc3b70dab1fe048587";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
A change in GitHub's hashing scheme caused this to evaluate differently. Add a temporary override to nix2container to unbreak CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1294)
<!-- Reviewable:end -->
