### PR TITLE
Change AwaitedAction's API to always return Result<Future>

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -133,7 +133,7 @@ pub trait AwaitedActionSubscriber: Send + Sync + Sized + 'static {
     fn changed(&mut self) -> impl Future<Output = Result<AwaitedAction, Error>> + Send;
 
     /// Get the current awaited action.
-    fn borrow(&self) -> AwaitedAction;
+    fn borrow(&self) -> impl Future<Output = Result<AwaitedAction, Error>> + Send;
 }
 
 /// A trait that defines the interface for an AwaitedActionDb.
@@ -149,7 +149,9 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + Unpin + 'static {
     /// Get all AwaitedActions. This call should be avoided as much as possible.
     fn get_all_awaited_actions(
         &self,
-    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send> + Send;
+    ) -> impl Future<
+        Output = Result<impl Stream<Item = Result<Self::Subscriber, Error>> + Send, Error>,
+    > + Send;
 
     /// Get the AwaitedAction by the operation id.
     fn get_by_operation_id(
@@ -164,7 +166,9 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + Unpin + 'static {
         start: Bound<SortedAwaitedAction>,
         end: Bound<SortedAwaitedAction>,
         desc: bool,
-    ) -> impl Future<Output = impl Stream<Item = Result<Self::Subscriber, Error>> + Send> + Send;
+    ) -> impl Future<
+        Output = Result<impl Stream<Item = Result<Self::Subscriber, Error>> + Send, Error>,
+    > + Send;
 
     /// Process a change changed AwaitedAction and notify any listeners.
     fn update_awaited_action(

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, SystemTime};
 
 use async_lock::Mutex;
 use async_trait::async_trait;
-use futures::{future, stream, StreamExt, TryStreamExt};
+use futures::{future, stream, FutureExt, StreamExt, TryStreamExt};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::action_messages::{
@@ -222,7 +222,13 @@ where
     NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
 {
     async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
-        Ok(self.awaited_action_sub.borrow().state().clone())
+        Ok(self
+            .awaited_action_sub
+            .borrow()
+            .await
+            .err_tip(|| "In MatchingEngineActionStateResult::as_state")?
+            .state()
+            .clone())
     }
 
     async fn changed(&mut self) -> Result<Arc<ActionState>, Error> {
@@ -239,7 +245,11 @@ where
                 }
             }
 
-            let awaited_action = self.awaited_action_sub.borrow();
+            let awaited_action = self
+                .awaited_action_sub
+                .borrow()
+                .await
+                .err_tip(|| "In MatchingEngineActionStateResult::changed")?;
 
             if matches!(awaited_action.state().stage, ActionStage::Queued) {
                 // Actions in queued state do not get periodically updated,
@@ -280,7 +290,13 @@ where
     }
 
     async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
-        Ok(self.awaited_action_sub.borrow().action_info().clone())
+        Ok(self
+            .awaited_action_sub
+            .borrow()
+            .await
+            .err_tip(|| "In MatchingEngineActionStateResult::as_action_info")?
+            .action_info()
+            .clone())
     }
 }
 
@@ -367,7 +383,10 @@ where
                 format!("Operation id {operation_id} does not exist in SimpleSchedulerStateManager::timeout_operation_id")
             })?;
 
-        let awaited_action = awaited_action_subscriber.borrow();
+        let awaited_action = awaited_action_subscriber
+            .borrow()
+            .await
+            .err_tip(|| "In SimpleSchedulerStateManager::timeout_operation_id")?;
 
         // If the action is not executing, we should not timeout the action.
         if !matches!(awaited_action.state().stage, ActionStage::Executing) {
@@ -425,7 +444,10 @@ where
                 None => return Ok(()),
             };
 
-            let mut awaited_action = awaited_action_subscriber.borrow();
+            let mut awaited_action = awaited_action_subscriber
+                .borrow()
+                .await
+                .err_tip(|| "In SimpleSchedulerStateManager::update_operation")?;
 
             // Make sure the worker id matches the awaited action worker id.
             // This might happen if the worker sending the update is not the
