### PR TITLE
Use an empty instance_name in docker compose example

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,11 +33,9 @@ build --test_output=errors
 
 build:debug -c dbg
 
-build:self_test --remote_instance_name=main
 build:self_test --remote_cache=grpc://127.0.0.1:50051
 
 build:self_execute --remote_executor=grpc://127.0.0.1:50052
-build:self_execute --remote_instance_name=main
 build:self_execute --remote_default_exec_properties=cpu_count=1
 build:self_execute --platform_suffix=self-execute
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,7 +159,6 @@ jobs:
         docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
           bazel clean && \
           bazel test //... \
-          --remote_instance_name=main \
           --remote_cache=grpc://127.0.0.1:50051 \
           --remote_executor=grpc://127.0.0.1:50052 \
           --remote_default_exec_properties=cpu_count=1 \
@@ -167,7 +166,6 @@ jobs:
         docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
           bazel clean && \
           bazel test //... \
-          --remote_instance_name=main \
           --remote_cache=grpc://127.0.0.1:50051 \
           --remote_executor=grpc://127.0.0.1:50052 \
           --remote_default_exec_properties=cpu_count=1 \

--- a/deployment-examples/docker-compose/README.md
+++ b/deployment-examples/docker-compose/README.md
@@ -24,7 +24,6 @@ something like:
 
 ```sh
 bazel test //... \
-  --remote_instance_name=main \
   --remote_cache=grpc://127.0.0.1:50051 \
   --remote_executor=grpc://127.0.0.1:50052 \
   --remote_default_exec_properties=cpu_count=1

--- a/deployment-examples/docker-compose/local-storage-cas.json
+++ b/deployment-examples/docker-compose/local-storage-cas.json
@@ -41,19 +41,19 @@
     },
     "services": {
       "cas": {
-        "main": {
+        "": {
           "cas_store": "CAS_MAIN_STORE"
         }
       },
       "ac": {
-        "main": {
+        "": {
           "ac_store": "AC_MAIN_STORE"
         }
       },
       "capabilities": {},
       "bytestream": {
         "cas_stores": {
-          "main": "CAS_MAIN_STORE",
+          "": "CAS_MAIN_STORE",
         }
       }
     }
@@ -80,21 +80,26 @@
         }
       }
     },
+    // Each of the services below is keyed on an instance_name.
+    // By default, an empty string is used, but if a different
+    // instance_name is provided, the instance name must be
+    // specified by the invoking tool (e.g. using
+    // `--remote_instance_name=` for Bazel)
     "services": {
       "cas": {
-        "main": {
+        "": {
           "cas_store": "CAS_MAIN_STORE"
         }
       },
       "ac": {
-        "main": {
+        "": {
           "ac_store": "AC_MAIN_STORE"
         }
       },
       "capabilities": {},
       "bytestream": {
         "cas_stores": {
-          "main": "CAS_MAIN_STORE",
+          "": "CAS_MAIN_STORE",
         }
       },
       "health": {},

--- a/deployment-examples/docker-compose/scheduler.json
+++ b/deployment-examples/docker-compose/scheduler.json
@@ -3,7 +3,7 @@
     "GRPC_LOCAL_STORE": {
       // Note: This file is used to test GRPC store.
       "grpc": {
-        "instance_name": "main",
+        "instance_name": "",
         "endpoints": [
           {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
         ],
@@ -13,7 +13,7 @@
     "GRPC_LOCAL_AC_STORE": {
       // Note: This file is used to test GRPC store.
       "grpc": {
-        "instance_name": "main",
+        "instance_name": "",
         "endpoints": [
           {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
         ],
@@ -38,20 +38,25 @@
         "socket_address": "0.0.0.0:50052",
       }
     },
+    // Each of the services below is keyed on an instance_name.
+    // By default, an empty string is used, but if a different
+    // instance_name is provided, the instance name must be
+    // specified by the invoking tool (e.g. using
+    // `--remote_instance_name=` for Bazel)
     "services": {
       "ac": {
-        "main": {
+        "": {
           "ac_store": "GRPC_LOCAL_AC_STORE"
         }
       },
       "execution": {
-        "main": {
+        "": {
           "cas_store": "GRPC_LOCAL_STORE",
           "scheduler": "MAIN_SCHEDULER",
         }
       },
       "capabilities": {
-        "main": {
+        "": {
           "remote_execution": {
             "scheduler": "MAIN_SCHEDULER",
           }

--- a/deployment-examples/docker-compose/worker.json
+++ b/deployment-examples/docker-compose/worker.json
@@ -3,7 +3,7 @@
     "GRPC_LOCAL_STORE": {
       // Note: This file is used to test GRPC store.
       "grpc": {
-        "instance_name": "main",
+        "instance_name": "",
         "endpoints": [
           {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
         ],
@@ -13,7 +13,7 @@
     "GRPC_LOCAL_AC_STORE": {
       // Note: This file is used to test GRPC store.
       "grpc": {
-        "instance_name": "main",
+        "instance_name": "",
         "endpoints": [
           {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
         ],


### PR DESCRIPTION
# Description

Previously, the `docker compose` example used a default `instance_name` of "main", which meant that `--remote_instance_name=main` needed to be added to Bazel to get it to work as expected. This can be confusing for people who are just getting started and unfamiliar with all of the available configuration options. Since the value defaults to an empty string if this configuration item isn't provided, using that in the example should make it easier for someone to spin-up.

Fixes #1484

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist

- [x] Updated documentation if needed (n/a)
- [x] Tests added/amended (n/a)
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1486)
<!-- Reviewable:end -->
