### PR TITLE
Add tekton operator to local dev cluster

### DIFF
--- a/native-cli/components/flux.go
+++ b/native-cli/components/flux.go
@@ -9,7 +9,8 @@ import (
 
 // The configuration for Flux.
 type Flux struct {
-	Version string
+	Version      string
+	Dependencies []pulumi.Resource
 }
 
 // Install sets up Flux in the cluster.
@@ -22,7 +23,11 @@ func (component *Flux) Install(
 			"https://github.com/fluxcd/flux2/releases/download/v%s/install.yaml",
 			component.Version,
 		),
-	})
+	},
+		pulumi.DependsOn(
+			component.Dependencies,
+		),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errPulumi, err)
 	}

--- a/native-cli/programs/local.go
+++ b/native-cli/programs/local.go
@@ -50,6 +50,21 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 		},
 	))
 
+	tektonOperator, err := components.AddComponent(
+		ctx,
+		"tekton-operator",
+		&components.TektonOperator{
+			Version: "0.72.0",
+			Dependencies: slices.Concat(
+				cilium,
+			),
+		},
+	)
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+
 	flux, err := components.AddComponent(
 		ctx,
 		"flux",
@@ -70,49 +85,15 @@ func ProgramForLocalCluster(ctx *pulumi.Context) error {
 		},
 	))
 
-	tektonPipelines, err := components.AddComponent(
-		ctx,
-		"tekton-pipelines",
-		&components.TektonPipelines{
-			Version: "0.58.0",
-		},
-	)
-	if err != nil {
-		log.Println(err)
-		os.Exit(1)
-	}
-
-	tektonTriggers, err := components.AddComponent(
-		ctx,
-		"tekton-triggers",
-		&components.TektonTriggers{
-			Version: "0.26.1",
-			Dependencies: slices.Concat(
-				tektonPipelines,
-			),
-		},
-	)
-	if err != nil {
-		log.Println(err)
-		os.Exit(1)
-	}
-
-	components.Check(components.AddComponent(
-		ctx,
-		"tekton-dashboard",
-		&components.TektonDashboard{
-			Version: "0.45.0",
-			Dependencies: slices.Concat(
-				tektonPipelines, tektonTriggers,
-			),
-		},
-	))
-
 	nativeLinkGateways, err := components.AddComponent(
 		ctx,
-		"nativelink-gatways",
+		"nativelink-gateways",
 		&components.NativeLinkGateways{
-			Dependencies: cilium,
+			Dependencies: slices.Concat(
+				cilium,
+				flux,
+				tektonOperator,
+			),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR introduces the Tekton operator with a TektonConfig to replace the existing Tekton pipelines, triggers, and dashboard.

## Known Issue:
There is currently a bug where we are only waiting for 60 seconds for the webhooks, instead of checking if they have reached a running/ready status, so there is a possibility that the tekton-webhooks are in an unready state when trying to deploy the tasks, pipelines and triggers.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1337)
<!-- Reviewable:end -->
