### PR TITLE
Cleanup digest function to use u64 instead of i64

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -253,7 +253,7 @@ impl ByteStreamServer {
                     digest,
                     rx,
                     UploadSizeInfo::ExactSize(
-                        usize::try_from(digest.size_bytes).err_tip(|| "Invalid digest size")?,
+                        usize::try_from(digest.size_bytes()).err_tip(|| "Invalid digest size")?,
                     ),
                 )
                 .await

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -123,7 +123,7 @@ impl CasServer {
                     .err_tip(|| "Digest not found in request")?;
                 let request_data = request.data;
                 let digest_info = DigestInfo::try_from(digest.clone())?;
-                let size_bytes = usize::try_from(digest_info.size_bytes)
+                let size_bytes = usize::try_from(digest_info.size_bytes())
                     .err_tip(|| "Digest size_bytes was not convertible to usize")?;
                 error_if!(
                     size_bytes != request_data.len(),
@@ -280,7 +280,7 @@ impl CasServer {
         // `next_page_token` will return the `{hash_str}:{size_bytes}` of the next request's first directory digest.
         // It will be an empty string when it reached the end of the directory tree.
         let next_page_token: String = if let Some(value) = deque.front() {
-            format!("{}-{}", value.hash_str(), value.size_bytes)
+            format!("{value}")
         } else {
             String::new()
         };

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -120,7 +120,7 @@ async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(err.code(), Code::NotFound);
     assert_eq!(
             err.message(),
-            "Key Digest(DigestInfo { size_bytes: 0, hash: \"0123456789abcdef000000000000000000000000000000000123456789abcdef\" }) not found"
+            "Key Digest(DigestInfo(\"0123456789abcdef000000000000000000000000000000000123456789abcdef-0\")) not found"
         );
     Ok(())
 }
@@ -165,7 +165,7 @@ async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error
     assert_eq!(err.code(), Code::NotFound);
     assert_eq!(
             err.message(),
-            "Key Digest(DigestInfo { size_bytes: 146, hash: \"0123456789abcdef000000000000000000000000000000000123456789abcdef\" }) not found"
+            "Key Digest(DigestInfo(\"0123456789abcdef000000000000000000000000000000000123456789abcdef-146\")) not found"
         );
     Ok(())
 }

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -842,11 +842,11 @@ pub async fn read_with_not_found_does_not_deadlock() -> Result<(), Error> {
 
         let result = result_fut.await.err_tip(|| "Expected result to be ready")?;
         let expected_err_str = concat!(
-                "status: NotFound, message: \"Key Digest(DigestInfo { size_bytes: 55, hash: \\\"0123456789abcdef000000000000000000000000000000000123456789abcdef\\\" }) not found\", details: [], metadata: MetadataMap { headers: {} }",
+                "status: NotFound, message: \"Key Digest(DigestInfo(\\\"0123456789abcdef000000000000000000000000000000000123456789abcdef-55\\\")) not found\", details: [], metadata: MetadataMap { headers: {} }",
             );
         assert_eq!(
             Error::from(result.unwrap_err()),
-            make_err!(Code::NotFound, "{}", expected_err_str),
+            make_err!(Code::NotFound, "{expected_err_str}"),
             "Expected error data to match"
         );
     }

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -387,11 +387,7 @@ async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::e
         .get_tree(Request::new(GetTreeRequest {
             instance_name: INSTANCE_NAME.to_string(),
             page_size: 0,
-            page_token: format!(
-                "{}-{}",
-                root_directory_digest_info.hash_str(),
-                root_directory_digest_info.size_bytes
-            ),
+            page_token: format!("{root_directory_digest_info}"),
             root_digest: Some(root_directory_digest_info.into()),
             digest_function: digest_function::Value::Sha256.into(),
         }))
@@ -442,11 +438,7 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
         .get_tree(Request::new(GetTreeRequest {
             instance_name: INSTANCE_NAME.to_string(),
             page_size: 2,
-            page_token: format!(
-                "{}-{}",
-                root_directory_digest_info.hash_str(),
-                root_directory_digest_info.size_bytes
-            ),
+            page_token: format!("{root_directory_digest_info}"),
             root_digest: Some(root_directory_digest_info.into()),
             digest_function: digest_function::Value::Sha256.into(),
         }))
@@ -461,22 +453,14 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
             .await,
         vec![GetTreeResponse {
             directories: vec![root_directory.clone(), sub_directories[0].clone()],
-            next_page_token: format!(
-                "{}-{}",
-                sub_directory_digest_infos[1].hash_str(),
-                sub_directory_digest_infos[1].size_bytes
-            ),
+            next_page_token: format!("{}", sub_directory_digest_infos[1]),
         }]
     );
     let raw_response = cas_server
         .get_tree(Request::new(GetTreeRequest {
             instance_name: INSTANCE_NAME.to_string(),
             page_size: 2,
-            page_token: format!(
-                "{}-{}",
-                sub_directory_digest_infos[1].hash_str(),
-                sub_directory_digest_infos[1].size_bytes
-            ),
+            page_token: format!("{}", sub_directory_digest_infos[1]),
             root_digest: Some(root_directory_digest_info.into()),
             digest_function: digest_function::Value::Sha256.into(),
         }))
