### PR TITLE
Implement DropGuard to ensure future Completion

### DIFF
--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -17,12 +17,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::{
-    action_messages::{ActionInfo, OperationId},
-    known_platform_property_provider::KnownPlatformPropertyProvider,
-    operation_state_manager::{
-        ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
-    },
+use nativelink_util::action_messages::{ActionInfo, OperationId};
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
 };
 use tokio::sync::{mpsc, Mutex};
 

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
         "src/common.rs",
         "src/connection_manager.rs",
         "src/digest_hasher.rs",
+        "src/drop_protected_future.rs",
         "src/evicting_map.rs",
         "src/fastcdc.rs",
         "src/fs.rs",

--- a/nativelink-util/src/drop_protected_future.rs
+++ b/nativelink-util/src/drop_protected_future.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tracing::{Instrument, Span};
+
+use crate::origin_context::{ContextAwareFuture, OriginContext};
+use crate::spawn;
+#[derive(Clone)]
+pub struct DropProtectedFuture<F, T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static + Unpin + Clone,
+{
+    future: ContextAwareFuture<F>,
+}
+
+impl<F, T> DropProtectedFuture<F, T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static + Unpin + Clone,
+{
+    pub fn new(f: F, span: Span, ctx: Option<Arc<OriginContext>>) -> Self {
+        Self {
+            future: ContextAwareFuture::new(ctx, f.instrument(span)),
+        }
+    }
+}
+
+impl<F, T> Future for DropProtectedFuture<F, T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static + Unpin + Clone,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.future).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(output) => Poll::Ready(output),
+        }
+    }
+}
+
+impl<F, T> Drop for DropProtectedFuture<F, T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static + Unpin + Clone,
+{
+    fn drop(&mut self) {
+        spawn!("DropProtectedFuture::drop", self.future.clone());
+    }
+}

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -19,6 +19,7 @@ pub mod chunked_stream;
 pub mod common;
 pub mod connection_manager;
 pub mod digest_hasher;
+pub mod drop_protected_future;
 pub mod evicting_map;
 pub mod fastcdc;
 pub mod fs;

--- a/nativelink-util/src/origin_context.rs
+++ b/nativelink-util/src/origin_context.rs
@@ -284,6 +284,7 @@ impl Drop for ContextDropGuard {
 
 pin_project! {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
+    #[derive(Clone)]
     pub struct ContextAwareFuture<F> {
         // `ManuallyDrop` is used so we can call `self.span.enter()` in the `drop()`
         // of our inner future, then drop the span.


### PR DESCRIPTION


# Description

To manage state transitions safely across `await` boundaries, we introduced a `DropGuard` wrapper. This ensures that even if a future is dropped before completion, it will continue executing in the background via `tokio::spawn`. This approach allows us to avoid the pitfalls of incomplete state transitions in critical futures without the overhead of spawning all futures immediately.

The `DropGuard` checks if the inner future has completed; if not, it safely spawns the future in the background during its drop. This solution strikes a balance between stack-based future management and the necessity to complete crucial futures.

Fixes https://github.com/TraceMachina/nativelink/issues/1156

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

`cargo test --all` and `bazel test //...` passes as expected.

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1300)
<!-- Reviewable:end -->
