### PR TITLE
Remove duplicated deno deploy env variables

### DIFF
--- a/web/platform/deno.lock
+++ b/web/platform/deno.lock
@@ -2580,6 +2580,9 @@
     "https://deno.land/x/smtp@v0.7.0/smtp.ts": "47c72a99925ad07f3174037f9325dbb8b703dc1177277b9161dc6209c7fa4f90"
   },
   "workspace": {
+    "dependencies": [
+      "jsr:@deno/deployctl@^1.12.0"
+    ],
     "packageJson": {
       "dependencies": [
         "npm:@astrojs/check@^0.9.3",

--- a/web/platform/package.json
+++ b/web/platform/package.json
@@ -21,8 +21,8 @@
     "lint": "biome check --write --unsafe .",
     "preview": "bun run build && bun serve",
     "setup": "bun install && bun run deno install -Arf jsr:@deno/deployctl@1.12.0",
-    "staging": "bun setup && bun run docs && bun run build && bun run deploy --project=nativelink --org=nativelink",
-    "prod": "bun setup && bun run docs && bun run build && bun run deploy --project=nativelink --org=nativelink --prod",
+    "staging": "bun setup && bun run docs && bun run build && bun run deploy",
+    "prod": "bun setup && bun run docs && bun run build && bun run deploy --prod",
     "serve": "deno run -A --allow-net --allow-read --allow-env ./dist/server/entry.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

The deno deploy variables --org and --project are already set in the web workflow

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1362)
<!-- Reviewable:end -->
