### PR TITLE
Improve debugging on some error messages

### DIFF
--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -511,7 +511,9 @@ where
                             },
                             error: Some(err.clone().merge(make_err!(
                                 Code::Internal,
-                                "Job cancelled because it attempted to execute too many times and failed {}",
+                                "Job cancelled because it attempted to execute too many times {} > {} times {}",
+                                awaited_action.attempts,
+                                self.max_job_retries,
                                 format!("for operation_id: {operation_id}, maybe_worker_id: {maybe_worker_id:?}"),
                             ))),
                             ..ActionResult::default()

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -2008,8 +2008,8 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         if let ActionStage::Completed(stage) = &mut received_state.stage {
             if let Some(real_err) = &mut stage.error {
                 assert!(
-                    real_err.to_string().contains("Job cancelled because it attempted to execute too many times and failed"),
-                    "{real_err} did not contain 'Job cancelled because it attempted to execute too many times and failed'",
+                    real_err.to_string().contains("Job cancelled because it attempted to execute too many times"),
+                    "{real_err} did not contain 'Job cancelled because it attempted to execute too many times'",
                 );
                 *real_err = err;
             }

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -213,6 +213,8 @@ impl std::fmt::Display for ActionUniqueQualifier {
             Self::Uncachable(action) => (false, action),
         };
         f.write_fmt(format_args!(
+            // Note: We use underscores because it makes escaping easier
+            // for redis.
             "{}/{}/{}-{}/{}",
             unique_key.instance_name,
             unique_key.digest_function,


### PR DESCRIPTION
In debugging Scheduler errors when developing the Redis scheduler,
adding these messages to the hints helped find the bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1313)
<!-- Reviewable:end -->
