### PR TITLE
Fix misspellings in code files

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -468,7 +468,7 @@ pub enum EnvironmentSource {
     /// (requested by the client).
     timeout_millis,
 
-    /// A special file path will be provided that can be used to comminicate
+    /// A special file path will be provided that can be used to communicate
     /// with the parent process about out-of-band information. This file
     /// will be read after the command has finished executing. Based on the
     /// contents of the file, the behavior of the result may be modified.
@@ -665,7 +665,7 @@ pub enum WorkerConfig {
 pub struct GlobalConfig {
     /// Maximum number of open files that can be opened at one time.
     /// This value is not strictly enforced, it is a best effort. Some internal libraries
-    /// open files or read metadata from a files which do not obay this limit, however
+    /// open files or read metadata from a files which do not obey this limit, however
     /// the vast majority of cases will have this limit be honored.
     /// As a rule of thumb this value should be less than half the value of `ulimit -n`.
     /// Any network open file descriptors is not counted in this limit, but is counted
@@ -696,7 +696,7 @@ pub struct GlobalConfig {
     /// are collected at runtime (performance metrics) from being tallied. The
     /// overhead of collecting metrics is very low, so this flag should only be
     /// used if there is a very good reason to disable metrics.
-    /// This flag can be forcably set using the `NATIVELINK_DISABLE_METRICS` variable.
+    /// This flag can be forcibly set using the `NATIVELINK_DISABLE_METRICS` variable.
     /// If the variable is set it will always disable metrics regardless of what
     /// this flag is set to.
     ///

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -157,8 +157,8 @@ impl CacheLookupScheduler {
         action_info: Arc<ActionInfo>,
     ) -> Result<Box<dyn ActionStateResult>, Error> {
         let unique_key = match &action_info.unique_qualifier {
-            ActionUniqueQualifier::Cachable(unique_key) => unique_key.clone(),
-            ActionUniqueQualifier::Uncachable(_) => {
+            ActionUniqueQualifier::Cacheable(unique_key) => unique_key.clone(),
+            ActionUniqueQualifier::Uncacheable(_) => {
                 // Cache lookup skipped, forward to the upstream.
                 return self
                     .action_scheduler
@@ -214,12 +214,12 @@ impl CacheLookupScheduler {
             let _scope_guard = scope_guard;
 
             let unique_key = match &action_info.unique_qualifier {
-                ActionUniqueQualifier::Cachable(unique_key) => unique_key,
-                ActionUniqueQualifier::Uncachable(unique_key) => {
+                ActionUniqueQualifier::Cacheable(unique_key) => unique_key,
+                ActionUniqueQualifier::Uncacheable(unique_key) => {
                     event!(
                         Level::ERROR,
                         ?action_info,
-                        "ActionInfo::unique_qualifier should be ActionUniqueQualifier::Cachable()"
+                        "ActionInfo::unique_qualifier should be ActionUniqueQualifier::Cacheable()"
                     );
                     unique_key
                 }

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -265,8 +265,8 @@ impl GrpcScheduler {
             })
         };
         let skip_cache_lookup = match action_info.unique_qualifier {
-            ActionUniqueQualifier::Cachable(_) => false,
-            ActionUniqueQualifier::Uncachable(_) => true,
+            ActionUniqueQualifier::Cacheable(_) => false,
+            ActionUniqueQualifier::Uncacheable(_) => true,
         };
         let request = ExecuteRequest {
             instance_name: action_info.instance_name().clone(),

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -415,7 +415,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                     let awaited_action = tx.borrow().clone();
                     // Cleanup action_info_hash_key_to_awaited_action if it was marked cached.
                     match &awaited_action.action_info().unique_qualifier {
-                        ActionUniqueQualifier::Cachable(action_key) => {
+                        ActionUniqueQualifier::Cacheable(action_key) => {
                             let maybe_awaited_action = self
                                 .action_info_hash_key_to_awaited_action
                                 .remove(action_key);
@@ -431,7 +431,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                                 );
                             }
                         }
-                        ActionUniqueQualifier::Uncachable(_action_key) => {
+                        ActionUniqueQualifier::Uncacheable(_action_key) => {
                             // This Operation should not be in the hash_key map.
                         }
                     }
@@ -543,7 +543,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
             return Ok(());
         }
         match &new_awaited_action.action_info().unique_qualifier {
-            ActionUniqueQualifier::Cachable(action_key) => {
+            ActionUniqueQualifier::Cacheable(action_key) => {
                 let maybe_awaited_action =
                     action_info_hash_key_to_awaited_action.remove(action_key);
                 match maybe_awaited_action {
@@ -569,8 +569,8 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                 }
                 Ok(())
             }
-            ActionUniqueQualifier::Uncachable(_action_key) => {
-                // If we are not cachable, the action should not be in the
+            ActionUniqueQualifier::Uncacheable(_action_key) => {
+                // If we are not cacheable, the action should not be in the
                 // hash_key map, so we don't need to process anything in
                 // action_info_hash_key_to_awaited_action.
                 Ok(())
@@ -691,8 +691,8 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
         }
 
         let maybe_unique_key = match &action_info.unique_qualifier {
-            ActionUniqueQualifier::Cachable(unique_key) => Some(unique_key.clone()),
-            ActionUniqueQualifier::Uncachable(_unique_key) => None,
+            ActionUniqueQualifier::Cacheable(unique_key) => Some(unique_key.clone()),
+            ActionUniqueQualifier::Uncacheable(_unique_key) => None,
         };
         let operation_id = OperationId::default();
         let awaited_action =
@@ -718,7 +718,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
             .insert(client_operation_id.clone(), client_awaited_action)
             .await;
 
-        // Note: We only put items in the map that are cachable.
+        // Note: We only put items in the map that are cacheable.
         if let Some(unique_key) = maybe_unique_key {
             let old_value = self
                 .action_info_hash_key_to_awaited_action
@@ -761,8 +761,8 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
         _priority: i32,
     ) -> Result<Option<MemoryAwaitedActionSubscriber<I, NowFn>>, Error> {
         let unique_key = match unique_qualifier {
-            ActionUniqueQualifier::Cachable(unique_key) => unique_key,
-            ActionUniqueQualifier::Uncachable(_unique_key) => return Ok(None),
+            ActionUniqueQualifier::Cacheable(unique_key) => unique_key,
+            ActionUniqueQualifier::Uncacheable(_unique_key) => return Ok(None),
         };
 
         let Some(operation_id) = self.action_info_hash_key_to_awaited_action.get(unique_key) else {

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -76,12 +76,12 @@ fn apply_filter_predicate(awaited_action: &AwaitedAction, filter: &OperationFilt
     {
         if let Some(filter_unique_key) = &filter.unique_key {
             match &awaited_action.action_info().unique_qualifier {
-                ActionUniqueQualifier::Cachable(unique_key) => {
+                ActionUniqueQualifier::Cacheable(unique_key) => {
                     if filter_unique_key != unique_key {
                         return false;
                     }
                 }
-                ActionUniqueQualifier::Uncachable(_) => {
+                ActionUniqueQualifier::Uncacheable(_) => {
                     return false;
                 }
             }
@@ -806,9 +806,9 @@ where
     async fn assign_operation(
         &self,
         operation_id: &OperationId,
-        worker_id_or_reason_for_unsassign: Result<&WorkerId, Error>,
+        worker_id_or_reason_for_unassign: Result<&WorkerId, Error>,
     ) -> Result<(), Error> {
-        let (maybe_worker_id, update) = match worker_id_or_reason_for_unsassign {
+        let (maybe_worker_id, update) = match worker_id_or_reason_for_unassign {
             Ok(worker_id) => (
                 Some(worker_id),
                 UpdateOperationType::UpdateWithActionStage(ActionStage::Executing),

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -250,8 +250,8 @@ impl SchedulerStoreDataProvider for UpdateOperationIdToAwaitedAction {
     fn get_indexes(&self) -> Result<Vec<(&'static str, Bytes)>, Error> {
         let unique_qualifier = &self.0.action_info().unique_qualifier;
         let maybe_unique_qualifier = match &unique_qualifier {
-            ActionUniqueQualifier::Cachable(_) => Some(unique_qualifier),
-            ActionUniqueQualifier::Uncachable(_) => None,
+            ActionUniqueQualifier::Cacheable(_) => Some(unique_qualifier),
+            ActionUniqueQualifier::Uncacheable(_) => None,
         };
         let mut output = Vec::with_capacity(1 + maybe_unique_qualifier.map_or(0, |_| 1));
         if maybe_unique_qualifier.is_some() {
@@ -357,8 +357,8 @@ impl<S: SchedulerStore, F: Fn() -> OperationId> StoreAwaitedActionDb<S, F> {
         _priority: i32,
     ) -> Result<Option<OperationSubscriber<S>>, Error> {
         match unique_qualifier {
-            ActionUniqueQualifier::Cachable(_) => {}
-            ActionUniqueQualifier::Uncachable(_) => return Ok(None),
+            ActionUniqueQualifier::Cacheable(_) => {}
+            ActionUniqueQualifier::Uncacheable(_) => return Ok(None),
         }
         let stream = self
             .store

--- a/nativelink-scheduler/tests/action_messages_test.rs
+++ b/nativelink-scheduler/tests/action_messages_test.rs
@@ -30,7 +30,7 @@ use pretty_assertions::assert_eq;
 
 #[nativelink_test]
 async fn action_state_any_url_test() -> Result<(), Error> {
-    let unique_qualifier = ActionUniqueQualifier::Cachable(ActionUniqueKey {
+    let unique_qualifier = ActionUniqueQualifier::Cacheable(ActionUniqueKey {
         instance_name: "foo_instance".to_string(),
         digest_function: DigestHasherFunc::Sha256,
         digest: DigestInfo::new([1u8; 32], 5),

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -74,11 +74,11 @@ async fn add_action_handles_skip_cache() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    let ActionUniqueQualifier::Cachable(action_key) = action_info.unique_qualifier.clone() else {
+    let ActionUniqueQualifier::Cacheable(action_key) = action_info.unique_qualifier.clone() else {
         panic!("This test should be testing when item was cached first");
     };
     let mut skip_cache_action = action_info.as_ref().clone();
-    skip_cache_action.unique_qualifier = ActionUniqueQualifier::Uncachable(action_key);
+    skip_cache_action.unique_qualifier = ActionUniqueQualifier::Uncacheable(action_key);
     let skip_cache_action = Arc::new(skip_cache_action);
     let client_operation_id = OperationId::default();
     let _ = join!(

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -160,7 +160,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
             priority: 0,
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
-            unique_qualifier: ActionUniqueQualifier::Cachable(ActionUniqueKey {
+            unique_qualifier: ActionUniqueQualifier::Cacheable(ActionUniqueKey {
                 instance_name: INSTANCE_NAME.to_string(),
                 digest_function: DigestHasherFunc::Sha256,
                 digest: DigestInfo::zero_digest(),

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -40,7 +40,7 @@ pub fn make_base_action_info(
         priority: 0,
         load_timestamp: UNIX_EPOCH,
         insert_timestamp,
-        unique_qualifier: ActionUniqueQualifier::Cachable(ActionUniqueKey {
+        unique_qualifier: ActionUniqueQualifier::Cacheable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -134,9 +134,9 @@ impl InstanceInfo {
             digest: action_digest,
         };
         let unique_qualifier = if skip_cache_lookup {
-            ActionUniqueQualifier::Uncachable(action_key)
+            ActionUniqueQualifier::Uncacheable(action_key)
         } else {
-            ActionUniqueQualifier::Cachable(action_key)
+            ActionUniqueQualifier::Cacheable(action_key)
         };
 
         Ok(ActionInfo {

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -376,7 +376,7 @@ pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error:
     let action_digest = DigestInfo::new([7u8; 32], 123);
     let instance_name = "instance_name".to_string();
 
-    let unique_qualifier = ActionUniqueQualifier::Uncachable(ActionUniqueKey {
+    let unique_qualifier = ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
         instance_name: instance_name.clone(),
         digest_function: DigestHasherFunc::Sha256,
         digest: action_digest,

--- a/nativelink-util/src/common.rs
+++ b/nativelink-util/src/common.rs
@@ -191,7 +191,7 @@ impl Serialize for DigestInfo {
     }
 }
 
-/// Custom deserializer for `DigestInfo` becaues the default Deserializer
+/// Custom deserializer for `DigestInfo` because the default Deserializer
 /// would try to decode the data as a byte array, but we use {hex}-{size}.
 impl<'de> Deserialize<'de> for DigestInfo {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -31,7 +31,7 @@ use crate::common::DigestInfo;
 use crate::origin_context::{ActiveOriginContext, OriginContext};
 use crate::{fs, make_symbol, spawn_blocking};
 
-// The symbol can be use to retrieve the active hasher function.
+// The symbol can be used to retrieve the active hasher function.
 // from an `OriginContext`.
 make_symbol!(ACTIVE_HASHER_FUNC, DigestHasherFunc);
 

--- a/nativelink-util/src/fastcdc.rs
+++ b/nativelink-util/src/fastcdc.rs
@@ -25,7 +25,7 @@ impl State {
 /// In layman's terms this means we can take an input of unknown size and composition
 /// and chunk it into smaller chunks with chunk boundaries that will be very similar
 /// even when a small part of the file is changed. This use cases where a large file
-/// (say 1G) has a few minor changes weather they byte inserts, deletes or updates
+/// (say 1G) has a few minor changes whether they byte inserts, deletes or updates
 /// and when running through this algorithm it will slice the file up so that under
 /// normal conditions all the chunk boundaries will be identical except the ones near
 /// the mutations.

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -161,7 +161,7 @@ impl ResumeableFileSlot {
 
     /// Utility function to read data from a handler and handles file descriptor
     /// timeouts. Chunk size is based on the `buf`'s capacity.
-    /// Note: If the `handler` changes `buf`s capcity, it is responsible for reserving
+    /// Note: If the `handler` changes `buf`s capacity, it is responsible for reserving
     /// more before returning.
     pub async fn read_buf_cb<'b, T, F, Fut>(
         &'b mut self,

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -124,7 +124,7 @@ pub struct HealthRegistryBuilder {
 
 /// Health registry builder that is used to build a health registry.
 /// The builder provides creation, registering of health status indicators,
-/// sub building scoped health registries and building the health registry.
+/// sub-building scoped health registries and building the health registry.
 /// `build()` should be called once for finalizing the production of a health registry.
 impl HealthRegistryBuilder {
     pub fn new(namespace: Cow<'static, str>) -> Self {

--- a/nativelink-util/src/known_platform_property_provider.rs
+++ b/nativelink-util/src/known_platform_property_provider.rs
@@ -26,6 +26,6 @@ use crate::operation_state_manager::ClientStateManager;
 pub trait KnownPlatformPropertyProvider:
     ClientStateManager + Sync + Send + Unpin + RootMetricsComponent + 'static
 {
-    // / Returns the platform property manager.
+    // Returns the platform property manager.
     async fn get_known_properties(&self, instance_name: &str) -> Result<Vec<String>, Error>;
 }

--- a/nativelink-util/src/metrics_utils.rs
+++ b/nativelink-util/src/metrics_utils.rs
@@ -157,7 +157,7 @@ pub struct AsyncCounterWrapper {
     pub successes: AtomicU64,
     pub failures: AtomicU64,
     pub drops: AtomicU64,
-    // Time spent in nano seconds in the future.
+    // Time spent in nanoseconds in the future.
     // 64 bit address space gives ~584 years of nanoseconds.
     pub sum_func_duration_ns: AtomicU64,
 }
@@ -278,7 +278,7 @@ impl AsyncCounterWrapper {
     }
 }
 
-/// Tracks an number.
+/// Tracks a number.
 #[derive(Default)]
 pub struct Counter(AtomicU64);
 

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -81,7 +81,7 @@ pub struct OperationFilter {
     /// The digest of the action that the operation must have.
     pub action_digest: Option<DigestInfo>,
 
-    /// The operation must have it's worker timestamp before this time.
+    /// The operation must have its worker timestamp before this time.
     pub worker_update_before: Option<SystemTime>,
 
     /// The operation must have been completed before this time.
@@ -160,6 +160,6 @@ pub trait MatchingEngineStateManager: Sync + Send + MetricsComponent {
     async fn assign_operation(
         &self,
         operation_id: &OperationId,
-        worker_id_or_reason_for_unsassign: Result<&WorkerId, Error>,
+        worker_id_or_reason_for_unassign: Result<&WorkerId, Error>,
     ) -> Result<(), Error>;
 }

--- a/nativelink-util/src/origin_context.rs
+++ b/nativelink-util/src/origin_context.rs
@@ -31,13 +31,13 @@ use tracing::{Instrument, Span};
 use crate::background_spawn;
 
 /// Make a symbol that represents a unique memory pointer that is
-/// constant and choosen at compile time. This enables two modules
+/// constant and chosen at compile time. This enables two modules
 /// to use that memory location to reference data that lives in a
-/// shared module without the two modules knowing about eachother.
-/// For example, lets say we have a context that holds anonymous
+/// shared module without the two modules knowing about each other.
+/// For example, let's say we have a context that holds anonymous
 /// data; we can use these symbols to let one module set the data
 /// and tie the data to a symbol and another module read the data
-/// with the symbol, without the two modules knowing about eachother.
+/// with the symbol, without the two modules knowing about each other.
 #[macro_export]
 macro_rules! make_symbol {
     ($name:ident, $type:ident) => {
@@ -132,7 +132,7 @@ impl OriginContext {
     }
 
     /// Consumes the context and runs the given function with the context set
-    /// as the active context. When the function exists the context is restored
+    /// as the active context. When the function exits, the context is restored
     /// to the previous global context.
     #[inline]
     pub fn run<T>(self, span: Span, func: impl FnOnce() -> T) -> T {
@@ -140,7 +140,7 @@ impl OriginContext {
     }
 
     /// Wraps a function so when it is called the passed in context is set as
-    /// the active context and when the function exists the context is restored
+    /// the active context and when the function exits, the context is restored
     /// to the previous global context.
     #[inline]
     fn wrap<T>(self: Arc<Self>, span: Span, func: impl FnOnce() -> T) -> impl FnOnce() -> T {
@@ -153,7 +153,7 @@ impl OriginContext {
     }
 
     /// Wraps a future so when it is called the passed in context is set as
-    /// the active context and when the future exists the context is restored
+    /// the active context and when the future exits, the context is restored
     /// to the previous global context.
     #[inline]
     pub fn wrap_async<T>(
@@ -299,7 +299,7 @@ pin_project! {
             let this = this.project();
             // Note: If the future panics, the context will not be restored, so
             // this is a best effort to provide access to our global context
-            // in the desturctors the event of a panic.
+            // in the destructors the event of a panic.
             let _enter = this.context.take().map(OriginContext::enter);
             // SAFETY: 1. `Pin::get_unchecked_mut()` is safe, because this isn't
             //             different from wrapping `T` in `Option` and calling

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -206,9 +206,9 @@ enum State {
     OptionalMetadata,
 }
 
-// Iterate backwards looking for "(compressed-)blobs", once found, move foward
+// Iterate backwards looking for "(compressed-)blobs", once found, move forward
 // populating the output struct. This recursive function utilises the stack to
-// temporarly hold the reference to the previous item reducing the need for
+// temporarily hold the reference to the previous item reducing the need for
 // a heap allocation.
 fn recursive_parse<'a>(
     rparts: &mut impl Iterator<Item = &'a str>,

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -847,7 +847,7 @@ pub trait SchedulerStore: Send + Sync + 'static {
 }
 
 /// A type that is used to let the scheduler store know what
-/// index is beign requested.
+/// index is being requested.
 pub trait SchedulerIndexProvider {
     /// Only keys inserted with this prefix will be indexed.
     const KEY_PREFIX: &'static str;

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -100,7 +100,7 @@ async fn test_random_20mb_16k_chunks() -> Result<(), std::io::Error> {
 }
 
 #[nativelink_test]
-async fn insert_garbage_check_boundarys_recover_test() -> Result<(), std::io::Error> {
+async fn insert_garbage_check_boundaries_recover_test() -> Result<(), std::io::Error> {
     let mut rand_data = {
         let mut data = vec![0u8; 100_000];
         let mut rng = SmallRng::seed_from_u64(1);

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -56,7 +56,7 @@ use crate::worker_utils::make_supported_properties;
 /// consider an error to have occurred.
 const ACTIONS_IN_TRANSIT_TIMEOUT_S: f32 = 10.;
 
-/// If we loose connection to the worker api server we will wait this many seconds
+/// If we lose connection to the worker api server we will wait this many seconds
 /// before trying to connect.
 const CONNECTION_RETRY_DELAY_S: f32 = 0.5;
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -93,7 +93,7 @@ const DEFAULT_HISTORICAL_RESULTS_STRATEGY: UploadCacheResultsStrategy =
 #[allow(non_camel_case_types)]
 #[derive(Debug, Deserialize)]
 enum SideChannelFailureReason {
-    /// Task should be considered timedout.
+    /// Task should be considered timed out.
     timeout,
 }
 

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -232,7 +232,7 @@ async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Blake3,
             digest: action_digest,
@@ -314,7 +314,7 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
@@ -576,7 +576,7 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Sha256,
             digest: action_digest,
@@ -661,7 +661,7 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         priority: 0,
         load_timestamp: SystemTime::UNIX_EPOCH,
         insert_timestamp: SystemTime::UNIX_EPOCH,
-        unique_qualifier: ActionUniqueQualifier::Uncachable(ActionUniqueKey {
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
             instance_name: INSTANCE_NAME.to_string(),
             digest_function: DigestHasherFunc::Blake3,
             digest: action_digest,

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -102,7 +102,9 @@ impl MockRunningActionsManager {
             .expect("Could not recieve msg in mpsc")
         {
             RunningActionManagerCalls::CacheActionResult(req) => *req,
-            RunningActionManagerCalls::CreateAndAddAction(_) => panic!("Got incorrect call waiting for cache_action_result"),
+            RunningActionManagerCalls::CreateAndAddAction(_) => {
+                panic!("Got incorrect call waiting for cache_action_result")
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Currently, we are doing an strict misspelling check on document files but not on code files. According to intensive misspelling check on all code files, catched 92 occurrences in 27 files and fixed.

Fixes #1419 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
