### PR TITLE
Ensure that EvictingMap is threadsafe

### DIFF
--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -590,7 +590,7 @@ async fn remove_evicts_on_time() -> Result<(), Error> {
 async fn range_multiple_items_test() -> Result<(), Error> {
     async fn get_map_range(
         evicting_map: &EvictingMap<String, BytesWrapper, MockInstantWrapped>,
-        range: impl std::ops::RangeBounds<String>,
+        range: impl std::ops::RangeBounds<String> + Send,
     ) -> Vec<(String, Bytes)> {
         let mut found_values = Vec::new();
         evicting_map


### PR DESCRIPTION
Clamp down some trait bounds so that thread safety issues have a higher chance of providing useful compiler errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1564)
<!-- Reviewable:end -->
