### PR TITLE
SimpleScheduler version matching uses Aborted to know if failure

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -77,6 +77,7 @@ rust_test_suite(
         "//nativelink-proto",
         "//nativelink-store",
         "//nativelink-util",
+        "@crates//:async-lock",
         "@crates//:futures",
         "@crates//:mock_instant",
         "@crates//:pretty_assertions",

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 pub mod api_worker_scheduler;
-mod awaited_action_db;
+pub mod awaited_action_db;
 pub mod cache_lookup_scheduler;
 pub mod default_scheduler_factory;
 pub mod grpc_scheduler;
-mod memory_awaited_action_db;
+pub mod memory_awaited_action_db;
 pub mod platform_property_manager;
 pub mod property_modifier_scheduler;
 pub mod simple_scheduler;


### PR DESCRIPTION
In the event of a failure of version matching for scheduler owning an
operation we use Aborted error code to now signal that the version
failed and can be retried.

This is not a bug, current in-memory scheduler guarantees protections
here, this is for lockless schedulers.

towards #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1308)
<!-- Reviewable:end -->
