### PR TITLE
Redirect indexed broken link

### DIFF
--- a/web/platform/astro.config.ts
+++ b/web/platform/astro.config.ts
@@ -26,6 +26,12 @@ export default defineConfig({
     port: 8881,
     hostname: "localhost",
   }),
+  redirects: {
+    "/blog/case-study%3A-samsung-internet's-integration-with-nativelink": {
+      status: 301,
+      destination: "/resources/blog/case-study-samsung",
+    },
+  },
   integrations: [
     qwik({
       include: ["**/components/qwik/**/*"],


### PR DESCRIPTION
# Description

Add a 301 redirect for the indexed  "/blog/case-study%3A-samsung-internet's-integration-with-nativelink"
to "/resources/blog/case-study-samsung"


## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1378)
<!-- Reviewable:end -->
