### PR TITLE
Add nativelink version in BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,6 +13,9 @@ rust_binary(
     srcs = [
         "src/bin/nativelink.rs",
     ],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.5.3",
+    },
     deps = [
         "//nativelink-config",
         "//nativelink-error",


### PR DESCRIPTION

# Description

This PR adds the nativelink version for bazel builds in `nativelink -V`

## How Has This Been Tested?

`bazel test ...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1436)
<!-- Reviewable:end -->
