### PR TITLE
Remove nix2container patch hash workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,17 +126,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1724912665,
-        "narHash": "sha256-29cabSYFmIIfIR29ReoJsrvC95gtxmzQeEnFRlcLdH0=",
+        "lastModified": 1724996935,
+        "narHash": "sha256-njRK9vvZ1JJsP8oV2OgkBrpJhgQezI03S7gzskCcHos=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "80e34774e5904aae7a3542bc3b70dab1fe048587",
+        "rev": "fa6bb0a1159f55d071ba99331355955ae30b3401",
         "type": "github"
       },
       "original": {
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "80e34774e5904aae7a3542bc3b70dab1fe048587",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nix2container = {
-      # TODO(aaronmondal): Remove this once it lands in nix2container main.
-      url = "github:nlewo/nix2container/80e34774e5904aae7a3542bc3b70dab1fe048587";
+      url = "github:nlewo/nix2container";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
The fix has landed upstream so this is no longer necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1296)
<!-- Reviewable:end -->
