### PR TITLE
[Experimental] Move identity & origin event middleware config

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -209,13 +209,6 @@ pub struct BepConfig {
     /// The store name referenced in the `stores` map in the main config.
     #[serde(deserialize_with = "convert_string_with_shellexpand")]
     pub store: StoreRefName,
-
-    /// The config related to identifying the client.
-    /// The value of this header will be used to identify the caller and
-    /// will be added to the `BuildEvent::identity` field of the message.
-    /// Default: {see `IdentityHeaderSpec`}
-    #[serde(default)]
-    pub experimental_identity_header: IdentityHeaderSpec,
 }
 
 #[derive(Deserialize, Clone, Debug, Default)]
@@ -250,11 +243,6 @@ pub struct OriginEventsSpec {
     /// Default: 65536 (zero defaults to this)
     #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_event_queue_size: usize,
-
-    /// The config related to identifying the client.
-    /// Default: {see `IdentityHeaderSpec`}
-    #[serde(default)]
-    pub identity_header: IdentityHeaderSpec,
 }
 
 #[derive(Deserialize, Debug)]
@@ -452,6 +440,11 @@ pub struct ServerConfig {
 
     /// Services to attach to server.
     pub services: Option<ServicesConfig>,
+
+    /// The config related to identifying the client.
+    /// Default: {see `IdentityHeaderSpec`}
+    #[serde(default)]
+    pub experimental_identity_header: IdentityHeaderSpec,
 }
 
 #[allow(non_camel_case_types)]

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use hyper::body::Frame;
-use nativelink_config::cas_server::{BepConfig, IdentityHeaderSpec};
+use nativelink_config::cas_server::BepConfig;
 use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
@@ -69,7 +69,6 @@ fn make_bep_server(store_manager: &StoreManager) -> Result<BepServer, Error> {
     BepServer::new(
         &BepConfig {
             store: BEP_STORE_NAME.to_string(),
-            experimental_identity_header: IdentityHeaderSpec::default(),
         },
         store_manager,
     )

--- a/nativelink-util/src/origin_context.rs
+++ b/nativelink-util/src/origin_context.rs
@@ -52,6 +52,10 @@ macro_rules! make_symbol {
     };
 }
 
+// Symbol that represents the identity of the origin of a request.
+// See: IdentityHeaderSpec for details.
+make_symbol!(ORIGIN_IDENTITY, String);
+
 pub struct NLSymbol<T: Send + Sync + 'static> {
     pub name: &'static str,
     pub _phantom: std::marker::PhantomData<T>,

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -251,6 +251,56 @@ async fn inner_main(
         schedulers: action_schedulers.clone(),
     }));
 
+    // let maybe_middleware_layer = cfg
+    //     .experimental_origin_events
+    //     .as_ref()
+    //     .map(|origin_events_cfg| {
+    //         let mut max_queued_events = origin_events_cfg.max_event_queue_size;
+    //         if max_queued_events == 0 {
+    //             max_queued_events = DEFAULT_MAX_QUEUE_EVENTS;
+    //         }
+    //         let (tx, rx) = mpsc::channel(max_queued_events);
+    //         let store_name = origin_events_cfg.publisher.store.as_str();
+    //         let store = store_manager.get_store(store_name).err_tip(|| {
+    //             format!("Could not get store {store_name} for origin event publisher")
+    //         })?;
+
+    //         root_futures.push(Box::pin(
+    //             OriginEventPublisher::new(store, rx, shutdown_tx.clone())
+    //                 .run()
+    //                 .map(Ok),
+    //         ));
+
+    //         Ok::<_, Error>(OriginEventMiddlewareLayer::new(
+    //             tx, server_cfg.experimental_identity_header.clone()
+    //         ))
+    //     })
+    //     .transpose()?;
+
+    let maybe_origin_event_tx = cfg
+        .experimental_origin_events
+        .as_ref()
+        .map(|origin_events_cfg| {
+            let mut max_queued_events = origin_events_cfg.max_event_queue_size;
+            if max_queued_events == 0 {
+                max_queued_events = DEFAULT_MAX_QUEUE_EVENTS;
+            }
+            let (tx, rx) = mpsc::channel(max_queued_events);
+            let store_name = origin_events_cfg.publisher.store.as_str();
+            let store = store_manager.get_store(store_name).err_tip(|| {
+                format!("Could not get store {store_name} for origin event publisher")
+            })?;
+
+            root_futures.push(Box::pin(
+                OriginEventPublisher::new(store, rx, shutdown_tx.clone())
+                    .run()
+                    .map(Ok),
+            ));
+
+            Ok::<_, Error>(tx)
+        })
+        .transpose()?;
+
     for (server_cfg, connected_clients_mux) in servers_and_clients {
         let services = server_cfg
             .services
@@ -457,37 +507,12 @@ async fn inner_main(
 
         let health_registry = health_registry_builder.lock().await.build();
 
-        let mut svc = Router::new();
-        let maybe_middleware_layer = cfg
-            .experimental_origin_events
-            .as_ref()
-            .map(|origin_events_cfg| {
-                let mut max_queued_events = origin_events_cfg.max_event_queue_size;
-                if max_queued_events == 0 {
-                    max_queued_events = DEFAULT_MAX_QUEUE_EVENTS;
-                }
-                let (tx, rx) = mpsc::channel(max_queued_events);
-                let store_name = origin_events_cfg.publisher.store.as_str();
-                let store = store_manager.get_store(store_name).err_tip(|| {
-                    format!("Could not get store {store_name} for origin event publisher")
-                })?;
-
-                root_futures.push(Box::pin(
-                    OriginEventPublisher::new(store, rx, shutdown_tx.clone())
-                        .run()
-                        .map(Ok),
-                ));
-
-                Ok::<_, Error>((tx, origin_events_cfg))
-            })
-            .transpose()?
-            .map(|(tx, cfg)| OriginEventMiddlewareLayer::new(tx, cfg.identity_header.clone()));
-        let tonic_axum_rounter = tonic_services.into_service().into_axum_router();
-        svc = if let Some(middleware) = maybe_middleware_layer {
-            svc.merge(tonic_axum_rounter.layer(middleware))
-        } else {
-            svc.merge(tonic_axum_rounter)
-        };
+        let mut svc = Router::new().merge(tonic_services.into_service().into_axum_router().layer(
+            OriginEventMiddlewareLayer::new(
+                maybe_origin_event_tx.clone(),
+                server_cfg.experimental_identity_header.clone(),
+            ),
+        ));
 
         if let Some(health_cfg) = services.health {
             let path = if health_cfg.path.is_empty() {


### PR DESCRIPTION
Restructure the config slightly for better management of http specific configs allowing them to be configured per http service.
