### PR TITLE
Work around trivy ratelimits

### DIFF
--- a/tools/local-image-test.nix
+++ b/tools/local-image-test.nix
@@ -24,5 +24,9 @@ writeShellScriptBin "local-image-test" ''
     ''${IMAGE_NAME}:''${IMAGE_TAG} \
     --highestWastedBytes=0
 
-  ${trivy}/bin/trivy image ''${IMAGE_NAME}:''${IMAGE_TAG}
+  # TODO(aaronmondal): Keep monitoring this for better solutions to ratelimits:
+  #                    https://github.com/aquasecurity/trivy-action/issues/389
+  ${trivy}/bin/trivy image \
+    ''${IMAGE_NAME}:''${IMAGE_TAG} \
+    --db-repository public.ecr.aws/aquasecurity/trivy-db:2
 ''


### PR DESCRIPTION
The ECR registry currently has a lower chance to run into ratelimiting issues. Technically it's a less scalable registry though, so we might need to revisit this in the future.

Fixes #1438

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1442)
<!-- Reviewable:end -->
