### PR TITLE
Add gnused to createWorker

### DIFF
--- a/tools/create-worker.nix
+++ b/tools/create-worker.nix
@@ -3,6 +3,7 @@
   buildEnv,
   buildImage,
   coreutils,
+  gnused,
   lib,
   runCommand,
   runtimeShell,
@@ -85,7 +86,7 @@ in
         mkEnvSymlink
         (buildEnv {
           name = "${image.imageName}-buildEnv";
-          paths = [coreutils bash];
+          paths = [coreutils bash gnused];
           pathsToLink = ["/bin"];
         })
       ];


### PR DESCRIPTION
Bazel's `generate-xml.sh` script expects sed in the default environment.

See: https://github.com/bazelbuild/bazel/blob/3831e852c3b2530afb67e33c92e9990199ce8c03/tools/test/generate-xml.sh#L75