### PR TITLE
Delete ~/Applications and iOS simulators/cache from Mac runners

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,17 +58,20 @@ jobs:
             bun setup && bun docs && bun run build
           "
 
-      - name: Delete all Xcode installations to free up disk space
-        if: matrix.os == 'macos-14'
+      - name: Free disk space
+        uses: >- # v2.0.0
+          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: false
+
+      - name: Delete Applications and Simulators to free up disk space
+        if: contains(matrix.os, 'macos')
         run: |
-          echo "Available Xcode installations:"
-          xcodes installed
-          selected_path="$(xcode-select -p)"; selected_path="${selected_path%/Contents/Developer}"
-          find /Applications \
-            -depth 1 \
-            -name "Xcode*.app" \
-            -not -path "${selected_path}" \
-            -exec rm -rf {} +
+          echo "Deleting Applications"
+          sudo rm -rf ~/Applications/*
           echo "Deleting all iOS simulators"
           xcrun simctl delete all
           echo "Deleting iOS Simulator caches"

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -35,6 +35,16 @@ jobs:
         with:
           bazelisk-cache: true
 
+      - name: Delete Applications and Simulators to free up disk space
+        if: contains(matrix.os, 'macos')
+        run: |
+          echo "Deleting Applications"
+          sudo rm -rf ~/Applications/*
+          echo "Deleting all iOS simulators"
+          xcrun simctl delete all
+          echo "Deleting iOS Simulator caches"
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+
       - name: Determine Bazel cache mountpoint
         id: bazel-cache
         run: |

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -95,6 +95,16 @@ jobs:
           remove_haskell: true
           remove_tool_cache: false
 
+      - name: Delete Applications and Simulators to free up disk space
+        if: contains(matrix.os, 'macos')
+        run: |
+          echo "Deleting Applications"
+          sudo rm -rf ~/Applications/*
+          echo "Deleting all iOS simulators"
+          xcrun simctl delete all
+          echo "Deleting iOS Simulator caches"
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+
       - name: Cache Nix derivations
         uses: >- # v4
           DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
@@ -129,6 +139,16 @@ jobs:
           remove_dotnet: true
           remove_haskell: true
           remove_tool_cache: false
+
+      - name: Delete Applications and Simulators to free up disk space
+        if: contains(matrix.os, 'macos')
+        run: |
+          echo "Deleting Applications"
+          sudo rm -rf ~/Applications/*
+          echo "Deleting all iOS simulators"
+          xcrun simctl delete all
+          echo "Deleting iOS Simulator caches"
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
       - name: Cache Nix derivations
         uses: >- # v4


### PR DESCRIPTION
# Description

Reduce out of disk space errors on Mac runners by deleting `~/Applications/*` and iOS Simulators/cache

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1334)
<!-- Reviewable:end -->
