### PR TITLE
Minor fix to BEP key encoding

### DIFF
--- a/nativelink-service/src/bep_server.rs
+++ b/nativelink-service/src/bep_server.rs
@@ -82,7 +82,7 @@ impl BepServer {
         let sequence_number = build_event.sequence_number;
 
         let store_key = StoreKey::Str(Cow::Owned(format!(
-            "BepEvent:{}:{}:{}",
+            "BepEvent:le:{}:{}:{}",
             &stream_id.build_id, &stream_id.invocation_id, sequence_number,
         )));
 
@@ -140,7 +140,7 @@ impl BepServer {
             store
                 .update_oneshot(
                     StoreKey::Str(Cow::Owned(format!(
-                        "BepEvent:{}:{}:{}",
+                        "BepEvent:be:{}:{}:{}",
                         &stream_id.build_id, &stream_id.invocation_id, sequence_number,
                     ))),
                     buf.freeze(),

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -117,7 +117,7 @@ async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>
     let sequence_number = request.clone().build_event.unwrap().sequence_number;
 
     let store_key = StoreKey::Str(Cow::Owned(format!(
-        "BepEvent:{}:{}:{}",
+        "BepEvent:le:{}:{}:{}",
         stream_id.clone().build_id,
         stream_id.clone().invocation_id,
         sequence_number
@@ -287,7 +287,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error
                 .iter()
                 .map(|request| {
                     StoreKey::Str(Cow::Owned(format!(
-                        "BepEvent:{}:{}:{}",
+                        "BepEvent:be:{}:{}:{}",
                         stream_id.build_id,
                         stream_id.invocation_id,
                         request


### PR DESCRIPTION
LifetimeEvents and BuildEvents were racing to who would get the entry first. This partitions the data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1539)
<!-- Reviewable:end -->
