### PR TITLE
Revert "Allow nativelink flake module to upload results (#1369)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
             --bes_backend=grpcs://bes-tracemachina-shared.build-faster.nativelink.net \
             --bes_header=x-nativelink-api-key=$NL_COM_API_KEY \
             --bes_results_url=https://app.nativelink.com/a/e3b1e0e0-4b73-45d6-85bc-5cb7b02edea5/build \
-            ${{ github.ref == 'refs/heads/main' && ' ' || '--nogenerate_json_trace_profile --remote_upload_local_results=false' }} \
+            ${{ github.ref == 'refs/heads/main' && '--remote_upload_local_results=true' || '--nogenerate_json_trace_profile --remote_upload_local_results=false' }} \
             //..."
 
   docker-compose-compiles-nativelink:

--- a/modules/nativelink.nix
+++ b/modules/nativelink.nix
@@ -20,6 +20,7 @@
     "--remote_instance_name=main"
     "--remote_header=x-nativelink-project=nativelink-ci"
     "--nogenerate_json_trace_profile"
+    "--remote_upload_local_results=false"
     "--experimental_remote_cache_async"
   ];
 

--- a/web/platform/src/content/docs/docs/nativelink-cloud/nix.mdx
+++ b/web/platform/src/content/docs/docs/nativelink-cloud/nix.mdx
@@ -95,6 +95,7 @@ build --remote_header=x-nativelink-api-key=065f02f53f26a12331d5cfd00a778fb243bfb
 build --remote_instance_name=main
 build --remote_header=x-nativelink-project=nativelink-ci
 build --nogenerate_json_trace_profile
+build --remote_upload_local_results=false
 build --experimental_remote_cache_async
 ```
 
@@ -116,5 +117,6 @@ build:nativelink --remote_cache=grpcs://my-custom-endpoints.com
 build:nativelink --remote_header=x-nativelink-api-key=my-custom-readonly-api-key
 build:nativelink --remote_header=x-nativelink-project=nativelink-ci
 build:nativelink --nogenerate_json_trace_profile
+build:nativelink --remote_upload_local_results=false
 build:nativelink --experimental_remote_cache_async
 ```


### PR DESCRIPTION
This reverts commit 9600839bd2ba0a6915908c55fca24f373c3a2106.

The original idea was to implement a `readonly` setting to dynamically configure `--remote_upload_local_results`. While this is fairly straightforward to implement it turned out that the UX implications around the environment variables/scripts/files to configure this are nontrivial and we need to evaluate the different approaches in more depth first.

For now, revert to readonly by default and also add a small modifier to the relevant workflow so that the write-access workflow retains the ability to write artifacts on pushes to main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1372)
<!-- Reviewable:end -->
