### PR TITLE
Add OriginEvent for scheduler scheduling action

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/events.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/events.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package com.github.trace_machina.nativelink.events;
 
+import "com/github/trace_machina/nativelink/remote_execution/worker_api.proto";
 import "build/bazel/remote/execution/v2/remote_execution.proto";
 import "google/bytestream/bytestream.proto";
 import "google/devtools/build/v1/publish_build_event.proto";
@@ -81,7 +82,10 @@ message RequestEvent {
         google.bytestream.QueryWriteStatusRequest query_write_status_request = 10;
         build.bazel.remote.execution.v2.ExecuteRequest execute_request = 11;
         build.bazel.remote.execution.v2.WaitExecutionRequest wait_execution_request = 12;
+
+        com.github.trace_machina.nativelink.remote_execution.StartExecute scheduler_start_execute = 13;
     }
+    reserved 14; // NextId.
 }
 
 message ResponseEvent {

--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -169,7 +169,14 @@ message StartExecute {
     /// of the ActionResult.
     google.protobuf.Timestamp queued_timestamp = 3;
 
-    reserved 5; // NextId.
+    /// The post-computed platform properties that the scheduler has reserved for
+    /// the action.
+    build.bazel.remote.execution.v2.Platform platform = 5;
+
+    /// The ID of the worker that is executing the action.
+    string worker_id = 6;
+
+    reserved 7; // NextId.
 }
 
 /// This is a special message used to save actions into the CAS that can be used

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.events.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.events.pb.rs
@@ -100,7 +100,7 @@ pub struct WriteRequestOverride {
 pub struct RequestEvent {
     #[prost(
         oneof = "request_event::Event",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13"
     )]
     pub event: ::core::option::Option<request_event::Event>,
 }
