### PR TITLE
Fix `docs.nativelink.com` based URL not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ NativeLink seamlessly integrates with build tools that use the Remote Execution 
 
 To start, you can deploy NativeLink as a Docker image (as shown below) or by using our cloud-hosted solution, [NativeLink Cloud](https://app.nativelink.com). It's **FREE** for individuals, open-source projects, and cloud production environments, with support for unlimited team members.
 
-The setups below are **production-grade** installations. See the [contribution docs](https://docs.nativelink.com/contribute/nix/) for instructions on how to build from source with [Bazel](https://docs.nativelink.com/contribute/bazel/), [Cargo](https://docs.nativelink.com/contribute/cargo/), and [Nix](https://docs.nativelink.com/contribute/nix/).
+The setups below are **production-grade** installations. See the [contribution docs](https://nativelink.com/docs/contribute/nix/) for instructions on how to build from source with [Bazel](https://nativelink.com/docs/contribute/bazel/), [Cargo](https://nativelink.com/docs/contribute/cargo/), and [Nix](https://nativelink.com/docs/contribute/nix/).
 
 
 ### 📦 Prebuilt images
 
 Fast to spin up, but currently limited to `x86_64` systems. See the [container
 registry](https://github.com/TraceMachina/nativelink/pkgs/container/nativelink)
-for all image tags and the [contribution docs](https://docs.nativelink.com/contribute/nix)
+for all image tags and the [contribution docs](https://nativelink.com/docs/contribute/nix)
 for how to build the images yourself.
 
 **Linux x86_64**
@@ -120,7 +120,7 @@ curl -O \
 nix run github:TraceMachina/nativelink ./basic_cas.json
 ```
 
-See the [contribution docs](https://docs.nativelink.com/contribute/nix) for further information.
+See the [contribution docs](https://nativelink.com/docs/contribute/nix) for further information.
 
 ## ✍️ Contributors
 

--- a/web/platform/README.md
+++ b/web/platform/README.md
@@ -20,7 +20,7 @@ challenging. Feel free to copy-paste it into your own projects.
 
 ## 🚀 Common workflows
 
-See [`docs/package.json`](https://github.com/TraceMachina/nativelink/blob/main/docs/package.json)
+See [`web/platform/package.json`](https://github.com/TraceMachina/nativelink/blob/main/web/platform/package.json)
 for build scripts.
 
 This project requires `bun` and `deno`. The nix flake ships compatible versions.

--- a/web/platform/src/content/docs/docs/faq/lre.mdx
+++ b/web/platform/src/content/docs/docs/faq/lre.mdx
@@ -11,4 +11,4 @@ custom toolchain configurations. This system aims to be transparent, fully
 hermetic, and reproducible across machines with the same system architecture.
 
 For more detailed information about Local Remote Execution (LRE), please
-visit our [LRE Documentation](https://docs.nativelink.com/explanations/lre/).
+visit our [LRE Documentation](https://nativelink.com/docs/explanations/lre/).

--- a/web/platform/src/content/docs/docs/faq/remote-execution.mdx
+++ b/web/platform/src/content/docs/docs/faq/remote-execution.mdx
@@ -19,7 +19,7 @@ a development team are working in the same environment, reducing the
  reducing redundant work and further speeding up the development process.
 
 For more information on how to get started with remote execution in NativeLink,
-please refer to our [NativeLink On-Prem Guide](https://docs.nativelink.com/introduction/on-prem).
+please refer to our [NativeLink On-Prem Guide](https://nativelink.com/docs/introduction/on-prem).
 
 For more detailed information about remote execution, you can visit the below links:
 [Bazel Remote Execution Documentation](https://bazel.build/remote/rbe).

--- a/web/platform/src/content/docs/docs/introduction/contributors.mdx
+++ b/web/platform/src/content/docs/docs/introduction/contributors.mdx
@@ -6,7 +6,7 @@ pagefind: true
 Open source is at the heart of NativeLink.
 We're always immensely grateful for the contributions from our community!
 
-For more details on how to contribute, please refer to our [Contribution Guide](https://docs.nativelink.com/contribute/guidelines).
+For more details on how to contribute, please refer to our [Contribution Guide](https://nativelink.com/docs/contribute/guidelines).
 
 ## Have additional questions?
 


### PR DESCRIPTION
# Description

URLs starting `docs.nativelink.com` is redirected to introduction URL always. Found all occurrences of `docs.nativelink.com` and replaced that with `nativelink.com/docs`.

More details can be found in the link below.

Fixes #1385 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1386)
<!-- Reviewable:end -->
