### PR TITLE
Fix incorrect spellings of log messages in `FilesystemStore`

### DIFF
--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -325,7 +325,7 @@ impl LenEntry for FileEntryImpl {
         let result = self
             .get_file_path_locked(move |full_content_path| async move {
                 let full_content_path = full_content_path.to_os_string();
-                spawn_blocking!("filesystem_touch_set_mtime", move || {
+                spawn_blocking!("filesystem_touch_set_atime", move || {
                     set_file_atime(&full_content_path, FileTime::now()).err_tip(|| {
                         format!("Failed to touch file in filesystem store {full_content_path:?}")
                     })
@@ -619,7 +619,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
                 // File -> File, it can cause a deadlock if the Write file is not sending
                 // data because it is waiting for a file descriotor to open before sending data.
                 resumeable_temp_file.close_file().await.err_tip(|| {
-                    "Could not close file due to timeout in FileSystemStore::update_file"
+                    "Could not close file due to timeout in FilesystemStore::update_file"
                 })?;
                 continue;
             };
@@ -861,7 +861,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
             resumeable_temp_file
                 .as_reader()
                 .await
-                .err_tip(|| "In FileSystemStore::get_part()")?
+                .err_tip(|| "In FilesystemStore::get_part()")?
                 .read_buf(&mut buf)
                 .await
                 .err_tip(|| "Failed to read data in filesystem store")?;
@@ -883,7 +883,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
                         resumeable_temp_file
                             .close_file()
                             .await
-                            .err_tip(|| "Could not close file due to timeout in FileSystemStore::get_part")?;
+                            .err_tip(|| "Could not close file due to timeout in FilesystemStore::get_part")?;
                         continue;
                     }
                     res = writer.send(buf_content.clone()) => {


### PR DESCRIPTION
# Description

There were two types of incorrect spellings in `FilesystemStore`.

1. Task name for touching file and setting atime property is misspelled as `filesystem_touch_set_mtime`. That should be renamed as `filesystem_touch_set_atime`.

2. `FileSystemStore` in log messages should be renamed as `FilesystemStore` which is file system store's correct name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
