### PR TITLE
Fix rare case where eof was sent on buf_channel when retry happens

### DIFF
--- a/nativelink-util/tests/buf_channel_test.rs
+++ b/nativelink-util/tests/buf_channel_test.rs
@@ -301,3 +301,13 @@ async fn bind_buffered_test() -> Result<(), Error> {
     .unwrap();
     Ok(())
 }
+
+#[nativelink_test]
+async fn eof_can_send_twice() -> Result<(), Error> {
+    let (mut tx, _rx) = make_buf_channel_pair();
+    tx.send(DATA1.into()).await.unwrap();
+    tx.send_eof().unwrap();
+    // EOF needs to be able to be sent twice just in case a "retry" is triggered.
+    tx.send_eof().unwrap();
+    Ok(())
+}


### PR DESCRIPTION
In a rare case if an EOF is sent, then a retry is triggered by contract an EOF needs to be sent again, but without this patch we are not allowed to send and EOF after one is already sent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1295)
<!-- Reviewable:end -->
