### PR TITLE
Allow empty page_token for get_tree

### DIFF
--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -236,18 +236,23 @@ impl CasServer {
         let mut deque: VecDeque<DigestInfo> = VecDeque::new();
         let mut directories: Vec<Directory> = Vec::new();
         // `page_token` will return the `{hash_str}-{size_bytes}` of the current request's first directory digest.
-        let mut page_token_parts = request.page_token.split('-');
-        let page_token_digest = DigestInfo::try_new(
-            page_token_parts
-                .next()
-                .err_tip(|| "Failed to parse `hash_str` in `page_token`")?,
-            page_token_parts
-                .next()
-                .err_tip(|| "Failed to parse `size_bytes` in `page_token`")?
-                .parse::<i64>()
-                .err_tip(|| "Failed to parse `size_bytes` as i64")?,
-        )
-        .err_tip(|| "Failed to parse `page_token` as `Digest` in `GetTreeRequest`")?;
+        let page_token_digest = match request.page_token.len() {
+            0 => root_digest,
+            _ => {
+                let mut page_token_parts = request.page_token.split('-');
+                DigestInfo::try_new(
+                    page_token_parts
+                        .next()
+                        .err_tip(|| "Failed to parse `hash_str` in `page_token`")?,
+                    page_token_parts
+                        .next()
+                        .err_tip(|| "Failed to parse `size_bytes` in `page_token`")?
+                        .parse::<i64>()
+                        .err_tip(|| "Failed to parse `size_bytes` as i64")?,
+                )
+                .err_tip(|| "Failed to parse `page_token` as `Digest` in `GetTreeRequest`")?
+            }
+        };
         let page_size = request.page_size;
         // If `page_size` is 0, paging is not necessary.
         let mut page_token_matched = page_size == 0;

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -383,35 +383,71 @@ async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::e
 
     // Must work when paging is disabled ( `page_size` is 0 ).
     // It reads all directories at once.
-    let raw_response = cas_server
-        .get_tree(Request::new(GetTreeRequest {
-            instance_name: INSTANCE_NAME.to_string(),
-            page_size: 0,
-            page_token: format!("{root_directory_digest_info}"),
-            root_digest: Some(root_directory_digest_info.into()),
-            digest_function: digest_function::Value::Sha256.into(),
-        }))
-        .await;
-    assert!(raw_response.is_ok());
-    assert_eq!(
-        raw_response
-            .unwrap()
-            .into_inner()
-            .filter_map(|x| async move { Some(x.unwrap()) })
-            .collect::<Vec<_>>()
-            .await,
-        vec![GetTreeResponse {
-            directories: vec![
-                root_directory.clone(),
-                sub_directories[0].clone(),
-                sub_directories[1].clone(),
-                sub_directories[2].clone(),
-                sub_directories[3].clone(),
-                sub_directories[4].clone()
-            ],
-            next_page_token: String::new()
-        }]
-    );
+
+    // First verify that using an empty page token is treated as if the client had sent the root
+    // digest.
+    {
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 0,
+                page_token: String::new(),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![
+                    root_directory.clone(),
+                    sub_directories[0].clone(),
+                    sub_directories[1].clone(),
+                    sub_directories[2].clone(),
+                    sub_directories[3].clone(),
+                    sub_directories[4].clone()
+                ],
+                next_page_token: String::new()
+            }]
+        );
+    }
+
+    // Also verify that sending the root digest returns the entire tree as well.
+    {
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 0,
+                page_token: format!("{root_directory_digest_info}"),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![
+                    root_directory.clone(),
+                    sub_directories[0].clone(),
+                    sub_directories[1].clone(),
+                    sub_directories[2].clone(),
+                    sub_directories[3].clone(),
+                    sub_directories[4].clone()
+                ],
+                next_page_token: String::new()
+            }]
+        );
+    }
 
     Ok(())
 }
@@ -434,72 +470,105 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
     // First, it reads `root_directory` and `sub_directory[0]`.
     // Then, it reads `sub_directory[1]` and `sub_directory[2]`.
     // Finally, it reads `sub_directory[3]` and `sub_directory[4]`.
