### PR TITLE
Achieve perfect reproducibility for Linux Bazel builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,14 @@ common --enable_platform_specific_config
 common --incompatible_enable_cc_toolchain_resolution
 common --incompatible_enable_proto_toolchain_resolution
 
+# Simulate rules_python's initialization with a script and use a statically
+# linked musl Python toolchain.
+# TODO(aaronmondal): This is a hack. It works for us because have just a few
+#                    simple python scripts in the repository and don't have
+#                    complex Python dependencies. Implement LRE for Python.
+common --@rules_python//python/config_settings:bootstrap_impl=script
+common --@rules_python//python/config_settings:py_linux_libc=musl
+
 # Don't leak PATH and LD_LIBRARY_PATH into the build.
 build --incompatible_strict_action_env
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_python", version = "0.40.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/nativelink-proto/BUILD.bazel
+++ b/nativelink-proto/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load(
     "@rules_rust//rust:defs.bzl",
     "rust_binary",


### PR DESCRIPTION
Close the final nonhermeticity by reconfiguring rules_python to use a statically linked musl toolchain. This makes nativelink fully buildable and testable with lre-rs in remote execution with perfect parity to local execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1543)
<!-- Reviewable:end -->
