### PR TITLE
Add graceful shutdown to worker instances

### DIFF
--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -28,7 +28,7 @@ use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    execute_result, ExecuteResult, KeepAliveRequest, UpdateForWorker,
+    execute_result, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
 };
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_util::action_messages::{ActionResult, ActionStage, OperationId};
@@ -39,7 +39,7 @@ use nativelink_util::origin_context::ActiveOriginContext;
 use nativelink_util::store_trait::Store;
 use nativelink_util::{spawn, tls_utils};
 use tokio::process;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::Streaming;
@@ -168,6 +168,7 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
     async fn run(
         &mut self,
         update_for_worker_stream: Streaming<UpdateForWorker>,
+        shutdown_rx: &mut broadcast::Receiver<Arc<oneshot::Sender<()>>>,
     ) -> Result<(), Error> {
         // This big block of logic is designed to help simplify upstream components. Upstream
         // components can write standard futures that return a `Result<(), Error>` and this block
@@ -349,6 +350,22 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                     futures.push(fut);
                 },
                 res = futures.next() => res.err_tip(|| "Keep-alive should always pending. Likely unable to send data to scheduler")??,
+                complete_msg = shutdown_rx.recv().fuse() => {
+                    event!(Level::WARN, "Worker loop reveiced shutdown signal. Shutting down worker...",);
+                    let mut grpc_client = self.grpc_client.clone();
+                    let worker_id = self.worker_id.clone();
+                    let running_actions_manager = self.running_actions_manager.clone();
+                    let complete_msg_clone = complete_msg.map_err(|e| make_err!(Code::Internal, "Failed to receive shutdown message: {e:?}"))?.clone();
+                    let shutdown_future = async move {
+                        if let Err(e) = grpc_client.going_away(GoingAwayRequest { worker_id }).await {
+                            event!(Level::ERROR, "Failed to send GoingAwayRequest: {e}",);
+                            return Err(e.into());
+                        }
+                        running_actions_manager.complete_actions(complete_msg_clone).await;
+                        Ok::<(), Error>(())
+                    };
+                    futures.push(shutdown_future.boxed());
+                },
             };
         }
         // Unreachable.
@@ -478,7 +495,7 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
     }
 
     async fn register_worker(
-        &mut self,
+        &self,
         client: &mut T,
     ) -> Result<(String, Streaming<UpdateForWorker>), Error> {
         let supported_properties =
@@ -509,7 +526,10 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
     }
 
     #[instrument(skip(self), level = Level::INFO)]
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub async fn run(
+        mut self,
+        mut shutdown_rx: broadcast::Receiver<Arc<oneshot::Sender<()>>>,
+    ) -> Result<(), Error> {
         let sleep_fn = self
             .sleep_fn
             .take()
@@ -555,7 +575,7 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
             );
 
             // Now listen for connections and run all other services.
-            if let Err(err) = inner.run(update_for_worker_stream).await {
+            if let Err(err) = inner.run(update_for_worker_stream, &mut shutdown_rx).await {
                 'no_more_actions: {
                     // Ensure there are no actions in transit before we try to kill
                     // all our actions.

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1349,6 +1349,11 @@ pub trait RunningActionsManager: Sync + Send + Sized + Unpin + 'static {
         hasher: DigestHasherFunc,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 
+    fn complete_actions(
+        &self,
+        complete_msg: Arc<oneshot::Sender<()>>,
+    ) -> impl Future<Output = ()> + Send;
+
     fn kill_all(&self) -> impl Future<Output = ()> + Send;
 
     fn kill_operation(
@@ -1877,6 +1882,17 @@ impl RunningActionsManager for RunningActionsManagerImpl {
         };
         Self::kill_operation(running_action).await;
         Ok(())
+    }
+
+    // Waits for all running actions to complete and signals completion.
+    // Use the Arc<oneshot::Sender<()>> to signal the completion of the actions
+    // Dropping the sender automatically notifies the process to terminate.
+    async fn complete_actions(&self, _complete_msg: Arc<oneshot::Sender<()>>) {
+        let _ = self
+            .action_done_tx
+            .subscribe()
+            .wait_for(|_| self.running_actions.lock().is_empty())
+            .await;
     }
 
     // Note: When the future returns the process should be fully killed and cleaned up.

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future;
 use std::sync::Arc;
 
 use async_lock::Mutex;
+use futures::Future;
 use nativelink_error::{make_input_err, Error};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_util::action_messages::{ActionResult, OperationId};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_worker::running_actions_manager::{Metrics, RunningAction, RunningActionsManager};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 enum RunningActionManagerCalls {
@@ -163,6 +165,13 @@ impl RunningActionsManager for MockRunningActionsManager {
             ))))
             .expect("Could not send request to mpsc");
         Ok(())
