### PR TITLE
AwaitedAction's operation_id and client_operation_id now separated

### DIFF
--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -246,13 +246,13 @@ impl CacheLookupScheduler {
                         return; // Nobody is waiting for this action anymore.
                     };
                     let mut action_state = ActionState {
-                        operation_id: OperationId::default(),
+                        client_operation_id: OperationId::default(),
                         stage: ActionStage::CompletedFromCache(action_result),
                         action_digest: action_info.unique_qualifier.digest(),
                     };
 
                     for (client_operation_id, pending_tx) in pending_txs {
-                        action_state.operation_id = client_operation_id;
+                        action_state.client_operation_id = client_operation_id;
                         // Ignore errors here, as the other end may have hung up.
                         let _ = pending_tx.send(Ok(Box::new(CacheLookupActionStateResult {
                             action_state: Arc::new(action_state.clone()),

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -56,7 +56,7 @@ struct GrpcActionStateResult {
 impl ActionStateResult for GrpcActionStateResult {
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
         let mut action_state = self.rx.borrow().clone();
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 
@@ -68,7 +68,7 @@ impl ActionStateResult for GrpcActionStateResult {
             )
         })?;
         let mut action_state = self.rx.borrow().clone();
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -75,7 +75,7 @@ impl ActionStateResult for SimpleSchedulerActionStateResult {
             .err_tip(|| "In SimpleSchedulerActionStateResult")?;
         // We need to ensure the client is not aware of the downstream
         // operation id, so override it before it goes out.
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 
@@ -87,7 +87,7 @@ impl ActionStateResult for SimpleSchedulerActionStateResult {
             .err_tip(|| "In SimpleSchedulerActionStateResult")?;
         // We need to ensure the client is not aware of the downstream
         // operation id, so override it before it goes out.
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 
@@ -223,7 +223,7 @@ impl SimpleScheduler {
                     .as_state()
                     .await
                     .err_tip(|| "Failed to get action_info from as_state_result stream")?;
-                action_state.operation_id.clone()
+                action_state.client_operation_id.clone()
             };
 
             // Tell the matching engine that the operation is being assigned to a worker.

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -255,8 +255,9 @@ where
             event!(
                 Level::WARN,
                 ?awaited_action,
-                "OperationId {} timed out after {} seconds issuing a retry",
+                "OperationId {} / {} timed out after {} seconds issuing a retry",
                 awaited_action.operation_id(),
+                awaited_action.state().client_operation_id,
                 self.no_event_action_timeout.as_secs_f32(),
             );
 
@@ -509,10 +510,13 @@ where
             awaited_action.set_state(
                 Arc::new(ActionState {
                     stage,
-                    operation_id: operation_id.clone(),
+                    // Client id is not known here, it is the responsibility of
+                    // the the subscriber impl to replace this with the
+                    // correct client id.
+                    client_operation_id: operation_id.clone(),
                     action_digest: awaited_action.action_info().digest(),
                 }),
-                now,
+                Some(now),
             );
 
             let update_action_result = self

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -39,7 +39,7 @@ async fn action_state_any_url_test() -> Result<(), Error> {
     let client_id = OperationId::default();
     let operation_id = OperationId::default();
     let action_state = ActionState {
-        operation_id: operation_id.clone(),
+        client_operation_id: operation_id.clone(),
         // Result is only populated if has_action_result.
         stage: ActionStage::Completed(ActionResult::default()),
         action_digest,

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -70,7 +70,7 @@ async fn add_action_handles_skip_cache() -> Result<(), Error> {
         .await?;
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -67,7 +67,7 @@ async fn add_action_adds_property() -> Result<(), Error> {
     let action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest());
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
@@ -111,7 +111,7 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
     let action_info = Arc::new(action_info);
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
@@ -150,7 +150,7 @@ async fn add_action_property_added_after_remove() -> Result<(), Error> {
     let action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest());
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
@@ -189,7 +189,7 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
     let action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest());
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
@@ -227,7 +227,7 @@ async fn add_action_property_remove() -> Result<(), Error> {
     let action_info = Arc::new(action_info);
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
         watch::channel(Arc::new(ActionState {
-            operation_id: OperationId::default(),
+            client_operation_id: OperationId::default(),
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -75,7 +75,7 @@ impl TokioWatchActionStateResult {
 impl ActionStateResult for TokioWatchActionStateResult {
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
         let mut action_state = self.rx.borrow().clone();
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 
@@ -87,7 +87,7 @@ impl ActionStateResult for TokioWatchActionStateResult {
             )
         })?;
         let mut action_state = self.rx.borrow().clone();
-        Arc::make_mut(&mut action_state).operation_id = self.client_operation_id.clone();
+        Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
         Ok(action_state)
     }
 

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -282,7 +282,7 @@ impl ExecutionServer {
                     .as_state()
                     .await
                     .err_tip(|| "In ExecutionServer::inner_execute")?
-                    .operation_id
+                    .client_operation_id
                     .clone(),
             ),
             action_listener,

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -1055,7 +1055,7 @@ pub struct ActionState {
     #[metric(help = "The current stage of the action.")]
     pub stage: ActionStage,
     #[metric(help = "The unique identifier of the action.")]
-    pub operation_id: OperationId,
+    pub client_operation_id: OperationId,
     #[metric(help = "The digest of the action.")]
     pub action_digest: DigestInfo,
 }
@@ -1063,7 +1063,7 @@ pub struct ActionState {
 impl ActionState {
     pub fn try_from_operation(
         operation: Operation,
-        operation_id: OperationId,
+        client_operation_id: OperationId,
     ) -> Result<Self, Error> {
         let metadata = from_any::<ExecuteOperationMetadata>(
             &operation
@@ -1110,7 +1110,7 @@ impl ActionState {
             .err_tip(|| "Could not convert action_digest into DigestInfo")?;
 
         Ok(Self {
-            operation_id,
+            client_operation_id,
             stage,
             action_digest,
         })


### PR DESCRIPTION
Gives more clear separation of client_operation_id and operation_id in
AwaitedAction.

towards #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1311)
<!-- Reviewable:end -->