@@ -491,22 +475,14 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
             .await,
         vec![GetTreeResponse {
             directories: vec![sub_directories[1].clone(), sub_directories[2].clone()],
-            next_page_token: format!(
-                "{}-{}",
-                sub_directory_digest_infos[3].hash_str(),
-                sub_directory_digest_infos[3].size_bytes
-            ),
+            next_page_token: format!("{}", sub_directory_digest_infos[3]),
         }]
     );
     let raw_response = cas_server
         .get_tree(Request::new(GetTreeRequest {
             instance_name: INSTANCE_NAME.to_string(),
             page_size: 2,
-            page_token: format!(
-                "{}-{}",
-                sub_directory_digest_infos[3].hash_str(),
-                sub_directory_digest_infos[3].size_bytes
-            ),
+            page_token: format!("{}", sub_directory_digest_infos[3]),
             root_digest: Some(root_directory_digest_info.into()),
             digest_function: digest_function::Value::Sha256.into(),
         }))

--- a/nativelink-store/src/cas_utils.rs
+++ b/nativelink-store/src/cas_utils.rs
@@ -39,7 +39,7 @@ pub const ZERO_BYTE_DIGESTS: [DigestInfo; 2] = [
 #[inline]
 pub fn is_zero_digest<'a>(digest: impl Into<StoreKey<'a>>) -> bool {
     match digest.into() {
-        StoreKey::Digest(digest) => digest.size_bytes == 0 && ZERO_BYTE_DIGESTS.contains(&digest),
+        StoreKey::Digest(digest) => digest.size_bytes() == 0 && ZERO_BYTE_DIGESTS.contains(&digest),
         _ => false,
     }
 }

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -209,7 +209,7 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
             .get_part(digest, writer, offset, length)
             .await;
         if result.is_ok() {
-            let size = usize::try_from(digest.size_bytes)
+            let size = usize::try_from(digest.size_bytes())
                 .err_tip(|| "Could not convert size_bytes in ExistenceCacheStore::get_part")?;
             let _ = self
                 .existence_cache

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -565,7 +565,7 @@ impl StoreDriver for GrpcStore {
         {
             match missing_digests.binary_search(&digest) {
                 Ok(_) => *result = None,
-                Err(_) => *result = Some(usize::try_from(digest.size_bytes)?),
+                Err(_) => *result = Some(usize::try_from(digest.size_bytes())?),
             }
         }
 
@@ -589,7 +589,7 @@ impl StoreDriver for GrpcStore {
             &self.instance_name,
             Uuid::new_v4().hyphenated().encode_lower(&mut buf),
             digest.hash_str(),
-            digest.size_bytes,
+            digest.size_bytes(),
         );
 
         struct LocalState {
@@ -666,7 +666,7 @@ impl StoreDriver for GrpcStore {
         }
 
         // Shortcut for empty blobs.
-        if digest.size_bytes == 0 {
+        if digest.size_bytes() == 0 {
             return writer.send_eof();
         }
 
@@ -674,7 +674,7 @@ impl StoreDriver for GrpcStore {
             "{}/blobs/{}/{}",
             &self.instance_name,
             digest.hash_str(),
-            digest.size_bytes,
+            digest.size_bytes(),
         );
 
         struct LocalState<'a> {

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -93,30 +93,30 @@ impl ShardStore {
                 //     array length. They optimize especially well when the optimizer can easily determine
                 //     the slice length, e.g. <[u8; 4]>::try_from(&slice[4..8]).unwrap(). Array implements
                 //     TryFrom returning.
-                let size_bytes = digest.size_bytes.to_le_bytes();
+                let size_bytes = digest.size_bytes().to_le_bytes();
                 0.bitxor(u32::from_le_bytes(
-                    digest.packed_hash[0..4].try_into().unwrap(),
+                    digest.packed_hash()[0..4].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[4..8].try_into().unwrap(),
+                    digest.packed_hash()[4..8].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[8..12].try_into().unwrap(),
+                    digest.packed_hash()[8..12].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[12..16].try_into().unwrap(),
+                    digest.packed_hash()[12..16].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[16..20].try_into().unwrap(),
+                    digest.packed_hash()[16..20].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[20..24].try_into().unwrap(),
+                    digest.packed_hash()[20..24].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[24..28].try_into().unwrap(),
+                    digest.packed_hash()[24..28].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(
-                    digest.packed_hash[28..32].try_into().unwrap(),
+                    digest.packed_hash()[28..32].try_into().unwrap(),
                 ))
                 .bitxor(u32::from_le_bytes(size_bytes[0..4].try_into().unwrap()))
                 .bitxor(u32::from_le_bytes(size_bytes[4..8].try_into().unwrap()))

--- a/nativelink-store/tests/cas_utils_test.rs
+++ b/nativelink-store/tests/cas_utils_test.rs
@@ -19,10 +19,7 @@ use sha2::{Digest, Sha256};
 
 #[test]
 fn sha256_is_zero_digest() {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
     assert!(is_zero_digest(digest));
 }
 
@@ -30,19 +27,13 @@ fn sha256_is_zero_digest() {
 fn sha256_is_non_zero_digest() {
     let mut hasher = Sha256::new();
     hasher.update(b"a");
-    let digest = DigestInfo {
-        packed_hash: hasher.finalize().into(),
-        size_bytes: 1,
-    };
+    let digest = DigestInfo::new(hasher.finalize().into(), 1);
     assert!(!is_zero_digest(digest));
 }
 
 #[test]
 fn blake_is_zero_digest() {
-    let digest = DigestInfo {
-        packed_hash: Blake3::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Blake3::new().finalize().into(), 0);
     assert!(is_zero_digest(digest));
 }
 
@@ -50,9 +41,6 @@ fn blake_is_zero_digest() {
 fn blake_is_non_zero_digest() {
     let mut hasher = Blake3::new();
     hasher.update(b"a");
-    let digest = DigestInfo {
-        packed_hash: hasher.finalize().into(),
-        size_bytes: 1,
-    };
+    let digest = DigestInfo::new(hasher.finalize().into(), 1);
     assert!(!is_zero_digest(digest));
 }

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -487,10 +487,7 @@ async fn check_footer_test() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn get_part_is_zero_digest() -> Result<(), Error> {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
 
     const BLOCK_SIZE: u32 = 32 * 1024;
     let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -249,7 +249,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             if let Some(has_digest) = self.digest {
                 for (digest, result) in digests.iter().zip(results.iter_mut()) {
                     if *digest == has_digest.into() {
-                        *result = Some(has_digest.size_bytes as usize);
+                        *result = Some(has_digest.size_bytes() as usize);
                     }
                 }
             }
@@ -286,7 +286,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
         ) -> Result<(), Error> {
             // Gets called in the slow store and we provide the data that's
             // sent to the upstream and the fast store.
-            let bytes = length.unwrap_or(key.into_digest().size_bytes as usize) - offset;
+            let bytes = length.unwrap_or(key.into_digest().size_bytes() as usize) - offset;
             let data = vec![0_u8; bytes];
             writer.send(Bytes::copy_from_slice(&data)).await?;
             writer.send_eof()
@@ -350,7 +350,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             // Drop get_part as soon as rx.drain() completes
             tokio::select!(
                 res = rx.drain() => res,
-                res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes as usize)) => res,
+                res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes() as usize)) => res,
             )
         },
         async move {

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -240,10 +240,7 @@ async fn errors_with_invalid_inputs() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn get_part_is_zero_digest() -> Result<(), Error> {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
 
     let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
     let store_clone = store.clone();
@@ -269,10 +266,7 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn has_with_results_on_zero_digests() -> Result<(), Error> {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
     let keys = vec![digest.into()];
     let mut results = vec![None];
 

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -126,7 +126,7 @@ async fn upload_and_get_data() -> Result<(), Error> {
 
     // Construct a digest for our data and create a key based on that digest.
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
-    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+    let packed_hash_hex = format!("{digest}");
 
     // Construct our Redis store with a mocked out backend.
     let temp_key = RedisValue::Bytes(make_temp_key(&packed_hash_hex).into());
@@ -211,7 +211,7 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
     let prefix = "TEST_PREFIX-";
 
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
-    let packed_hash_hex = format!("{prefix}{}-{}", digest.hash_str(), digest.size_bytes);
+    let packed_hash_hex = format!("{prefix}{digest}");
 
     let temp_key = RedisValue::Bytes(make_temp_key(&packed_hash_hex).into());
     let real_key = RedisValue::Bytes(packed_hash_hex.into());
@@ -337,7 +337,7 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
     let data = Bytes::from(vec![0u8; READ_CHUNK_SIZE + 128]);
 
     let digest = DigestInfo::try_new(VALID_HASH1, 1)?;
-    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+    let packed_hash_hex = format!("{digest}");
 
     let temp_key = RedisValue::Bytes(make_temp_key(&packed_hash_hex).into());
     let real_key = RedisValue::Bytes(packed_hash_hex.into());
@@ -435,7 +435,7 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
     let data_p2 = Bytes::from(vec![0u8; 4 * 1024]);
 
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
-    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+    let packed_hash_hex = format!("{digest}");
 
     let temp_key = RedisValue::Bytes(make_temp_key(&packed_hash_hex).into());
     let real_key = RedisValue::Bytes(packed_hash_hex.into());
@@ -525,7 +525,7 @@ async fn zero_len_items_exist_check() -> Result<(), Error> {
     let mocks = Arc::new(MockRedisBackend::new());
 
     let digest = DigestInfo::try_new(VALID_HASH1, 0)?;
-    let packed_hash_hex = format!("{}-{}", digest.hash_str(), digest.size_bytes);
+    let packed_hash_hex = format!("{digest}");
     let real_key = RedisValue::Bytes(packed_hash_hex.into());
 
     mocks

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -603,10 +603,7 @@ async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn get_part_is_zero_digest() -> Result<(), Error> {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
 
     let mock_client = StaticReplayClient::new(vec![]);
     let test_config = Builder::new()
@@ -646,10 +643,7 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn has_with_results_on_zero_digests() -> Result<(), Error> {
-    let digest = DigestInfo {
-        packed_hash: Sha256::new().finalize().into(),
-        size_bytes: 0,
-    };
+    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
     let keys = vec![digest.into()];
     let mut results = vec![None];
 

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -215,11 +215,10 @@ impl std::fmt::Display for ActionUniqueQualifier {
         f.write_fmt(format_args!(
             // Note: We use underscores because it makes escaping easier
             // for redis.
-            "{}/{}/{}-{}/{}",
+            "{}/{}/{}/{}",
             unique_key.instance_name,
             unique_key.digest_function,
-            unique_key.digest.hash_str(),
-            unique_key.digest.size_bytes,
+            unique_key.digest,
             if cachable { 'c' } else { 'u' },
         ))
     }
@@ -243,11 +242,8 @@ pub struct ActionUniqueKey {
 impl std::fmt::Display for ActionUniqueKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "{}/{}/{}-{}",
-            self.instance_name,
-            self.digest_function,
-            self.digest.hash_str(),
-            self.digest.size_bytes
+            "{}/{}/{}",
+            self.instance_name, self.digest_function, self.digest,
         ))
     }
 }

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -221,7 +221,7 @@ pub enum DigestHasherFuncImpl {
 
 /// The individual implementation of the hash function.
 pub struct DigestHasherImpl {
-    hashed_size: i64,
+    hashed_size: u64,
     hash_func_impl: DigestHasherFuncImpl,
 }
 
@@ -243,7 +243,7 @@ impl DigestHasherImpl {
 impl DigestHasher for DigestHasherImpl {
     #[inline]
     fn update(&mut self, input: &[u8]) {
-        self.hashed_size += input.len() as i64;
+        self.hashed_size += input.len() as u64;
         match &mut self.hash_func_impl {
             DigestHasherFuncImpl::Sha256(h) => sha2::digest::Update::update(h, input),
             DigestHasherFuncImpl::Blake3(h) => {
@@ -288,7 +288,7 @@ impl DigestHasher for DigestHasherImpl {
                         make_err!(Code::Internal, "Error in blake3's update_mmap: {e:?}")
                     })?;
                     Result::<_, Error>::Ok((
-                        DigestInfo::new(hasher.finalize().into(), hasher.count() as i64),
+                        DigestInfo::new(hasher.finalize().into(), hasher.count()),
                         file,
                     ))
                 })

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -245,7 +245,7 @@ impl<'a> StoreKey<'a> {
         match self {
             StoreKey::Str(Cow::Owned(s)) => Cow::Borrowed(s),
             StoreKey::Str(Cow::Borrowed(s)) => Cow::Borrowed(s),
-            StoreKey::Digest(d) => Cow::Owned(format!("{}-{}", d.hash_str(), d.size_bytes)),
+            StoreKey::Digest(d) => Cow::Owned(format!("{d}")),
         }
     }
 }

--- a/nativelink-util/tests/proto_stream_utils_test.rs
+++ b/nativelink-util/tests/proto_stream_utils_test.rs
@@ -35,12 +35,12 @@ async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Resul
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<WriteRequest, Error>>();
 
     const RAW_DATA: &str = "thisdatafoo";
-    const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], RAW_DATA.len() as i64);
+    const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], RAW_DATA.len() as u64);
     let message1 = WriteRequest {
         resource_name: format!(
             "{INSTANCE_NAME}/uploads/some-uuid/blobs/{}/{}",
             DIGEST.hash_str(),
-            DIGEST.size_bytes
+            DIGEST.size_bytes()
         ),
         write_offset: 0,
         finish_write: false,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -184,7 +184,7 @@ pub fn download_to_directory<'a>(
                         }
                         Ok(())
                     })
-                    .map_err(move |e| e.append(format!("for digest {digest:?}")))
+                    .map_err(move |e| e.append(format!("for digest {digest}")))
                     .boxed(),
             );
         }
@@ -287,7 +287,7 @@ async fn upload_file(
         .update_with_whole_file(
             digest.into(),
             resumeable_file,
-            UploadSizeInfo::ExactSize(digest.size_bytes as usize),
+            UploadSizeInfo::ExactSize(digest.size_bytes() as usize),
         )
         .await
         .err_tip(|| format!("for {full_path:?}"))?;
@@ -1473,10 +1473,13 @@ impl UploadActionResults {
             hasher.proto_digest_func().as_str_name().to_lowercase(),
         );
         template_str.replace("action_digest_hash", action_digest_info.hash_str());
-        template_str.replace("action_digest_size", action_digest_info.size_bytes);
+        template_str.replace("action_digest_size", action_digest_info.size_bytes());
         if let Some(historical_digest_info) = maybe_historical_digest_info {
             template_str.replace("historical_results_hash", historical_digest_info.hash_str());
-            template_str.replace("historical_results_size", historical_digest_info.size_bytes);
+            template_str.replace(
+                "historical_results_size",
+                historical_digest_info.size_bytes(),
+            );
         } else {
             template_str.replace("historical_results_hash", "");
             template_str.replace("historical_results_size", "");
@@ -1539,7 +1542,7 @@ impl UploadActionResults {
             &mut hasher.hasher(),
         )
         .await
-        .err_tip(|| format!("Caching HistoricalExecuteResponse for digest: {action_digest:?}"))?;
+        .err_tip(|| format!("Caching HistoricalExecuteResponse for digest: {action_digest}"))?;
 
         Self::format_execute_response_message(
             message_template,


### PR DESCRIPTION
It is weird that we use i64 in the code base for this in the first place. There is some historical reason for having it this way, specifically around keeping it in sync with the Digest proto, but once converted we don't need to do this.

Also implement a more standard format/display function for DigestInfo using the common '{hash}-{size}' format.

Removes direct access to modify the internals of DigestInfo and requires member access to go through accessors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1327)
<!-- Reviewable:end -->
