### PR TITLE
Removes touch() api from EvictionMap

### DIFF
--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -354,11 +354,6 @@ async fn unref_called_on_replace() -> Result<(), Error> {
             unreachable!("We are not testing this functionality");
         }
 
-        async fn touch(&self) -> bool {
-            // Do nothing. We are not testing this functionality.
-            true
-        }
-
         async fn unref(&self) {
             self.unref_called.store(true, Ordering::Relaxed);
         }


### PR DESCRIPTION
The only reason this existed is for FilesystemStore to make it more
deterministic when starting up from a cold start, however the
overhead of changing the atime on every has() or get() request is
a bit excessive so we remove it to reduce the sys calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1428)
<!-- Reviewable:end -->
