### PR TITLE
Fix broken Slack link

### DIFF
--- a/web/platform/src/components/qwik/components/header.tsx
+++ b/web/platform/src/components/qwik/components/header.tsx
@@ -138,7 +138,7 @@ const Widgets = component$(() => {
         <a
           target="_blank"
           class="md:hidden"
-          href="https://nativelink.slack.com/join/shared_invite/zt-2i2mipfr5-lZAEeWYEy4Eru94b3IOcdg#/shared-invite/email"
+          href="https://join.slack.com/t/nativelink/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A"
           rel="noreferrer"
         >
           <Slack />
@@ -146,7 +146,7 @@ const Widgets = component$(() => {
         <a
           target="_blank"
           class="hidden md:flex hover:rotate-360 transition-all duration-300"
-          href="https://nativelink.slack.com/join/shared_invite/zt-2i2mipfr5-lZAEeWYEy4Eru94b3IOcdg#/shared-invite/email"
+          href="https://join.slack.com/t/nativelink/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A"
           rel="noreferrer"
         >
           <SlackIcon />

--- a/web/platform/src/components/qwik/pages/community.tsx
+++ b/web/platform/src/components/qwik/pages/community.tsx
@@ -9,7 +9,7 @@ const connectOn = [
     title: "Connect on Slack",
     description:
       "Join our Slack community to connect with fellow NativeLink users, share tips, and get support from our community and team.",
-    link: "https://nativelink.slack.com/join/shared_invite/zt-2i2mipfr5-lZAEeWYEy4Eru94b3IOcdg#/shared-invite/email",
+    link: "https://join.slack.com/t/nativelink/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A",
     icon: <Slack />,
   },
   {

--- a/web/platform/src/components/qwik/sections/community.tsx
+++ b/web/platform/src/components/qwik/sections/community.tsx
@@ -16,7 +16,7 @@ const communityLinks = [
   {
     name: "Slack",
     icon: <Slack />,
-    link: "https://nativelink.slack.com/join/shared_invite/zt-2i2mipfr5-lZAEeWYEy4Eru94b3IOcdg#/shared-invite/email",
+    link: "https://join.slack.com/t/nativelink/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A",
   },
   {
     name: "GitHub",

--- a/web/platform/starlight.conf.ts
+++ b/web/platform/starlight.conf.ts
@@ -16,7 +16,7 @@ export const starlightConfig = {
   social: {
     github: "https://github.com/TraceMachina/nativelink",
     slack:
-      "https://nativelink.slack.com/join/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A",
+      "https://join.slack.com/t/nativelink/shared_invite/zt-281qk1ho0-krT7HfTUIYfQMdwflRuq7A",
   },
   customCss: [
     "/styles/tailwind.css",


### PR DESCRIPTION
# Description

The Slack link on the website is now expired, though it was previously a never expires.  This change converts that link to a functioning one. 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I sent the URL to a user.

## Checklist

- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1557)
<!-- Reviewable:end -->
