### PR TITLE
Add ability to prefix worker_id in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "prost-types",
+ "rand",
  "serde_json5",
  "tokio",
  "tokio-stream",

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -605,7 +605,8 @@ pub struct UploadActionResultConfig {
 #[serde(deny_unknown_fields)]
 pub struct LocalWorkerConfig {
     /// Name of the worker. This is give a more friendly name to a worker for logging
-    /// and metric publishing.
+    /// and metric publishing. This is also the prefix of the worker id
+    /// (ie: "{name}{uuidv6}").
     /// Default: {Index position in the workers list}
     #[serde(default, deserialize_with = "convert_string_with_shellexpand")]
     pub name: String,

--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -33,7 +33,7 @@ service WorkerApi {
     /// this worker supports. The response must be listened on the client
     /// side for updates from the server. The first item sent will always be
     /// a ConnectionResult, after that it is undefined.
-    rpc ConnectWorker(SupportedProperties) returns (stream UpdateForWorker);
+    rpc ConnectWorker(ConnectWorkerRequest) returns (stream UpdateForWorker);
 
     /// Message used to let the scheduler know that it is still alive as
     /// well as check to see if the scheduler is still alive. The scheduler
@@ -74,8 +74,8 @@ message GoingAwayRequest {
 }
 
 /// Represents the initial request sent to the scheduler informing the
-/// scheduler about this worker's capabilities.
-message SupportedProperties {
+/// scheduler about this worker's capabilities and metadata.
+message ConnectWorkerRequest {
     /// The list of properties this worker can support. The exact
     /// implementation is driven by the configuration matrix between the
     /// worker and scheduler.
@@ -87,7 +87,13 @@ message SupportedProperties {
     /// The details on how to use this property can be found here:
     /// https://github.com/TraceMachina/nativelink/blob/3147265047544572e3483c985e4aab0f9fdded38/nativelink-config/src/cas_server.rs
     repeated build.bazel.remote.execution.v2.Platform.Property properties = 1;
-    reserved 2; // NextId.
+
+    /// Prefix to use for worker IDs. This is primarily used for debugging
+    /// or for other systems to identify workers. The scheduler will always
+    /// append this prefix to the assigned worker_id followed by a UUIDv6.
+    string worker_id_prefix = 2;
+
+    reserved 3; // NextId.
 }
 
 /// The result of an ExecutionRequest.

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -156,8 +156,8 @@ impl AwaitedAction {
         self.maybe_origin_metadata.as_ref()
     }
 
-    pub(crate) fn worker_id(&self) -> Option<WorkerId> {
-        self.worker_id
+    pub(crate) fn worker_id(&self) -> Option<&WorkerId> {
+        self.worker_id.as_ref()
     }
 
     pub(crate) fn last_worker_updated_timestamp(&self) -> SystemTime {

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -354,7 +354,7 @@ where
             }
         }
 
-        if filter.worker_id.is_some() && filter.worker_id != awaited_action.worker_id() {
+        if filter.worker_id.is_some() && filter.worker_id.as_ref() != awaited_action.worker_id() {
             return false;
         }
 
@@ -500,7 +500,7 @@ where
             // worker that was assigned.
             if awaited_action.worker_id().is_some()
                 && maybe_worker_id.is_some()
-                && maybe_worker_id != awaited_action.worker_id().as_ref()
+                && maybe_worker_id != awaited_action.worker_id()
             {
                 // If another worker is already assigned to the action, another
                 // worker probably picked up the action. We should not update the
@@ -575,7 +575,7 @@ where
                 // which worker sent the update.
                 awaited_action.set_worker_id(None, now);
             } else {
-                awaited_action.set_worker_id(maybe_worker_id.copied(), now);
+                awaited_action.set_worker_id(maybe_worker_id.cloned(), now);
             }
             awaited_action.worker_set_state(
                 Arc::new(ActionState {

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -160,7 +160,7 @@ impl Worker {
         send_msg_to_worker(
             &mut self.tx,
             update_for_worker::Update::ConnectionResult(ConnectionResult {
-                worker_id: self.id.to_string(),
+                worker_id: self.id.clone().into(),
             }),
         )
         .err_tip(|| format!("Failed to send ConnectionResult to worker : {}", self.id))
@@ -181,7 +181,7 @@ impl Worker {
 
     pub fn keep_alive(&mut self) -> Result<(), Error> {
         let tx = &mut self.tx;
-        let id = self.id;
+        let id = &self.id;
         self.metrics.keep_alive.wrap(move || {
             send_msg_to_worker(tx, update_for_worker::Update::KeepAlive(()))
                 .err_tip(|| format!("Failed to send KeepAlive to worker : {id}"))
@@ -196,7 +196,7 @@ impl Worker {
         let tx = &mut self.tx;
         let worker_platform_properties = &mut self.platform_properties;
         let running_action_infos = &mut self.running_action_infos;
-        let worker_id = self.id.to_string();
+        let worker_id = self.id.clone().into();
         self.metrics
             .run_action
             .wrap(async move {

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -35,6 +35,7 @@ rust_library(
         "@crates//:hyper-1.5.2",
         "@crates//:parking_lot",
         "@crates//:prost",
+        "@crates//:rand",
         "@crates//:serde_json5",
         "@crates//:tokio",
         "@crates//:tonic",

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -16,6 +16,7 @@ futures = { version = "0.3.31", default-features = false }
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 hyper = { version = "1.5.2" }
+rand = { version = "0.8.5", default-features = false }
 serde_json5 = "0.1.0"
 parking_lot = "0.12.3"
 prost = { version = "0.13.4", default-features = false }

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -87,10 +87,6 @@ impl MetricsComponent for OperationId {
     }
 }
 
-fn uuid_to_string(uuid: &Uuid) -> String {
-    uuid.hyphenated().to_string()
-}
-
 impl From<&str> for OperationId {
     fn from(value: &str) -> Self {
         match Uuid::parse_str(value) {
@@ -140,8 +136,8 @@ impl TryFrom<Bytes> for OperationId {
 }
 
 /// Unique id of worker.
-#[derive(Default, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
-pub struct WorkerId(pub Uuid);
+#[derive(Default, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
+pub struct WorkerId(pub String);
 
 impl MetricsComponent for WorkerId {
     fn publish(
@@ -149,15 +145,13 @@ impl MetricsComponent for WorkerId {
         _kind: MetricKind,
         _field_metadata: MetricFieldData,
     ) -> Result<MetricPublishKnownKindData, nativelink_metric::Error> {
-        Ok(MetricPublishKnownKindData::String(uuid_to_string(&self.0)))
+        Ok(MetricPublishKnownKindData::String(self.0.clone()))
     }
 }
 
 impl std::fmt::Display for WorkerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut buf = Uuid::encode_buffer();
-        let worker_id_str = self.0.hyphenated().encode_lower(&mut buf);
-        f.write_fmt(format_args!("{worker_id_str}"))
+        f.write_fmt(format_args!("{}", self.0))
     }
 }
 
@@ -167,15 +161,15 @@ impl std::fmt::Debug for WorkerId {
     }
 }
 
-impl TryFrom<String> for WorkerId {
-    type Error = Error;
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        match Uuid::parse_str(&s) {
-            Err(e) => Err(make_input_err!(
-                "Failed to convert string to WorkerId : {s} : {e:?}",
-            )),
-            Ok(my_uuid) => Ok(WorkerId(my_uuid)),
-        }
+impl From<WorkerId> for String {
+    fn from(val: WorkerId) -> Self {
+        val.0
+    }
+}
+
+impl From<String> for WorkerId {
+    fn from(s: String) -> Self {
+        WorkerId(s)
     }
 }
 

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -51,7 +51,7 @@ use crate::running_actions_manager::{
     RunningActionsManager, RunningActionsManagerArgs, RunningActionsManagerImpl,
 };
 use crate::worker_api_client_wrapper::{WorkerApiClientTrait, WorkerApiClientWrapper};
-use crate::worker_utils::make_supported_properties;
+use crate::worker_utils::make_connect_worker_request;
 
 /// Amount of time to wait if we have actions in transit before we try to
 /// consider an error to have occurred.
@@ -499,10 +499,11 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
         &self,
         client: &mut T,
     ) -> Result<(String, Streaming<UpdateForWorker>), Error> {
-        let supported_properties =
-            make_supported_properties(&self.config.platform_properties).await?;
+        let connect_worker_request =
+            make_connect_worker_request(self.config.name.clone(), &self.config.platform_properties)
+                .await?;
         let mut update_for_worker_stream = client
-            .connect_worker(supported_properties)
+            .connect_worker(connect_worker_request)
             .await
             .err_tip(|| "Could not call connect_worker() in worker")?
             .into_inner();

--- a/nativelink-worker/src/worker_api_client_wrapper.rs
+++ b/nativelink-worker/src/worker_api_client_wrapper.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ExecuteResult, GoingAwayRequest, KeepAliveRequest, SupportedProperties, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
 };
 use tonic::codec::Streaming;
 use tonic::transport::Channel;
@@ -27,7 +27,7 @@ use tonic::{Response, Status};
 pub trait WorkerApiClientTrait: Clone + Sync + Send + Sized + Unpin {
     fn connect_worker(
         &mut self,
-        request: SupportedProperties,
+        request: ConnectWorkerRequest,
     ) -> impl Future<Output = Result<Response<Streaming<UpdateForWorker>>, Status>> + Send;
 
     fn keep_alive(
@@ -60,7 +60,7 @@ impl From<WorkerApiClient<Channel>> for WorkerApiClientWrapper {
 impl WorkerApiClientTrait for WorkerApiClientWrapper {
     async fn connect_worker(
         &mut self,
-        request: SupportedProperties,
+        request: ConnectWorkerRequest,
     ) -> Result<Response<Streaming<UpdateForWorker>>, Status> {
         self.inner.connect_worker(request).await
     }

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -22,13 +22,14 @@ use futures::future::try_join_all;
 use nativelink_config::cas_server::WorkerProperty;
 use nativelink_error::{make_err, make_input_err, Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
-use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::SupportedProperties;
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::ConnectWorkerRequest;
 use tokio::process;
 use tracing::{event, Level};
 
-pub async fn make_supported_properties<S: BuildHasher>(
+pub async fn make_connect_worker_request<S: BuildHasher>(
+    worker_id_prefix: String,
     worker_properties: &HashMap<String, WorkerProperty, S>,
-) -> Result<SupportedProperties, Error> {
+) -> Result<ConnectWorkerRequest, Error> {
     let mut futures = vec![];
     for (property_name, worker_property) in worker_properties {
         futures.push(async move {
@@ -97,7 +98,8 @@ pub async fn make_supported_properties<S: BuildHasher>(
         });
     }
 
-    Ok(SupportedProperties {
+    Ok(ConnectWorkerRequest {
+        worker_id_prefix,
         properties: try_join_all(futures).await?.into_iter().flatten().collect(),
     })
 }

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -21,7 +21,7 @@ use hyper::body::Frame;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_error::Error;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ExecuteResult, GoingAwayRequest, KeepAliveRequest, SupportedProperties, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
 };
 use nativelink_util::channel_body_for_tests::ChannelBody;
 use nativelink_util::shutdown_guard::ShutdownGuard;
@@ -47,7 +47,7 @@ const BROADCAST_CAPACITY: usize = 1;
 
 #[derive(Debug)]
 enum WorkerClientApiCalls {
-    ConnectWorker(SupportedProperties),
+    ConnectWorker(ConnectWorkerRequest),
     ExecutionResponse(ExecuteResult),
 }
 
@@ -88,7 +88,7 @@ impl MockWorkerApiClient {
     pub async fn expect_connect_worker(
         &mut self,
         result: Result<Response<Streaming<UpdateForWorker>>, Status>,
-    ) -> SupportedProperties {
+    ) -> ConnectWorkerRequest {
         let mut rx_call_lock = self.rx_call.lock().await;
         let req = match rx_call_lock
             .recv()
@@ -131,7 +131,7 @@ impl MockWorkerApiClient {
 impl WorkerApiClientTrait for MockWorkerApiClient {
     async fn connect_worker(
         &mut self,
-        request: SupportedProperties,
+        request: ConnectWorkerRequest,
     ) -> Result<Response<Streaming<UpdateForWorker>>, Status> {
         self.tx_call
             .send(WorkerClientApiCalls::ConnectWorker(request))

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -48,7 +48,6 @@ use nativelink_service::health_server::HealthServer;
 use nativelink_service::worker_api_server::WorkerApiServer;
 use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
-use nativelink_util::action_messages::WorkerId;
 use nativelink_util::common::fs::{set_idle_file_descriptor_timeout, set_open_file_limit};
 use nativelink_util::digest_hasher::{set_default_digest_hasher_func, DigestHasherFunc};
 use nativelink_util::health_utils::HealthRegistryBuilder;
@@ -663,10 +662,7 @@ async fn inner_main(
                                         )
                                     })?
                                     .clone()
-                                    .set_drain_worker(
-                                        &WorkerId::try_from(worker_id.clone())?,
-                                        is_draining,
-                                    )
+                                    .set_drain_worker(&worker_id.clone().into(), is_draining)
                                     .await?;
                                 Ok::<_, Error>(format!("Draining worker {worker_id}"))
                             })


### PR DESCRIPTION
WorkerId can now be prefixed with a config. This will cause all internal WorkerIds to be prefixed with this config followed by a generated UUIDv6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1578)
<!-- Reviewable:end -->
