### PR TITLE
[Change] BEP Redis key format

### DIFF
--- a/nativelink-service/src/bep_server.rs
+++ b/nativelink-service/src/bep_server.rs
@@ -75,7 +75,7 @@ impl BepServer {
         self.store
             .update_oneshot(
                 StoreKey::Str(Cow::Owned(format!(
-                    "LifecycleEvent-{}-{}-{}",
+                    "LifecycleEvent:{}:{}:{}",
                     &stream_id.build_id, &stream_id.invocation_id, sequence_number,
                 ))),
                 buf.freeze(),
@@ -114,7 +114,7 @@ impl BepServer {
             store
                 .update_oneshot(
                     StoreKey::Str(Cow::Owned(format!(
-                        "BuildToolEventStream-{}-{}-{}",
+                        "BuildToolEventStream:{}:{}:{}",
                         &stream_id.build_id, &stream_id.invocation_id, sequence_number,
                     ))),
                     buf.freeze(),

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -117,7 +117,7 @@ async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>
     let sequence_number = request.clone().build_event.unwrap().sequence_number;
 
     let store_key = StoreKey::Str(Cow::Owned(format!(
-        "LifecycleEvent-{}-{}-{}",
+        "LifecycleEvent:{}:{}:{}",
         stream_id.clone().build_id,
         stream_id.clone().invocation_id,
         sequence_number
@@ -280,7 +280,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error
                 .iter()
                 .map(|request| {
                     StoreKey::Str(Cow::Owned(format!(
-                        "BuildToolEventStream-{}-{}-{}",
+                        "BuildToolEventStream:{}:{}:{}",
                         stream_id.build_id,
                         stream_id.invocation_id,
                         request


### PR DESCRIPTION
":" is the preferred way since Redis Insight from Redis itself shows your keys inside directories with ":"

This might break existing client setups which rely on the bep events.

## Type of change

 - [x]  Breaking change (fix or feature that would cause existing functionality to
not work as expected)
 - [x]  This change requires a documentation update

## How Has This Been Tested?

Used bazel with the bep_backend to inspect the delivered bep keys in redis.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1345)
<!-- Reviewable:end -->
