### PR TITLE
Allow nativelink flake module to upload results

### DIFF
--- a/modules/nativelink.nix
+++ b/modules/nativelink.nix
@@ -20,7 +20,6 @@
     "--remote_instance_name=main"
     "--remote_header=x-nativelink-project=nativelink-ci"
     "--nogenerate_json_trace_profile"
-    "--remote_upload_local_results=false"
     "--experimental_remote_cache_async"
   ];
 

--- a/web/platform/src/content/docs/docs/nativelink-cloud/nix.mdx
+++ b/web/platform/src/content/docs/docs/nativelink-cloud/nix.mdx
@@ -12,7 +12,7 @@ artifacts from your CI builds.
 Cache sharing between CI and local development environments requires perfect
 reproducibility between the two.
 
-Consider using [Local Remote Execution](./explanations/lre) to create
+Consider using [Local Remote Execution](/docs/explanations/lre) to create
 environments that are reproducible across distributions.
 
 Containerized environments that are the same for local development and CI might
@@ -95,7 +95,6 @@ build --remote_header=x-nativelink-api-key=065f02f53f26a12331d5cfd00a778fb243bfb
 build --remote_instance_name=main
 build --remote_header=x-nativelink-project=nativelink-ci
 build --nogenerate_json_trace_profile
-build --remote_upload_local_results=false
 build --experimental_remote_cache_async
 ```
 
@@ -117,6 +116,5 @@ build:nativelink --remote_cache=grpcs://my-custom-endpoints.com
 build:nativelink --remote_header=x-nativelink-api-key=my-custom-readonly-api-key
 build:nativelink --remote_header=x-nativelink-project=nativelink-ci
 build:nativelink --nogenerate_json_trace_profile
-build:nativelink --remote_upload_local_results=false
 build:nativelink --experimental_remote_cache_async
 ```


### PR DESCRIPTION
After verifying that the LRE workflows behave as intended it's safe to enable this by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1369)
<!-- Reviewable:end -->
