### PR TITLE
Remove atime references to FilesystemStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,6 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "const_format",
- "filetime",
  "fred",
  "futures",
  "hex",

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -318,9 +318,7 @@ pub enum StoreSpec {
     /// Stores the data on the filesystem. This store is designed for
     /// local persistent storage. Restarts of this program should restore
     /// the previous state, meaning anything uploaded will be persistent
-    /// as long as the filesystem integrity holds. This store uses the
-    /// filesystem's `atime` (access time) to hold the last touched time
-    /// of the file(s).
+    /// as long as the filesystem integrity holds.
     ///
     /// **Example JSON Config:**
     /// ```json

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -52,7 +52,6 @@ rust_library(
         "@crates//:bytes",
         "@crates//:bytes-utils",
         "@crates//:const_format",
-        "@crates//:filetime",
         "@crates//:fred",
         "@crates//:futures",
         "@crates//:hex",

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -28,7 +28,6 @@ byteorder = { version = "1.5.0", default-features = false }
 bytes = { version = "1.9.0", default-features = false }
 bytes-utils = { version = "0.1.4", default-features = false }
 const_format = { version = "0.2.34", default-features = false }
-filetime = "0.2.25"
 fred = { version = "10.0.3", default-features = false, features = [
   "i-std",
   "i-scripts",

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -50,13 +50,6 @@ pub trait LenEntry: 'static {
     /// Returns `true` if `self` has zero length.
     fn is_empty(&self) -> bool;
 
-    /// Called when an entry is touched.  On failure, will remove the entry
-    /// from the map.
-    #[inline]
-    fn touch(&self) -> impl Future<Output = bool> + Send {
-        std::future::ready(true)
-    }
-
     /// This will be called when object is removed from map.
     /// Note: There may still be a reference to it held somewhere else, which
     /// is why it can't be mutable. This is a good place to mark the item
@@ -84,11 +77,6 @@ impl<T: LenEntry + Send + Sync> LenEntry for Arc<T> {
     #[inline]
     fn is_empty(&self) -> bool {
         T::is_empty(self.as_ref())
-    }
-
-    #[inline]
-    async fn touch(&self) -> bool {
-        self.as_ref().touch().await
     }
 
     #[inline]
@@ -347,27 +335,21 @@ where
             };
             match maybe_entry {
                 Some(entry) => {
-                    // Since we are not inserting anythign we don't need to evict based
-                    // on the size of the store.
                     // Note: We need to check eviction because the item might be expired
                     // based on the current time. In such case, we remove the item while
                     // we are here.
-                    let should_evict = self.should_evict(lru_len, entry, 0, u64::MAX);
-                    if !should_evict && peek {
-                        *result = Some(entry.data.len());
-                    } else if !should_evict && entry.data.touch().await {
-                        entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
-                        *result = Some(entry.data.len());
-                    } else {
+                    if self.should_evict(lru_len, entry, 0, u64::MAX) {
                         *result = None;
                         if let Some((key, eviction_item)) = state.lru.pop_entry(key.borrow()) {
-                            if should_evict {
-                                event!(Level::INFO, ?key, "Item expired, evicting");
-                            } else {
-                                event!(Level::INFO, ?key, "Touch failed, evicting");
-                            }
+                            event!(Level::INFO, ?key, "Item expired, evicting");
                             state.remove(key.borrow(), &eviction_item, false).await;
                         }
+                    } else {
+                        if !peek {
+                            entry.seconds_since_anchor =
+                                self.anchor_time.elapsed().as_secs() as i32;
+                        }
+                        *result = Some(entry.data.len());
                     }
                 }
                 None => *result = None,
@@ -385,15 +367,8 @@ where
 
         let entry = state.lru.get_mut(key.borrow())?;
 
-        if entry.data.touch().await {
-            entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
-            return Some(entry.data.clone());
-        }
-
-        let (key, eviction_item) = state.lru.pop_entry(key.borrow())?;
-        event!(Level::INFO, ?key, "Touch failed, evicting");
-        state.remove(key.borrow(), &eviction_item, false).await;
-        None
+        entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
+        Some(entry.data.clone())
     }
 
     /// Returns the replaced item if any.

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -356,11 +356,6 @@ async fn unref_called_on_replace() -> Result<(), Error> {
             unreachable!("We are not testing this functionality");
         }
 
-        async fn touch(&self) -> bool {
-            // Do nothing. We are not testing this functionality.
-            true
-        }
-
         async fn unref(&self) {
             self.unref_called.store(true, Ordering::Relaxed);
         }


### PR DESCRIPTION
FilesystemStore will no longer keep atime of files up-to-date. This
was an expensive operation, since every time any CAS/AC item was
touched, it'd update the atime, which caused a lot of sys calls.

While the system is running this PR has no effect, but when the
program is restarted, items are now inserted in order of atime then
mtime, but it relies on the filesystem to keep atime up-to-date.
This means that .has() calls do not "refresh" the atime on disk.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1584)
<!-- Reviewable:end -->