+    }
+
+    fn complete_actions(
+        &self,
+        _complete_msg: Arc<oneshot::Sender<()>>,
+    ) -> impl Future<Output = ()> + Send {
+        future::ready(())
     }
 
     async fn kill_operation(&self, operation_id: &OperationId) -> Result<(), Error> {

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_lock::Mutex as AsyncMutex;
 use axum::Router;
 use clap::Parser;
-use futures::future::{select_all, BoxFuture, Either, OptionFuture, TryFutureExt};
+use futures::future::{try_join_all, BoxFuture, Either, OptionFuture, TryFutureExt};
 use hyper::{Response, StatusCode};
 use hyper_util::rt::tokio::TokioIo;
 use hyper_util::server::conn::auto;
@@ -66,8 +66,10 @@ use prometheus::{Encoder, TextEncoder};
 use rustls_pemfile::{certs as extract_certs, crls as extract_crls};
 use scopeguard::guard;
 use tokio::net::TcpListener;
+use tokio::select;
 #[cfg(target_family = "unix")]
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::{broadcast, oneshot};
 use tokio_rustls::rustls::pki_types::{CertificateDer, CertificateRevocationListDer};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig as TlsServerConfig};
@@ -91,6 +93,10 @@ const DEFAULT_HEALTH_STATUS_CHECK_PATH: &str = "/status";
 
 /// Name of environment variable to disable metrics.
 const METRICS_DISABLE_ENV: &str = "NATIVELINK_DISABLE_METRICS";
+
+/// Broadcast Channel Capacity
+/// Note: The actual capacity may be greater than the provided capacity.
+const BROADCAST_CAPACITY: usize = 1;
 
 /// Backend for bazel remote execution / cache API.
 #[derive(Parser, Debug)]
