### PR TITLE
Convert usize to u64 in Store trait APIs

### DIFF
--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -83,7 +83,7 @@ impl Drop for ClientAwaitedAction {
 /// why the implementation has fixed default values in it.
 impl LenEntry for ClientAwaitedAction {
     #[inline]
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         0
     }
 

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -17,12 +17,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nativelink_error::{make_input_err, Error};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
-use nativelink_util::{
-    action_messages::{ActionInfo, OperationId},
-    known_platform_property_provider::KnownPlatformPropertyProvider,
-    operation_state_manager::{
-        ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
-    },
+use nativelink_util::action_messages::{ActionInfo, OperationId};
+use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
+use nativelink_util::operation_state_manager::{
+    ActionStateResult, ActionStateResultStream, ClientStateManager, OperationFilter,
 };
 use tokio::sync::{mpsc, Mutex};
 

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -132,12 +132,12 @@ impl CompletenessCheckingStore {
     async fn inner_has_with_results(
         &self,
         action_result_digests: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         // Holds shared state between the different futures.
         // This is how get around lifetime issues.
         struct State<'a> {
-            results: &'a mut [Option<usize>],
+            results: &'a mut [Option<u64>],
             digests_to_check: Vec<StoreKey<'a>>,
             digests_to_check_idxs: Vec<usize>,
             notify: Arc<Notify>,
@@ -342,7 +342,7 @@ impl StoreDriver for CompletenessCheckingStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.inner_has_with_results(keys, results).await
     }
@@ -360,8 +360,8 @@ impl StoreDriver for CompletenessCheckingStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         let results = &mut [None];
         self.inner_has_with_results(&[key.borrow()], results)

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -42,7 +42,7 @@ pub const CURRENT_STREAM_FORMAT_VERSION: u8 = 1;
 // Default block size that will be used to slice stream into.
 pub const DEFAULT_BLOCK_SIZE: u32 = 64 * 1024;
 
-const U32_SZ: usize = std::mem::size_of::<u8>();
+const U32_SZ: u64 = std::mem::size_of::<u8>() as u64;
 
 type BincodeOptions = WithOtherIntEncoding<DefaultOptions, FixintEncoding>;
 
@@ -145,25 +145,25 @@ pub struct Footer {
 /// lz4_flex::block::get_maximum_output_size() way over estimates, so we use the
 /// one provided here: https://github.com/torvalds/linux/blob/master/include/linux/lz4.h#L61
 /// Local testing shows this gives quite accurate worst case given random input.
-fn lz4_compress_bound(input_size: usize) -> usize {
+fn lz4_compress_bound(input_size: u64) -> u64 {
     input_size + (input_size / 255) + 16
 }
 
 struct UploadState {
     header: Header,
     footer: Footer,
-    max_output_size: usize,
-    input_max_size: usize,
+    max_output_size: u64,
+    input_max_size: u64,
 }
 
 impl UploadState {
-    pub fn new(store: &CompressionStore, upload_size: UploadSizeInfo) -> Self {
+    pub fn new(store: &CompressionStore, upload_size: UploadSizeInfo) -> Result<Self, Error> {
         let input_max_size = match upload_size {
             UploadSizeInfo::ExactSize(sz) => sz,
             UploadSizeInfo::MaxSize(sz) => sz,
         };
 
-        let max_index_count = (input_max_size / store.config.block_size as usize) + 1;
+        let max_index_count = (input_max_size / store.config.block_size as u64) + 1;
 
         let header = Header {
             version: CURRENT_STREAM_FORMAT_VERSION,
@@ -177,7 +177,8 @@ impl UploadState {
                 SliceIndex {
                     ..Default::default()
                 };
-                max_index_count
+                usize::try_from(max_index_count)
+                    .err_tip(|| "Could not convert max_index_count to usize")?
             ],
             index_count: max_index_count as u32,
             uncompressed_data_size: 0, // Updated later.
@@ -186,22 +187,22 @@ impl UploadState {
         };
 
         // This is more accurate of an estimate than what get_maximum_output_size calculates.
-        let max_block_size = lz4_compress_bound(store.config.block_size as usize) + U32_SZ + 1;
+        let max_block_size = lz4_compress_bound(store.config.block_size as u64) + U32_SZ + 1;
 
         let max_output_size = {
-            let header_size = store.bincode_options.serialized_size(&header).unwrap() as usize;
+            let header_size = store.bincode_options.serialized_size(&header).unwrap();
             let max_content_size = max_block_size * max_index_count;
             let max_footer_size =
-                U32_SZ + 1 + store.bincode_options.serialized_size(&footer).unwrap() as usize;
+                U32_SZ + 1 + store.bincode_options.serialized_size(&footer).unwrap();
             header_size + max_content_size + max_footer_size
         };
 
-        Self {
+        Ok(Self {
             header,
             footer,
             max_output_size,
             input_max_size,
-        }
+        })
     }
 }
 
@@ -246,7 +247,7 @@ impl StoreDriver for CompressionStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.inner_store.has_with_results(digests, results).await
     }
@@ -257,7 +258,7 @@ impl StoreDriver for CompressionStore {
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error> {
-        let mut output_state = UploadState::new(&self, upload_size);
+        let mut output_state = UploadState::new(&self, upload_size)?;
 
         let (mut tx, rx) = make_buf_channel_pair();
 
@@ -307,7 +308,8 @@ impl StoreDriver for CompressionStore {
                     break; // EOF.
                 }
 
-                received_amt += chunk.len();
+                received_amt += u64::try_from(chunk.len())
+                    .err_tip(|| "Could not convert chunk.len() to u64")?;
                 error_if!(
                     received_amt > output_state.input_max_size,
                     "Got more data than stated in compression store upload request"
@@ -360,7 +362,7 @@ impl StoreDriver for CompressionStore {
                 },
             );
             output_state.footer.index_count = output_state.footer.indexes.len() as u32;
-            output_state.footer.uncompressed_data_size = received_amt as u64;
+            output_state.footer.uncompressed_data_size = received_amt;
             {
                 // Write Footer.
                 let serialized_footer = self
@@ -392,8 +394,8 @@ impl StoreDriver for CompressionStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         if is_zero_digest(key.borrow()) {
             writer
@@ -402,7 +404,6 @@ impl StoreDriver for CompressionStore {
             return Ok(());
         }
 
-        let offset = offset as u64;
         let (tx, mut rx) = make_buf_channel_pair();
 
         let inner_store = self.inner_store.clone();
@@ -474,7 +475,7 @@ impl StoreDriver for CompressionStore {
             let mut frame_sz = chunk.get_u32_le();
 
             let mut uncompressed_data_sz: u64 = 0;
-            let mut remaining_bytes_to_send: u64 = length.unwrap_or(usize::MAX) as u64;
+            let mut remaining_bytes_to_send: u64 = length.unwrap_or(u64::MAX);
             let mut chunks_count: u32 = 0;
             while frame_type != FOOTER_FRAME_TYPE {
                 error_if!(

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -34,9 +34,9 @@ use tracing::{event, Level};
 
 // NOTE: If these change update the comments in `stores.rs` to reflect
 // the new defaults.
-const DEFAULT_MIN_SIZE: usize = 64 * 1024;
-const DEFAULT_NORM_SIZE: usize = 256 * 1024;
-const DEFAULT_MAX_SIZE: usize = 512 * 1024;
+const DEFAULT_MIN_SIZE: u64 = 64 * 1024;
+const DEFAULT_NORM_SIZE: u64 = 256 * 1024;
+const DEFAULT_MAX_SIZE: u64 = 512 * 1024;
 const DEFAULT_MAX_CONCURRENT_FETCH_PER_GET: usize = 10;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
@@ -61,37 +61,42 @@ impl DedupStore {
         config: &nativelink_config::stores::DedupStore,
         index_store: Store,
         content_store: Store,
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>, Error> {
         let min_size = if config.min_size == 0 {
             DEFAULT_MIN_SIZE
         } else {
-            config.min_size as usize
+            config.min_size as u64
         };
         let normal_size = if config.normal_size == 0 {
             DEFAULT_NORM_SIZE
         } else {
-            config.normal_size as usize
+            config.normal_size as u64
         };
         let max_size = if config.max_size == 0 {
             DEFAULT_MAX_SIZE
         } else {
-            config.max_size as usize
+            config.max_size as u64
         };
         let max_concurrent_fetch_per_get = if config.max_concurrent_fetch_per_get == 0 {
             DEFAULT_MAX_CONCURRENT_FETCH_PER_GET
         } else {
             config.max_concurrent_fetch_per_get as usize
         };
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             index_store,
             content_store,
-            fast_cdc_decoder: FastCDC::new(min_size, normal_size, max_size),
+            fast_cdc_decoder: FastCDC::new(
+                usize::try_from(min_size).err_tip(|| "Could not convert min_size to usize")?,
+                usize::try_from(normal_size)
+                    .err_tip(|| "Could not convert normal_size to usize")?,
+                usize::try_from(max_size).err_tip(|| "Could not convert max_size to usize")?,
+            ),
             max_concurrent_fetch_per_get,
             bincode_options: DefaultOptions::new().with_fixint_encoding(),
-        })
+        }))
     }
 
-    async fn has(self: Pin<&Self>, key: StoreKey<'_>) -> Result<Option<usize>, Error> {
+    async fn has(self: Pin<&Self>, key: StoreKey<'_>) -> Result<Option<u64>, Error> {
         // First we need to load the index that contains where the individual parts actually
         // can be fetched from.
         let index_entries = {
@@ -148,7 +153,7 @@ impl StoreDriver for DedupStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         digests
             .iter()
@@ -225,8 +230,8 @@ impl StoreDriver for DedupStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         // Special case for if a client tries to read zero bytes.
         if length == Some(0) {
@@ -255,7 +260,7 @@ impl StoreDriver for DedupStore {
                 })?
         };
 
-        let mut start_byte_in_stream: usize = 0;
+        let mut start_byte_in_stream: u64 = 0;
         let entries = {
             if offset == 0 && length.is_none() {
                 index_entries.entries
@@ -264,8 +269,7 @@ impl StoreDriver for DedupStore {
                 let mut entries = Vec::with_capacity(index_entries.entries.len());
                 for entry in index_entries.entries {
                     let first_byte = current_entries_sum;
-                    let entry_size = usize::try_from(entry.size_bytes())
-                        .err_tip(|| "Failed to convert to usize in DedupStore")?;
+                    let entry_size = entry.size_bytes();
                     current_entries_sum += entry_size;
                     // Filter any items who's end byte is before the first requested byte.
                     if current_entries_sum <= offset {
@@ -308,8 +312,10 @@ impl StoreDriver for DedupStore {
         // In the event any of these error, we will abort early and abandon all the rest of the
         // streamed data.
         // Note: Need to take special care to ensure we send the proper slice of data requested.
-        let mut bytes_to_skip = offset - start_byte_in_stream;
-        let mut bytes_to_send = length.unwrap_or(usize::MAX - offset);
+        let mut bytes_to_skip = usize::try_from(offset - start_byte_in_stream)
+            .err_tip(|| "Could not convert (offset - start_byte_in_stream) to usize")?;
+        let mut bytes_to_send = usize::try_from(length.unwrap_or(u64::MAX - offset))
+            .err_tip(|| "Could not convert length to usize")?;
         while let Some(result) = entries_stream.next().await {
             let mut data = result.err_tip(|| "Inner store iterator closed early in DedupStore")?;
             assert!(

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -66,7 +66,7 @@ pub fn store_factory<'a>(
                 config,
                 store_factory(&config.index_store, store_manager, None).await?,
                 store_factory(&config.content_store, store_manager, None).await?,
-            ),
+            )?,
             StoreConfig::existence_cache(config) => ExistenceCacheStore::new(
                 config,
                 store_factory(&config.backend, store_manager, None).await?,

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -29,11 +29,11 @@ use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo};
 
 #[derive(Clone, Debug)]
-struct ExistanceItem(usize);
+struct ExistanceItem(u64);
 
 impl LenEntry for ExistanceItem {
     #[inline]
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         self.0
     }
 
@@ -85,7 +85,7 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
     async fn inner_has_with_results(
         self: Pin<&Self>,
         keys: &[DigestInfo],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.existence_cache
             .sizes_for_keys(keys, results, true /* peek */)
@@ -151,7 +151,7 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         // TODO(allada) This is a bit of a hack to get around the lifetime issues with the
         // existence_cache. We need to convert the digests to owned values to be able to
@@ -200,8 +200,8 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         let digest = key.into_digest();
         let result = self
@@ -209,11 +209,9 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
             .get_part(digest, writer, offset, length)
             .await;
         if result.is_ok() {
-            let size = usize::try_from(digest.size_bytes())
-                .err_tip(|| "Could not convert size_bytes in ExistenceCacheStore::get_part")?;
             let _ = self
                 .existence_cache
-                .insert(digest, ExistanceItem(size))
+                .insert(digest, ExistanceItem(digest.size_bytes()))
                 .await;
         }
         result

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -312,8 +312,8 @@ fn make_temp_digest(digest: &mut DigestInfo) {
 
 impl LenEntry for FileEntryImpl {
     #[inline]
-    fn len(&self) -> usize {
-        self.size_on_disk() as usize
+    fn len(&self) -> u64 {
+        self.size_on_disk()
     }
 
     fn is_empty(&self) -> bool {
@@ -729,7 +729,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         // TODO(allada) This is a bit of a hack to get around the lifetime issues with the
         // existence_cache. We need to convert the digests to owned values to be able to
@@ -799,7 +799,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         let digest = key.into_digest();
         let path = file.get_path().as_os_str().to_os_string();
         let file_size = match upload_size {
-            UploadSizeInfo::ExactSize(size) => size as u64,
+            UploadSizeInfo::ExactSize(size) => size,
             UploadSizeInfo::MaxSize(_) => file
                 .as_reader()
                 .await
@@ -835,8 +835,8 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         let digest = key.into_digest();
         if is_zero_digest(digest) {
@@ -853,8 +853,8 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
             self.evicting_map.get(&digest).await.ok_or_else(|| {
                 make_err!(Code::NotFound, "{digest} not found in filesystem store")
             })?;
-        let read_limit = length.unwrap_or(usize::MAX) as u64;
-        let mut resumeable_temp_file = entry.read_file_part(offset as u64, read_limit).await?;
+        let read_limit = length.unwrap_or(u64::MAX);
+        let mut resumeable_temp_file = entry.read_file_part(offset, read_limit).await?;
 
         loop {
             let mut buf = BytesMut::with_capacity(self.read_buffer_size);

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -48,7 +48,7 @@ impl StoreDriver for NoopStore {
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         results.iter_mut().for_each(|r| *r = None);
         Ok(())
@@ -75,8 +75,8 @@ impl StoreDriver for NoopStore {
         self: Pin<&Self>,
         _key: StoreKey<'_>,
         _writer: &mut DropCloserWriteHalf,
-        _offset: usize,
-        _length: Option<usize>,
+        _offset: u64,
+        _length: Option<u64>,
     ) -> Result<(), Error> {
         Err(make_err!(Code::NotFound, "Not found in noop store"))
     }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -199,7 +199,7 @@ impl StoreDriver for RedisStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         // TODO(caass): Optimize for the case where `keys.len() == 1`
         let pipeline = self.client_pool.next().pipeline();
@@ -397,9 +397,14 @@ impl StoreDriver for RedisStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
+        let offset = usize::try_from(offset).err_tip(|| "Could not convert offset to usize")?;
+        let length = length
+            .map(|v| usize::try_from(v).err_tip(|| "Could not convert length to usize"))
+            .transpose()?;
+
         // To follow RBE spec we need to consider any digest's with
         // zero size to be existing.
         if is_zero_digest(key.borrow()) {

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -105,7 +105,7 @@ impl StoreDriver for RefStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.get_store()?.has_with_results(keys, results).await
     }
@@ -123,8 +123,8 @@ impl StoreDriver for RefStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         self.get_store()?
             .get_part(key, writer, offset, length)

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -144,7 +144,7 @@ impl StoreDriver for ShardStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         if keys.len() == 1 {
             // Hot path: It is very common to lookup only one key.
@@ -212,8 +212,8 @@ impl StoreDriver for ShardStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         let store = self.get_store(&key);
         store

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -52,7 +52,7 @@ impl StoreDriver for SizePartitioningStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         let mut non_digest_sample = None;
         let (lower_digests, upper_digests): (Vec<_>, Vec<_>) =
@@ -120,8 +120,8 @@ impl StoreDriver for SizePartitioningStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         let digest = match key {
             StoreKey::Digest(digest) => digest,

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -148,7 +148,7 @@ impl StoreDriver for VerifyStore {
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],
-        results: &mut [Option<usize>],
+        results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.inner_store.has_with_results(digests, results).await
     }
@@ -169,7 +169,7 @@ impl StoreDriver for VerifyStore {
         };
         let digest_size = digest.size_bytes();
         if let UploadSizeInfo::ExactSize(expected_size) = size_info {
-            if self.verify_size && expected_size as u64 != digest_size {
+            if self.verify_size && expected_size != digest_size {
                 self.size_verification_failures.inc();
                 return Err(make_input_err!(
                     "Expected size to match. Got {} but digest says {} on update",
@@ -215,8 +215,8 @@ impl StoreDriver for VerifyStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         writer: &mut DropCloserWriteHalf,
-        offset: usize,
-        length: Option<usize>,
+        offset: u64,
+        length: Option<u64>,
     ) -> Result<(), Error> {
         self.inner_store.get_part(key, writer, offset, length).await
     }

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -66,7 +66,7 @@ async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
             .update_with_whole_file(
                 digest,
                 resumeable_file,
-                UploadSizeInfo::ExactSize(expected_data.len()),
+                UploadSizeInfo::ExactSize(expected_data.len() as u64),
             )
             .await?;
     }

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -142,7 +142,7 @@ async fn partial_reads_test() -> Result<(), Error> {
     for read_slice_size in 0..(RAW_DATA.len() + 5) {
         for offset in 0..(RAW_DATA.len() + 5) {
             let store_data = store
-                .get_part_unchunked(digest, offset, Some(read_slice_size))
+                .get_part_unchunked(digest, offset as u64, Some(read_slice_size as u64))
                 .await
                 .err_tip(|| {
                     format!("Failed to get from inner store at {offset} - {read_slice_size}")
@@ -255,7 +255,7 @@ async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
 #[nativelink_test]
 async fn check_header_test() -> Result<(), Error> {
     const BLOCK_SIZE: u32 = 150;
-    const MAX_SIZE_INPUT: usize = 1024 * 1024; // 1MB.
+    const MAX_SIZE_INPUT: u64 = 1024 * 1024; // 1MB.
     let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
     let store_owned = CompressionStore::new(
         nativelink_config::stores::CompressionStore {

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -58,7 +58,7 @@ async fn simple_exist_cache_test() -> Result<(), Error> {
             .has(digest)
             .await
             .err_tip(|| "Failed to check store")?,
-        Some(VALUE.len()),
+        Some(VALUE.len() as u64),
         "Expected digest to exist in store"
     );
 
@@ -145,20 +145,20 @@ async fn ensure_has_requests_eventually_do_let_evictions_happen() -> Result<(), 
         MockInstantWrapped::default(),
     );
 
-    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len())));
+    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len() as u64)));
     MockClock::advance(Duration::from_secs(3));
 
     // Now that our existence cache has been populated, remove
     // it from the inner store.
     inner_store.remove_entry(digest.into()).await;
 
-    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len())));
+    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len() as u64)));
     MockClock::advance(Duration::from_secs(3));
 
-    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len())));
+    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len() as u64)));
     MockClock::advance(Duration::from_secs(3));
 
-    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len())));
+    assert_eq!(store.has(digest).await, Ok(Some(VALUE.len() as u64)));
     MockClock::advance(Duration::from_secs(3));
 
     // It should have been evicted from the existence cache by now.

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -140,7 +140,7 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
 }
 
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> LenEntry for TestFileEntry<Hooks> {
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         self.inner.as_ref().unwrap().len()
     }
 
@@ -272,7 +272,7 @@ async fn valid_results_after_shutdown_test() -> Result<(), Error> {
 
         assert_eq!(
             store.has(digest).await,
-            Ok(Some(VALUE1.len())),
+            Ok(Some(VALUE1.len() as u64)),
             "Expected filesystem store to have hash: {}",
             HASH1
         );
@@ -1355,7 +1355,7 @@ async fn update_with_whole_file_closes_file() -> Result<(), Error> {
     }
 
     store
-        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len() as u64))
         .await?;
     Ok(())
 }
@@ -1423,7 +1423,7 @@ async fn update_with_whole_file_slow_path_when_low_file_descriptors() -> Result<
     }
 
     store
-        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len() as u64))
         .await?;
     Ok(())
 }
@@ -1466,7 +1466,7 @@ async fn update_with_whole_file_uses_same_inode() -> Result<(), Error> {
         .ino();
 
     let result = store
-        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len()))
+        .update_with_whole_file(digest, file, UploadSizeInfo::ExactSize(value.len() as u64))
         .await?;
     assert!(
         result.is_none(),

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -44,15 +44,15 @@ async fn insert_one_item_then_update() -> Result<(), Error> {
     // Insert dummy value into store.
     store
         .update_oneshot(
-            DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+            DigestInfo::try_new(VALID_HASH1, VALUE1.len() as u64)?,
             VALUE1.into(),
         )
         .await?;
     assert_eq!(
         store
-            .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len())?)
+            .has(DigestInfo::try_new(VALID_HASH1, VALUE1.len() as u64)?)
             .await,
-        Ok(Some(VALUE1.len())),
+        Ok(Some(VALUE1.len() as u64)),
         "Expected memory store to have hash: {}",
         VALID_HASH1
     );

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -237,7 +237,7 @@ async fn upload_and_get_data() -> Result<(), Error> {
     );
 
     let result = store
-        .get_part_unchunked(digest, 0, Some(data.len()))
+        .get_part_unchunked(digest, 0, Some(data.len() as u64))
         .await
         .unwrap();
 
@@ -318,7 +318,7 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
     );
 
     let result = store
-        .get_part_unchunked(digest, 0, Some(data.len()))
+        .get_part_unchunked(digest, 0, Some(data.len() as u64))
         .await
         .unwrap();
 
@@ -462,7 +462,7 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
     );
 
     let get_result: Bytes = store
-        .get_part_unchunked(digest, 0, Some(data.clone().len()))
+        .get_part_unchunked(digest, 0, Some(data.clone().len() as u64))
         .await
         .unwrap();
 
@@ -553,7 +553,7 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
     tokio::try_join!(
         async {
             store
-                .update(digest, rx, UploadSizeInfo::ExactSize(data.len()))
+                .update(digest, rx, UploadSizeInfo::ExactSize(data.len() as u64))
                 .await
                 .unwrap();
 
@@ -576,7 +576,7 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
     );
 
     let result = store
-        .get_part_unchunked(digest, 0, Some(data.clone().len()))
+        .get_part_unchunked(digest, 0, Some(data.clone().len() as u64))
         .await
         .unwrap();
 

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -64,7 +64,7 @@ async fn has_test() -> Result<(), Error> {
             .await;
         assert_eq!(
             has_result,
-            Ok(Some(VALUE1.len())),
+            Ok(Some(VALUE1.len() as u64)),
             "Expected ref store to have data in ref store : {}",
             VALID_HASH1
         );

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -221,7 +221,7 @@ async fn simple_update_ac() -> Result<(), Error> {
             .update(
                 DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
                 rx,
-                UploadSizeInfo::ExactSize(CONTENT_LENGTH),
+                UploadSizeInfo::ExactSize(CONTENT_LENGTH as u64),
             )
             .await
     });
@@ -350,8 +350,8 @@ async fn smoke_test_get_part() -> Result<(), Error> {
     store
         .get_part_unchunked(
             DigestInfo::try_new(VALID_HASH1, AC_ENTRY_SIZE)?,
-            OFFSET,
-            Some(LENGTH),
+            OFFSET as u64,
+            Some(LENGTH as u64),
         )
         .await?;
 
@@ -589,7 +589,7 @@ async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
         store.get_part_unchunked(
             DigestInfo::try_new(VALID_HASH1, CAS_ENTRY_SIZE)?,
             0,
-            Some(CAS_ENTRY_SIZE),
+            Some(CAS_ENTRY_SIZE as u64),
         )
     );
     assert_eq!(

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -106,7 +106,7 @@ async fn has_with_one_digest() -> Result<(), Error> {
         .update_oneshot(digest1, original_data.clone().into())
         .await?;
 
-    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
     Ok(())
 }
 
@@ -141,7 +141,7 @@ async fn has_with_many_digests_one_missing() -> Result<(), Error> {
         shard_store
             .has_many(&[digest1.into(), missing_digest.into()])
             .await,
-        Ok(vec![Some(MEGABYTE_SZ), None])
+        Ok(vec![Some(MEGABYTE_SZ as u64), None])
     );
     Ok(())
 }
@@ -165,7 +165,10 @@ async fn has_with_many_digests_both_exist() -> Result<(), Error> {
         shard_store
             .has_many(&[digest1.into(), digest2.into()])
             .await,
-        Ok(vec![Some(original_data1.len()), Some(original_data2.len())])
+        Ok(vec![
+            Some(original_data1.len() as u64),
+            Some(original_data2.len() as u64)
+        ])
     );
     Ok(())
 }
@@ -253,7 +256,7 @@ async fn upload_download_has_check() -> Result<(), Error> {
         shard_store.get_part_unchunked(digest1, 0, None).await,
         Ok(original_data1.into())
     );
-    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
     Ok(())
 }
 
@@ -268,7 +271,7 @@ async fn weights_send_to_proper_store() -> Result<(), Error> {
         .update_oneshot(digest1, original_data1.clone().into())
         .await?;
 
-    assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ)));
+    assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
     assert_eq!(stores[1].has(digest1).await, Ok(None));
     Ok(())
 }

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -84,7 +84,7 @@ async fn has_test() -> Result<(), Error> {
             .await;
         assert_eq!(
             small_has_result,
-            Ok(Some(SMALL_VALUE.len())),
+            Ok(Some(SMALL_VALUE.len() as u64)),
             "Expected size part store to have data in ref store : {}",
             SMALL_HASH
         );
@@ -96,7 +96,7 @@ async fn has_test() -> Result<(), Error> {
             .await;
         assert_eq!(
             small_has_result,
-            Ok(Some(BIG_VALUE.len())),
+            Ok(Some(BIG_VALUE.len() as u64)),
             "Expected size part store to have data in ref store : {}",
             BIG_HASH
         );

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -55,7 +55,7 @@ async fn verify_size_false_passes_on_update() -> Result<(), Error> {
     );
     assert_eq!(
         inner_store.has(digest).await,
-        Ok(Some(VALUE1.len())),
+        Ok(Some(VALUE1.len() as u64)),
         "Expected data to exist in store after update"
     );
     Ok(())
@@ -121,7 +121,7 @@ async fn verify_size_true_suceeds_on_update() -> Result<(), Error> {
     assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
     assert_eq!(
         inner_store.has(digest).await,
-        Ok(Some(VALUE1.len())),
+        Ok(Some(VALUE1.len() as u64)),
         "Expected data to exist in store after update"
     );
     Ok(())
@@ -187,7 +187,7 @@ async fn verify_sha256_hash_true_suceeds_on_update() -> Result<(), Error> {
     assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
     assert_eq!(
         inner_store.has(digest).await,
-        Ok(Some(VALUE.len())),
+        Ok(Some(VALUE.len() as u64)),
         "Expected data to exist in store after update"
     );
     Ok(())
@@ -256,7 +256,7 @@ async fn verify_blake3_hash_true_suceeds_on_update() -> Result<(), Error> {
     assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
     assert_eq!(
         inner_store.has(digest).await,
-        Ok(Some(VALUE.len())),
+        Ok(Some(VALUE.len() as u64)),
         "Expected data to exist in store after update"
     );
     Ok(())
@@ -374,7 +374,7 @@ async fn verify_size_and_hash_suceeds_on_small_data() -> Result<(), Error> {
     assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
     assert_eq!(
         inner_store.has(digest).await,
-        Ok(Some(VALUE.len())),
+        Ok(Some(VALUE.len() as u64)),
         "Expected data to exist in store after update"
     );
     Ok(())

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -266,8 +266,8 @@ impl DropCloserReadHalf {
     /// Sets the maximum size of the recent_data buffer. If the number of bytes
     /// received exceeds this size, the recent_data buffer will be cleared and
     /// no longer populated.
-    pub fn set_max_recent_data_size(&mut self, size: usize) {
-        self.max_recent_data_size = size as u64;
+    pub fn set_max_recent_data_size(&mut self, size: u64) {
+        self.max_recent_data_size = size;
     }
 
     /// Attempts to reset the stream to before any data was received. This will

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -45,7 +45,7 @@ struct EvictionItem<T: LenEntry + Debug> {
 
 pub trait LenEntry: 'static {
     /// Length of referenced data.
-    fn len(&self) -> usize;
+    fn len(&self) -> u64;
 
     /// Returns `true` if `self` has zero length.
     fn is_empty(&self) -> bool;
@@ -77,7 +77,7 @@ pub trait LenEntry: 'static {
 
 impl<T: LenEntry + Send + Sync> LenEntry for Arc<T> {
     #[inline]
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         T::len(self.as_ref())
     }
 
@@ -126,13 +126,13 @@ impl<K: Ord + Hash + Eq + Clone + Debug, T: LenEntry + Debug + Sync> State<K, T>
         if let Some(btree) = &mut self.btree {
             btree.remove(key.borrow());
         }
-        self.sum_store_size -= eviction_item.data.len() as u64;
+        self.sum_store_size -= eviction_item.data.len();
         if replaced {
             self.replaced_items.inc();
-            self.replaced_bytes.add(eviction_item.data.len() as u64);
+            self.replaced_bytes.add(eviction_item.data.len());
         } else {
             self.evicted_items.inc();
-            self.evicted_bytes.add(eviction_item.data.len() as u64);
+            self.evicted_bytes.add(eviction_item.data.len());
         }
         // Note: See comment in `unref()` requring global lock of insert/remove.
         eviction_item.data.unref().await;
@@ -210,7 +210,7 @@ where
     /// and return the number of items that were processed.
     /// The `handler` function should return `true` to continue processing the next item
     /// or `false` to stop processing.
-    pub async fn range<F, Q>(&self, prefix_range: impl RangeBounds<Q>, mut handler: F) -> usize
+    pub async fn range<F, Q>(&self, prefix_range: impl RangeBounds<Q>, mut handler: F) -> u64
     where
         F: FnMut(&K, &T) -> bool,
         K: Borrow<Q> + Ord,
@@ -300,7 +300,7 @@ where
     }
 
     /// Return the size of a `key`, if not found `None` is returned.
-    pub async fn size_for_key<Q>(&self, key: &Q) -> Option<usize>
+    pub async fn size_for_key<Q>(&self, key: &Q) -> Option<u64>
     where
         K: Borrow<Q>,
         Q: Ord + Hash + Eq + Debug,
@@ -316,12 +316,8 @@ where
     /// If no key is found in the internal map, `None` is filled in its place.
     /// If `peek` is set to `true`, the items are not promoted to the front of the
     /// LRU cache. Note: peek may still evict, but won't promote.
-    pub async fn sizes_for_keys<It, Q, R>(
-        &self,
-        keys: It,
-        results: &mut [Option<usize>],
-        peek: bool,
-    ) where
+    pub async fn sizes_for_keys<It, Q, R>(&self, keys: It, results: &mut [Option<u64>], peek: bool)
+    where
         It: IntoIterator<Item = R>,
         // This may look strange, but what we are doing is saying:
         // * `K` must be able to borrow `Q`
@@ -428,7 +424,7 @@ where
     ) -> Vec<T> {
         let mut replaced_items = Vec::new();
         for (key, data) in inserts.into_iter() {
-            let new_item_size = data.len() as u64;
+            let new_item_size = data.len();
             let eviction_item = EvictionItem {
                 seconds_since_anchor,
                 data,

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -31,8 +31,8 @@ pub struct BytesWrapper(Bytes);
 
 impl LenEntry for BytesWrapper {
     #[inline]
-    fn len(&self) -> usize {
-        Bytes::len(&self.0)
+    fn len(&self) -> u64 {
+        Bytes::len(&self.0) as u64
     }
 
     #[inline]
@@ -152,14 +152,14 @@ async fn insert_purges_at_max_bytes() -> Result<(), Error> {
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 3"
     );
     assert_eq!(
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 4"
     );
 
@@ -216,7 +216,7 @@ async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 4"
     );
 
@@ -263,21 +263,21 @@ async fn insert_purges_at_max_seconds() -> Result<(), Error> {
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH2, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 2"
     );
     assert_eq!(
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 3"
     );
     assert_eq!(
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH4, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 4"
     );
 
@@ -329,7 +329,7 @@ async fn get_refreshes_time() -> Result<(), Error> {
         evicting_map
             .size_for_key(&DigestInfo::try_new(HASH3, 0)?)
             .await,
-        Some(DATA.len()),
+        Some(DATA.len() as u64),
         "Expected map to have item 3"
     );
 
@@ -345,7 +345,7 @@ async fn unref_called_on_replace() -> Result<(), Error> {
     }
 
     impl LenEntry for MockEntry {
-        fn len(&self) -> usize {
+        fn len(&self) -> u64 {
             // Note: We are not testing this functionality.
             0
         }

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -287,7 +287,7 @@ async fn upload_file(
         .update_with_whole_file(
             digest.into(),
             resumeable_file,
-            UploadSizeInfo::ExactSize(digest.size_bytes() as usize),
+            UploadSizeInfo::ExactSize(digest.size_bytes()),
         )
         .await
         .err_tip(|| format!("for {full_path:?}"))?;


### PR DESCRIPTION
# Description

APIs in `StoreLike` now uses `u64` instead of `usize` It's because `u64` expresses the size of the data, but `usize` expresses local memory limits.

It includes bunch of files changed.

Fixes #1328 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1344)
<!-- Reviewable:end -->
