### PR TITLE
In redis scheduler removes items that are queued for too long

### DIFF
--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -100,6 +100,12 @@ pub struct SimpleScheduler {
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
     pub retain_completed_for_s: u32,
 
+    /// Mark operations as completed with error if no client has updated them
+    /// within this duration.
+    /// Default: 60 (seconds)
+    #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
+    pub client_action_timeout_s: u64,
+
     /// Remove workers from pool once the worker has not responded in this
     /// amount of time in seconds.
     /// Default: 5 (seconds)

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -201,18 +201,14 @@ where
         // At this stage we know that this event is a client request, so we need
         // to populate the client_operation_id.
         let mut awaited_action = self.awaited_action_rx.borrow().clone();
-        let mut state = awaited_action.state().as_ref().clone();
-        state.client_operation_id = client_operation_id;
-        awaited_action.set_state(Arc::new(state), None);
+        awaited_action.set_client_operation_id(client_operation_id);
         Ok(awaited_action)
     }
 
     async fn borrow(&self) -> Result<AwaitedAction, Error> {
         let mut awaited_action = self.awaited_action_rx.borrow().clone();
         if let Some(client_info) = self.client_info.as_ref() {
-            let mut state = awaited_action.state().as_ref().clone();
-            state.client_operation_id = client_info.client_operation_id.clone();
-            awaited_action.set_state(Arc::new(state), None);
+            awaited_action.set_client_operation_id(client_info.client_operation_id.clone());
         }
         Ok(awaited_action)
     }

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -44,6 +44,11 @@ use crate::worker_scheduler::WorkerScheduler;
 /// If this changes, remember to change the documentation in the config.
 const DEFAULT_WORKER_TIMEOUT_S: u64 = 5;
 
+/// Mark operations as completed with error if no client has updated them
+/// within this duration.
+/// If this changes, remember to change the documentation in the config.
+const DEFAULT_CLIENT_ACTION_TIMEOUT_S: u64 = 60;
+
 /// Default times a job can retry before failing.
 /// If this changes, remember to change the documentation in the config.
 const DEFAULT_MAX_JOB_RETRIES: usize = 3;
@@ -324,6 +329,11 @@ impl SimpleScheduler {
             worker_timeout_s = DEFAULT_WORKER_TIMEOUT_S;
         }
 
+        let mut client_action_timeout_s = scheduler_cfg.client_action_timeout_s;
+        if client_action_timeout_s == 0 {
+            client_action_timeout_s = DEFAULT_CLIENT_ACTION_TIMEOUT_S;
+        }
+
         let mut max_job_retries = scheduler_cfg.max_job_retries;
         if max_job_retries == 0 {
             max_job_retries = DEFAULT_MAX_JOB_RETRIES;
@@ -333,6 +343,7 @@ impl SimpleScheduler {
         let state_manager = SimpleSchedulerStateManager::new(
             max_job_retries,
             Duration::from_secs(worker_timeout_s),
+            Duration::from_secs(client_action_timeout_s),
             awaited_action_db,
             now_fn,
         );

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -38,6 +38,7 @@ use nativelink_util::action_messages::{
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::instant_wrapper::MockInstantWrapped;
 use nativelink_util::store_trait::{SchedulerStore, SchedulerSubscriptionManager};
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
@@ -188,7 +189,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         let mut new_awaited_action = worker_awaited_action.clone();
         let mut new_state = new_awaited_action.state().as_ref().clone();
         new_state.stage = ActionStage::Executing;
-        new_awaited_action.set_state(Arc::new(new_state), Some(MockSystemTime::now().into()));
+        new_awaited_action.worker_set_state(Arc::new(new_state), MockSystemTime::now().into());
         new_awaited_action
     };
 
@@ -428,7 +429,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
     let awaited_action_db = StoreAwaitedActionDb::new(
         store.clone(),
         notifier.clone(),
-        || MockSystemTime::now().into(),
+        MockInstantWrapped::default,
         move || WORKER_OPERATION_ID.into(),
     )
     .unwrap();


### PR DESCRIPTION
In the event a client is no longer requesting to execute a task, the
scheduler will now move items out of the queued state after 60 seconds
(configurable). This will ensure we don't end up with items in the queue
forever.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1414)
<!-- Reviewable:end -->
