### PR TITLE
Bikeshed {Store, Scheduler}Config -> {Store, Scheduler}Spec

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -16,14 +16,14 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::schedulers::SchedulerConfig;
+use crate::schedulers::SchedulerSpec;
 use crate::serde_utils::{
     convert_data_size_with_shellexpand, convert_duration_with_shellexpand,
     convert_numeric_with_shellexpand, convert_optional_numeric_with_shellexpand,
     convert_optional_string_with_shellexpand, convert_string_with_shellexpand,
     convert_vec_string_with_shellexpand,
 };
-use crate::stores::{ClientTlsConfig, ConfigDigestHashFunction, StoreConfig, StoreRefName};
+use crate::stores::{ClientTlsConfig, ConfigDigestHashFunction, StoreRefName, StoreSpec};
 
 /// Name of the scheduler. This type will be used when referencing a
 /// scheduler in the `CasConfig::schedulers`'s map key.
@@ -215,12 +215,12 @@ pub struct BepConfig {
 #[serde(deny_unknown_fields)]
 pub struct ServicesConfig {
     /// The Content Addressable Storage (CAS) backend config.
-    /// The key is the instance_name used in the protocol and the
+    /// The key is the `instance_name` used in the protocol and the
     /// value is the underlying CAS store config.
     pub cas: Option<HashMap<InstanceName, CasStoreConfig>>,
 
     /// The Action Cache (AC) backend config.
-    /// The key is the instance_name used in the protocol and the
+    /// The key is the `instance_name` used in the protocol and the
     /// value is the underlying AC store config.
     pub ac: Option<HashMap<InstanceName, AcStoreConfig>>,
 
@@ -413,7 +413,7 @@ pub struct ServerConfig {
 pub enum WorkerProperty {
     /// List of static values.
     /// Note: Generally there should only ever be 1 value, but if the platform
-    /// property key is PropertyType::Priority it may have more than one value.
+    /// property key is `PropertyType::Priority` it may have more than one value.
     #[serde(deserialize_with = "convert_vec_string_with_shellexpand")]
     values(Vec<String>),
 
@@ -511,11 +511,11 @@ pub struct UploadActionResultConfig {
     /// Default: {No uploading is done}
     pub ac_store: Option<StoreRefName>,
 
-    /// In which situations should the results be published to the ac_store, if
-    /// set to SuccessOnly then only results with an exit code of 0 will be
+    /// In which situations should the results be published to the `ac_store`,
+    /// if set to `SuccessOnly` then only results with an exit code of 0 will be
     /// uploaded, if set to Everything all completed results will be uploaded.
     ///
-    /// Default: UploadCacheResultsStrategy::SuccessOnly
+    /// Default: `UploadCacheResultsStrategy::SuccessOnly`
     #[serde(default)]
     pub upload_ac_results_strategy: UploadCacheResultsStrategy,
 
@@ -529,18 +529,18 @@ pub struct UploadActionResultConfig {
     /// to the CAS key-value lookup format and are always a `HistoricalExecuteResponse`
     /// serialized message.
     ///
-    /// Default: UploadCacheResultsStrategy::FailuresOnly
+    /// Default: `UploadCacheResultsStrategy::FailuresOnly`
     #[serde(default)]
     pub upload_historical_results_strategy: Option<UploadCacheResultsStrategy>,
 
     /// Template to use for the `ExecuteResponse.message` property. This message
     /// is attached to the response before it is sent to the client. The following
     /// special variables are supported:
-    /// - {digest_function} - Digest function used to calculate the action digest.
-    /// - {action_digest_hash} - Action digest hash.
-    /// - {action_digest_size} - Action digest size.
-    /// - {historical_results_hash} - HistoricalExecuteResponse digest hash.
-    /// - {historical_results_size} - HistoricalExecuteResponse digest size.
+    /// - `digest_function`: Digest function used to calculate the action digest.
+    /// - `action_digest_hash`: Action digest hash.
+    /// - `action_digest_size`: Action digest size.
+    /// - `historical_results_hash`: `HistoricalExecuteResponse` digest hash.
+    /// - `historical_results_size`: `HistoricalExecuteResponse` digest size.
     ///
     /// A common use case of this is to provide a link to the web page that
     /// contains more useful information for the user.
@@ -571,7 +571,7 @@ pub struct LocalWorkerConfig {
     #[serde(default, deserialize_with = "convert_string_with_shellexpand")]
     pub name: String,
 
-    /// Endpoint which the worker will connect to the scheduler's WorkerApiService.
+    /// Endpoint which the worker will connect to the scheduler's `WorkerApiService`.
     pub worker_api_endpoint: EndpointConfig,
 
     /// The maximum time an action is allowed to run. If a task requests for a timeout
@@ -582,10 +582,10 @@ pub struct LocalWorkerConfig {
     pub max_action_timeout: usize,
 
     /// If timeout is handled in `entrypoint` or another wrapper script.
-    /// If set to true NativeLink will not honor the timeout the action requested
-    /// and instead will always force kill the action after max_action_timeout
+    /// If set to true `NativeLink` will not honor the timeout the action requested
+    /// and instead will always force kill the action after `max_action_timeout`
     /// has been reached. If this is set to false, the smaller value of the action's
-    /// timeout and max_action_timeout will be used to which NativeLink will kill
+    /// timeout and `max_action_timeout` will be used to which `NativeLink` will kill
     /// the action.
     ///
     /// The real timeout can be received via an environment variable set in:
@@ -597,7 +597,7 @@ pub struct LocalWorkerConfig {
     /// the action. In this case, action will likely be wrapped in another program,
     /// like `timeout` and propagate timeouts via `EnvironmentSource::SideChannelFile`.
     ///
-    /// Default: false (NativeLink fully handles timeouts)
+    /// Default: false (`NativeLink` fully handles timeouts)
     #[serde(default)]
     pub timeout_handled_externally: bool,
 
@@ -633,10 +633,10 @@ pub struct LocalWorkerConfig {
 
     /// The directory work jobs will be executed from. This directory will be fully
     /// managed by the worker service and will be purged on startup.
-    /// This directory and the directory referenced in local_filesystem_store_ref's
-    /// stores::FilesystemStore::content_path must be on the same filesystem.
+    /// This directory and the directory referenced in `local_filesystem_store_ref`'s
+    /// `stores::FilesystemStore::content_path` must be on the same filesystem.
     /// Hardlinks will be used when placing files that are accessible to the jobs
-    /// that are sourced from local_filesystem_store_ref's content_path.
+    /// that are sourced from `local_filesystem_store_ref`'s `content_path`.
     #[serde(deserialize_with = "convert_string_with_shellexpand")]
     pub work_directory: String,
 
@@ -679,7 +679,7 @@ pub struct GlobalConfig {
     /// If a file descriptor is idle for this many milliseconds, it will be closed.
     /// In the event a client or store takes a long time to send or receive data
     /// the file descriptor will be closed, and since `max_open_files` blocks new
-    /// open_file requests until a slot opens up, it will allow new requests to be
+    /// `open_file` requests until a slot opens up, it will allow new requests to be
     /// processed. If a read or write is attempted on a closed file descriptor, the
     /// file will be reopened and the operation will continue.
     ///
@@ -707,7 +707,7 @@ pub struct GlobalConfig {
     /// Default hash function to use while uploading blobs to the CAS when not set
     /// by client.
     ///
-    /// Default: ConfigDigestHashFunction::sha256
+    /// Default: `ConfigDigestHashFunction::sha256`
     pub default_digest_hash_function: Option<ConfigDigestHashFunction>,
 
     /// Default digest size to use for health check when running
@@ -725,7 +725,7 @@ pub struct GlobalConfig {
 pub struct CasConfig {
     /// List of stores available to use in this config.
     /// The keys can be used in other configs when needing to reference a store.
-    pub stores: HashMap<StoreRefName, StoreConfig>,
+    pub stores: HashMap<StoreRefName, StoreSpec>,
 
     /// Worker configurations used to execute jobs.
     pub workers: Option<Vec<WorkerConfig>>,
@@ -733,7 +733,7 @@ pub struct CasConfig {
     /// List of schedulers available to use in this config.
     /// The keys can be used in other configs when needing to reference a
     /// scheduler.
-    pub schedulers: Option<HashMap<SchedulerRefName, SchedulerConfig>>,
+    pub schedulers: Option<HashMap<SchedulerRefName, SchedulerSpec>>,
 
     /// Servers to setup for this process.
     pub servers: Vec<ServerConfig>,

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -15,7 +15,9 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use nativelink_config::schedulers::{ExperimentalSimpleSchedulerBackend, SchedulerConfig};
+use nativelink_config::schedulers::{
+    ExperimentalSimpleSchedulerBackend, SchedulerSpec, SimpleSpec,
+};
 use nativelink_config::stores::EvictionPolicy;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_store::redis_store::RedisStore;
@@ -42,27 +44,27 @@ pub type SchedulerFactoryResults = (
 );
 
 pub fn scheduler_factory(
-    scheduler_type_cfg: &SchedulerConfig,
+    spec: &SchedulerSpec,
     store_manager: &StoreManager,
 ) -> Result<SchedulerFactoryResults, Error> {
-    inner_scheduler_factory(scheduler_type_cfg, store_manager)
+    inner_scheduler_factory(spec, store_manager)
 }
 
 fn inner_scheduler_factory(
-    scheduler_type_cfg: &SchedulerConfig,
+    spec: &SchedulerSpec,
     store_manager: &StoreManager,
 ) -> Result<SchedulerFactoryResults, Error> {
-    let scheduler: SchedulerFactoryResults = match scheduler_type_cfg {
-        SchedulerConfig::simple(config) => {
-            simple_scheduler_factory(config, store_manager, SystemTime::now)?
+    let scheduler: SchedulerFactoryResults = match spec {
+        SchedulerSpec::simple(spec) => {
+            simple_scheduler_factory(spec, store_manager, SystemTime::now)?
         }
-        SchedulerConfig::grpc(config) => (Some(Arc::new(GrpcScheduler::new(config)?)), None),
-        SchedulerConfig::cache_lookup(config) => {
+        SchedulerSpec::grpc(spec) => (Some(Arc::new(GrpcScheduler::new(spec)?)), None),
+        SchedulerSpec::cache_lookup(spec) => {
             let ac_store = store_manager
-                .get_store(&config.ac_store)
-                .err_tip(|| format!("'ac_store': '{}' does not exist", config.ac_store))?;
+                .get_store(&spec.ac_store)
+                .err_tip(|| format!("'ac_store': '{}' does not exist", spec.ac_store))?;
             let (action_scheduler, worker_scheduler) =
-                inner_scheduler_factory(&config.scheduler, store_manager)
+                inner_scheduler_factory(&spec.scheduler, store_manager)
                     .err_tip(|| "In nested CacheLookupScheduler construction")?;
             let cache_lookup_scheduler = Arc::new(CacheLookupScheduler::new(
                 ac_store,
@@ -70,12 +72,12 @@ fn inner_scheduler_factory(
             )?);
             (Some(cache_lookup_scheduler), worker_scheduler)
         }
-        SchedulerConfig::property_modifier(config) => {
+        SchedulerSpec::property_modifier(spec) => {
             let (action_scheduler, worker_scheduler) =
-                inner_scheduler_factory(&config.scheduler, store_manager)
+                inner_scheduler_factory(&spec.scheduler, store_manager)
                     .err_tip(|| "In nested PropertyModifierScheduler construction")?;
             let property_modifier_scheduler = Arc::new(PropertyModifierScheduler::new(
-                config,
+                spec,
                 action_scheduler.err_tip(|| "Nested scheduler is not an action scheduler")?,
             ));
             (Some(property_modifier_scheduler), worker_scheduler)
@@ -86,11 +88,11 @@ fn inner_scheduler_factory(
 }
 
 fn simple_scheduler_factory(
-    config: &nativelink_config::schedulers::SimpleScheduler,
+    spec: &SimpleSpec,
     store_manager: &StoreManager,
     now_fn: fn() -> SystemTime,
 ) -> Result<SchedulerFactoryResults, Error> {
-    match config
+    match spec
         .experimental_backend
         .as_ref()
         .unwrap_or(&ExperimentalSimpleSchedulerBackend::memory)
@@ -98,12 +100,12 @@ fn simple_scheduler_factory(
         ExperimentalSimpleSchedulerBackend::memory => {
             let task_change_notify = Arc::new(Notify::new());
             let awaited_action_db = memory_awaited_action_db_factory(
-                config.retain_completed_for_s,
+                spec.retain_completed_for_s,
                 &task_change_notify.clone(),
                 SystemTime::now,
             );
             let (action_scheduler, worker_scheduler) =
-                SimpleScheduler::new(config, awaited_action_db, task_change_notify);
+                SimpleScheduler::new(spec, awaited_action_db, task_change_notify);
             Ok((Some(action_scheduler), Some(worker_scheduler)))
         }
         ExperimentalSimpleSchedulerBackend::redis(redis_config) => {
@@ -133,7 +135,7 @@ fn simple_scheduler_factory(
             )
             .err_tip(|| "In state_manager_factory::redis_state_manager")?;
             let (action_scheduler, worker_scheduler) =
-                SimpleScheduler::new(config, awaited_action_db, task_change_notify);
+                SimpleScheduler::new(spec, awaited_action_db, task_change_notify);
             Ok((Some(action_scheduler), Some(worker_scheduler)))
         }
     }

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nativelink_config::schedulers::PropertyModification;
+use nativelink_config::schedulers::{PropertyModification, PropertyModifierSpec};
 use nativelink_error::{Error, ResultExt};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_util::action_messages::{ActionInfo, OperationId};
@@ -28,7 +28,7 @@ use parking_lot::Mutex;
 
 #[derive(MetricsComponent)]
 pub struct PropertyModifierScheduler {
-    modifications: Vec<nativelink_config::schedulers::PropertyModification>,
+    modifications: Vec<PropertyModification>,
     #[metric(group = "scheduler")]
     scheduler: Arc<dyn ClientStateManager>,
     #[metric(group = "property_manager")]
@@ -36,12 +36,9 @@ pub struct PropertyModifierScheduler {
 }
 
 impl PropertyModifierScheduler {
-    pub fn new(
-        config: &nativelink_config::schedulers::PropertyModifierScheduler,
-        scheduler: Arc<dyn ClientStateManager>,
-    ) -> Self {
+    pub fn new(spec: &PropertyModifierSpec, scheduler: Arc<dyn ClientStateManager>) -> Self {
         Self {
-            modifications: config.modifications.clone(),
+            modifications: spec.modifications.clone(),
             scheduler,
             known_properties: Mutex::new(HashMap::new()),
         }

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -21,6 +21,7 @@ mod utils {
 }
 
 use futures::join;
+use nativelink_config::stores::MemorySpec;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
@@ -48,9 +49,7 @@ struct TestContext {
 
 fn make_cache_scheduler() -> Result<TestContext, Error> {
     let mock_scheduler = Arc::new(MockActionScheduler::new());
-    let ac_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let ac_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let cache_scheduler = CacheLookupScheduler::new(ac_store.clone(), mock_scheduler.clone())?;
     Ok(TestContext {
         mock_scheduler,

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -22,7 +22,9 @@ mod utils {
 }
 
 use futures::{join, StreamExt};
-use nativelink_config::schedulers::{PlatformPropertyAddition, PropertyModification};
+use nativelink_config::schedulers::{
+    PlatformPropertyAddition, PropertyModification, PropertyModifierSpec, SchedulerSpec, SimpleSpec,
+};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
@@ -42,11 +44,9 @@ struct TestContext {
 
 fn make_modifier_scheduler(modifications: Vec<PropertyModification>) -> TestContext {
     let mock_scheduler = Arc::new(MockActionScheduler::new());
-    let config = nativelink_config::schedulers::PropertyModifierScheduler {
+    let config = PropertyModifierSpec {
         modifications,
-        scheduler: Box::new(nativelink_config::schedulers::SchedulerConfig::simple(
-            nativelink_config::schedulers::SimpleScheduler::default(),
-        )),
+        scheduler: Box::new(SchedulerSpec::simple(SimpleSpec::default())),
     };
     let modifier_scheduler = PropertyModifierScheduler::new(&config, mock_scheduler.clone());
     TestContext {

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -24,7 +24,7 @@ use async_lock::Mutex;
 use futures::task::Poll;
 use futures::{poll, Stream, StreamExt};
 use mock_instant::thread_local::{MockClock, SystemTime as MockSystemTime};
-use nativelink_config::schedulers::PropertyType;
+use nativelink_config::schedulers::{PropertyType, SimpleSpec};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_metric::MetricsComponent;
@@ -160,7 +160,7 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -228,7 +228,7 @@ async fn client_does_not_receive_update_timeout() -> Result<(), Error> {
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },
@@ -291,7 +291,7 @@ async fn find_executing_action() -> Result<(), Error> {
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -368,7 +368,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
     let worker_id2: WorkerId = WorkerId(Uuid::new_v4());
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },
@@ -546,7 +546,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -630,7 +630,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             supported_platform_properties: Some(prop_defs),
             ..Default::default()
         },
@@ -724,7 +724,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -825,7 +825,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
 async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(), Error> {
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -985,7 +985,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
         let (senders, awaited_action) = MockAwaitedAction::new();
 
         let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
+            &SimpleSpec::default(),
             awaited_action,
             || async move {},
             task_change_notify,
@@ -1030,7 +1030,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
         let (senders, awaited_action) = MockAwaitedAction::new();
 
         let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-            &nativelink_config::schedulers::SimpleScheduler::default(),
+            &SimpleSpec::default(),
             awaited_action,
             || async move {},
             task_change_notify,
@@ -1081,7 +1081,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
     let worker_id2: WorkerId = WorkerId(Uuid::new_v4());
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },
@@ -1206,7 +1206,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -1307,7 +1307,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -1425,7 +1425,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -1523,7 +1523,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -1663,7 +1663,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
     supported_props.insert("prop1".to_string(), PropertyType::minimum);
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             supported_platform_properties: Some(supported_props),
             ..Default::default()
         },
@@ -1825,7 +1825,7 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
     supported_props.insert("prop1".to_string(), PropertyType::minimum);
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             supported_platform_properties: Some(supported_props),
             ..Default::default()
         },
@@ -1892,7 +1892,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             max_job_retries: 1,
             ..Default::default()
         },
@@ -2044,7 +2044,7 @@ async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
     // DropChecker.
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -2077,7 +2077,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler::default(),
+        &SimpleSpec::default(),
         memory_awaited_action_db_factory(
             0,
             &task_change_notify.clone(),
@@ -2149,7 +2149,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
 async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
-        &nativelink_config::schedulers::SimpleScheduler {
+        &SimpleSpec {
             worker_timeout_s: WORKER_TIMEOUT_S,
             ..Default::default()
         },

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use maplit::hashmap;
+use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::action_cache_server::ActionCache;
@@ -55,9 +56,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            &StoreSpec::memory(MemorySpec::default()),
             &store_manager,
             None,
         )
@@ -66,9 +65,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_ac",
         store_factory(
-            &nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            &StoreSpec::memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use hyper::body::Frame;
 use nativelink_config::cas_server::BepConfig;
+use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::google::devtools::build::v1::build_event::console_output::Output;
@@ -53,9 +54,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         BEP_STORE_NAME,
         store_factory(
-            &nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            &StoreSpec::memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -25,6 +25,7 @@ use hyper_util::server::conn::auto;
 use hyper_util::service::TowerToHyperService;
 use maplit::hashmap;
 use nativelink_config::cas_server::ByteStreamConfig;
+use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::google::bytestream::byte_stream_client::ByteStreamClient;
@@ -60,9 +61,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            &StoreSpec::memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use maplit::hashmap;
+use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::content_addressable_storage_server::ContentAddressableStorage;
@@ -49,9 +50,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            &StoreSpec::memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -23,6 +23,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::future::FutureExt;
 use lz4_flex::block::{compress_into, decompress_into, get_maximum_output_size};
+use nativelink_config::stores::CompressionSpec;
 use nativelink_error::{error_if, make_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
@@ -218,11 +219,8 @@ pub struct CompressionStore {
 }
 
 impl CompressionStore {
-    pub fn new(
-        compression_config: &nativelink_config::stores::CompressionStore,
-        inner_store: Store,
-    ) -> Result<Arc<Self>, Error> {
-        let lz4_config = match compression_config.compression_algorithm {
+    pub fn new(spec: &CompressionSpec, inner_store: Store) -> Result<Arc<Self>, Error> {
+        let lz4_config = match spec.compression_algorithm {
             nativelink_config::stores::CompressionAlgorithm::lz4(mut lz4_config) => {
                 if lz4_config.block_size == 0 {
                     lz4_config.block_size = DEFAULT_BLOCK_SIZE;

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
-use nativelink_config::stores::{EvictionPolicy, ExistenceCacheStore as ExistenceCacheStoreConfig};
+use nativelink_config::stores::{EvictionPolicy, ExistenceCacheSpec};
 use nativelink_error::{error_if, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -51,19 +51,19 @@ pub struct ExistenceCacheStore<I: InstantWrapper> {
 }
 
 impl ExistenceCacheStore<SystemTime> {
-    pub fn new(config: &ExistenceCacheStoreConfig, inner_store: Store) -> Arc<Self> {
-        Self::new_with_time(config, inner_store, SystemTime::now())
+    pub fn new(spec: &ExistenceCacheSpec, inner_store: Store) -> Arc<Self> {
+        Self::new_with_time(spec, inner_store, SystemTime::now())
     }
 }
 
 impl<I: InstantWrapper> ExistenceCacheStore<I> {
     pub fn new_with_time(
-        config: &ExistenceCacheStoreConfig,
+        spec: &ExistenceCacheSpec,
         inner_store: Store,
         anchor_time: I,
     ) -> Arc<Self> {
         let empty_policy = EvictionPolicy::default();
-        let eviction_policy = config.eviction_policy.as_ref().unwrap_or(&empty_policy);
+        let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
             inner_store,
             existence_cache: EvictingMap::new(eviction_policy, anchor_time),

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use futures::{join, FutureExt};
+use nativelink_config::stores::FastSlowSpec;
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
@@ -52,11 +53,7 @@ pub struct FastSlowStore {
 }
 
 impl FastSlowStore {
-    pub fn new(
-        _config: &nativelink_config::stores::FastSlowStore,
-        fast_store: Store,
-        slow_store: Store,
-    ) -> Arc<Self> {
+    pub fn new(_spec: &FastSlowSpec, fast_store: Store, slow_store: Store) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| Self {
             fast_store,
             slow_store,

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
+use nativelink_config::stores::MemorySpec;
 use nativelink_error::{Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -57,9 +58,9 @@ pub struct MemoryStore {
 }
 
 impl MemoryStore {
-    pub fn new(config: &nativelink_config::stores::MemoryStore) -> Arc<Self> {
+    pub fn new(spec: &MemorySpec) -> Arc<Self> {
         let empty_policy = nativelink_config::stores::EvictionPolicy::default();
-        let eviction_policy = config.eviction_policy.as_ref().unwrap_or(&empty_policy);
+        let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
             evicting_map: EvictingMap::new(eviction_policy, SystemTime::now()),
         })

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -17,6 +17,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
 
 use async_trait::async_trait;
+use nativelink_config::stores::RefSpec;
 use nativelink_error::{make_err, make_input_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -45,12 +46,9 @@ pub struct RefStore {
 }
 
 impl RefStore {
-    pub fn new(
-        config: &nativelink_config::stores::RefStore,
-        store_manager: Weak<StoreManager>,
-    ) -> Arc<Self> {
+    pub fn new(spec: &RefSpec, store_manager: Weak<StoreManager>) -> Arc<Self> {
         Arc::new(RefStore {
-            ref_store_name: config.name.clone(),
+            ref_store_name: spec.name.clone(),
             store_manager,
             ref_store: StoreReference {
                 mux: Mutex::new(()),

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use nativelink_config::stores::SizePartitioningSpec;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -34,13 +35,9 @@ pub struct SizePartitioningStore {
 }
 
 impl SizePartitioningStore {
-    pub fn new(
-        config: &nativelink_config::stores::SizePartitioningStore,
-        lower_store: Store,
-        upper_store: Store,
-    ) -> Arc<Self> {
+    pub fn new(spec: &SizePartitioningSpec, lower_store: Store, upper_store: Store) -> Arc<Self> {
         Arc::new(SizePartitioningStore {
-            partition_size: config.size,
+            partition_size: spec.size,
             lower_store,
             upper_store,
         })

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use nativelink_config::stores::VerifySpec;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
@@ -47,11 +48,11 @@ pub struct VerifyStore {
 }
 
 impl VerifyStore {
-    pub fn new(config: &nativelink_config::stores::VerifyStore, inner_store: Store) -> Arc<Self> {
+    pub fn new(spec: &VerifySpec, inner_store: Store) -> Arc<Self> {
         Arc::new(VerifyStore {
             inner_store,
-            verify_size: config.verify_size,
-            verify_hash: config.verify_hash,
+            verify_size: spec.verify_size,
+            verify_hash: spec.verify_hash,
             size_verification_failures: CounterWithTime::default(),
             hash_verification_failures: CounterWithTime::default(),
         })

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -15,6 +15,7 @@
 use std::env;
 use std::ffi::OsString;
 
+use nativelink_config::stores::MemorySpec;
 use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -46,7 +47,7 @@ const HASH1_SIZE: i64 = 147;
 async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
     let filepath = make_temp_path("test.txt").await;
     let expected_data = vec![0x88; 1024 * 1024]; // 1MB.
-    let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = MemoryStore::new(&MemorySpec::default());
     let digest = DigestInfo::try_new(HASH1, HASH1_SIZE)?; // Dummy hash data.
     {
         // Write 1MB of 0x88s to the file.

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use nativelink_config::stores::MemoryStore as MemoryStoreConfig;
+use nativelink_config::stores::MemorySpec;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::{
@@ -36,8 +36,8 @@ const STDOUT: DigestInfo = DigestInfo::new([5u8; 32], 0);
 const STDERR: DigestInfo = DigestInfo::new([6u8; 32], 0);
 
 async fn setup() -> Result<(Arc<CompletenessCheckingStore>, Arc<MemoryStore>, DigestInfo), Error> {
-    let backend_store = Store::new(MemoryStore::new(&MemoryStoreConfig::default()));
-    let cas_store = MemoryStore::new(&MemoryStoreConfig::default());
+    let backend_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let cas_store = MemoryStore::new(&MemorySpec::default());
     let ac_store =
         CompletenessCheckingStore::new(backend_store.clone(), Store::new(cas_store.clone()));
 

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
+use nativelink_config::stores::{CompressionSpec, MemorySpec, StoreSpec};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::compression_store::{
@@ -73,19 +74,15 @@ async fn simple_smoke_test() -> Result<(), Error> {
     const RAW_INPUT: &str = "123";
 
     let store = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
                 },
             ),
         },
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )),
+        Store::new(MemoryStore::new(&MemorySpec::default())),
     )
     .err_tip(|| "Failed to create compression store")?;
 
@@ -114,10 +111,8 @@ async fn partial_reads_test() -> Result<(), Error> {
     ];
 
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: 10,
@@ -125,9 +120,7 @@ async fn partial_reads_test() -> Result<(), Error> {
                 },
             ),
         },
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )),
+        Store::new(MemoryStore::new(&MemorySpec::default())),
     )
     .err_tip(|| "Failed to create compression store")?;
     let store = Pin::new(&store_owned);
@@ -167,19 +160,15 @@ async fn partial_reads_test() -> Result<(), Error> {
 #[nativelink_test]
 async fn rand_5mb_smoke_test() -> Result<(), Error> {
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
                 },
             ),
         },
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )),
+        Store::new(MemoryStore::new(&MemorySpec::default())),
     )
     .err_tip(|| "Failed to create compression store")?;
     let store = Pin::new(&store_owned);
@@ -202,12 +191,10 @@ async fn rand_5mb_smoke_test() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
@@ -259,12 +246,10 @@ async fn check_header_test() -> Result<(), Error> {
     const MAX_SIZE_INPUT: u64 = 1024 * 1024; // 1MB.
     const RAW_INPUT: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,
@@ -347,12 +332,10 @@ async fn check_footer_test() -> Result<(), Error> {
     const BLOCK_SIZE: u32 = 32 * 1024;
     const EXPECTED_INDEXES: [u32; 7] = [32898, 32898, 32898, 32898, 140, 140, 140];
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,
@@ -495,12 +478,10 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
 
     let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
-        &nativelink_config::stores::CompressionStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &CompressionSpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use nativelink_config::stores::{DedupSpec, MemorySpec, StoreSpec};
 use nativelink_error::{Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::cas_utils::ZERO_BYTE_DIGESTS;
@@ -23,14 +24,10 @@ use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-fn make_default_config() -> nativelink_config::stores::DedupStore {
-    nativelink_config::stores::DedupStore {
-        index_store: nativelink_config::stores::StoreConfig::memory(
-            nativelink_config::stores::MemoryStore::default(),
-        ),
-        content_store: nativelink_config::stores::StoreConfig::memory(
-            nativelink_config::stores::MemoryStore::default(),
-        ),
+fn make_default_config() -> DedupSpec {
+    DedupSpec {
+        index_store: StoreSpec::memory(MemorySpec::default()),
+        content_store: StoreSpec::memory(MemorySpec::default()),
         min_size: 8 * 1024,
         normal_size: 32 * 1024,
         max_size: 128 * 1024,
@@ -53,12 +50,8 @@ const MEGABYTE_SZ: usize = 1024 * 1024;
 async fn simple_round_trip_test() -> Result<(), Error> {
     let store = DedupStore::new(
         &make_default_config(),
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Index store.
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Content store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Index store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Content store.
     )?;
 
     let original_data = make_random_data(MEGABYTE_SZ);
@@ -85,12 +78,10 @@ async fn check_missing_last_chunk_test() -> Result<(), Error> {
         "7c8608f5b079bef66c45bd67f7d8ede15d2e1830ea38fd8ad4c6de08b6f21a0c";
     const LAST_CHUNK_SIZE: usize = 25779;
 
-    let content_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let content_store = MemoryStore::new(&MemorySpec::default());
     let store = DedupStore::new(
         &make_default_config(),
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Index store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Index store.
         Store::new(content_store.clone()),
     )?;
 
@@ -132,12 +123,8 @@ async fn fetch_part_test() -> Result<(), Error> {
 
     let store = DedupStore::new(
         &make_default_config(),
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Index store.
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Content store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Index store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Content store.
     )?;
 
     let original_data = make_random_data(DATA_SIZE);
@@ -173,24 +160,16 @@ async fn check_length_not_set_with_chunk_read_beyond_first_chunk_regression_test
     const START_READ_BYTE: usize = 7;
 
     let store = DedupStore::new(
-        &nativelink_config::stores::DedupStore {
-            index_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            content_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &DedupSpec {
+            index_store: StoreSpec::memory(MemorySpec::default()),
+            content_store: StoreSpec::memory(MemorySpec::default()),
             min_size: 5,
             normal_size: 6,
             max_size: 7,
             max_concurrent_fetch_per_get: 10,
         },
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Index store.
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Content store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Index store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Content store.
     )?;
 
     let original_data = make_random_data(DATA_SIZE);
@@ -226,24 +205,16 @@ async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
     const START_READ_BYTE: usize = 10;
 
     let store = DedupStore::new(
-        &nativelink_config::stores::DedupStore {
-            index_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            content_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &DedupSpec {
+            index_store: StoreSpec::memory(MemorySpec::default()),
+            content_store: StoreSpec::memory(MemorySpec::default()),
             min_size: 5,
             normal_size: 6,
             max_size: 7,
             max_concurrent_fetch_per_get: 10,
         },
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Index store.
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )), // Content store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Index store.
+        Store::new(MemoryStore::new(&MemorySpec::default())), // Content store.
     )?;
 
     let original_data = make_random_data(DATA_SIZE);
@@ -307,8 +278,8 @@ async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
 async fn has_checks_content_store() -> Result<(), Error> {
     const DATA_SIZE: usize = MEGABYTE_SZ / 4;
 
-    let index_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-    let content_store = MemoryStore::new(&nativelink_config::stores::MemoryStore {
+    let index_store = MemoryStore::new(&MemorySpec::default());
+    let content_store = MemoryStore::new(&MemorySpec {
         eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
             max_count: 10,
             ..Default::default()
@@ -373,8 +344,8 @@ async fn has_checks_content_store() -> Result<(), Error> {
 async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
     const DATA_SIZE: usize = 10;
 
-    let index_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-    let content_store = MemoryStore::new(&nativelink_config::stores::MemoryStore {
+    let index_store = MemoryStore::new(&MemorySpec::default());
+    let content_store = MemoryStore::new(&MemorySpec {
         eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
             max_count: 10,
             ..Default::default()
@@ -404,8 +375,8 @@ async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
 /// properly return Some(0).
 #[nativelink_test]
 async fn has_with_zero_digest_returns_some_test() -> Result<(), Error> {
-    let index_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-    let content_store = MemoryStore::new(&nativelink_config::stores::MemoryStore {
+    let index_store = MemoryStore::new(&MemorySpec::default());
+    let content_store = MemoryStore::new(&MemorySpec {
         eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
             max_count: 10,
             ..Default::default()

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use nativelink_config::stores::{FastSlowSpec, MemorySpec, NoopSpec, StoreSpec};
 use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_metric::MetricsComponent;
@@ -35,20 +36,12 @@ use rand::{Rng, SeedableRng};
 const MEGABYTE_SZ: usize = 1024 * 1024;
 
 fn make_stores() -> (Store, Store, Store) {
-    let fast_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
-    let slow_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let fast_slow_store = Store::new(FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
-            fast: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            slow: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &FastSlowSpec {
+            fast: StoreSpec::memory(MemorySpec::default()),
+            slow: StoreSpec::memory(MemorySpec::default()),
         },
         fast_store.clone(),
         slow_store.clone(),
@@ -336,13 +329,9 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
     }));
 
     let fast_slow_store = FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
-            fast: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            slow: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &FastSlowSpec {
+            fast: StoreSpec::memory(MemorySpec::default()),
+            slow: StoreSpec::memory(MemorySpec::default()),
         },
         fast_store,
         slow_store,
@@ -378,20 +367,12 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn ignore_value_in_fast_store() -> Result<(), Error> {
-    let fast_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
-    let slow_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let fast_slow_store = Arc::new(FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
-            fast: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            slow: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &FastSlowSpec {
+            fast: StoreSpec::memory(MemorySpec::default()),
+            slow: StoreSpec::memory(MemorySpec::default()),
         },
         fast_store.clone(),
         slow_store,
@@ -410,15 +391,11 @@ async fn ignore_value_in_fast_store() -> Result<(), Error> {
 // Regression test for https://github.com/TraceMachina/nativelink/issues/665
 #[nativelink_test]
 async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
-    let fast_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let slow_store = Store::new(NoopStore::new());
-    let fast_slow_store_config = nativelink_config::stores::FastSlowStore {
-        fast: nativelink_config::stores::StoreConfig::memory(
-            nativelink_config::stores::MemoryStore::default(),
-        ),
-        slow: nativelink_config::stores::StoreConfig::noop,
+    let fast_slow_store_config = FastSlowSpec {
+        fast: StoreSpec::memory(MemorySpec::default()),
+        slow: StoreSpec::noop(NoopSpec::default()),
     };
     let fast_slow_store = Arc::new(FastSlowStore::new(
         &fast_slow_store_config,

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -17,6 +17,7 @@ use std::pin::Pin;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use memory_stats::memory_stats;
+use nativelink_config::stores::MemorySpec;
 use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -39,7 +40,7 @@ const INVALID_HASH: &str = "g111111111111111111111111111111111111111111111111111
 async fn insert_one_item_then_update() -> Result<(), Error> {
     const VALUE1: &str = "13";
     const VALUE2: &str = "23";
-    let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = MemoryStore::new(&MemorySpec::default());
 
     // Insert dummy value into store.
     store
@@ -91,7 +92,7 @@ async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
 
     let mut sum_memory_usage_increase_perc: f64 = 0.0;
     for _ in 0..MAX_STATS_ITERATIONS {
-        let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+        let store_owned = MemoryStore::new(&MemorySpec::default());
         let store = Pin::new(&store_owned);
 
         let initial_virtual_mem = memory_stats()
@@ -130,7 +131,7 @@ async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {
 #[nativelink_test]
 async fn read_partial() -> Result<(), Error> {
     const VALUE1: &str = "1234";
-    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store_owned = MemoryStore::new(&MemorySpec::default());
     let store = Pin::new(&store_owned);
 
     let digest = DigestInfo::try_new(VALID_HASH1, 4).unwrap();
@@ -153,7 +154,7 @@ async fn read_partial() -> Result<(), Error> {
 #[nativelink_test]
 async fn read_zero_size_item_test() -> Result<(), Error> {
     const VALUE: &str = "";
-    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store_owned = MemoryStore::new(&MemorySpec::default());
     let store = Pin::new(&store_owned);
 
     // Insert dummy value into store.
@@ -173,7 +174,7 @@ async fn read_zero_size_item_test() -> Result<(), Error> {
 #[nativelink_test]
 async fn errors_with_invalid_inputs() -> Result<(), Error> {
     const VALUE1: &str = "123";
-    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store_owned = MemoryStore::new(&MemorySpec::default());
     let store = Pin::new(store_owned.as_ref());
     {
         // .has() tests.
@@ -241,7 +242,7 @@ async fn errors_with_invalid_inputs() -> Result<(), Error> {
 async fn get_part_is_zero_digest() -> Result<(), Error> {
     let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
 
-    let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = MemoryStore::new(&MemorySpec::default());
     let store_clone = store.clone();
     let (mut writer, mut reader) = make_buf_channel_pair();
 
@@ -269,7 +270,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
     let keys = vec![digest.into()];
     let mut results = vec![None];
 
-    let store_owned = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store_owned = MemoryStore::new(&MemorySpec::default());
     let store = Pin::new(&store_owned);
 
     let _ = store
@@ -304,7 +305,7 @@ async fn list_test() -> Result<(), Error> {
     const KEY3: StoreKey = StoreKey::new_str("key3");
     const VALUE: &str = "value1";
 
-    let store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let store = MemoryStore::new(&MemorySpec::default());
     store.update_oneshot(KEY1, VALUE.into()).await?;
     store.update_oneshot(KEY2, VALUE.into()).await?;
     store.update_oneshot(KEY3, VALUE.into()).await?;

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -15,6 +15,7 @@
 use std::ptr::from_ref;
 use std::sync::Arc;
 
+use nativelink_config::stores::{MemorySpec, RefSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -29,13 +30,11 @@ const VALID_HASH1: &str = "0123456789abcdef0000000000000000000100000000000001234
 fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
     let store_manager = Arc::new(StoreManager::new());
 
-    let memory_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let memory_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     store_manager.add_store("foo", memory_store.clone());
 
     let ref_store = Store::new(RefStore::new(
-        &nativelink_config::stores::RefStore {
+        &RefSpec {
             name: "foo".to_string(),
         },
         Arc::downgrade(&store_manager),
@@ -140,13 +139,11 @@ async fn update_test() -> Result<(), Error> {
 async fn inner_store_test() -> Result<(), Error> {
     let store_manager = Arc::new(StoreManager::new());
 
-    let memory_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let memory_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     store_manager.add_store("mem_store", memory_store.clone());
 
     let ref_store_inner = Store::new(RefStore::new(
-        &nativelink_config::stores::RefStore {
+        &RefSpec {
             name: "mem_store".to_string(),
         },
         Arc::downgrade(&store_manager),
@@ -154,7 +151,7 @@ async fn inner_store_test() -> Result<(), Error> {
     store_manager.add_store("ref_store_inner", ref_store_inner.clone());
 
     let ref_store_outer = Store::new(RefStore::new(
-        &nativelink_config::stores::RefStore {
+        &RefSpec {
             name: "ref_store_inner".to_string(),
         },
         Arc::downgrade(&store_manager),

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -26,6 +26,7 @@ use http::header;
 use http::status::StatusCode;
 use hyper::Body;
 use mock_instant::thread_local::MockClock;
+use nativelink_config::stores::S3Spec;
 use nativelink_error::{make_input_err, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::s3_store::S3Store;
@@ -59,7 +60,7 @@ async fn simple_has_object_found() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -94,7 +95,7 @@ async fn simple_has_object_not_found() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -153,7 +154,7 @@ async fn simple_has_retries() -> Result<(), Error> {
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
 
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             retry: nativelink_config::stores::Retry {
                 max_retries: 1024,
@@ -205,7 +206,7 @@ async fn simple_update_ac() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -293,7 +294,7 @@ async fn simple_get_ac() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -338,7 +339,7 @@ async fn smoke_test_get_part() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -399,7 +400,7 @@ async fn get_part_simple_retries() -> Result<(), Error> {
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
 
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             retry: nativelink_config::stores::Retry {
                 max_retries: 1024,
@@ -530,7 +531,7 @@ async fn multipart_update_large_cas() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -570,7 +571,7 @@ async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -613,7 +614,7 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = Arc::new(S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -655,7 +656,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -698,7 +699,7 @@ async fn has_with_expired_result() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &nativelink_config::stores::S3Store {
+        &S3Spec {
             bucket: BUCKET_NAME.to_string(),
             consider_expired_after_s: 2 * 24 * 60 * 60, // 2 days.
             ..Default::default()

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use nativelink_config::stores::{MemorySpec, ShardSpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -28,15 +29,15 @@ use rand::{Rng, SeedableRng};
 const MEGABYTE_SZ: usize = 1024 * 1024;
 
 fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<MemoryStore>>) {
-    let memory_store_config = nativelink_config::stores::MemoryStore::default();
-    let store_config = nativelink_config::stores::StoreConfig::memory(memory_store_config.clone());
+    let memory_store_config = MemorySpec::default();
+    let store_config = StoreSpec::memory(memory_store_config.clone());
     let stores: Vec<_> = weights
         .iter()
         .map(|_| MemoryStore::new(&memory_store_config))
         .collect();
 
     let shard_store = ShardStore::new(
-        &nativelink_config::stores::ShardStore {
+        &ShardSpec {
             stores: weights
                 .iter()
                 .map(|weight| nativelink_config::stores::ShardConfig {

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use nativelink_config::stores::{MemorySpec, SizePartitioningSpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -37,18 +38,14 @@ fn setup_stores(
     Arc<MemoryStore>,
     Arc<MemoryStore>,
 ) {
-    let lower_memory_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
-    let upper_memory_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let lower_memory_store = MemoryStore::new(&MemorySpec::default());
+    let upper_memory_store = MemoryStore::new(&MemorySpec::default());
 
     let size_part_store = SizePartitioningStore::new(
-        &nativelink_config::stores::SizePartitioningStore {
+        &SizePartitioningSpec {
             size,
-            lower_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            upper_store: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            lower_store: StoreSpec::memory(MemorySpec::default()),
+            upper_store: StoreSpec::memory(MemorySpec::default()),
         },
         Store::new(lower_memory_store.clone()),
         Store::new(upper_memory_store.clone()),

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 
 use futures::future::pending;
 use futures::try_join;
+use nativelink_config::stores::{MemorySpec, StoreSpec, VerifySpec};
 use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::memory_store::MemoryStore;
@@ -34,12 +35,10 @@ const VALID_HASH1: &str = "0123456789abcdef0000000000000000000100000000000001234
 async fn verify_size_false_passes_on_update() -> Result<(), Error> {
     const VALUE1: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: false,
         },
@@ -67,12 +66,10 @@ async fn verify_size_true_fails_on_update() -> Result<(), Error> {
     const VALUE1: &str = "123";
     const EXPECTED_ERR: &str = "Expected size 100 but got size 3 on insert";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -107,12 +104,10 @@ async fn verify_size_true_fails_on_update() -> Result<(), Error> {
 async fn verify_size_true_suceeds_on_update() -> Result<(), Error> {
     const VALUE1: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -132,12 +127,10 @@ async fn verify_size_true_suceeds_on_update() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn verify_size_true_suceeds_on_multi_chunk_stream_update() -> Result<(), Error> {
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -174,12 +167,10 @@ async fn verify_sha256_hash_true_suceeds_on_update() -> Result<(), Error> {
     const HASH: &str = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3";
     const VALUE: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -204,12 +195,10 @@ async fn verify_sha256_hash_true_fails_on_update() -> Result<(), Error> {
     const VALUE: &str = "123";
     const ACTUAL_HASH: &str = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -239,12 +228,10 @@ async fn verify_blake3_hash_true_suceeds_on_update() -> Result<(), Error> {
     const HASH: &str = "b3d4f8803f7e24b8f389b072e75477cdbcfbe074080fb5e500e53e26e054158e";
     const VALUE: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -275,12 +262,10 @@ async fn verify_blake3_hash_true_fails_on_update() -> Result<(), Error> {
     const VALUE: &str = "123";
     const ACTUAL_HASH: &str = "b3d4f8803f7e24b8f389b072e75477cdbcfbe074080fb5e500e53e26e054158e";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -320,12 +305,10 @@ async fn verify_fails_immediately_on_too_much_data_sent_update() -> Result<(), E
     const VALUE: &str = "123";
     const EXPECTED_ERR: &str = "Expected size 4 but already received 6 on insert";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -366,12 +349,10 @@ async fn verify_size_and_hash_suceeds_on_small_data() -> Result<(), Error> {
     const HASH: &str = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3";
     const VALUE: &str = "123";
 
-    let inner_store = MemoryStore::new(&nativelink_config::stores::MemoryStore::default());
+    let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
-        &nativelink_config::stores::VerifyStore {
-            backend: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+        &VerifySpec {
+            backend: StoreSpec::memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: true,
         },

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -31,6 +31,7 @@ mod utils {
 
 use hyper::body::Frame;
 use nativelink_config::cas_server::{LocalWorkerConfig, WorkerProperty};
+use nativelink_config::stores::{FastSlowSpec, FilesystemSpec, MemorySpec, StoreSpec};
 use nativelink_error::{make_err, make_input_err, Code, Error};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
@@ -406,30 +407,22 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
 #[nativelink_test]
 async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn std::error::Error>> {
     let cas_store = Store::new(FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
+        &FastSlowSpec {
             // Note: These are not needed for this test, so we put dummy memory stores here.
-            fast: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            slow: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            fast: StoreSpec::memory(MemorySpec::default()),
+            slow: StoreSpec::memory(MemorySpec::default()),
         },
         Store::new(
-            <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
+            <FilesystemStore>::new(&FilesystemSpec {
                 content_path: make_temp_path("content_path"),
                 temp_path: make_temp_path("temp_path"),
                 ..Default::default()
             })
             .await?,
         ),
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )),
+        Store::new(MemoryStore::new(&MemorySpec::default())),
     ));
-    let ac_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let ac_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let work_directory = make_temp_path("foo");
     new_local_worker(
         Arc::new(LocalWorkerConfig {
@@ -454,30 +447,22 @@ async fn new_local_worker_creates_work_directory_test() -> Result<(), Box<dyn st
 async fn new_local_worker_removes_work_directory_before_start_test(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cas_store = Store::new(FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
+        &FastSlowSpec {
             // Note: These are not needed for this test, so we put dummy memory stores here.
-            fast: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
-            slow: nativelink_config::stores::StoreConfig::memory(
-                nativelink_config::stores::MemoryStore::default(),
-            ),
+            fast: StoreSpec::memory(MemorySpec::default()),
+            slow: StoreSpec::memory(MemorySpec::default()),
         },
         Store::new(
-            <FilesystemStore>::new(&nativelink_config::stores::FilesystemStore {
+            <FilesystemStore>::new(&FilesystemSpec {
                 content_path: make_temp_path("content_path"),
                 temp_path: make_temp_path("temp_path"),
                 ..Default::default()
             })
             .await?,
         ),
-        Store::new(MemoryStore::new(
-            &nativelink_config::stores::MemoryStore::default(),
-        )),
+        Store::new(MemoryStore::new(&MemorySpec::default())),
     ));
-    let ac_store = Store::new(MemoryStore::new(
-        &nativelink_config::stores::MemoryStore::default(),
-    ));
+    let ac_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let work_directory = make_temp_path("foo");
     fs::create_dir_all(format!("{}/{}", work_directory, "another_dir")).await?;
     let mut file =

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use nativelink_config::cas_server::EnvironmentSource;
+use nativelink_config::stores::{FastSlowSpec, FilesystemSpec, MemorySpec, StoreSpec};
 use nativelink_error::{make_input_err, Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::command::EnvironmentVariable;
@@ -88,20 +89,20 @@ async fn setup_stores() -> Result<
     ),
     Error,
 > {
-    let fast_config = nativelink_config::stores::FilesystemStore {
+    let fast_config = FilesystemSpec {
         content_path: make_temp_path("content_path"),
         temp_path: make_temp_path("temp_path"),
         eviction_policy: None,
         ..Default::default()
     };
-    let slow_config = nativelink_config::stores::MemoryStore::default();
+    let slow_config = MemorySpec::default();
     let fast_store = FilesystemStore::new(&fast_config).await?;
     let slow_store = MemoryStore::new(&slow_config);
     let ac_store = MemoryStore::new(&slow_config);
     let cas_store = FastSlowStore::new(
-        &nativelink_config::stores::FastSlowStore {
-            fast: nativelink_config::stores::StoreConfig::filesystem(fast_config),
-            slow: nativelink_config::stores::StoreConfig::memory(slow_config),
+        &FastSlowSpec {
+            fast: StoreSpec::filesystem(fast_config),
+            slow: StoreSpec::memory(slow_config),
         },
         Store::new(fast_store.clone()),
         Store::new(slow_store.clone()),


### PR DESCRIPTION
This non-functional change simplifies the naming for the configuration from "Config" to "Spec". This makes it clearer when we operate on Store implementations and configuration fragments. The new naming scheme is also closer aligned with common K8s intuition and a bit shorter to type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1483)
<!-- Reviewable:end -->
