### PR TITLE
DigestInfo now does string conversions on the stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "prost-types",
  "rand",
  "serde",
+ "serde_json",
  "sha2",
  "tokio",
  "tokio-stream",
@@ -2803,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.5.0",
  "itoa",

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -588,7 +588,7 @@ impl StoreDriver for GrpcStore {
             "{}/uploads/{}/blobs/{}/{}",
             &self.instance_name,
             Uuid::new_v4().hyphenated().encode_lower(&mut buf),
-            digest.hash_str(),
+            digest.packed_hash(),
             digest.size_bytes(),
         );
 
@@ -673,7 +673,7 @@ impl StoreDriver for GrpcStore {
         let resource_name = format!(
             "{}/blobs/{}/{}",
             &self.instance_name,
-            digest.hash_str(),
+            digest.packed_hash(),
             digest.size_bytes(),
         );
 

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -21,6 +21,7 @@ use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
     make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf,
 };
+use nativelink_util::common::PackedHash;
 use nativelink_util::digest_hasher::{
     default_digest_hasher_func, DigestHasher, ACTIVE_HASHER_FUNC,
 };
@@ -61,7 +62,7 @@ impl VerifyStore {
         mut tx: DropCloserWriteHalf,
         mut rx: DropCloserReadHalf,
         maybe_expected_digest_size: Option<u64>,
-        original_hash: &[u8; 32],
+        original_hash: &PackedHash,
         mut maybe_hasher: Option<&mut D>,
     ) -> Result<(), Error> {
         let mut sum_size: u64 = 0;
@@ -119,9 +120,7 @@ impl VerifyStore {
                     if original_hash != hash_result {
                         self.hash_verification_failures.inc();
                         return Err(make_input_err!(
-                            "Hashes do not match, got: {} but digest hash was {}",
-                            hex::encode(original_hash),
-                            hex::encode(hash_result),
+                            "Hashes do not match, got: {original_hash} but digest hash was {hash_result}",
                         ));
                     }
                 }

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -79,6 +79,7 @@ rust_test_suite(
     srcs = [
         "tests/buf_channel_test.rs",
         "tests/channel_body_for_tests_test.rs",
+        "tests/common_test.rs",
         "tests/evicting_map_test.rs",
         "tests/fastcdc_test.rs",
         "tests/fs_test.rs",
@@ -109,6 +110,7 @@ rust_test_suite(
         "@crates//:parking_lot",
         "@crates//:pretty_assertions",
         "@crates//:rand",
+        "@crates//:serde_json",
         "@crates//:sha2",
         "@crates//:tokio",
         "@crates//:tokio-stream",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -23,7 +23,7 @@ pin-project = "1.1.5"
 #                    Release PR: https://github.com/tokio-rs/console/pull/576
 console-subscriber = { git = "https://github.com/tokio-rs/console", rev = "5f6faa2" , default-features = false }
 futures = { version = "0.3.30", default-features = false }
-hex = { version = "0.4.3", default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }
 hyper = "1.4.1"
 hyper-util = "0.1.6"
 lru = { version = "0.12.3", default-features = false }
@@ -49,3 +49,4 @@ nativelink-macro = { path = "../nativelink-macro" }
 http-body-util = "0.1.2"
 pretty_assertions = { version = "1.4.0", features = ["std"] }
 rand = { version = "0.8.5", default-features = false }
+serde_json = { version = "1.0.128", default-features = false }

--- a/nativelink-util/tests/common_test.rs
+++ b/nativelink-util/tests/common_test.rs
@@ -1,0 +1,132 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nativelink_error::{make_input_err, Error};
+use nativelink_macro::nativelink_test;
+use nativelink_util::common::DigestInfo;
+use pretty_assertions::assert_eq;
+
+const MIN_DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000-0";
+const MAX_SAFE_DIGEST: &str =
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff-9223372036854775807";
+const MAX_UNSAFE_DIGEST: &str =
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff-18446744073709551615";
+
+#[nativelink_test]
+async fn digest_info_min_max_test() -> Result<(), Error> {
+    {
+        const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], u64::MIN);
+        assert_eq!(&format!("{DIGEST}"), MIN_DIGEST);
+    }
+    {
+        const DIGEST: DigestInfo = DigestInfo::new([255u8; 32], u64::MAX);
+        assert_eq!(&format!("{DIGEST}"), MAX_UNSAFE_DIGEST);
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn digest_info_try_new_min_max_test() -> Result<(), Error> {
+    {
+        let digest_parts: (&str, u64) = MIN_DIGEST
+            .split_once('-')
+            .map(|(s, n)| (s, n.parse().unwrap()))
+            .unwrap();
+        let digest = DigestInfo::try_new(digest_parts.0, digest_parts.1).unwrap();
+        assert_eq!(&format!("{digest}"), MIN_DIGEST);
+    }
+    {
+        let digest_parts: (&str, u64) = MAX_SAFE_DIGEST
+            .split_once('-')
+            .map(|(s, n)| (s, n.parse().unwrap()))
+            .unwrap();
+        let digest = DigestInfo::try_new(digest_parts.0, digest_parts.1).unwrap();
+        assert_eq!(&format!("{digest}"), MAX_SAFE_DIGEST);
+    }
+    {
+        let digest_parts: (&str, u64) = MAX_UNSAFE_DIGEST
+            .split_once('-')
+            .map(|(s, n)| (s, n.parse().unwrap()))
+            .unwrap();
+        let digest_res = DigestInfo::try_new(digest_parts.0, digest_parts.1);
+        assert_eq!(
+            digest_res,
+            Err(make_input_err!(
+                "Size bytes is too large: 18446744073709551615 - max: 9223372036854775807"
+            ))
+        );
+    }
+    {
+        // Sanity check to ensure non-repeating digests print properly
+        const DIGEST: &str =
+            "123456789abcdeffedcba987654321089abcde0123456789ffedcba987654321-123456789";
+        let digest_parts: (&str, u64) = DIGEST
+            .split_once('-')
+            .map(|(s, n)| (s, n.parse().unwrap()))
+            .unwrap();
+        let digest = DigestInfo::try_new(digest_parts.0, digest_parts.1).unwrap();
+        assert_eq!(&format!("{digest}"), DIGEST);
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn digest_info_serialize_test() -> Result<(), Error> {
+    {
+        const DIGEST: DigestInfo = DigestInfo::new([0u8; 32], u64::MIN);
+        assert_eq!(
+            serde_json::to_string(&DIGEST).unwrap(),
+            format!("\"{MIN_DIGEST}\"")
+        );
+    }
+    {
+        const DIGEST: DigestInfo = DigestInfo::new([255u8; 32], i64::MAX as u64);
+        assert_eq!(
+            serde_json::to_string(&DIGEST).unwrap(),
+            format!("\"{MAX_SAFE_DIGEST}\"")
+        );
+    }
+    {
+        const DIGEST: DigestInfo = DigestInfo::new([255u8; 32], u64::MAX);
+        assert_eq!(
+            serde_json::to_string(&DIGEST).unwrap(),
+            format!("\"{MAX_UNSAFE_DIGEST}\"")
+        );
+    }
+    Ok(())
+}
+
+#[nativelink_test]
+async fn digest_info_deserialize_test() -> Result<(), Error> {
+    {
+        assert_eq!(
+            serde_json::from_str::<DigestInfo>(&format!("\"{MIN_DIGEST}\"")).unwrap(),
+            DigestInfo::new([0u8; 32], u64::MIN)
+        );
+    }
+    {
+        assert_eq!(
+            serde_json::from_str::<DigestInfo>(&format!("\"{MAX_SAFE_DIGEST}\"")).unwrap(),
+            DigestInfo::new([255u8; 32], i64::MAX as u64)
+        );
+    }
+    {
+        let digest_res = serde_json::from_str::<DigestInfo>(&format!("\"{MAX_UNSAFE_DIGEST}\""));
+        assert_eq!(
+            format!("{}", digest_res.err().unwrap()),
+            "Could not create DigestInfo: Error { code: InvalidArgument, messages: [\"Size bytes is too large: 18446744073709551615 - max: 9223372036854775807\"] } at line 1 column 87",
+        );
+    }
+    Ok(())
+}

--- a/nativelink-util/tests/proto_stream_utils_test.rs
+++ b/nativelink-util/tests/proto_stream_utils_test.rs
@@ -39,7 +39,7 @@ async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Resul
     let message1 = WriteRequest {
         resource_name: format!(
             "{INSTANCE_NAME}/uploads/some-uuid/blobs/{}/{}",
-            DIGEST.hash_str(),
+            DIGEST.packed_hash(),
             DIGEST.size_bytes()
         ),
         write_offset: 0,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1472,10 +1472,16 @@ impl UploadActionResults {
             "digest_function",
             hasher.proto_digest_func().as_str_name().to_lowercase(),
         );
-        template_str.replace("action_digest_hash", action_digest_info.hash_str());
+        template_str.replace(
+            "action_digest_hash",
+            action_digest_info.packed_hash().to_string(),
+        );
         template_str.replace("action_digest_size", action_digest_info.size_bytes());
         if let Some(historical_digest_info) = maybe_historical_digest_info {
-            template_str.replace("historical_results_hash", historical_digest_info.hash_str());
+            template_str.replace(
+                "historical_results_hash",
+                format!("{}", historical_digest_info.packed_hash()),
+            );
             template_str.replace(
                 "historical_results_size",
                 historical_digest_info.size_bytes(),


### PR DESCRIPTION
We no longer make a few heap allocations to convert DigestInfo messages into strings. Now we can get a &str of a DigestInfo and do all the operations on the stack.

In addition serde's [De]Serialization now treats DigestInfo as a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1338)
<!-- Reviewable:end -->