-    let raw_response = cas_server
-        .get_tree(Request::new(GetTreeRequest {
-            instance_name: INSTANCE_NAME.to_string(),
-            page_size: 2,
-            page_token: format!("{root_directory_digest_info}"),
-            root_digest: Some(root_directory_digest_info.into()),
-            digest_function: digest_function::Value::Sha256.into(),
-        }))
-        .await;
-    assert!(raw_response.is_ok());
-    assert_eq!(
-        raw_response
-            .unwrap()
-            .into_inner()
-            .filter_map(|x| async move { Some(x.unwrap()) })
-            .collect::<Vec<_>>()
-            .await,
-        vec![GetTreeResponse {
-            directories: vec![root_directory.clone(), sub_directories[0].clone()],
-            next_page_token: format!("{}", sub_directory_digest_infos[1]),
-        }]
-    );
-    let raw_response = cas_server
-        .get_tree(Request::new(GetTreeRequest {
-            instance_name: INSTANCE_NAME.to_string(),
-            page_size: 2,
-            page_token: format!("{}", sub_directory_digest_infos[1]),
-            root_digest: Some(root_directory_digest_info.into()),
-            digest_function: digest_function::Value::Sha256.into(),
-        }))
-        .await;
-    assert!(raw_response.is_ok());
-    assert_eq!(
-        raw_response
-            .unwrap()
-            .into_inner()
-            .filter_map(|x| async move { Some(x.unwrap()) })
-            .collect::<Vec<_>>()
-            .await,
-        vec![GetTreeResponse {
-            directories: vec![sub_directories[1].clone(), sub_directories[2].clone()],
-            next_page_token: format!("{}", sub_directory_digest_infos[3]),
-        }]
-    );
-    let raw_response = cas_server
-        .get_tree(Request::new(GetTreeRequest {
-            instance_name: INSTANCE_NAME.to_string(),
-            page_size: 2,
-            page_token: format!("{}", sub_directory_digest_infos[3]),
-            root_digest: Some(root_directory_digest_info.into()),
-            digest_function: digest_function::Value::Sha256.into(),
-        }))
-        .await;
-    assert!(raw_response.is_ok());
-    assert_eq!(
-        raw_response
-            .unwrap()
-            .into_inner()
-            .filter_map(|x| async move { Some(x.unwrap()) })
-            .collect::<Vec<_>>()
-            .await,
-        vec![GetTreeResponse {
-            directories: vec![sub_directories[3].clone(), sub_directories[4].clone()],
-            next_page_token: String::new(),
-        }]
-    );
+
+    // First, verify that an empty initial page token is treated as if the client had sent the
+    // root digest and respects the page size.
+    {
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 2,
+                page_token: String::new(),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![root_directory.clone(), sub_directories[0].clone()],
+                next_page_token: format!("{}", sub_directory_digest_infos[1]),
+            }]
+        );
+    }
+
+    // Also verify that sending the root digest as the page token is treated as paging from the
+    // beginning and respects page size.
+    {
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 2,
+                page_token: format!("{root_directory_digest_info}"),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![root_directory.clone(), sub_directories[0].clone()],
+                next_page_token: format!("{}", sub_directory_digest_infos[1]),
+            }]
+        );
+    }
+
+    // Verify that paging from a non-initial page token will return the expected content.
+    {
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 2,
+                page_token: format!("{}", sub_directory_digest_infos[1]),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![sub_directories[1].clone(), sub_directories[2].clone()],
+                next_page_token: format!("{}", sub_directory_digest_infos[3]),
+            }]
+        );
+
+        let raw_response = cas_server
+            .get_tree(Request::new(GetTreeRequest {
+                instance_name: INSTANCE_NAME.to_string(),
+                page_size: 2,
+                page_token: format!("{}", sub_directory_digest_infos[3]),
+                root_digest: Some(root_directory_digest_info.into()),
+                digest_function: digest_function::Value::Sha256.into(),
+            }))
+            .await;
+        assert_eq!(
+            raw_response
+                .unwrap()
+                .into_inner()
+                .filter_map(|x| async move { Some(x.unwrap()) })
+                .collect::<Vec<_>>()
+                .await,
+            vec![GetTreeResponse {
+                directories: vec![sub_directories[3].clone(), sub_directories[4].clone()],
+                next_page_token: String::new(),
+            }]
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Fixes issue #1339

The RemoteExecution v2 API `GetTreeRequest` does not require that the `page_token` value be a non-empty string (or exist) only that it should only exist when the client wants the resume/offset the response based on a prior `GetTreeResponse.next_page_token`. The original implementation of the `get_tree` functionality (https://github.com/TraceMachina/nativelink/pull/905) requires that there _always_ be a value in the `page_token` field.

The [reference implementation in `buildfarm`](https://github.com/bazelbuild/bazel-buildfarm/blob/635d9fed03bedc076d019dcf4f430f20744eafe8/src/main/java/build/buildfarm/common/TreeIterator.java#L51-L52) treats an empty `page_token` as an initial request which seems entirely reasonable.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new unit tests.

Follow details in #1339 but run a local build of NativeLink using the changes in this PR and verify that the downloaded content exactly matches the uploaded content and there were no errors or warnings from NativeLink.

## Checklist

- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1340)
<!-- Reviewable:end -->