@@ -160,6 +166,7 @@ impl RootMetricsComponent for ConnectedClientsMetrics {}
 async fn inner_main(
     cfg: CasConfig,
     server_start_timestamp: u64,
+    shutdown_tx: broadcast::Sender<Arc<oneshot::Sender<()>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let health_registry_builder =
         Arc::new(AsyncMutex::new(HealthRegistryBuilder::new("nativelink")));
@@ -769,100 +776,104 @@ async fn inner_main(
         if let Some(value) = http_config.experimental_http2_max_header_list_size {
             http.http2().max_header_list_size(value);
         }
-
         event!(Level::WARN, "Ready, listening on {socket_addr}",);
         root_futures.push(Box::pin(async move {
             loop {
-                // Wait for client to connect.
-                let (tcp_stream, remote_addr) = match tcp_listener.accept().await {
-                    Ok(result) => result,
-                    Err(err) => {
-                        event!(Level::ERROR, ?err, "Failed to accept tcp connection");
-                        continue;
-                    }
-                };
-                event!(
-                    target: "nativelink::services",
-                    Level::INFO,
-                    ?remote_addr,
-                    ?socket_addr,
-                    "Client connected"
-                );
-                connected_clients_mux
-                    .inner
-                    .lock()
-                    .insert(SocketAddrWrapper(remote_addr));
-                connected_clients_mux.counter.inc();
+                select! {
+                    accept_result = tcp_listener.accept() => {
+                        match accept_result {
+                            Ok((tcp_stream, remote_addr)) => {
+                                event!(
+                                    target: "nativelink::services",
+                                    Level::INFO,
+                                    ?remote_addr,
+                                    ?socket_addr,
+                                    "Client connected"
+                                );
+                                connected_clients_mux
+                                    .inner
+                                    .lock()
+                                    .insert(SocketAddrWrapper(remote_addr));
+                                connected_clients_mux.counter.inc();
 
-                // This is the safest way to guarantee that if our future
-                // is ever dropped we will cleanup our data.
-                let scope_guard = guard(
-                    Arc::downgrade(&connected_clients_mux),
-                    move |weak_connected_clients_mux| {
-                        event!(
-                            target: "nativelink::services",
-                            Level::INFO,
-                            ?remote_addr,
-                            ?socket_addr,
-                            "Client disconnected"
-                        );
-                        if let Some(connected_clients_mux) = weak_connected_clients_mux.upgrade() {
-                            connected_clients_mux
-                                .inner
-                                .lock()
-                                .remove(&SocketAddrWrapper(remote_addr));
-                        }
-                    },
-                );
+                                // This is the safest way to guarantee that if our future
+                                // is ever dropped we will cleanup our data.
+                                let scope_guard = guard(
+                                    Arc::downgrade(&connected_clients_mux),
+                                    move |weak_connected_clients_mux| {
+                                        event!(
+                                            target: "nativelink::services",
+                                            Level::INFO,
+                                            ?remote_addr,
+                                            ?socket_addr,
+                                            "Client disconnected"
+                                        );
+                                        if let Some(connected_clients_mux) = weak_connected_clients_mux.upgrade() {
+                                            connected_clients_mux
+                                                .inner
+                                                .lock()
+                                                .remove(&SocketAddrWrapper(remote_addr));
+                                        }
+                                    },
+                                );
 
-                let (http, svc, maybe_tls_acceptor) =
-                    (http.clone(), svc.clone(), maybe_tls_acceptor.clone());
-                Arc::new(OriginContext::new()).background_spawn(
-                    error_span!(
-                        target: "nativelink::services",
-                        "http_connection",
-                        ?remote_addr,
-                        ?socket_addr
-                    ),
-                    async move {},
-                );
-                background_spawn!(
-                    name: "http_connection",
-                    fut: async move {
-                        // Move it into our spawn, so if our spawn dies the cleanup happens.
-                        let _guard = scope_guard;
-                        let serve_connection = if let Some(tls_acceptor) = maybe_tls_acceptor {
-                            match tls_acceptor.accept(tcp_stream).await {
-                                Ok(tls_stream) => Either::Left(http.serve_connection(
-                                    TokioIo::new(tls_stream),
-                                    TowerToHyperService::new(svc),
-                                )),
-                                Err(err) => {
-                                    event!(Level::ERROR, ?err, "Failed to accept tls stream");
-                                    return;
-                                }
+                                let (http, svc, maybe_tls_acceptor) =
+                                    (http.clone(), svc.clone(), maybe_tls_acceptor.clone());
+                                Arc::new(OriginContext::new()).background_spawn(
+                                    error_span!(
+                                        target: "nativelink::services",
+                                        "http_connection",
+                                        ?remote_addr,
+                                        ?socket_addr
+                                    ),
+                                    async move {},
+                                );
+                                background_spawn!(
+                                    name: "http_connection",
+                                    fut: async move {
+                                        // Move it into our spawn, so if our spawn dies the cleanup happens.
+                                        let _guard = scope_guard;
+                                        let serve_connection = if let Some(tls_acceptor) = maybe_tls_acceptor {
+                                            match tls_acceptor.accept(tcp_stream).await {
+                                                Ok(tls_stream) => Either::Left(http.serve_connection(
+                                                    TokioIo::new(tls_stream),
+                                                    TowerToHyperService::new(svc),
+                                                )),
+                                                Err(err) => {
+                                                    event!(Level::ERROR, ?err, "Failed to accept tls stream");
+                                                    return;
+                                                }
+                                            }
+                                        } else {
+                                            Either::Right(http.serve_connection(
+                                                TokioIo::new(tcp_stream),
+                                                TowerToHyperService::new(svc),
+                                            ))
+                                        };
+
+                                        if let Err(err) = serve_connection.await {
+                                            event!(
+                                                target: "nativelink::services",
+                                                Level::ERROR,
+                                                ?err,
+                                                "Failed running service"
+                                            );
+                                        }
+                                    },
+                                    target: "nativelink::services",
+                                    ?remote_addr,
+                                    ?socket_addr,
+                                );
+                            },
+                            Err(err) => {
+                                event!(Level::ERROR, ?err, "Failed to accept tcp connection");
+                                continue;
                             }
-                        } else {
-                            Either::Right(http.serve_connection(
-                                TokioIo::new(tcp_stream),
-                                TowerToHyperService::new(svc),
-                            ))
-                        };
-
-                        if let Err(err) = serve_connection.await {
-                            event!(
-                                target: "nativelink::services",
-                                Level::ERROR,
-                                ?err,
-                                "Failed running service"
-                            );
                         }
                     },
-                    target: "nativelink::services",
-                    ?remote_addr,
-                    ?socket_addr,
-                );
+                }
             }
+            // Unreachable
         }));
     }
 
@@ -915,11 +926,13 @@ async fn inner_main(
                     )
                     .await
                     .err_tip(|| "Could not make LocalWorker")?;
+
                     let name = if local_worker.name().is_empty() {
                         format!("worker_{i}")
                     } else {
                         local_worker.name().clone()
                     };
+
                     if worker_names.contains(&name) {
                         Err(Box::new(make_err!(
                             Code::InvalidArgument,
@@ -929,8 +942,9 @@ async fn inner_main(
                     }
                     worker_names.insert(name.clone());
                     worker_metrics.insert(name.clone(), metrics);
+                    let shutdown_rx = shutdown_tx.subscribe();
                     let fut = Arc::new(OriginContext::new())
-                        .wrap_async(trace_span!("worker_ctx"), local_worker.run());
+                        .wrap_async(trace_span!("worker_ctx"), local_worker.run(shutdown_rx));
                     spawn!("worker", fut, ?name)
                 }
             };
@@ -939,10 +953,11 @@ async fn inner_main(
         root_metrics.write().workers = worker_metrics;
     }
 
-    if let Err(e) = select_all(root_futures).await.0 {
+    if let Err(e) = try_join_all(root_futures).await {
         panic!("{e:?}");
-    }
-    unreachable!("None of the futures should resolve in main()");
+    };
+
+    Ok(())
 }
 
 async fn get_config() -> Result<CasConfig, Box<dyn std::error::Error>> {
@@ -1021,6 +1036,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enable_all()
             .on_thread_start(move || set_metrics_enabled_for_this_thread(metrics_enabled))
             .build()?;
+
+        // Initiates the shutdown process by broadcasting the shutdown signal via the `oneshot::Sender` to all listeners.
+        // Each listener will perform its cleanup and then drop its `oneshot::Sender`, signaling completion.
+        // Once all `oneshot::Sender` instances are dropped, the worker knows it can safely terminate.
+        let (shutdown_tx, _) = broadcast::channel::<Arc<oneshot::Sender<()>>>(BROADCAST_CAPACITY);
+        let shutdown_tx_clone = shutdown_tx.clone();
+        let (complete_tx, complete_rx) = oneshot::channel::<()>();
+
         runtime.spawn(async move {
             tokio::signal::ctrl_c()
                 .await
@@ -1030,18 +1053,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
         #[cfg(target_family = "unix")]
-        runtime.spawn(async move {
-            signal(SignalKind::terminate())
-                .expect("Failed to listen to SIGTERM")
-                .recv()
-                .await;
-            eprintln!("Process terminated via SIGTERM");
-            std::process::exit(143);
-        });
+        {
+            let complete_tx = Arc::new(complete_tx);
+            runtime.spawn(async move {
+                signal(SignalKind::terminate())
+                    .expect("Failed to listen to SIGTERM")
+                    .recv()
+                    .await;
+                event!(Level::WARN, "Process terminated via SIGTERM",);
+                let _ = shutdown_tx_clone.send(complete_tx);
+                let _ = complete_rx.await;
+                event!(Level::WARN, "Successfully shut down nativelink.",);
+                std::process::exit(143);
+            });
+        }
 
-        runtime.block_on(
-            Arc::new(OriginContext::new())
-                .wrap_async(trace_span!("main"), inner_main(cfg, server_start_time)),
-        )
+        let _ = runtime.block_on(Arc::new(OriginContext::new()).wrap_async(
+            trace_span!("main"),
+            inner_main(cfg, server_start_time, shutdown_tx),
+        ));
     }
+    Ok(())
 }


### PR DESCRIPTION
# Description

This PR implements graceful shutdown for worker instances to ensure that the scheduler is properly notified when workers are shutting down.


## How Has This Been Tested?

`bazel test ...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1394)
<!-- Reviewable:end -->