@@ -579,67 +601,81 @@ where
         }
 
         if let Some(operation_id) = &filter.operation_id {
-            return Ok(self
+            let maybe_subscriber = self
                 .action_db
                 .get_by_operation_id(operation_id)
                 .await
-                .err_tip(|| "In MemorySchedulerStateManager::filter_operations")?
-                .filter(|awaited_action_rx| {
-                    let awaited_action = awaited_action_rx.borrow();
-                    apply_filter_predicate(&awaited_action, &filter)
-                })
-                .map(|awaited_action| -> ActionStateResultStream {
-                    Box::pin(stream::once(async move {
-                        to_action_state_result(awaited_action)
-                    }))
-                })
-                .unwrap_or_else(|| Box::pin(stream::empty())));
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+            let Some(subscriber) = maybe_subscriber else {
+                return Ok(Box::pin(stream::empty()));
+            };
+            let awaited_action = subscriber
+                .borrow()
+                .await
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+            if !apply_filter_predicate(&awaited_action, &filter) {
+                return Ok(Box::pin(stream::empty()));
+            }
+            return Ok(Box::pin(stream::once(async move {
+                to_action_state_result(subscriber)
+            })));
         }
         if let Some(client_operation_id) = &filter.client_operation_id {
-            return Ok(self
+            let maybe_subscriber = self
                 .action_db
                 .get_awaited_action_by_id(client_operation_id)
                 .await
-                .err_tip(|| "In MemorySchedulerStateManager::filter_operations")?
-                .filter(|awaited_action_rx| {
-                    let awaited_action = awaited_action_rx.borrow();
-                    apply_filter_predicate(&awaited_action, &filter)
-                })
-                .map(|awaited_action| -> ActionStateResultStream {
-                    Box::pin(stream::once(async move {
-                        to_action_state_result(awaited_action)
-                    }))
-                })
-                .unwrap_or_else(|| Box::pin(stream::empty())));
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+            let Some(subscriber) = maybe_subscriber else {
+                return Ok(Box::pin(stream::empty()));
+            };
+            let awaited_action = subscriber
+                .borrow()
+                .await
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+            if !apply_filter_predicate(&awaited_action, &filter) {
+                return Ok(Box::pin(stream::empty()));
+            }
+            return Ok(Box::pin(stream::once(async move {
+                to_action_state_result(subscriber)
+            })));
         }
 
         let Some(sorted_awaited_action_state) =
             sorted_awaited_action_state_for_flags(filter.stages)
         else {
-            let mut all_items: Vec<T::Subscriber> = self
+            let mut all_items: Vec<_> = self
                 .action_db
                 .get_all_awaited_actions()
                 .await
-                .try_filter(|awaited_action_subscriber| {
-                    future::ready(apply_filter_predicate(
-                        &awaited_action_subscriber.borrow(),
-                        &filter,
-                    ))
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?
+                .and_then(|awaited_action_subscriber| async move {
+                    let awaited_action = awaited_action_subscriber
+                        .borrow()
+                        .await
+                        .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+                    Ok((awaited_action_subscriber, awaited_action))
+                })
+                .try_filter_map(|(subscriber, awaited_action)| {
+                    if apply_filter_predicate(&awaited_action, &filter) {
+                        future::ready(Ok(Some((subscriber, awaited_action.sort_key()))))
+                            .left_future()
+                    } else {
+                        future::ready(Result::<_, Error>::Ok(None)).right_future()
+                    }
                 })
                 .try_collect()
                 .await
-                .err_tip(|| "In MemorySchedulerStateManager::filter_operations")?;
+                .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
             match filter.order_by_priority_direction {
-                Some(OrderDirection::Asc) => {
-                    all_items.sort_unstable_by_key(|a| a.borrow().sort_key())
-                }
-                Some(OrderDirection::Desc) => {
-                    all_items.sort_unstable_by_key(|a| std::cmp::Reverse(a.borrow().sort_key()))
-                }
+                Some(OrderDirection::Asc) => all_items.sort_unstable_by(|(_, a), (_, b)| a.cmp(b)),
+                Some(OrderDirection::Desc) => all_items.sort_unstable_by(|(_, a), (_, b)| b.cmp(a)),
                 None => {}
             }
             return Ok(Box::pin(stream::iter(
-                all_items.into_iter().map(to_action_state_result),
+                all_items
+                    .into_iter()
+                    .map(move |(subscriber, _)| to_action_state_result(subscriber)),
             )));
         };
 
@@ -647,7 +683,6 @@ where
             filter.order_by_priority_direction,
             Some(OrderDirection::Desc)
         );
-        let filter = filter.clone();
         let stream = self
             .action_db
             .get_range_of_actions(
@@ -657,7 +692,21 @@ where
                 desc,
             )
             .await
-            .try_filter(move |sub| future::ready(apply_filter_predicate(&sub.borrow(), &filter)))
+            .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?
+            .and_then(|awaited_action_subscriber| async move {
+                let awaited_action = awaited_action_subscriber
+                    .borrow()
+                    .await
+                    .err_tip(|| "In SimpleSchedulerStateManager::filter_operations")?;
+                Ok((awaited_action_subscriber, awaited_action))
+            })
+            .try_filter_map(move |(subscriber, awaited_action)| {
+                if apply_filter_predicate(&awaited_action, &filter) {
+                    future::ready(Ok(Some(subscriber))).left_future()
+                } else {
+                    future::ready(Result::<_, Error>::Ok(None)).right_future()
+                }
+            })
             .map(move |result| -> Box<dyn ActionStateResult> {
                 result.map_or_else(
                     |e| -> Box<dyn ActionStateResult> { Box::new(ErrorActionStateResult(e)) },

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -869,11 +869,11 @@ impl AwaitedActionSubscriber for MockAwaitedActionSubscriber {
         unreachable!();
     }
 
-    fn borrow(&self) -> AwaitedAction {
-        AwaitedAction::new(
+    async fn borrow(&self) -> Result<AwaitedAction, Error> {
+        Ok(AwaitedAction::new(
             OperationId::default(),
             make_base_action_info(SystemTime::UNIX_EPOCH, DigestInfo::zero_digest()),
-        )
+        ))
     }
 }
 
@@ -933,8 +933,8 @@ impl AwaitedActionDb for MockAwaitedAction {
 
     async fn get_all_awaited_actions(
         &self,
-    ) -> impl Stream<Item = Result<Self::Subscriber, Error>> + Send {
-        futures::stream::empty()
+    ) -> Result<impl Stream<Item = Result<Self::Subscriber, Error>> + Send, Error> {
+        Ok(futures::stream::empty())
     }
 
     async fn get_by_operation_id(
@@ -953,12 +953,12 @@ impl AwaitedActionDb for MockAwaitedAction {
         _start: Bound<SortedAwaitedAction>,
         _end: Bound<SortedAwaitedAction>,
         _desc: bool,
-    ) -> impl Stream<Item = Result<Self::Subscriber, Error>> + Send {
+    ) -> Result<impl Stream<Item = Result<Self::Subscriber, Error>> + Send, Error> {
         let mut rx_get_range_of_actions = self.rx_get_range_of_actions.lock().await;
         let items = rx_get_range_of_actions
             .try_recv()
             .expect("Could not receive msg in mpsc");
-        futures::stream::iter(items)
+        Ok(futures::stream::iter(items))
     }
 
     async fn update_awaited_action(&self, _new_awaited_action: AwaitedAction) -> Result<(), Error> {


### PR DESCRIPTION
Cosmetic change to make it easier to support databases that are async in
nature. This makes all operations in the AwaitedAction API to be able to
return a result before returning a stream or other items.

towards #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1312)
<!-- Reviewable:end -->
