### PR TITLE
Add KeepAlive updating to ApiWorkerScheduler

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -54,16 +54,6 @@ impl TryFrom<ActionStage> for SortedAwaitedActionState {
     }
 }
 
-impl std::fmt::Display for SortedAwaitedActionState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SortedAwaitedActionState::CacheCheck => write!(f, "CacheCheck"),
-            SortedAwaitedActionState::Queued => write!(f, "Queued"),
-            SortedAwaitedActionState::Executing => write!(f, "Executing"),
-            SortedAwaitedActionState::Completed => write!(f, "Completed"),
-        }
-    }
-}
 /// A struct pointing to an AwaitedAction that can be sorted.
 #[derive(Debug, Clone, Serialize, Deserialize, MetricsComponent)]
 pub struct SortedAwaitedAction {

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use futures::Future;
@@ -21,6 +22,7 @@ use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_util::action_messages::{
     ActionInfo, ActionStage, ActionState, OperationId, WorkerId,
 };
+use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
@@ -295,6 +297,7 @@ impl SimpleScheduler {
                 tokio::time::sleep(Duration::from_millis(1))
             },
             task_change_notify,
+            SystemTime::now,
         )
     }
 
@@ -302,11 +305,14 @@ impl SimpleScheduler {
         Fut: Future<Output = ()> + Send,
         F: Fn() -> Fut + Send + Sync + 'static,
         A: AwaitedActionDb,
+        I: InstantWrapper,
+        NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
     >(
         scheduler_cfg: &nativelink_config::schedulers::SimpleScheduler,
         awaited_action_db: A,
         on_matching_engine_run: F,
         task_change_notify: Arc<Notify>,
+        now_fn: NowFn,
     ) -> (Arc<Self>, Arc<dyn WorkerScheduler>) {
         let platform_property_manager = Arc::new(PlatformPropertyManager::new(
             scheduler_cfg
@@ -326,7 +332,13 @@ impl SimpleScheduler {
         }
 
         let worker_change_notify = Arc::new(Notify::new());
-        let state_manager = SimpleSchedulerStateManager::new(max_job_retries, awaited_action_db);
+        let state_manager = SimpleSchedulerStateManager::new(
+            max_job_retries,
+            // TODO(allada) This should probably have its own config.
+            Duration::from_secs(worker_timeout_s),
+            awaited_action_db,
+            now_fn,
+        );
 
         let worker_scheduler = ApiWorkerScheduler::new(
             state_manager.clone(),

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -19,14 +19,12 @@ use async_trait::async_trait;
 use futures::Future;
 use nativelink_error::{Code, Error, ResultExt};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::action_messages::{
-    ActionInfo, ActionStage, ActionState, OperationId, WorkerId,
-};
+use nativelink_util::action_messages::{ActionInfo, ActionState, OperationId, WorkerId};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
-    OperationFilter, OperationStageFlags, OrderDirection,
+    OperationFilter, OperationStageFlags, OrderDirection, UpdateOperationType,
 };
 use nativelink_util::spawn;
 use nativelink_util::task::JoinHandleDropGuard;
@@ -438,10 +436,10 @@ impl WorkerScheduler for SimpleScheduler {
         &self,
         worker_id: &WorkerId,
         operation_id: &OperationId,
-        action_stage: Result<ActionStage, Error>,
+        update: UpdateOperationType,
     ) -> Result<(), Error> {
         self.worker_scheduler
-            .update_action(worker_id, operation_id, action_stage)
+            .update_action(worker_id, operation_id, update)
             .await
     }
 

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use std::ops::Bound;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
+use std::time::{Duration, SystemTime};
 
+use async_lock::Mutex;
 use async_trait::async_trait;
 use futures::{future, stream, StreamExt, TryStreamExt};
 use nativelink_error::{make_err, Code, Error, ResultExt};
@@ -23,6 +25,7 @@ use nativelink_util::action_messages::{
     ActionInfo, ActionResult, ActionStage, ActionState, ActionUniqueQualifier, ExecutionMetadata,
     OperationId, WorkerId,
 };
+use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
@@ -121,20 +124,48 @@ fn apply_filter_predicate(awaited_action: &AwaitedAction, filter: &OperationFilt
     true
 }
 
-struct ClientActionStateResult<T> {
-    inner: MatchingEngineActionStateResult<T>,
+struct ClientActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
+    inner: MatchingEngineActionStateResult<U, T, I, NowFn>,
 }
 
-impl<T: AwaitedActionSubscriber> ClientActionStateResult<T> {
-    fn new(sub: T) -> Self {
+impl<U, T, I, NowFn> ClientActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
+    fn new(
+        sub: U,
+        simple_scheduler_state_manager: Weak<SimpleSchedulerStateManager<T, I, NowFn>>,
+        no_event_action_timeout: Duration,
+        now_fn: NowFn,
+    ) -> Self {
         Self {
-            inner: MatchingEngineActionStateResult::new(sub),
+            inner: MatchingEngineActionStateResult::new(
+                sub,
+                simple_scheduler_state_manager,
+                no_event_action_timeout,
+                now_fn,
+            ),
         }
     }
 }
 
 #[async_trait]
-impl<T: AwaitedActionSubscriber> ActionStateResult for ClientActionStateResult<T> {
+impl<U, T, I, NowFn> ActionStateResult for ClientActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
         self.inner.as_state().await
     }
@@ -148,26 +179,101 @@ impl<T: AwaitedActionSubscriber> ActionStateResult for ClientActionStateResult<T
     }
 }
 
-struct MatchingEngineActionStateResult<T> {
-    awaited_action_sub: T,
+struct MatchingEngineActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
+    awaited_action_sub: U,
+    simple_scheduler_state_manager: Weak<SimpleSchedulerStateManager<T, I, NowFn>>,
+    no_event_action_timeout: Duration,
+    now_fn: NowFn,
 }
-impl<T: AwaitedActionSubscriber> MatchingEngineActionStateResult<T> {
-    fn new(awaited_action_sub: T) -> Self {
-        Self { awaited_action_sub }
+impl<U, T, I, NowFn> MatchingEngineActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
+    fn new(
+        awaited_action_sub: U,
+        simple_scheduler_state_manager: Weak<SimpleSchedulerStateManager<T, I, NowFn>>,
+        no_event_action_timeout: Duration,
+        now_fn: NowFn,
+    ) -> Self {
+        Self {
+            awaited_action_sub,
+            simple_scheduler_state_manager,
+            no_event_action_timeout,
+            now_fn,
+        }
     }
 }
 
 #[async_trait]
-impl<T: AwaitedActionSubscriber> ActionStateResult for MatchingEngineActionStateResult<T> {
+impl<U, T, I, NowFn> ActionStateResult for MatchingEngineActionStateResult<U, T, I, NowFn>
+where
+    U: AwaitedActionSubscriber,
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
         Ok(self.awaited_action_sub.borrow().state().clone())
     }
 
     async fn changed(&mut self) -> Result<Arc<ActionState>, Error> {
-        self.awaited_action_sub
-            .changed()
-            .await
-            .map(|v| v.state().clone())
+        let mut timeout_attempts = 0;
+        loop {
+            tokio::select! {
+                awaited_action_result = self.awaited_action_sub.changed() => {
+                    return awaited_action_result
+                        .err_tip(|| "In MatchingEngineActionStateResult::changed")
+                        .map(|v| v.state().clone());
+                }
+                _ = (self.now_fn)().sleep(self.no_event_action_timeout) => {
+                    // Timeout happened, do additional checks below.
+                }
+            }
+
+            let awaited_action = self.awaited_action_sub.borrow();
+
+            if matches!(awaited_action.state().stage, ActionStage::Queued) {
+                // Actions in queued state do not get periodically updated,
+                // so we don't need to timeout them.
+                continue;
+            }
+
+            let simple_scheduler_state_manager = self
+                .simple_scheduler_state_manager
+                .upgrade()
+                .err_tip(|| format!("Failed to upgrade weak reference to SimpleSchedulerStateManager in MatchingEngineActionStateResult::changed at attempt: {timeout_attempts}"))?;
+
+            event!(
+                Level::WARN,
+                ?awaited_action,
+                "OperationId {} timed out after {} seconds issuing a retry",
+                awaited_action.operation_id(),
+                self.no_event_action_timeout.as_secs_f32(),
+            );
+
+            simple_scheduler_state_manager
+                .timeout_operation_id(awaited_action.operation_id())
+                .await
+                .err_tip(|| "In MatchingEngineActionStateResult::changed")?;
+
+            if timeout_attempts >= MAX_UPDATE_RETRIES {
+                return Err(make_err!(
+                    Code::Internal,
+                    "Failed to update action after {} retries with no error set in MatchingEngineActionStateResult::changed",
+                    MAX_UPDATE_RETRIES,
+                ));
+            }
+            timeout_attempts += 1;
+        }
     }
 
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
@@ -180,7 +286,12 @@ impl<T: AwaitedActionSubscriber> ActionStateResult for MatchingEngineActionState
 /// It also includes the workers that are available to execute actions based on allocation
 /// strategy.
 #[derive(MetricsComponent)]
-pub struct SimpleSchedulerStateManager<T: AwaitedActionDb> {
+pub struct SimpleSchedulerStateManager<T, I, NowFn>
+where
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     /// Database for storing the state of all actions.
     #[metric(group = "action_db")]
     action_db: T,
@@ -190,14 +301,101 @@ pub struct SimpleSchedulerStateManager<T: AwaitedActionDb> {
     // of always having it on every SimpleScheduler.
     #[metric(help = "Maximum number of times a job can be retried")]
     max_job_retries: usize,
+
+    /// Duration after which an action is considered to be timed out if
+    /// no event is received.
+    #[metric(
+        help = "Duration after which an action is considered to be timed out if no event is received"
+    )]
+    no_event_action_timeout: Duration,
+
+    // A lock to ensure only one timeout operation is running at a time
+    // on this service.
+    timeout_operation_mux: Mutex<()>,
+
+    /// Weak reference to self.
+    weak_self: Weak<Self>,
+
+    /// Function to get the current time.
+    now_fn: NowFn,
 }
 
-impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
-    pub fn new(max_job_retries: usize, action_db: T) -> Arc<Self> {
-        Arc::new(Self {
+impl<T, I, NowFn> SimpleSchedulerStateManager<T, I, NowFn>
+where
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
+    pub fn new(
+        max_job_retries: usize,
+        no_event_action_timeout: Duration,
+        action_db: T,
+        now_fn: NowFn,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
             action_db,
             max_job_retries,
+            no_event_action_timeout,
+            timeout_operation_mux: Mutex::new(()),
+            weak_self: weak_self.clone(),
+            now_fn,
         })
+    }
+
+    /// Let the scheduler know that an operation has timed out from
+    /// the client side (ie: worker has not updated in a while).
+    async fn timeout_operation_id(&self, operation_id: &OperationId) -> Result<(), Error> {
+        // Ensure that only one timeout operation is running at a time.
+        // Failing to do this could result in the same operation being
+        // timed out multiple times at the same time.
+        // Note: We could implement this on a per-operation_id basis, but it is quite
+        // complex to manage the locks.
+        let _lock = self.timeout_operation_mux.lock().await;
+
+        let awaited_action_subscriber = self
+            .action_db
+            .get_by_operation_id(operation_id)
+            .await
+            .err_tip(|| "In SimpleSchedulerStateManager::timeout_operation_id")?
+            .err_tip(|| {
+                format!("Operation id {operation_id} does not exist in SimpleSchedulerStateManager::timeout_operation_id")
+            })?;
+
+        let awaited_action = awaited_action_subscriber.borrow();
+
+        // If the action is not executing, we should not timeout the action.
+        if !matches!(awaited_action.state().stage, ActionStage::Executing) {
+            return Ok(());
+        }
+
+        let last_worker_updated = awaited_action
+            .last_worker_updated_timestamp()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|e| {
+                make_err!(
+                    Code::Internal,
+                    "Failed to convert last_worker_updated to duration since epoch {e:?}"
+                )
+            })?;
+        let worker_should_update_before = last_worker_updated
+            .checked_add(self.no_event_action_timeout)
+            .err_tip(|| "Timestamp too big in SimpleSchedulerStateManager::timeout_operation_id")?;
+        if worker_should_update_before < (self.now_fn)().elapsed() {
+            // The action was updated recently, we should not timeout the action.
+            // This is to prevent timing out actions that have recently been updated
+            // (like multiple clients timeout the same action at the same time).
+            return Ok(());
+        }
+
+        self.assign_operation(
+            operation_id,
+            Err(make_err!(
+                Code::DeadlineExceeded,
+                "Operation timed out after {} seconds",
+                self.no_event_action_timeout.as_secs_f32(),
+            )),
+        )
+        .await
     }
 
     async fn inner_update_operation(
@@ -222,16 +420,6 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
             };
 
             let mut awaited_action = awaited_action_subscriber.borrow();
-
-            // Make sure we don't update an action that is already completed.
-            if awaited_action.state().stage.is_finished() {
-                return Err(make_err!(
-                    Code::Internal,
-                    "Action {operation_id:?} is already completed with state {:?} - maybe_worker_id: {:?}",
-                    awaited_action.state().stage,
-                    maybe_worker_id,
-                ));
-            }
 
             // Make sure the worker id matches the awaited action worker id.
             // This might happen if the worker sending the update is not the
@@ -258,6 +446,16 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
                     awaited_action,
                 );
                 return Err(err);
+            }
+
+            // Make sure we don't update an action that is already completed.
+            if awaited_action.state().stage.is_finished() {
+                return Err(make_err!(
+                    Code::Internal,
+                    "Action {operation_id:?} is already completed with state {:?} - maybe_worker_id: {:?}",
+                    awaited_action.state().stage,
+                    maybe_worker_id,
+                ));
             }
 
             let stage = match &action_stage_result {
@@ -450,7 +648,12 @@ impl<T: AwaitedActionDb> SimpleSchedulerStateManager<T> {
 }
 
 #[async_trait]
-impl<T: AwaitedActionDb> ClientStateManager for SimpleSchedulerStateManager<T> {
+impl<T, I, NowFn> ClientStateManager for SimpleSchedulerStateManager<T, I, NowFn>
+where
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     async fn add_action(
         &self,
         client_operation_id: OperationId,
@@ -460,15 +663,27 @@ impl<T: AwaitedActionDb> ClientStateManager for SimpleSchedulerStateManager<T> {
             .inner_add_operation(client_operation_id.clone(), action_info.clone())
             .await?;
 
-        Ok(Box::new(ClientActionStateResult::new(sub)))
+        Ok(Box::new(ClientActionStateResult::new(
+            sub,
+            self.weak_self.clone(),
+            self.no_event_action_timeout,
+            self.now_fn.clone(),
+        )))
     }
 
     async fn filter_operations<'a>(
         &'a self,
         filter: OperationFilter,
     ) -> Result<ActionStateResultStream<'a>, Error> {
-        self.inner_filter_operations(filter, move |rx| Box::new(ClientActionStateResult::new(rx)))
-            .await
+        self.inner_filter_operations(filter, move |rx| {
+            Box::new(ClientActionStateResult::new(
+                rx,
+                self.weak_self.clone(),
+                self.no_event_action_timeout,
+                self.now_fn.clone(),
+            ))
+        })
+        .await
     }
 
     fn as_known_platform_property_provider(&self) -> Option<&dyn KnownPlatformPropertyProvider> {
@@ -477,7 +692,12 @@ impl<T: AwaitedActionDb> ClientStateManager for SimpleSchedulerStateManager<T> {
 }
 
 #[async_trait]
-impl<T: AwaitedActionDb> WorkerStateManager for SimpleSchedulerStateManager<T> {
+impl<T, I, NowFn> WorkerStateManager for SimpleSchedulerStateManager<T, I, NowFn>
+where
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     async fn update_operation(
         &self,
         operation_id: &OperationId,
@@ -490,13 +710,23 @@ impl<T: AwaitedActionDb> WorkerStateManager for SimpleSchedulerStateManager<T> {
 }
 
 #[async_trait]
-impl<T: AwaitedActionDb> MatchingEngineStateManager for SimpleSchedulerStateManager<T> {
+impl<T, I, NowFn> MatchingEngineStateManager for SimpleSchedulerStateManager<T, I, NowFn>
+where
+    T: AwaitedActionDb,
+    I: InstantWrapper,
+    NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
+{
     async fn filter_operations<'a>(
         &'a self,
         filter: OperationFilter,
     ) -> Result<ActionStateResultStream<'a>, Error> {
         self.inner_filter_operations(filter, |rx| {
-            Box::new(MatchingEngineActionStateResult::new(rx))
+            Box::new(MatchingEngineActionStateResult::new(
+                rx,
+                self.weak_self.clone(),
+                self.no_event_action_timeout,
+                self.now_fn.clone(),
+            ))
         })
         .await
     }

--- a/nativelink-scheduler/src/worker_scheduler.rs
+++ b/nativelink-scheduler/src/worker_scheduler.rs
@@ -15,7 +15,8 @@
 use async_trait::async_trait;
 use nativelink_error::Error;
 use nativelink_metric::RootMetricsComponent;
-use nativelink_util::action_messages::{ActionStage, OperationId, WorkerId};
+use nativelink_util::action_messages::{OperationId, WorkerId};
+use nativelink_util::operation_state_manager::UpdateOperationType;
 
 use crate::platform_property_manager::PlatformPropertyManager;
 use crate::worker::{Worker, WorkerTimestamp};
@@ -35,7 +36,7 @@ pub trait WorkerScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static 
         &self,
         worker_id: &WorkerId,
         operation_id: &OperationId,
-        action_stage: Result<ActionStage, Error>,
+        update: UpdateOperationType,
     ) -> Result<(), Error>;
 
     /// Event for when the keep alive message was received from the worker.

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -47,7 +47,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::instant_wrapper::MockInstantWrapped;
 use nativelink_util::operation_state_manager::{
-    ActionStateResult, ClientStateManager, OperationFilter,
+    ActionStateResult, ClientStateManager, OperationFilter, UpdateOperationType,
 };
 use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
 use pretty_assertions::assert_eq;
@@ -1276,7 +1276,9 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
         .update_action(
             &worker_id,
             &OperationId::from(operation_id),
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await?;
 
@@ -1380,7 +1382,9 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         .update_action(
             &worker_id,
             &operation_id,
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await?;
 
@@ -1477,7 +1481,9 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         .update_action(
             &rogue_worker_id,
             &OperationId::default(),
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await;
 
@@ -1607,7 +1613,9 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         .update_action(
             &worker_id,
             &operation_id,
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await
         .unwrap();
@@ -1739,7 +1747,9 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         .update_action(
             &worker_id,
             &operation_id1,
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await
         .unwrap();
@@ -1780,7 +1790,9 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         .update_action(
             &worker_id,
             &operation_id2,
-            Ok(ActionStage::Completed(action_result.clone())),
+            UpdateOperationType::UpdateWithActionStage(ActionStage::Completed(
+                action_result.clone(),
+            )),
         )
         .await
         .unwrap();
@@ -1915,7 +1927,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         .update_action(
             &worker_id,
             &operation_id,
-            Err(make_err!(Code::Internal, "Some error")),
+            UpdateOperationType::UpdateWithError(make_err!(Code::Internal, "Some error")),
         )
         .await;
 
@@ -1950,7 +1962,11 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
     let err = make_err!(Code::Internal, "Some error");
     // Send internal error from worker again.
     let _ = scheduler
-        .update_action(&worker_id, &operation_id, Err(err.clone()))
+        .update_action(
+            &worker_id,
+            &operation_id,
+            UpdateOperationType::UpdateWithError(err.clone()),
+        )
         .await;
 
     {
@@ -2100,7 +2116,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
         .update_action(
             &worker_id1,
             &operation_id,
-            Err(make_err!(Code::NotFound, "Some error")),
+            UpdateOperationType::UpdateWithError(make_err!(Code::NotFound, "Some error")),
         )
         .await;
 

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::ops::Bound;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -166,6 +168,7 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -211,6 +214,78 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn client_does_not_receive_update_timeout() -> Result<(), Error> {
+    let worker_id: WorkerId = WorkerId(Uuid::new_v4());
+
+    let task_change_notify = Arc::new(Notify::new());
+    let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
+        &nativelink_config::schedulers::SimpleScheduler {
+            worker_timeout_s: WORKER_TIMEOUT_S,
+            ..Default::default()
+        },
+        memory_awaited_action_db_factory(
+            0,
+            task_change_notify.clone(),
+            MockInstantWrapped::default,
+        ),
+        || async move {},
+        task_change_notify.clone(),
+        MockInstantWrapped::default,
+    );
+    let action_digest = DigestInfo::new([99u8; 32], 512);
+
+    let _rx_from_worker =
+        setup_new_worker(&scheduler, worker_id, PlatformProperties::default()).await?;
+    let mut action_listener = setup_action(
+        &scheduler,
+        action_digest,
+        HashMap::new(),
+        make_system_time(1),
+    )
+    .await
+    .unwrap();
+
+    // Trigger a do_try_match to ensure we get a state change.
+    scheduler.do_try_match_for_test().await.unwrap();
+    assert_eq!(
+        action_listener.changed().await.unwrap().stage,
+        ActionStage::Executing
+    );
+
+    async fn advance_time<T>(duration: Duration, poll_fut: &mut Pin<&mut impl Future<Output = T>>) {
+        const STEP_AMOUNT: Duration = Duration::from_millis(100);
+        for _ in 0..(duration.as_millis() / STEP_AMOUNT.as_millis()) {
+            MockClock::advance(STEP_AMOUNT);
+            tokio::task::yield_now().await;
+            assert!(poll!(&mut *poll_fut).is_pending());
+        }
+    }
+
+    let changed_fut = action_listener.changed();
+    tokio::pin!(changed_fut);
+
+    {
+        // No update should have been received yet.
+        assert_eq!(poll!(&mut changed_fut).is_ready(), false);
+    }
+    // Advance our time by just under the timeout.
+    advance_time(Duration::from_secs(WORKER_TIMEOUT_S - 1), &mut changed_fut).await;
+    {
+        // Sill no update should have been received yet.
+        assert_eq!(poll!(&mut changed_fut).is_ready(), false);
+    }
+    // Advance it by just over the timeout.
+    MockClock::advance(Duration::from_secs(2));
+    {
+        // Now we should have received a timeout and the action should have been
+        // put back in the queue.
+        assert_eq!(changed_fut.await.unwrap().stage, ActionStage::Queued);
+    }
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn find_executing_action() -> Result<(), Error> {
     let worker_id: WorkerId = WorkerId(Uuid::new_v4());
 
@@ -224,6 +299,7 @@ async fn find_executing_action() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -303,6 +379,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest1 = DigestInfo::new([99u8; 32], 512);
     let action_digest2 = DigestInfo::new([88u8; 32], 512);
@@ -477,6 +554,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -563,6 +641,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
     let mut platform_properties = HashMap::new();
@@ -653,6 +732,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -750,6 +830,7 @@ async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(),
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let worker_id: WorkerId = WorkerId(Uuid::new_v4());
     let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -904,6 +985,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
             awaited_action,
             || async move {},
             task_change_notify,
+            MockInstantWrapped::default,
         );
         // Initial worker calls do_try_match, so send it no items.
         senders.tx_get_range_of_actions.send(vec![]).unwrap();
@@ -948,6 +1030,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
             awaited_action,
             || async move {},
             task_change_notify,
+            MockInstantWrapped::default,
         );
         // senders.tx_get_awaited_action_by_id.send(Ok(None)).unwrap();
         senders.tx_get_range_of_actions.send(vec![]).unwrap();
@@ -1005,6 +1088,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1126,6 +1210,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1224,6 +1309,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1339,6 +1425,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1434,6 +1521,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1574,6 +1662,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest1 = DigestInfo::new([11u8; 32], 512);
     let action_digest2 = DigestInfo::new([99u8; 32], 512);
@@ -1731,6 +1820,7 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest1 = DigestInfo::new([11u8; 32], 512);
     let action_digest2 = DigestInfo::new([99u8; 32], 512);
@@ -1797,6 +1887,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1945,6 +2036,7 @@ async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
             async move {}
         },
         task_change_notify,
+        MockInstantWrapped::default,
     );
     assert_eq!(dropped.load(Ordering::Relaxed), false);
 
@@ -1973,6 +2065,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -2047,6 +2140,7 @@ async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
         ),
         || async move {},
         task_change_notify,
+        MockInstantWrapped::default,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -31,6 +31,7 @@ use nativelink_scheduler::worker::Worker;
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
 use nativelink_util::background_spawn;
 use nativelink_util::action_messages::{OperationId, WorkerId};
+use nativelink_util::operation_state_manager::UpdateOperationType;
 use nativelink_util::platform_properties::PlatformProperties;
 use tokio::sync::mpsc;
 use tokio::time::interval;
@@ -210,13 +211,21 @@ impl WorkerApiServer {
                     .try_into()
                     .err_tip(|| "Failed to convert ExecuteResponse into an ActionStage")?;
                 self.scheduler
-                    .update_action(&worker_id, &operation_id, Ok(action_stage))
+                    .update_action(
+                        &worker_id,
+                        &operation_id,
+                        UpdateOperationType::UpdateWithActionStage(action_stage),
+                    )
                     .await
                     .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
             }
             execute_result::Result::InternalError(e) => {
                 self.scheduler
-                    .update_action(&worker_id, &operation_id, Err(e.into()))
+                    .update_action(
+                        &worker_id,
+                        &operation_id,
+                        UpdateOperationType::UpdateWithError(e.into()),
+                    )
                     .await
                     .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
             }

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -22,6 +22,7 @@ use mock_instant::{Instant as MockInstant, MockClock};
 pub trait InstantWrapper: Send + Sync + Unpin + 'static {
     fn from_secs(secs: u64) -> Self;
     fn unix_timestamp(&self) -> u64;
+    fn now(&self) -> SystemTime;
     fn elapsed(&self) -> Duration;
     fn sleep(self, duration: Duration) -> impl Future<Output = ()> + Send + Sync + 'static;
 }
@@ -35,6 +36,10 @@ impl InstantWrapper for SystemTime {
 
     fn unix_timestamp(&self) -> u64 {
         self.duration_since(UNIX_EPOCH).unwrap().as_secs()
+    }
+
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
     }
 
     fn elapsed(&self) -> Duration {
@@ -66,6 +71,10 @@ impl InstantWrapper for MockInstantWrapped {
 
     fn unix_timestamp(&self) -> u64 {
         MockClock::time().as_secs()
+    }
+
+    fn now(&self) -> SystemTime {
+        UNIX_EPOCH + MockClock::time()
     }
 
     fn elapsed(&self) -> Duration {

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -121,6 +121,19 @@ pub trait ClientStateManager: Sync + Send + Unpin + MetricsComponent + 'static {
     fn as_known_platform_property_provider(&self) -> Option<&dyn KnownPlatformPropertyProvider>;
 }
 
+/// The type of update to perform on an operation.
+#[derive(Debug, PartialEq)]
+pub enum UpdateOperationType {
+    /// Notification that the operation is still alive.
+    KeepAlive,
+
+    /// Notification that the operation has been updated.
+    UpdateWithActionStage(ActionStage),
+
+    /// Notification that the operation has been completed.
+    UpdateWithError(Error),
+}
+
 #[async_trait]
 pub trait WorkerStateManager: Sync + Send + MetricsComponent {
     /// Update that state of an operation.
@@ -131,7 +144,7 @@ pub trait WorkerStateManager: Sync + Send + MetricsComponent {
         &self,
         operation_id: &OperationId,
         worker_id: &WorkerId,
-        action_stage: Result<ActionStage, Error>,
+        update: UpdateOperationType,
     ) -> Result<(), Error>;
 }
 


### PR DESCRIPTION
This ensures that actions are periodically updated with with a keep
alive message, which will be heavily used with a distributed scheduling
model.

towards #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1310)
<!-- Reviewable:end -->