@@ -152,6 +152,8 @@ pub mod request_event {
         WaitExecutionRequest(
             super::super::super::super::super::super::build::bazel::remote::execution::v2::WaitExecutionRequest,
         ),
+        #[prost(message, tag = "13")]
+        SchedulerStartExecute(super::super::remote_execution::StartExecute),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -143,6 +143,15 @@ pub struct StartExecute {
     /// / of the ActionResult.
     #[prost(message, optional, tag = "3")]
     pub queued_timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    /// / The post-computed platform properties that the scheduler has reserved for
+    /// / the action.
+    #[prost(message, optional, tag = "5")]
+    pub platform: ::core::option::Option<
+        super::super::super::super::super::build::bazel::remote::execution::v2::Platform,
+    >,
+    /// / The ID of the worker that is executing the action.
+    #[prost(string, tag = "6")]
+    pub worker_id: ::prost::alloc::string::String,
 }
 /// / This is a special message used to save actions into the CAS that can be used
 /// / by programs like bb_browswer to inspect the history of a build.

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -20,11 +20,12 @@ use nativelink_config::schedulers::{
 };
 use nativelink_config::stores::EvictionPolicy;
 use nativelink_error::{make_input_err, Error, ResultExt};
+use nativelink_proto::com::github::trace_machina::nativelink::events::OriginEvent;
 use nativelink_store::redis_store::RedisStore;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::operation_state_manager::ClientStateManager;
-use tokio::sync::Notify;
+use tokio::sync::{mpsc, Notify};
 
 use crate::cache_lookup_scheduler::CacheLookupScheduler;
 use crate::grpc_scheduler::GrpcScheduler;
@@ -46,17 +47,19 @@ pub type SchedulerFactoryResults = (
 pub fn scheduler_factory(
     spec: &SchedulerSpec,
     store_manager: &StoreManager,
+    maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
 ) -> Result<SchedulerFactoryResults, Error> {
-    inner_scheduler_factory(spec, store_manager)
+    inner_scheduler_factory(spec, store_manager, maybe_origin_event_tx)
 }
 
 fn inner_scheduler_factory(
     spec: &SchedulerSpec,
     store_manager: &StoreManager,
+    maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
 ) -> Result<SchedulerFactoryResults, Error> {
     let scheduler: SchedulerFactoryResults = match spec {
         SchedulerSpec::simple(spec) => {
-            simple_scheduler_factory(spec, store_manager, SystemTime::now)?
+            simple_scheduler_factory(spec, store_manager, SystemTime::now, maybe_origin_event_tx)?
         }
         SchedulerSpec::grpc(spec) => (Some(Arc::new(GrpcScheduler::new(spec)?)), None),
         SchedulerSpec::cache_lookup(spec) => {
@@ -64,7 +67,7 @@ fn inner_scheduler_factory(
                 .get_store(&spec.ac_store)
                 .err_tip(|| format!("'ac_store': '{}' does not exist", spec.ac_store))?;
             let (action_scheduler, worker_scheduler) =
-                inner_scheduler_factory(&spec.scheduler, store_manager)
+                inner_scheduler_factory(&spec.scheduler, store_manager, maybe_origin_event_tx)
                     .err_tip(|| "In nested CacheLookupScheduler construction")?;
             let cache_lookup_scheduler = Arc::new(CacheLookupScheduler::new(
                 ac_store,
@@ -74,7 +77,7 @@ fn inner_scheduler_factory(
         }
         SchedulerSpec::property_modifier(spec) => {
             let (action_scheduler, worker_scheduler) =
-                inner_scheduler_factory(&spec.scheduler, store_manager)
+                inner_scheduler_factory(&spec.scheduler, store_manager, maybe_origin_event_tx)
                     .err_tip(|| "In nested PropertyModifierScheduler construction")?;
             let property_modifier_scheduler = Arc::new(PropertyModifierScheduler::new(
                 spec,
@@ -91,6 +94,7 @@ fn simple_scheduler_factory(
     spec: &SimpleSpec,
     store_manager: &StoreManager,
     now_fn: fn() -> SystemTime,
+    maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
 ) -> Result<SchedulerFactoryResults, Error> {
     match spec
         .experimental_backend
@@ -104,8 +108,12 @@ fn simple_scheduler_factory(
                 &task_change_notify.clone(),
                 SystemTime::now,
             );
-            let (action_scheduler, worker_scheduler) =
-                SimpleScheduler::new(spec, awaited_action_db, task_change_notify);
+            let (action_scheduler, worker_scheduler) = SimpleScheduler::new(
+                spec,
+                awaited_action_db,
+                task_change_notify,
+                maybe_origin_event_tx.cloned(),
+            );
             Ok((Some(action_scheduler), Some(worker_scheduler)))
         }
         ExperimentalSimpleSchedulerBackend::redis(redis_config) => {
@@ -134,8 +142,12 @@ fn simple_scheduler_factory(
                 Default::default,
             )
             .err_tip(|| "In state_manager_factory::redis_state_manager")?;
-            let (action_scheduler, worker_scheduler) =
-                SimpleScheduler::new(spec, awaited_action_db, task_change_notify);
+            let (action_scheduler, worker_scheduler) = SimpleScheduler::new(
+                spec,
+                awaited_action_db,
+                task_change_notify,
+                maybe_origin_event_tx.cloned(),
+            );
             Ok((Some(action_scheduler), Some(worker_scheduler)))
         }
     }

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -339,7 +339,7 @@ impl SchedulerStoreDataProvider for UpdateOperationIdToAwaitedAction {
             ActionUniqueQualifier::Cachable(_) => Some(unique_qualifier),
             ActionUniqueQualifier::Uncachable(_) => None,
         };
-        let mut output = Vec::with_capacity(1 + maybe_unique_qualifier.map_or(0, |_| 1));
+        let mut output = Vec::with_capacity(2 + maybe_unique_qualifier.map_or(0, |_| 1));
         if maybe_unique_qualifier.is_some() {
             output.push((
                 "unique_qualifier",

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -193,10 +193,6 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
             stage: ActionStage::Queued,
             action_digest: action_info.unique_qualifier.digest(),
         }));
-    // let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::from([(
-    //     name,
-    //     PropertyType::exact,
-    // )])));
     let client_operation_id = OperationId::default();
     let (_, (passed_client_operation_id, action_info)) = join!(
         context

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -171,6 +171,7 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -204,7 +205,7 @@ async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
     }
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -244,6 +245,7 @@ async fn client_does_not_receive_update_timeout() -> Result<(), Error> {
         || async move {},
         task_change_notify.clone(),
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -261,7 +263,7 @@ async fn client_does_not_receive_update_timeout() -> Result<(), Error> {
     // Trigger a do_try_match to ensure we get a state change.
     scheduler.do_try_match_for_test().await.unwrap();
     assert_eq!(
-        action_listener.changed().await.unwrap().stage,
+        action_listener.changed().await.unwrap().0.stage,
         ActionStage::Executing
     );
 
@@ -283,7 +285,7 @@ async fn client_does_not_receive_update_timeout() -> Result<(), Error> {
     {
         // Now we should have received a timeout and the action should have been
         // put back in the queue.
-        assert_eq!(changed_fut.await.unwrap().stage, ActionStage::Queued);
+        assert_eq!(changed_fut.await.unwrap().0.stage, ActionStage::Queued);
     }
 
     Ok(())
@@ -304,6 +306,7 @@ async fn find_executing_action() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -318,6 +321,7 @@ async fn find_executing_action() -> Result<(), Error> {
         .as_state()
         .await
         .unwrap()
+        .0
         .client_operation_id
         .clone();
     // Drop our receiver and look up a new one.
@@ -355,7 +359,7 @@ async fn find_executing_action() -> Result<(), Error> {
     }
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -386,6 +390,7 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest1 = DigestInfo::new([99u8; 32], 512);
     let action_digest2 = DigestInfo::new([88u8; 32], 512);
@@ -480,14 +485,16 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client1_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client1_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client2_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client2_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }
@@ -509,14 +516,16 @@ async fn remove_worker_reschedules_multiple_running_job_test() -> Result<(), Err
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client1_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client1_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }
     {
         let expected_action_stage = ActionStage::Executing;
         // Client should get notification saying it's being executed.
-        let action_state = client2_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client2_action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         assert_eq!(&action_state.stage, &expected_action_stage);
     }
@@ -567,6 +576,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -586,7 +596,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
         };
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
         operation_id
@@ -603,7 +613,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
 
     {
         // Client should get notification saying it's been queued.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -619,7 +629,7 @@ async fn set_drain_worker_pauses_and_resumes_worker_test() -> Result<(), Error> 
 
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -654,6 +664,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
     let mut platform_properties = HashMap::new();
@@ -677,7 +688,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
 
     {
         // Client should get notification saying it's been queued.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -714,7 +725,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
     }
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -748,6 +759,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -767,8 +779,10 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
 
     let (operation_id1, operation_id2) = {
         // Clients should get notification saying it's been queued.
-        let action_state1 = client1_action_listener.changed().await.unwrap();
-        let action_state2 = client2_action_listener.changed().await.unwrap();
+        let (action_state1, _maybe_origin_metadata) =
+            client1_action_listener.changed().await.unwrap();
+        let (action_state2, _maybe_origin_metadata) =
+            client2_action_listener.changed().await.unwrap();
         let operation_id1 = action_state1.client_operation_id.clone();
         let operation_id2 = action_state2.client_operation_id.clone();
         // Name is random so we set force it to be the same.
@@ -815,12 +829,12 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         // Most importantly the `name` (which is random) will be the same.
         expected_action_state.client_operation_id = operation_id1.clone();
         assert_eq!(
-            client1_action_listener.changed().await.unwrap().as_ref(),
+            client1_action_listener.changed().await.unwrap().0.as_ref(),
             &expected_action_state
         );
         expected_action_state.client_operation_id = operation_id2.clone();
         assert_eq!(
-            client2_action_listener.changed().await.unwrap().as_ref(),
+            client2_action_listener.changed().await.unwrap().0.as_ref(),
             &expected_action_state
         );
     }
@@ -830,7 +844,8 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         let insert_timestamp3 = make_system_time(2);
         let mut client3_action_listener =
             setup_action(&scheduler, action_digest, HashMap::new(), insert_timestamp3).await?;
-        let action_state = client3_action_listener.changed().await.unwrap().clone();
+        let (action_state, _maybe_origin_metadata) =
+            client3_action_listener.changed().await.unwrap().clone();
         expected_action_state.client_operation_id = action_state.client_operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }
@@ -851,6 +866,7 @@ async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(),
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let worker_id: WorkerId = WorkerId(Uuid::new_v4());
     let action_digest = DigestInfo::new([99u8; 32], 512);
@@ -866,7 +882,7 @@ async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(),
         setup_action(&scheduler, action_digest, HashMap::new(), insert_timestamp).await?;
     {
         // Client should get notification saying it's being queued not executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1006,6 +1022,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
             || async move {},
             task_change_notify,
             MockInstantWrapped::default,
+            None,
         );
         // Initial worker calls do_try_match, so send it no items.
         senders.get_range_of_actions.send(vec![]).unwrap();
@@ -1051,6 +1068,7 @@ async fn matching_engine_fails_sends_abort() -> Result<(), Error> {
             || async move {},
             task_change_notify,
             MockInstantWrapped::default,
+            None,
         );
         // senders.tx_get_awaited_action_by_id.send(Ok(None)).unwrap();
         senders.get_range_of_actions.send(vec![]).unwrap();
@@ -1109,6 +1127,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1159,7 +1178,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
 
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         assert_eq!(
             action_state.as_ref(),
             &ActionState {
@@ -1192,7 +1211,7 @@ async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
     }
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         assert_eq!(
             action_state.as_ref(),
             &ActionState {
@@ -1232,6 +1251,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1247,7 +1267,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
             Some(update_for_worker::Update::StartAction(start_execute)) => {
                 // Other tests check full data. We only care if client thinks we are Executing.
                 assert_eq!(
-                    action_listener.changed().await.unwrap().stage,
+                    action_listener.changed().await.unwrap().0.stage,
                     ActionStage::Executing
                 );
                 start_execute.operation_id
@@ -1305,7 +1325,7 @@ async fn update_action_sends_completed_result_to_client_test() -> Result<(), Err
 
     {
         // Client should get notification saying it has been completed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1333,6 +1353,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1346,6 +1367,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         .as_state()
         .await
         .unwrap()
+        .0
         .client_operation_id
         .clone();
 
@@ -1422,7 +1444,7 @@ async fn update_action_sends_completed_result_after_disconnect() -> Result<(), E
         .expect("Action not found");
     {
         // Client should get notification saying it has been completed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1451,6 +1473,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1468,7 +1491,7 @@ async fn update_action_with_wrong_worker_id_errors_test() -> Result<(), Error> {
         }
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
     }
@@ -1549,6 +1572,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1601,7 +1625,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
 
     {
         // Client should get notification saying it's being executed.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         // We now know the name of the action so populate it.
         expected_action_state.client_operation_id = action_state.client_operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
@@ -1647,7 +1671,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
         // Action should now be executing.
         expected_action_state.stage = ActionStage::Completed(action_result.clone());
         assert_eq!(
-            action_listener.changed().await.unwrap().as_ref(),
+            action_listener.changed().await.unwrap().0.as_ref(),
             &expected_action_state
         );
     }
@@ -1663,7 +1687,7 @@ async fn does_not_crash_if_operation_joined_then_relaunched() -> Result<(), Erro
                 .unwrap();
         // We didn't disconnect our worker, so it will have scheduled it to the worker.
         expected_action_state.stage = ActionStage::Executing;
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         // The name of the action changed (since it's a new action), so update it.
         expected_action_state.client_operation_id = action_state.client_operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
@@ -1694,6 +1718,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest1 = DigestInfo::new([11u8; 32], 512);
     let action_digest2 = DigestInfo::new([99u8; 32], 512);
@@ -1732,8 +1757,8 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         v => panic!("Expected StartAction, got : {v:?}"),
     };
     {
-        let state_1 = client1_action_listener.changed().await.unwrap();
-        let state_2 = client2_action_listener.changed().await.unwrap();
+        let (state_1, _maybe_origin_metadata) = client1_action_listener.changed().await.unwrap();
+        let (state_2, _maybe_origin_metadata) = client2_action_listener.changed().await.unwrap();
         // First client should be in an Executing state.
         assert_eq!(state_1.stage, ActionStage::Executing);
         // Second client should be in a queued state.
@@ -1779,7 +1804,8 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
 
     {
         // First action should now be completed.
-        let action_state = client1_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client1_action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1802,7 +1828,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
         };
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            client2_action_listener.changed().await.unwrap().stage,
+            client2_action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
         operation_id
@@ -1822,7 +1848,8 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
 
     {
         // Our second client should be notified it completed.
-        let action_state = client2_action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) =
+            client2_action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1856,6 +1883,7 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest1 = DigestInfo::new([11u8; 32], 512);
     let action_digest2 = DigestInfo::new([99u8; 32], 512);
@@ -1892,12 +1920,12 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
     {
         // First client should be in an Executing state.
         assert_eq!(
-            client1_action_listener.changed().await.unwrap().stage,
+            client1_action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
         // Second client should be in a queued state.
         assert_eq!(
-            client2_action_listener.changed().await.unwrap().stage,
+            client2_action_listener.changed().await.unwrap().0.stage,
             ActionStage::Queued
         );
     }
@@ -1923,6 +1951,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -1940,7 +1969,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         };
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
         OperationId::from(operation_id.as_str())
@@ -1956,7 +1985,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
 
     {
         // Client should get notification saying it has been queued again.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -1977,7 +2006,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
         }
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
     }
@@ -1994,7 +2023,7 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
 
     {
         // Client should get notification saying it has been queued again.
-        let action_state = action_listener.changed().await.unwrap();
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
         let expected_action_state = ActionState {
             // Name is a random string, so we ignore it and just make it the same.
             client_operation_id: action_state.client_operation_id.clone(),
@@ -2076,6 +2105,7 @@ async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
         },
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     assert_eq!(dropped.load(Ordering::Relaxed), false);
 
@@ -2105,6 +2135,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -2129,7 +2160,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
         };
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
         OperationId::from(operation_id.as_str())
@@ -2154,7 +2185,7 @@ async fn ensure_task_or_worker_change_notification_received_test() -> Result<(),
             .err_tip(|| "worker went away")?;
         // Other tests check full data. We only care if client thinks we are Executing.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Executing
         );
     }
@@ -2180,6 +2211,7 @@ async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -2192,6 +2224,7 @@ async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
         .as_state()
         .await
         .unwrap()
+        .0
         .client_operation_id
         .clone();
 
@@ -2211,7 +2244,7 @@ async fn client_reconnect_keeps_action_alive() -> Result<(), Error> {
 
     // We should get one notification saying it's queued.
     assert_eq!(
-        new_action_listener.changed().await.unwrap().stage,
+        new_action_listener.changed().await.unwrap().0.stage,
         ActionStage::Queued
     );
 
@@ -2260,6 +2293,7 @@ async fn client_timesout_job_then_same_action_requested() -> Result<(), Error> {
         || async move {},
         task_change_notify,
         MockInstantWrapped::default,
+        None,
     );
     let action_digest = DigestInfo::new([99u8; 32], 512);
 
@@ -2272,7 +2306,7 @@ async fn client_timesout_job_then_same_action_requested() -> Result<(), Error> {
 
         // We should get one notification saying it's queued.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Queued
         );
 
@@ -2295,7 +2329,7 @@ async fn client_timesout_job_then_same_action_requested() -> Result<(), Error> {
 
         // We should get one notification saying it's queued.
         assert_eq!(
-            action_listener.changed().await.unwrap().stage,
+            action_listener.changed().await.unwrap().0.stage,
             ActionStage::Queued
         );
 

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -24,6 +24,7 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::operation_state_manager::ActionStateResult;
+use nativelink_util::origin_event::OriginMetadata;
 use tokio::sync::watch;
 
 pub const INSTANCE_NAME: &str = "foobar_instance_name";
@@ -73,13 +74,13 @@ impl TokioWatchActionStateResult {
 
 #[async_trait]
 impl ActionStateResult for TokioWatchActionStateResult {
-    async fn as_state(&self) -> Result<Arc<ActionState>, Error> {
+    async fn as_state(&self) -> Result<(Arc<ActionState>, Option<OriginMetadata>), Error> {
         let mut action_state = self.rx.borrow().clone();
         Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
-        Ok(action_state)
+        Ok((action_state, None))
     }
 
-    async fn changed(&mut self) -> Result<Arc<ActionState>, Error> {
+    async fn changed(&mut self) -> Result<(Arc<ActionState>, Option<OriginMetadata>), Error> {
         self.rx.changed().await.map_err(|_| {
             make_err!(
                 Code::Internal,
@@ -88,10 +89,10 @@ impl ActionStateResult for TokioWatchActionStateResult {
         })?;
         let mut action_state = self.rx.borrow().clone();
         Arc::make_mut(&mut action_state).client_operation_id = self.client_operation_id.clone();
-        Ok(action_state)
+        Ok((action_state, None))
     }
 
-    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error> {
-        Ok(self.action_info.clone())
+    async fn as_action_info(&self) -> Result<(Arc<ActionInfo>, Option<OriginMetadata>), Error> {
+        Ok((self.action_info.clone(), None))
     }
 }

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -206,7 +206,7 @@ impl ExecutionServer {
             async move {
                 let mut action_listener = maybe_action_listener?;
                 match action_listener.changed().await {
-                    Ok(action_update) => {
+                    Ok((action_update, _maybe_origin_metadata)) => {
                         event!(Level::INFO, ?action_update, "Execute Resp Stream");
                         // If the action is finished we won't be sending any more updates.
                         let maybe_action_listener = if action_update.stage.is_finished() {
@@ -279,6 +279,7 @@ impl ExecutionServer {
                     .as_state()
                     .await
                     .err_tip(|| "In ExecutionServer::inner_execute")?
+                    .0
                     .client_operation_id
                     .clone(),
             ),

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -422,7 +422,7 @@ impl StoreDriver for CompressionStore {
         let read_fut = async move {
             let header = {
                 // Read header.
-                static EMPTY_HEADER: Header = Header {
+                const EMPTY_HEADER: Header = Header {
                     version: CURRENT_STREAM_FORMAT_VERSION,
                     config: Lz4Config { block_size: 0 },
                     upload_size: UploadSizeInfo::ExactSize(0),

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -27,6 +27,7 @@ use crate::action_messages::{
 };
 use crate::common::DigestInfo;
 use crate::known_platform_property_provider::KnownPlatformPropertyProvider;
+use crate::origin_event::OriginMetadata;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -47,12 +48,12 @@ impl Default for OperationStageFlags {
 
 #[async_trait]
 pub trait ActionStateResult: Send + Sync + 'static {
-    // Provides the current state of the action.
-    async fn as_state(&self) -> Result<Arc<ActionState>, Error>;
-    // Waits for the state of the action to change.
-    async fn changed(&mut self) -> Result<Arc<ActionState>, Error>;
-    // Provide result as action info. This behavior will not be supported by all implementations.
-    async fn as_action_info(&self) -> Result<Arc<ActionInfo>, Error>;
+    /// Provides the current state of the action.
+    async fn as_state(&self) -> Result<(Arc<ActionState>, Option<OriginMetadata>), Error>;
+    /// Waits for the state of the action to change.
+    async fn changed(&mut self) -> Result<(Arc<ActionState>, Option<OriginMetadata>), Error>;
+    /// Provide result as action info. This behavior will not be supported by all implementations.
+    async fn as_action_info(&self) -> Result<(Arc<ActionInfo>, Option<OriginMetadata>), Error>;
 }
 
 /// The direction in which the results are ordered.

--- a/nativelink-util/src/origin_event.rs
+++ b/nativelink-util/src/origin_event.rs
@@ -30,6 +30,7 @@ use nativelink_proto::com::github::trace_machina::nativelink::events::{
     response_event, stream_event, BatchReadBlobsResponseOverride, BatchUpdateBlobsRequestOverride,
     Event, OriginEvent, RequestEvent, ResponseEvent, StreamEvent, WriteRequestOverride,
 };
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_proto::google::bytestream::{
     QueryWriteStatusRequest, QueryWriteStatusResponse, ReadRequest, ReadResponse, WriteRequest,
     WriteResponse,
@@ -73,6 +74,7 @@ pub fn get_id_for_event(event: &Event) -> [u8; 2] {
             Some(request_event::Event::QueryWriteStatusRequest(_)) => [0x01, 0x0A],
             Some(request_event::Event::ExecuteRequest(_)) => [0x01, 0x0B],
             Some(request_event::Event::WaitExecutionRequest(_)) => [0x01, 0x0C],
+            Some(request_event::Event::SchedulerStartExecute(_)) => [0x01, 0x0D],
         },
         Some(event::Event::Response(res)) => match res.event {
             None => [0x02, 0x00],
@@ -508,6 +510,7 @@ impl_as_event! {Request, (), Streaming<WriteRequest>, WriteRequest, to_empty_wri
 impl_as_event! {Request, (), QueryWriteStatusRequest}
 impl_as_event! {Request, (), ExecuteRequest}
 impl_as_event! {Request, (), WaitExecutionRequest}
+impl_as_event! {Request, (), StartExecute, SchedulerStartExecute}
 
 // -- Responses --
 
@@ -522,6 +525,7 @@ impl_as_event! {Response, BatchUpdateBlobsRequest, BatchUpdateBlobsResponse}
 impl_as_event! {Response, BatchReadBlobsRequest, BatchReadBlobsResponse, BatchReadBlobsResponseOverride, to_batch_read_blobs_response_override}
 impl_as_event! {Response, GetTreeRequest, Pin<Box<dyn Stream<Item = Result<GetTreeResponse, TonicStatus>> + Send + '_>>, Empty, to_empty_response}
 impl_as_event! {Response, ExecuteRequest, Pin<Box<dyn Stream<Item = Result<Operation, TonicStatus>> + Send + '_>>, Empty, to_empty_response}
+impl_as_event! {Response, StartExecute, (), Empty}
 
 // -- Streams --
 

--- a/nativelink-util/src/origin_event.rs
+++ b/nativelink-util/src/origin_event.rs
@@ -16,6 +16,8 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
+use base64::prelude::BASE64_STANDARD_NO_PAD;
+use base64::Engine;
 use futures::future::ready;
 use futures::task::{Context, Poll};
 use futures::{Future, FutureExt, Stream, StreamExt};
@@ -38,7 +40,9 @@ use nativelink_proto::google::bytestream::{
 use nativelink_proto::google::longrunning::Operation;
 use nativelink_proto::google::rpc::Status;
 use pin_project_lite::pin_project;
+use prost::Message;
 use rand::RngCore;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tonic::{Response, Status as TonicStatus, Streaming};
@@ -117,22 +121,64 @@ pub fn get_node_id(event: Option<&Event>) -> [u8; 6] {
     node_id
 }
 
+fn serialize_request_metadata<S>(
+    value: &Option<RequestMetadata>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(msg) => serializer.serialize_some(&BASE64_STANDARD_NO_PAD.encode(msg.encode_to_vec())),
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_request_metadata<'de, D>(
+    deserializer: D,
+) -> Result<Option<RequestMetadata>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    match opt {
+        Some(s) => {
+            let decoded = BASE64_STANDARD_NO_PAD
+                .decode(s.as_bytes())
+                .map_err(serde::de::Error::custom)?;
+            RequestMetadata::decode(&*decoded)
+                .map_err(serde::de::Error::custom)
+                .map(Some)
+        }
+        None => Ok(None),
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct OriginMetadata {
+    pub identity: String,
+    #[serde(
+        serialize_with = "serialize_request_metadata",
+        deserialize_with = "deserialize_request_metadata"
+    )]
+    pub bazel_metadata: Option<RequestMetadata>,
+}
+
 pub struct OriginEventCollector {
     sender: mpsc::Sender<OriginEvent>,
-    identity: String,
-    bazel_metadata: Option<RequestMetadata>,
+    pub metadata: OriginMetadata,
 }
 
 impl OriginEventCollector {
-    pub fn new(
-        sender: mpsc::Sender<OriginEvent>,
-        identity: String,
-        bazel_metadata: Option<RequestMetadata>,
-    ) -> Self {
+    pub fn new(sender: mpsc::Sender<OriginEvent>, metadata: OriginMetadata) -> Self {
+        Self { sender, metadata }
+    }
+
+    #[must_use]
+    pub fn clone_with_metadata(&self, metadata: OriginMetadata) -> Self {
         Self {
-            sender,
-            identity,
-            bazel_metadata,
+            sender: self.sender.clone(),
+            metadata,
         }
     }
 
@@ -153,8 +199,8 @@ impl OriginEventCollector {
                 version: ORIGIN_EVENT_VERSION,
                 event_id: event_id.as_hyphenated().to_string(),
                 parent_event_id,
-                bazel_request_metadata: self.bazel_metadata.clone(),
-                identity: self.identity.clone(),
+                bazel_request_metadata: self.metadata.bazel_metadata.clone(),
+                identity: self.metadata.identity.clone(),
                 event: Some(event),
             })
             .await;
@@ -174,8 +220,8 @@ impl OriginEventCollector {
                 version: ORIGIN_EVENT_VERSION,
                 event_id: event_id.as_hyphenated().to_string(),
                 parent_event_id,
-                bazel_request_metadata: self.bazel_metadata.clone(),
-                identity: self.identity.clone(),
+                bazel_request_metadata: self.metadata.bazel_metadata.clone(),
+                identity: self.metadata.identity.clone(),
                 event: Some(event),
             })
             .map_or_else(

--- a/nativelink-util/src/origin_event_middleware.rs
+++ b/nativelink-util/src/origin_event_middleware.rs
@@ -29,7 +29,7 @@ use tower::Service;
 use tracing::trace_span;
 
 use crate::origin_context::{ActiveOriginContext, ORIGIN_IDENTITY};
-use crate::origin_event::{OriginEventCollector, ORIGIN_EVENT_COLLECTOR};
+use crate::origin_event::{OriginEventCollector, OriginMetadata, ORIGIN_EVENT_COLLECTOR};
 
 /// Default identity header name.
 /// Note: If this is changed, the default value in the [`IdentityHeaderSpec`]
@@ -138,8 +138,10 @@ where
                 &ORIGIN_EVENT_COLLECTOR,
                 Arc::new(OriginEventCollector::new(
                     origin_event_tx.clone(),
-                    identity,
-                    bazel_metadata,
+                    OriginMetadata {
+                        identity,
+                        bazel_metadata,
+                    },
                 )),
             );
         }

--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use nativelink_metric::{
     publish, MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
 };
+use nativelink_proto::build::bazel::remote::execution::v2::platform::Property as ProtoProperty;
 use nativelink_proto::build::bazel::remote::execution::v2::Platform as ProtoPlatform;
 use serde::{Deserialize, Serialize};
 
@@ -66,6 +67,21 @@ impl From<ProtoPlatform> for PlatformProperties {
             );
         }
         Self { properties }
+    }
+}
+
+impl From<&PlatformProperties> for ProtoPlatform {
+    fn from(val: &PlatformProperties) -> Self {
+        ProtoPlatform {
+            properties: val
+                .properties
+                .iter()
+                .map(|(name, value)| ProtoProperty {
+                    name: name.clone(),
+                    value: value.as_str().to_string(),
+                })
+                .collect(),
+        }
     }
 }
 

--- a/nativelink-util/tests/origin_event_test.rs
+++ b/nativelink-util/tests/origin_event_test.rs
@@ -95,6 +95,7 @@ fn get_id_for_event_test() {
                     Some(request_event::Event::QueryWriteStatusRequest(_)) => [0x01, 0x0A],
                     Some(request_event::Event::ExecuteRequest(_)) => [0x01, 0x0B],
                     Some(request_event::Event::WaitExecutionRequest(_)) => [0x01, 0x0C],
+                    Some(request_event::Event::SchedulerStartExecute(_)) => [0x01, 0x0D],
                     // Don't forget to add new entries to test cases.
                 }
             }
@@ -144,6 +145,7 @@ fn get_id_for_event_test() {
     test_event!(Request, QueryWriteStatusRequest);
     test_event!(Request, ExecuteRequest);
     test_event!(Request, WaitExecutionRequest);
+    test_event!(Request, SchedulerStartExecute);
 
     test_event!(Response, None);
     test_event!(Response, Error);

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -35,6 +35,7 @@ use nativelink_config::stores::{FastSlowSpec, FilesystemSpec, MemorySpec, StoreS
 use nativelink_error::{make_err, make_input_err, Code, Error};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
+use nativelink_proto::build::bazel::remote::execution::v2::Platform;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
     execute_result, ConnectionResult, ExecuteResult, KillOperationRequest, StartExecute,
@@ -248,6 +249,8 @@ async fn blake3_digest_function_registerd_properly() -> Result<(), Box<dyn std::
                     execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
+                    platform: Some(Platform::default()),
+                    worker_id: expected_worker_id.clone(),
                 })),
             })?))
             .await
@@ -330,6 +333,8 @@ async fn simple_worker_start_action_test() -> Result<(), Box<dyn std::error::Err
                     execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
+                    platform: Some(Platform::default()),
+                    worker_id: expected_worker_id.clone(),
                 })),
             })?))
             .await
@@ -581,6 +586,8 @@ async fn experimental_precondition_script_fails() -> Result<(), Box<dyn std::err
                     execute_request: Some((&action_info).into()),
                     operation_id: String::new(),
                     queued_timestamp: None,
+                    platform: Some(Platform::default()),
+                    worker_id: expected_worker_id.clone(),
                 })),
             })?))
             .await
@@ -624,13 +631,15 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
         assert_eq!(props, SupportedProperties::default());
     }
 
+    let expected_worker_id = "foobar".to_string();
+
     // Handle registration (kill_all not called unless registered).
     let tx_stream = test_context.maybe_tx_stream.take().unwrap();
     {
         tx_stream
             .send(Frame::data(encode_stream_proto(&UpdateForWorker {
                 update: Some(Update::ConnectionResult(ConnectionResult {
-                    worker_id: "foobar".to_string(),
+                    worker_id: expected_worker_id.clone(),
                 })),
             })?))
             .await
@@ -662,6 +671,8 @@ async fn kill_action_request_kills_action() -> Result<(), Box<dyn std::error::Er
                     execute_request: Some((&action_info).into()),
                     operation_id: operation_id.to_string(),
                     queued_timestamp: None,
+                    platform: Some(Platform::default()),
+                    worker_id: expected_worker_id.clone(),
                 })),
             })?))
             .await

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -502,6 +502,8 @@ async fn ensure_output_files_full_directories_are_created_no_working_directory_t
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: None,
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -619,6 +621,8 @@ async fn ensure_output_files_full_directories_are_created_test(
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: None,
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -752,6 +756,8 @@ async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: None,
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -924,6 +930,8 @@ async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Er
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: None,
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -1085,6 +1093,8 @@ async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>>
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: Some(queued_timestamp.into()),
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -1280,6 +1290,8 @@ async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Erro
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: Some(queued_timestamp.into()),
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -1412,6 +1424,8 @@ async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -1563,6 +1577,8 @@ exit 0
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -1735,6 +1751,8 @@ exit 0
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -1876,6 +1894,8 @@ exit 1
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -2391,6 +2411,8 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: Some(make_system_time(1000).into()),
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .and_then(|action| {
@@ -2471,6 +2493,8 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: Some(make_system_time(1000).into()),
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .and_then(|action| {
@@ -2551,6 +2575,8 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: Some(make_system_time(1000).into()),
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .and_then(|action| {
@@ -2674,6 +2700,8 @@ async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .and_then(|action| {
@@ -2800,6 +2828,8 @@ async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::err
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -3048,6 +3078,8 @@ async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::erro
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(queued_timestamp.into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;
@@ -3182,6 +3214,8 @@ async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
                     execute_request: Some(execute_request),
                     operation_id,
                     queued_timestamp: None,
+                    platform: action.platform.clone(),
+                    worker_id: WORKER_ID.to_string(),
                 },
             )
             .await?;
@@ -3361,6 +3395,8 @@ async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn
                 execute_request: Some(execute_request),
                 operation_id,
                 queued_timestamp: Some(make_system_time(1000).into()),
+                platform: action.platform.clone(),
+                worker_id: WORKER_ID.to_string(),
             },
         )
         .await?;


### PR DESCRIPTION
Adds an OriginEvent for when the scheduler schedules an action. This can be used for external systems to give visuals to what is happening inside the system or for debugging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1574)
<!-- Reviewable:end -->
