### PR TITLE
MemoryStore now uses fixed memory pool per store

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,8 @@ rust_binary(
 filegroup(
     name = "docs",
     srcs = [
+        "//external-crates/alloc-bytes:docs",
+        "//external-crates/heap-allocator:docs",
         "//nativelink-config:docs",
         "//nativelink-error:docs",
         "//nativelink-macro:docs",
@@ -66,6 +68,8 @@ filegroup(
 test_suite(
     name = "doctests",
     tests = [
+        "//external-crates/alloc-bytes:doc_test",
+        "//external-crates/heap-allocator:doc_test",
         "//nativelink-config:doc_test",
         "//nativelink-error:doc_test",
         "//nativelink-macro:doc_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "alloc-bytes"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "heap-allocator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +604,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -687,9 +707,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytes-utils"
@@ -799,7 +819,7 @@ version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -862,6 +882,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const_format"
@@ -1412,6 +1438,21 @@ dependencies = [
  "nom",
  "num-traits",
 ]
+
+[[package]]
+name = "heap-allocator"
+version = "0.0.1"
+dependencies = [
+ "ouroboros",
+ "parking_lot",
+ "rlsf",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1982,10 +2023,12 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 name = "nativelink"
 version = "0.5.4"
 dependencies = [
+ "alloc-bytes",
  "async-lock",
  "axum",
  "clap",
  "futures",
+ "heap-allocator",
  "hyper 1.5.2",
  "hyper-util",
  "mimalloc",
@@ -2173,6 +2216,7 @@ dependencies = [
 name = "nativelink-store"
 version = "0.5.4"
 dependencies = [
+ "alloc-bytes",
  "async-lock",
  "async-trait",
  "aws-config",
@@ -2188,6 +2232,7 @@ dependencies = [
  "const_format",
  "fred",
  "futures",
+ "heap-allocator",
  "hex",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -2430,6 +2475,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2710,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,7 +2753,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -2884,6 +2966,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rlsf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "svgbobdoc",
 ]
 
 [[package]]
@@ -3316,6 +3410,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +3843,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ nativelink-util = { path = "nativelink-util" }
 nativelink-worker = { path = "nativelink-worker" }
 nativelink-metric = { path = "nativelink-metric" }
 nativelink-metric-collector = { path = "nativelink-metric-collector" }
+alloc-bytes = { path = "external-crates/alloc-bytes" }
+heap-allocator = { path = "external-crates/heap-allocator" }
 async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 axum = { version = "0.7.9", default-features = false }
 clap = { version = "4.5.26", features = ["derive"] }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,8 @@ crate.from_cargo(
     cargo_lockfile = "//:Cargo.lock",
     manifests = [
         "//:Cargo.toml",
+        "//external-crates/alloc-bytes:Cargo.toml",
+        "//external-crates/heap-allocator:Cargo.toml",
         "//nativelink-config:Cargo.toml",
         "//nativelink-error:Cargo.toml",
         "//nativelink-macro:Cargo.toml",

--- a/external-crates/alloc-bytes/BUILD.bazel
+++ b/external-crates/alloc-bytes/BUILD.bazel
@@ -1,0 +1,45 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+    "rust_test_suite",
+)
+
+rust_library(
+    name = "alloc-bytes",
+    srcs = [
+        "src/lib.rs",
+    ],
+    crate_features = ["bytes"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external-crates/heap-allocator",
+        "@crates//:bytes",
+    ],
+)
+
+rust_test_suite(
+    name = "integration",
+    timeout = "short",
+    srcs = [
+        "tests/alloc_bytes_test.rs",
+    ],
+    crate_features = ["bytes"],
+    deps = [
+        ":alloc-bytes",
+        "//external-crates/heap-allocator",
+    ],
+)
+
+rust_doc(
+    name = "docs",
+    crate = ":alloc-bytes",
+    visibility = ["//visibility:public"],
+)
+
+rust_doc_test(
+    name = "doc_test",
+    timeout = "short",
+    crate = ":alloc-bytes",
+)

--- a/external-crates/alloc-bytes/Cargo.toml
+++ b/external-crates/alloc-bytes/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "alloc-bytes"
+version = "0.0.1"
+edition = "2018"
+authors = [
+  "Nativelink Authors",
+  "Nathan (Blaise) Bruer <alloc-bytes.blaise@allada.com>"
+]
+license = "Apache-2.0"
+repository = "https://github.com/TraceMachina/nativelink/external-crates/alloc-bytes"
+description = "A lightweight crate offering custom-allocated byte buffers with user-specified allocators for efficient, fine-tuned memory management."
+keywords = ["bytes", "allocator", "buffers"]
+categories = ["network-programming", "data-structures"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+bytes = { version = "1.10.0", optional = true, default-features = false }
+heap-allocator = { path = "../heap-allocator", optional = true, default-features = false }
+
+[dev-dependencies]
+bytes = { version = "1.10.0", default-features = false }
+heap-allocator = { path = "../heap-allocator" }
+
+[features]
+default = []
+
+bytes = ["dep:bytes"]
+heap_allocator = ["dep:heap-allocator"]
+
+[package.metadata.docs.rs]
+features = ["bytes", "heap_allocator"]

--- a/external-crates/alloc-bytes/src/lib.rs
+++ b/external-crates/alloc-bytes/src/lib.rs
@@ -1,0 +1,418 @@
+// Copyright 2025 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+//! # `alloc_bytes`
+//!
+//! `alloc_bytes` is a crate that provides custom byte buffers allocated using a
+//! user-provided allocator. It offers both mutable and immutable byte buffers,
+//! enabling efficient memory allocation strategies in systems with custom
+//! memory requirements.
+//!
+//! ## Features
+//!
+//! - **Custom Allocator Support:** Allocate bytes via any allocator
+//!   implementing [`GlobalAlloc`].
+//! - **Mutable & Immutable Buffers:** Build data with [`AllocBytesMut`] and
+//!   freeze it into an immutable [`AllocBytes`].
+//! - **Interoperability with the `bytes` Crate:** Convert to [`Bytes`]
+//!   when the `bytes` feature is enabled.
+//!
+//! ## Usage Example
+//!
+//! This example demonstrates how to use the fixed heap allocator to repeatedly
+//! allocate, write to, and freeze byte buffers from a fixed memory slab. It
+//! also verifies that each allocated buffer's memory lies within the provided
+//! slab.
+//!
+//! ```rust
+//! use core::mem::MaybeUninit;
+//! use alloc_bytes::{AllocBytes, AllocBytesMut};
+//! use heap_allocator::FixedHeapAllocator;
+//!
+//! const SLAB_SIZE: usize = 1024; // 1 KiB.
+//! let mut raw_slab = [MaybeUninit::uninit(); SLAB_SIZE];
+//! let slab_range = raw_slab.as_ptr_range();
+//! let allocator = FixedHeapAllocator::new(&mut raw_slab);
+//!
+//! // Loop to allocate, write, and free buffers from the slab.
+//! for _ in 0..1024 {
+//!    // Create a new mutable byte buffer from the allocator.
+//!    let mut buffer = AllocBytesMut::new_unaligned(&allocator);
+//!    // Write data into the buffer.
+//!    buffer.extend_from_slice(b"Hello, world!").unwrap();
+//!    // Freeze the mutable buffer into an immutable byte buffer.
+//!    let data: AllocBytes<_, _> = buffer.freeze();
+//!
+//!    // Validate the buffer length and contents.
+//!    assert_eq!(data.len(), 13);
+//!    assert_eq!(data.as_ref(), b"Hello, world!");
+//!
+//!    // Assert that the allocated data pointer lies within the raw slab.
+//!    assert!(
+//!        slab_range.contains(&(data.as_ref().as_ptr() as *const _)),
+//!        "data pointer not in raw_slab"
+//!    );
+//! }
+//! ```
+//!
+//! ### Converting to [`Bytes`]
+//!
+//! When the `bytes` feature is enabled, you can convert an [`AllocBytesMut`]
+//! into a [`Bytes`] object.
+//!
+//! Note: We use [`heap_allocator::OwnedFixedHeapAllocator`] instead of
+//! [`heap_allocator::FixedHeapAllocator`] to mask the lifetime our allocator's
+//! data (which is 'static in our case). This is often needed when complex
+//! lifetimes are involved but data is owned anyway.
+//!
+//! ```rust
+//! # #[cfg(feature = "bytes")]
+//! # {
+//! use std::sync::Arc;
+//! use alloc_bytes::AllocBytesMut;
+//! use heap_allocator::OwnedFixedHeapAllocator;
+//! use bytes::Bytes;
+//! use core::mem::MaybeUninit;
+//!
+//! const SLAB_SIZE: usize = 1024; // 1 KiB.
+//! let mut raw_slab = Vec::with_capacity(SLAB_SIZE);
+//! raw_slab.resize(SLAB_SIZE, MaybeUninit::uninit());
+//! let allocator = Arc::new(OwnedFixedHeapAllocator::new(raw_slab));
+//!
+//! // Create a mutable byte buffer and write data.
+//! let mut buffer = AllocBytesMut::new_unaligned(allocator.clone());
+//! buffer.extend_from_slice(b"Hello Bytes!").unwrap();
+//!
+//! // Convert the mutable buffer into an immutable `Bytes` object.
+//! let bytes_data: Bytes = buffer.into_bytes();
+//! assert_eq!(bytes_data.as_ref(), b"Hello Bytes!");
+//! # }
+//! ```
+//!
+//! ## Related Crates and Resources
+//!
+//! - **[bytes](https://docs.rs/bytes):** Utilities for working with byte
+//!   buffers.
+//! - **[heap_allocator](https://crates.io/crates/heap_allocator):** An example
+//!   custom heap allocator.
+//!
+//! This crate is `no_std` compatible.
+use core::alloc::{GlobalAlloc, Layout};
+use core::ops::Deref;
+use core::ptr::NonNull;
+
+#[cfg(any(doc, feature = "bytes"))]
+use bytes::Bytes;
+
+/// Errors that can occur during allocation or reallocation.
+#[derive(Debug)]
+pub enum AllocBytesError {
+    /// Returned when allocation or reallocation fails.
+    FailedToRealloc,
+    /// Returned when the requested capacity addition would overflow.
+    ReserveTooLarge,
+    /// Returned when the requested layout is invalid.
+    Layout(core::alloc::LayoutError),
+}
+
+/// An immutable byte buffer allocated via a custom allocator.
+///
+/// This type holds a raw pointer to memory allocated using the provided
+/// allocator. It is not [`Sync`] because the inner pointer is mutated in
+/// controlled ways. If you need to share the buffer across threads concurrently
+/// (i.e. require [`Sync`]), consider converting it into a [`Bytes`]
+/// object via [`AllocBytesMut::into_bytes()`] or wrapping it in an `Arc`.
+///
+/// # Type Parameters
+/// - `T`: A type that can be converted to a reference to the allocator.
+/// - `A`: The allocator type that implements [`GlobalAlloc`].
+/// - `ALIGN`: The alignment to use for allocations (default is 1).
+pub struct AllocBytes<T, A, const ALIGN: usize = 1>
+where
+    T: Deref<Target = A>,
+    A: GlobalAlloc + ?Sized,
+{
+    heap: T,
+    ptr: NonNull<u8>,
+    size: usize,
+    cap: usize,
+    _phantom: core::marker::PhantomData<A>,
+}
+
+impl<T, A, const ALIGN: usize> AllocBytes<T, A, ALIGN>
+where
+    T: Deref<Target = A>,
+    A: GlobalAlloc + ?Sized,
+{
+    /// Returns the number of bytes in the buffer.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Returns if the buffer is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the capacity of the buffer in bytes.
+    #[inline]
+    pub const fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Returns a reference to the allocator used for the buffer.
+    #[inline]
+    pub fn heap(&self) -> &A {
+        &self.heap
+    }
+}
+
+/// Safety: Although [`AllocBytes`] contains a raw pointer, it is only mutated
+/// during deallocation (in [`Drop`]) and via exclusive mutable access in
+/// [`AllocBytesMut`]. Thus, it is safe to implement [`Send`] if the underlying
+/// allocator is thread-safe.
+unsafe impl<T, A, const ALIGN: usize> Send for AllocBytes<T, A, ALIGN>
+where
+    T: Deref<Target = A>,
+    A: GlobalAlloc + ?Sized,
+{
+}
+
+impl<T: Deref<Target = A>, A: GlobalAlloc, const ALIGN: usize> AsRef<[u8]>
+    for AllocBytes<T, A, ALIGN>
+{
+    /// Returns a byte slice of the allocated memory.
+    ///
+    /// # Safety
+    ///
+    /// This is safe because the invariants of [`AllocBytes`] ensure that the
+    /// pointer is valid for [`AllocBytes::len()`] bytes.
+    fn as_ref(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.size) }
+    }
+}
+
+impl<T: Deref<Target = A>, A: GlobalAlloc + ?Sized, const ALIGN: usize> Drop
+    for AllocBytes<T, A, ALIGN>
+{
+    /// Deallocates the allocated memory.
+    ///
+    /// # Safety
+    ///
+    /// The memory was allocated with a layout of size [`AllocBytes::cap()`] and
+    /// alignment `ALIGN`. If `ptr` is still [`NonNull::dangling()`], no
+    /// deallocation is performed.
+    fn drop(&mut self) {
+        if self.ptr == NonNull::dangling() {
+            // No allocation was ever performed.
+            return;
+        }
+        unsafe {
+            self.heap.dealloc(
+                self.ptr.as_ptr(),
+                // SAFETY: The layout here matches the one used during
+                // [re]allocation.
+                Layout::from_size_align_unchecked(self.cap, ALIGN),
+            );
+        }
+    }
+}
+
+/// A mutable byte buffer for building up data with a custom allocator.
+///
+/// This type allows extending the buffer and then "freezing" it into an
+/// immutable [`AllocBytes`] (using [`AllocBytesMut::freeze()`] and/or [`Bytes`]
+/// (using [`AllocBytesMut::into_bytes()`]).
+pub struct AllocBytesMut<'a, T, A, const ALIGN: usize>
+where
+    T: Deref<Target = A> + 'a,
+    A: GlobalAlloc + ?Sized + 'a,
+{
+    inner: AllocBytes<T, A, ALIGN>,
+    _phantom: core::marker::PhantomData<&'a ()>,
+}
+
+impl<T: Deref<Target = A>, A: GlobalAlloc> AllocBytesMut<'_, T, A, 1> {
+    /// Creates a new mutable byte buffer with unaligned allocations
+    /// (ie: alignment = 1).
+    pub fn new_unaligned(heap: T) -> Self {
+        Self {
+            inner: AllocBytes {
+                heap,
+                // Use dangling pointer as a sentinel for "no allocation".
+                ptr: NonNull::dangling(),
+                size: 0,
+                cap: 0,
+                _phantom: core::marker::PhantomData,
+            },
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, A, const ALIGN: usize> AllocBytesMut<'_, T, A, ALIGN>
+where
+    T: Deref<Target = A>,
+    A: GlobalAlloc,
+{
+    /// Creates a new mutable byte buffer.
+    ///
+    /// This is the same as [`AllocBytesMut::new_unaligned()`] but used
+    /// when `ALIGN` needs to be > 1.
+    ///
+    /// See: [`AllocBytesMut::new_unaligned()`]
+    pub fn new(heap: T) -> Self {
+        Self {
+            inner: AllocBytes {
+                heap,
+                ptr: NonNull::dangling(),
+                size: 0,
+                cap: 0,
+                _phantom: core::marker::PhantomData,
+            },
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Returns the current capacity of the buffer in bytes.
+    #[inline]
+    pub const fn capacity(&self) -> usize {
+        self.inner.cap
+    }
+
+    /// Returns the current length (number of bytes used) of the buffer.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.inner.size
+    }
+
+    /// Returns `true` if the buffer is empty.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Ensures that the buffer has at least `additional` extra bytes of
+    /// capacity.
+    ///
+    /// If the current capacity is insufficient, the buffer is reallocated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the new capacity calculation overflows, the layout
+    /// is invalid, or the allocation/reallocation fails.
+    ///
+    /// Data, length, and capacity are left unchanged if an error occurs.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) -> Result<(), AllocBytesError> {
+        let len = self.len();
+        debug_assert!(
+            self.inner.cap >= len,
+            "Capacity is less than length in AllocBytesMut::reserve"
+        );
+        // SAFETY: `AllocBytes::cap` is always >= `AllocBytes::size`.
+        let remaining = unsafe { self.inner.cap.unchecked_sub(len) };
+        if additional <= remaining {
+            return Ok(());
+        }
+        let new_capacity = len
+            .checked_add(additional)
+            .ok_or(AllocBytesError::ReserveTooLarge)?;
+        let new_ptr = unsafe {
+            if self.inner.ptr == NonNull::dangling() {
+                let layout = if ALIGN == 1 {
+                    // SAFETY: For alignment 1, layout creation cannot fail.
+                    Layout::from_size_align_unchecked(new_capacity, ALIGN)
+                } else {
+                    Layout::from_size_align(new_capacity, ALIGN).map_err(AllocBytesError::Layout)?
+                };
+                self.inner.heap.alloc(layout)
+            } else {
+                let layout = if ALIGN == 1 {
+                    // SAFETY: For alignment 1, layout creation cannot fail.
+                    Layout::from_size_align_unchecked(self.inner.cap, ALIGN)
+                } else {
+                    Layout::from_size_align(self.inner.cap, ALIGN)
+                        .map_err(AllocBytesError::Layout)?
+                };
+                self.inner
+                    .heap
+                    .realloc(self.inner.ptr.as_ptr(), layout, new_capacity)
+            }
+        };
+        let new_ptr = NonNull::new(new_ptr).ok_or(AllocBytesError::FailedToRealloc)?;
+        self.inner.cap = new_capacity;
+        self.inner.ptr = new_ptr;
+        Ok(())
+    }
+
+    /// Extends the buffer by copying bytes from the provided slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reserving additional capacity fails.
+    #[inline]
+    pub fn extend_from_slice(&mut self, extend: &[u8]) -> Result<(), AllocBytesError> {
+        let cnt = extend.len();
+        self.reserve(cnt)?;
+
+        unsafe {
+            // SAFETY:
+            // - We assume that `AllocBytes::size` <= `AllocBytes::cap`.
+            // - The source and destination cannot overlap if we own a mutable
+            //   reference to the data, since rust's borrow checker disallows
+            //   mutable references and non-mutable references to the same data.
+            debug_assert!(
+                self.inner.size <= self.inner.cap,
+                "Size is greater than capacity in AllocBytesMut::extend_from_slice"
+            );
+            core::ptr::copy_nonoverlapping(
+                extend.as_ptr(),
+                self.inner.ptr.as_ptr().add(self.inner.size),
+                cnt,
+            );
+            // SAFETY:
+            // - We previously reserved `cnt` additional bytes, so it should
+            //   have failed if the new size would overflow.
+            debug_assert!(
+                self.inner.size <= usize::MAX - cnt,
+                "Overflow in AllocBytesMut::extend_from_slice"
+            );
+            self.inner.size = self.inner.size.unchecked_add(cnt);
+        }
+        Ok(())
+    }
+
+    /// Freezes the mutable buffer, converting it into an immutable
+    /// [`AllocBytes`].
+    #[inline]
+    pub fn freeze(self) -> AllocBytes<T, A, ALIGN> {
+        self.inner
+    }
+
+    /// Converts the mutable buffer into a [`Bytes`] object.
+    ///
+    /// Requires the `bytes` feature to be  enabled.
+    #[cfg(any(doc, feature = "bytes"))]
+    #[inline]
+    pub fn into_bytes(self) -> Bytes
+    where
+        T: 'static,
+        A: 'static,
+    {
+        Bytes::from_owner(self.freeze())
+    }
+}

--- a/external-crates/alloc-bytes/tests/alloc_bytes_test.rs
+++ b/external-crates/alloc-bytes/tests/alloc_bytes_test.rs
@@ -1,0 +1,78 @@
+use std::mem::MaybeUninit;
+
+use alloc_bytes::{AllocBytesError, AllocBytesMut};
+use heap_allocator::FixedHeapAllocator;
+
+#[test]
+fn test_extend_and_freeze() {
+    let mut alloc_buf = [MaybeUninit::uninit(); 1024];
+    let alloc = FixedHeapAllocator::new(&mut alloc_buf);
+    let mut buf = AllocBytesMut::new_unaligned(&alloc);
+    // Initially the buffer should be empty.
+    assert_eq!(buf.len(), 0);
+    assert!(buf.is_empty());
+
+    // Extend the buffer with some data.
+    buf.extend_from_slice(b"Hello, world!").unwrap();
+    assert_eq!(buf.len(), 13);
+
+    // Freeze the mutable buffer into an immutable one.
+    let data = buf.freeze();
+    assert_eq!(data.len(), 13);
+    assert_eq!(data.as_ref(), b"Hello, world!");
+}
+
+#[test]
+fn test_reserve_increases_capacity() {
+    let mut alloc_buf = [MaybeUninit::uninit(); 1024];
+    let alloc = FixedHeapAllocator::new(&mut alloc_buf);
+    let mut buf = AllocBytesMut::new_unaligned(&alloc);
+
+    // Write some data into the buffer.
+    buf.extend_from_slice(b"12345").unwrap();
+    let old_capacity = buf.capacity();
+
+    // Reserve additional capacity.
+    buf.reserve(10).unwrap();
+    let new_capacity = buf.capacity();
+
+    // The new capacity should be at least current length + reserved extra.
+    assert!(new_capacity >= buf.len() + 10);
+    // In many cases the capacity will increase.
+    assert!(new_capacity >= old_capacity);
+}
+
+#[test]
+fn test_reserve_overflow() {
+    let mut alloc_buf = [MaybeUninit::uninit(); 1024];
+    let alloc = FixedHeapAllocator::new(&mut alloc_buf);
+    let mut buf = AllocBytesMut::new_unaligned(&alloc);
+
+    // Extend the buffer so that the length is non-zero.
+    buf.extend_from_slice(b"12345").unwrap();
+
+    // Attempting to reserve an extra huge amount should trigger an overflow error.
+    let result = buf.reserve(usize::MAX);
+    match result {
+        Err(AllocBytesError::ReserveTooLarge) => {} // expected error
+        _ => panic!("Expected ReserveTooLarge error"),
+    }
+}
+
+#[cfg(feature = "bytes")]
+#[test]
+fn test_into_bytes_conversion() {
+    use std::sync::Arc;
+
+    use heap_allocator::MutexOwnedFixedHeapAllocator;
+
+    let mut alloc_buf = Vec::with_capacity(1024);
+    alloc_buf.resize(1024, MaybeUninit::uninit());
+    let alloc = Arc::new(MutexOwnedFixedHeapAllocator::new(alloc_buf));
+    let mut buf = AllocBytesMut::new_unaligned(alloc);
+    buf.extend_from_slice(b"Hello Bytes!").unwrap();
+
+    // Convert the mutable buffer into a `Bytes` object.
+    let bytes_data = buf.into_bytes();
+    assert_eq!(bytes_data.as_ref(), b"Hello Bytes!");
+}

--- a/external-crates/heap-allocator/BUILD.bazel
+++ b/external-crates/heap-allocator/BUILD.bazel
@@ -1,0 +1,45 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+    "rust_test_suite",
+)
+
+rust_library(
+    name = "heap-allocator",
+    srcs = [
+        "src/lib.rs",
+    ],
+    crate_features = ["mutex"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:ouroboros",
+        "@crates//:parking_lot",
+        "@crates//:rlsf",
+    ],
+)
+
+rust_test_suite(
+    name = "integration",
+    timeout = "short",
+    srcs = [
+        "tests/heap_allocator_test.rs",
+    ],
+    crate_features = ["mutex"],
+    deps = [
+        ":heap-allocator",
+    ],
+)
+
+rust_doc(
+    name = "docs",
+    crate = ":heap-allocator",
+    visibility = ["//visibility:public"],
+)
+
+rust_doc_test(
+    name = "doc_test",
+    timeout = "short",
+    crate = ":heap-allocator",
+)

--- a/external-crates/heap-allocator/Cargo.toml
+++ b/external-crates/heap-allocator/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "heap-allocator"
+version = "0.0.1"
+edition = "2018"
+authors = [
+  "Nativelink Authors",
+  "Nathan (Blaise) Bruer <heap-allocator.blaise@allada.com>"
+]
+license = "Apache-2.0"
+repository = "https://github.com/TraceMachina/nativelink/external-crates/heap-allocator"
+description = "A fixed heap allocator based on TLSF for no_std"
+keywords = ["tlsf", "malloc", "allocator", "heap", "no_std", "embedded", "real-time", "memory-management", "mimalloc", "jemalloc", "glibc"]
+categories = ["memory-management", "api-bindings", "embedded", "performance"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+rlsf = { version = "0.2.1", default-features = false }
+ouroboros = { version = "0.18.5", default-features = false }
+parking_lot = { version = "0.12.3", default-features = false, optional = true }
+
+[features]
+default = []
+
+mutex = ["std", "dep:parking_lot"]
+std = []

--- a/external-crates/heap-allocator/src/lib.rs
+++ b/external-crates/heap-allocator/src/lib.rs
@@ -1,0 +1,464 @@
+// Copyright 2025 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+//! # Fixed Heap Allocator
+//!
+//! This crate provides a fixed heap allocator based on the TLSF (Two-Level
+//! Segregated Fit) algorithm. TLSF is a fast, constant-time memory allocation
+//! algorithm designed for real-time applications. It organizes free memory into
+//! segregated lists based on block sizes, allowing for quick allocation and
+//! deallocation with minimal fragmentation.
+//!
+//! This allocator is designed for use in `no_std` environments and allocates
+//! memory from a user-provided pre-allocated memory region. It supports both
+//! single-threaded and multi-threaded usage via conditional compilation
+//! features.
+//!
+//! ## Features
+//!
+//! - **Customizable Memory Block:** Supply your own memory region (as a slice
+//!   of `MaybeUninit<u8>`) to back the allocator.
+//! - **Thread-Safe Option:** When the `mutex` feature is enabled, a thread-safe
+//!   variant (`MutexOwnedFixedHeapAllocator`)
+//!   is available for multi-threaded environments.
+//! - **Zero-Size Allocations:** Zero-size allocations are handled by returning
+//!   a dangling pointer, following the Rust [`GlobalAlloc`] convention.
+//!
+//! ## Why This Crate?
+//!
+//! This crate was born out of the need to track memory usage for a specific
+//! module and to evict cache items when available memory becomes scarce. Our
+//! primary goal was to have fine-grained control over allocation sizes, which
+//! is crucial for efficient cache management.
+//!
+//! Initially, we attempted to use allocators like **mimalloc** and **jemalloc**
+//! as well as exploring **glibc**'s allocator. However, we encountered
+//! significant challenges:
+//!
+//! - **mimalloc:** Although mimalloc is renowned for its high performance and
+//!   thread-local caching, its internal handling of specialized heaps in
+//!   multi-threaded environments made it unsuitable for our need to precisely
+//!   track allocation sizes.
+//!
+//! - **jemalloc:** Despite its robustness, bundling jemalloc was problematic
+//!   due to the crate providing non-deterministic builds, which is a
+//!   requirement for our releases.
+//!
+//! Consequently, we turned to TLSF, implemented via the
+//! [rlsf](https://docs.rs/rlsf) crate. Benchmarking revealed that our
+//! TLSF-based allocator substantially outperformed our previous global-mimalloc
+//! implementation in our specific use-case, even though raw memory throughput
+//! was not our primary concern.
+//!
+//! This crate is a sister crate to [alloc_bytes](https://docs.rs/alloc_bytes),
+//! which provides custom byte buffers using a custom allocator. By leveraging
+//! an allocator/heap that is pre-allocated and fixed in size, we can ensure
+//! that memory usage is predictable and that we can track memory usage with
+//! precision.
+//!
+//! ## Usage Examples
+//!
+//! ### Multi-Threaded Example
+//!
+//! When using the `mutex` feature, you can use the thread-safe allocator in
+//! multi-threaded applications:
+//!
+//! ```rust
+//! use heap_allocator::MutexOwnedFixedHeapAllocator;
+//! use core::alloc::{GlobalAlloc, Layout};
+//! use core::mem::MaybeUninit;
+//! use std::sync::LazyLock;
+//! use std::thread;
+//!
+//! // Create a static, thread-safe allocator using std's LazyLock.
+//! // This allocator is backed by a Vec that serves as the memory pool.
+//! static ALLOCATOR: LazyLock<MutexOwnedFixedHeapAllocator<Vec<MaybeUninit<u8>>>> = LazyLock::new(|| {
+//!     let mut memory = Vec::with_capacity(64 * 1024);
+//!     // Fill the vector with uninitialized memory.
+//!     memory.resize(64 * 1024, MaybeUninit::uninit());
+//!     MutexOwnedFixedHeapAllocator::new(memory)
+//! });
+//!
+//! fn main() {
+//!     // Spawn multiple threads that allocate and deallocate memory
+//!     // concurrently.
+//!     let handles: Vec<_> = (0..4)
+//!         .map(|_| {
+//!             thread::spawn(|| {
+//!                 unsafe {
+//!                     let layout = Layout::from_size_align(128, 8).unwrap();
+//!                     let ptr = ALLOCATOR.alloc(layout);
+//!                     // Simulate work with allocated memory...
+//!                     ALLOCATOR.dealloc(ptr, layout);
+//!                 }
+//!             })
+//!         })
+//!         .collect();
+//!
+//!     for handle in handles {
+//!         handle.join().unwrap();
+//!     }
+//!
+//!     // For high-performance multi-threaded environments, consider using
+//!     // allocators such as mimalloc or jemalloc,
+//!     // which provide advanced techniques like thread-local caching to reduce
+//!     // contention.
+//! }
+//! ```
+//!
+//! This example uses `std::sync::LazyLock` (available in Rust 1.63+) to
+//! initialize a static allocator without relying on external crates.
+//!
+//! ### Single-Threaded Example
+//!
+//! In a single-threaded environment, you can use the unsynchronized allocator
+//! for improved performance:
+//!
+//! ```rust
+//! use heap_allocator::FixedHeapAllocator;
+//! use core::alloc::{GlobalAlloc, Layout};
+//!
+//! // Create a memory block for the heap.
+//! let mut memory = [core::mem::MaybeUninit::uninit(); 64 * 1024];
+//!
+//! // Create an unsynchronized allocator.
+//! let allocator = FixedHeapAllocator::new(&mut memory);
+//!
+//! // Allocation example.
+//! unsafe {
+//!     let layout = Layout::from_size_align(256, 8).unwrap();
+//!     let ptr = allocator.alloc(layout);
+//!     // Use allocated memory...
+//!     allocator.dealloc(ptr, layout);
+//! }
+//! ```
+//!
+//! ## About TLSF
+//!
+//! The TLSF (Two-Level Segregated Fit) algorithm is designed to offer
+//! constant-time allocation and deallocation in the worst-case scenario, making
+//! it especially suitable for real-time and embedded systems. TLSF divides free
+//! memory into several size classes using bit-level operations, which allows it
+//! to quickly locate a free block that best fits the requested allocation size.
+//!
+//! This allocator leverages TLSF to manage a fixed, user-supplied memory
+//! region, ensuring efficient and predictable memory management with low
+//! fragmentation.
+//!
+//! ## Related Crates
+//!
+//! - **`alloc_bytes`:** A crate that provides custom byte buffers using a
+//!   custom allocator. See [alloc_bytes](https://docs.rs/alloc_bytes) for more
+//!   details.
+//! - **rlsf:** The TLSF algorithm implementation is provided by the
+//!   [rlsf](https://docs.rs/rlsf) crate, which offers efficient, constant-time
+//!   memory allocation and deallocation routines suitable for real-time and
+//!   embedded systems.
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+
+use ouroboros::self_referencing;
+#[cfg(feature = "mutex")]
+use parking_lot::Mutex;
+use rlsf::Tlsf;
+
+#[cfg(feature = "mutex")]
+/// A thread-safe fixed heap allocator that wraps an [`OwnedFixedHeapAllocator`]
+/// in a [`parking_lot::Mutex`].
+///
+/// This type is enabled when the `mutex` feature is active and can be used as a
+/// global allocator in multi-threaded environments. Note that using a mutex for
+/// allocation may have performance implications. For high-performance
+/// scenarios, consider using an allocator with thread-local caching
+/// (e.g., `mimalloc` or `jemallocator`).
+///
+/// # Example
+///
+/// ```rust
+/// use heap_allocator::MutexOwnedFixedHeapAllocator;
+/// let mut memory = [core::mem::MaybeUninit::uninit(); 1024];
+/// let allocator = MutexOwnedFixedHeapAllocator::new(&mut memory);
+/// unsafe {
+///     let layout = core::alloc::Layout::from_size_align(128, 8).unwrap();
+///     let ptr = allocator.alloc(layout);
+///     allocator.dealloc(ptr, layout);
+/// }
+/// ```
+pub struct MutexOwnedFixedHeapAllocator<T: 'static> {
+    inner: Mutex<OwnedFixedHeapAllocator<T>>,
+}
+
+#[cfg(feature = "mutex")]
+impl<T> MutexOwnedFixedHeapAllocator<T>
+where
+    T: AsMut<[MaybeUninit<u8>]>,
+{
+    /// Creates a new instance of the mutex-protected fixed heap allocator.
+    #[inline]
+    pub fn new(data: T) -> Self {
+        Self {
+            inner: Mutex::new(OwnedFixedHeapAllocator::new(data)),
+        }
+    }
+}
+
+#[cfg(feature = "mutex")]
+unsafe impl<T> GlobalAlloc for MutexOwnedFixedHeapAllocator<T> {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.inner.lock().alloc(layout)
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner.lock().dealloc(ptr, layout);
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        self.inner.lock().realloc(ptr, layout, new_size)
+    }
+}
+
+/// An owned fixed heap allocator with erased lifetimes.
+///
+/// This type is identical to `FixedHeapAllocator<'static, T>` but erases the
+/// lifetime of the backing data. This can be useful in complex lifetime
+/// scenarios where you want to simplify the type signatures.
+///
+/// # Example
+///
+/// ```rust
+/// use core::alloc::{GlobalAlloc, Layout};
+/// use heap_allocator::OwnedFixedHeapAllocator;
+///
+/// let mut memory = Vec::with_capacity(64 * 1024);
+/// memory.resize(64 * 1024, core::mem::MaybeUninit::uninit());
+/// let allocator = OwnedFixedHeapAllocator::new(memory);
+/// unsafe {
+///     let layout = Layout::from_size_align(256, 8).unwrap();
+///     let ptr = allocator.alloc(layout);
+///     allocator.dealloc(ptr, layout);
+/// }
+/// ```
+pub struct OwnedFixedHeapAllocator<T: 'static> {
+    inner: FixedHeapAllocator<'static, T>,
+}
+
+impl<T> OwnedFixedHeapAllocator<T>
+where
+    T: AsMut<[MaybeUninit<u8>]> + 'static,
+{
+    /// Creates a new instance of the fixed heap allocator.
+    #[inline]
+    pub fn new(data: T) -> Self {
+        Self {
+            inner: FixedHeapAllocator::new(data),
+        }
+    }
+}
+
+unsafe impl<T> GlobalAlloc for OwnedFixedHeapAllocator<T> {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.inner.alloc(layout)
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner.dealloc(ptr, layout);
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        self.inner.realloc(ptr, layout, new_size)
+    }
+}
+
+/// Internal self-referencing structure for `FixedHeapAllocator`.
+///
+/// This structure ties the lifetime of the TLSF heap to the backing data
+/// provided by the user. The `heap` field is constructed using a mutable
+/// reference from `data`, allowing the TLSF heap to safely reference the
+/// user-provided memory block.
+///
+/// # Safety
+///
+/// The lifetime annotations and the use of `UnsafeCell` ensure that the heap
+/// does not outlive the backing data. It is critical that the provided memory
+/// meets the alignment and size requirements expected by the TLSF algorithm.
+#[self_referencing]
+struct FixedHeapAllocatorInner<'data, T: 'data> {
+    data: T,
+    // The TLSF heap is created from the provided memory block.
+    #[borrows(mut data)]
+    #[not_covariant]
+    heap: UnsafeCell<Tlsf<'this, usize, u8, 32, 8>>,
+    phantom: core::marker::PhantomData<&'data ()>,
+}
+
+/// A fixed heap allocator implemented on top of a user-provided memory region.
+///
+/// This allocator uses a TLSF (Two-Level Segregated Fit) algorithm to manage
+/// memory allocations and implements the [`GlobalAlloc`] trait, making it
+/// usable as a global allocator.
+///
+/// Note: If you encounter lifetime issues, consider using
+/// [`OwnedFixedHeapAllocator`], which erases lifetimes.
+pub struct FixedHeapAllocator<'data, T: 'data> {
+    inner: FixedHeapAllocatorInner<'data, T>,
+}
+
+impl<'data, T> FixedHeapAllocator<'data, T>
+where
+    T: AsMut<[MaybeUninit<u8>]> + 'data,
+{
+    /// Creates a new `FixedHeapAllocator` instance.
+    ///
+    /// The provided memory (`data`) is used to initialize a TLSF heap, and the
+    /// entire memory block is inserted as a free block.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A user-provided memory region as a slice of
+    ///   `MaybeUninit<u8>`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use heap_allocator::FixedHeapAllocator;
+    /// let mut memory = [core::mem::MaybeUninit::uninit(); 1024];
+    /// let allocator = FixedHeapAllocator::new(&mut memory);
+    /// ```
+    pub fn new(data: T) -> Self {
+        Self {
+            inner: FixedHeapAllocatorInnerBuilder {
+                data,
+                heap_builder: |data| {
+                    let mut heap = Tlsf::new();
+                    heap.insert_free_block(data.as_mut());
+                    UnsafeCell::new(heap)
+                },
+                phantom: core::marker::PhantomData,
+            }
+            .build(),
+        }
+    }
+}
+
+impl<T> FixedHeapAllocator<'_, T> {
+    #[inline]
+    fn inner_alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() == 0 {
+            return NonNull::dangling().as_ptr();
+        }
+        match self.inner.with_heap(|heap| {
+            // Safety: `heap` will always have a value.
+            // We will never hold a mutable reference to `heap` while it is
+            // borrowed
+            unsafe { &mut *heap.get() }.allocate(layout)
+        }) {
+            Some(ptr) => ptr.as_ptr(),
+            None => core::ptr::null_mut(),
+        }
+    }
+
+    #[inline]
+    fn inner_dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ptr == NonNull::dangling().as_ptr() {
+            return; // No deallocation necessary for zero-size allocations.
+        }
+        debug_assert!(!ptr.is_null(), "dealloc called with null pointer");
+        // Safety: We would rather have the program at a lower level
+        // with a segfault, rather than panic here if the user is calling
+        // `dealloc` with a null pointer.
+        let raw_ptr = unsafe { NonNull::new_unchecked(ptr) };
+        self.inner
+            // Safety: `heap` will always have a value.
+            // We will never hold a mutable reference to `heap` while it is
+            // borrowed.
+            .with_heap(|heap| unsafe { (*heap.get()).deallocate(raw_ptr, layout.align()) });
+    }
+
+    #[inline]
+    fn inner_realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ptr == NonNull::dangling().as_ptr() {
+            // Treat a dangling pointer as a zero-size allocation; allocate new
+            // memory.
+            let layout = unsafe {
+                // Safety: All we really want to do is modify `layout` to have the
+                // new size and call `alloc` with it, but there's now api for it.
+                Layout::from_size_align_unchecked(new_size, layout.align())
+            };
+            return self.inner_alloc(layout);
+        }
+        if new_size == 0 {
+            // Zero new size: deallocate existing memory and return a dangling
+            // pointer.
+            self.inner_dealloc(ptr, layout);
+            return NonNull::dangling().as_ptr();
+        }
+        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
+        debug_assert!(!ptr.is_null(), "realloc called with null pointer");
+        // Safety: We would rather have the program at a lower level
+        // with a segfault, rather than panic here if the user is calling
+        // `dealloc` with a null pointer.
+        let raw_ptr = unsafe { NonNull::new_unchecked(ptr) };
+        match self
+            .inner
+            // Safety: `heap` will always have a value.
+            // We will never hold a mutable reference to `heap` while it is
+            // borrowed.
+            .with_heap(|heap| unsafe { (*heap.get()).reallocate(raw_ptr, new_layout) })
+        {
+            Some(new_ptr) => new_ptr.as_ptr(),
+            None => core::ptr::null_mut(),
+        }
+    }
+}
+
+unsafe impl<T> GlobalAlloc for FixedHeapAllocator<'_, T> {
+    /// Allocates memory according to the specified `layout`.
+    ///
+    /// For zero-size allocations, a dangling pointer is returned in accordance
+    /// with the [`GlobalAlloc`] contract.
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.inner_alloc(layout)
+    }
+
+    /// Deallocates the memory referenced by `ptr` using the given `layout`.
+    ///
+    /// If `ptr` is a dangling pointer (i.e. representing a zero-size
+    /// allocation), no action is taken. A debug assertion ensures that a null
+    /// pointer is never deallocated.
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner_dealloc(ptr, layout);
+    }
+
+    /// Reallocates memory referenced by `ptr` to a new size (`new_size`).
+    ///
+    /// If `ptr` is a dangling pointer, a new allocation is performed.
+    /// If `new_size` is zero, the memory is deallocated and a dangling pointer
+    /// is returned. A debug assertion ensures that `ptr` is not null.
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        self.inner_realloc(ptr, layout, new_size)
+    }
+}

--- a/external-crates/heap-allocator/tests/heap_allocator_test.rs
+++ b/external-crates/heap-allocator/tests/heap_allocator_test.rs
@@ -1,0 +1,139 @@
+use core::mem::MaybeUninit;
+use std::alloc::{GlobalAlloc, Layout};
+
+use heap_allocator::{FixedHeapAllocator, OwnedFixedHeapAllocator};
+
+#[test]
+fn test_fixed_heap_alloc_dealloc() {
+    let mut memory = [MaybeUninit::uninit(); 1024];
+    let allocator = FixedHeapAllocator::new(&mut memory);
+
+    unsafe {
+        // Allocate 128 bytes with 8-byte alignment.
+        let layout = Layout::from_size_align(128, 8).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Allocation should return a valid pointer");
+        assert!(ptr as usize % 8 == 0, "Pointer should be 8-byte aligned");
+
+        for i in 0..128 {
+            *ptr.add(i) = i as u8;
+        }
+
+        allocator.dealloc(ptr, layout);
+    }
+}
+
+#[test]
+fn test_zero_size_allocation() {
+    let mut memory = [MaybeUninit::uninit(); 1024];
+    let allocator = FixedHeapAllocator::new(&mut memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(0, 8).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert_eq!(ptr, core::ptr::NonNull::dangling().as_ptr());
+    }
+}
+
+#[test]
+fn test_fixed_heap_realloc_increase() {
+    let mut memory = [MaybeUninit::uninit(); 1024];
+    let allocator = FixedHeapAllocator::new(&mut memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(64, 8).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Initial allocation should succeed");
+        assert!(ptr as usize % 8 == 0, "Pointer should be 8-byte aligned");
+
+        for i in 0..64 {
+            *ptr.add(i) = (i + 1) as u8;
+        }
+
+        // Increase the allocation size to 128 bytes.
+        let new_size = 128;
+        let new_ptr = allocator.realloc(ptr, layout, new_size);
+        assert!(!new_ptr.is_null(), "Reallocation should succeed");
+
+        for i in 0..64 {
+            assert_eq!(
+                *new_ptr.add(i),
+                (i + 1) as u8,
+                "Data should be preserved after realloc"
+            );
+        }
+
+        let new_layout = Layout::from_size_align(new_size, 8).unwrap();
+        allocator.dealloc(new_ptr, new_layout);
+    }
+}
+
+#[test]
+fn test_fixed_heap_realloc_decrease() {
+    let mut memory = [MaybeUninit::uninit(); 1024];
+    let allocator = FixedHeapAllocator::new(&mut memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(64, 1).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Initial allocation should succeed");
+
+        for i in 0..64 {
+            *ptr.add(i) = (i + 1) as u8;
+        }
+
+        // Shrink the allocation size to 0 bytes.
+        let new_ptr = allocator.realloc(ptr, layout, 0);
+        assert!(!new_ptr.is_null(), "Reallocation should succeed");
+        assert_eq!(new_ptr, core::ptr::NonNull::dangling().as_ptr());
+
+        let new_layout = Layout::from_size_align(0, 1).unwrap();
+        allocator.dealloc(new_ptr, new_layout);
+    }
+}
+
+#[test]
+fn test_fixed_heap_realloc_to_zero() {
+    let mut memory = [MaybeUninit::uninit(); 1024];
+    let allocator = FixedHeapAllocator::new(&mut memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(64, 1).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Initial allocation should succeed");
+
+        let new_ptr = allocator.realloc(ptr, layout, 0);
+        assert_eq!(new_ptr, core::ptr::NonNull::dangling().as_ptr());
+    }
+}
+
+#[test]
+fn test_owned_fixed_heap_alloc_dealloc() {
+    let mut memory = Vec::with_capacity(1024);
+    memory.resize(1024, MaybeUninit::uninit());
+    let allocator = OwnedFixedHeapAllocator::new(memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(128, 1).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Allocation should return a valid pointer");
+        allocator.dealloc(ptr, layout);
+    }
+}
+
+#[cfg(feature = "mutex")]
+#[test]
+fn test_mutex_owned_fixed_heap_alloc_dealloc() {
+    use heap_allocator::MutexOwnedFixedHeapAllocator;
+
+    let mut memory = Vec::with_capacity(1024);
+    memory.resize(1024, MaybeUninit::uninit());
+    let allocator = MutexOwnedFixedHeapAllocator::new(memory);
+
+    unsafe {
+        let layout = Layout::from_size_align(128, 1).unwrap();
+        let ptr = allocator.alloc(layout);
+        assert!(!ptr.is_null(), "Allocation should return a valid pointer");
+        allocator.dealloc(ptr, layout);
+    }
+}

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -37,6 +37,8 @@ rust_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//external-crates/alloc-bytes",
+        "//external-crates/heap-allocator",
         "//nativelink-config",
         "//nativelink-error",
         "//nativelink-metric",

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -9,6 +9,8 @@ nativelink-config = { path = "../nativelink-config" }
 nativelink-util = { path = "../nativelink-util" }
 nativelink-proto = { path = "../nativelink-proto" }
 nativelink-metric = { path = "../nativelink-metric" }
+alloc-bytes = { path = "../external-crates/alloc-bytes" }
+heap-allocator = { path = "../external-crates/heap-allocator", features = ["mutex"] }
 async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 async-trait = "0.1.85"
 aws-config = { version = "1.5.14", default-features = false, features = [

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -14,15 +14,18 @@
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
+use std::mem::MaybeUninit;
 use std::ops::Bound;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use alloc_bytes::{AllocBytesError, AllocBytesMut};
 use async_trait::async_trait;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
+use heap_allocator::MutexOwnedFixedHeapAllocator;
 use nativelink_config::stores::MemorySpec;
-use nativelink_error::{Code, Error, ResultExt};
+use nativelink_error::{make_err, Code, Error, ResultExt};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::evicting_map::{EvictingMap, LenEntry};
@@ -30,11 +33,18 @@ use nativelink_util::health_utils::{
     default_health_status_indicator, HealthRegistryBuilder, HealthStatusIndicator,
 };
 use nativelink_util::store_trait::{StoreDriver, StoreKey, StoreKeyBorrow, UploadSizeInfo};
+use tracing::{event, Level};
 
 use crate::cas_utils::is_zero_digest;
 
+/// Default amount of memory to evict when the cache is full.
+const DEFAULT_EVICT_BYTES: usize = 2 * 1024 * 1024; // 4MB.
+
+/// The maximum size of memory that can be allocated in a single call.
+const MEMORY_ALLOC_CHUNK_SIZE: usize = 4 * 1024 * 1024; // 4MB.
+
 #[derive(Clone)]
-pub struct BytesWrapper(Bytes);
+struct BytesWrapper(Bytes);
 
 impl Debug for BytesWrapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -58,19 +68,36 @@ impl LenEntry for BytesWrapper {
 pub struct MemoryStore {
     #[metric(group = "evicting_map")]
     evicting_map: EvictingMap<StoreKeyBorrow, BytesWrapper, SystemTime>,
+    heap_allocator: Arc<MutexOwnedFixedHeapAllocator<Vec<MaybeUninit<u8>>>>,
 }
 
 impl MemoryStore {
     pub fn new(spec: &MemorySpec) -> Arc<Self> {
-        let empty_policy = nativelink_config::stores::EvictionPolicy::default();
-        let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
+        let mut eviction_policy = spec.eviction_policy.clone().unwrap_or_default();
+        if eviction_policy.evict_bytes == 0 {
+            eviction_policy.evict_bytes = DEFAULT_EVICT_BYTES;
+        }
+        if eviction_policy.max_bytes == 0 {
+            eviction_policy.max_bytes = DEFAULT_EVICT_BYTES * 10;
+            event!(
+                Level::WARN,
+                "MemoryStore config' max_bytes is 0, setting to 10x evict_bytes({}). This will be required to be set in a future release.",
+                eviction_policy.max_bytes,
+            );
+        }
+        let max_bytes = eviction_policy.max_bytes;
+        let mut data = Vec::<MaybeUninit<u8>>::with_capacity(max_bytes);
+        // Safety: We are setting the length of the vector to the maximum
+        unsafe { data.set_len(max_bytes) };
+        let heap_allocator = Arc::new(MutexOwnedFixedHeapAllocator::new(data));
         Arc::new(Self {
-            evicting_map: EvictingMap::new(eviction_policy, SystemTime::now()),
+            evicting_map: EvictingMap::new(&eviction_policy, SystemTime::now()),
+            heap_allocator,
         })
     }
 
-    /// Returns the number of key-value pairs that are currently in the the cache.
-    /// Function is not for production code paths.
+    /// Returns the number of key-value pairs currently in the cache.
+    /// (Not used in production.)
     pub async fn len_for_test(&self) -> usize {
         self.evicting_map.len_for_test().await
     }
@@ -125,18 +152,82 @@ impl StoreDriver for MemoryStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
-        _size_info: UploadSizeInfo,
+        size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
         // Internally Bytes might hold a reference to more data than just our data. To prevent
         // this potential case, we make a full copy of our data for long-term storage.
         let final_buffer = {
-            let buffer = reader
-                .consume(None)
-                .await
-                .err_tip(|| "Failed to collect all bytes from reader in memory_store::update")?;
-            let mut new_buffer = BytesMut::with_capacity(buffer.len());
-            new_buffer.extend_from_slice(&buffer[..]);
-            new_buffer.freeze()
+            let max_size = match size_info {
+                UploadSizeInfo::ExactSize(size) | UploadSizeInfo::MaxSize(size) => {
+                    if size > self.evicting_map.max_bytes() {
+                        event!(
+                            Level::WARN,
+                            "Uploaded object too large {size} > {} in memory store, suggest wrapping in a size_partitioning store to ensure big files don't get sent to this store.",
+                            self.evicting_map.max_bytes()
+                        );
+                        reader.drain().await.err_tip(|| "Failed to drain reader in memory_store::update")?;
+                        return Ok(());
+                    }
+                    usize::try_from(size)
+                }
+            }
+            .err_tip(|| "Could not convert size to usize in memory_store::update")?;
+
+            let mut alloc_bytes_mut = AllocBytesMut::new_unaligned(self.heap_allocator.clone());
+            loop {
+                let chunk = reader
+                    .recv()
+                    .await
+                    .err_tip(|| "Failed to receive data in memory_store::update")?;
+                if chunk.is_empty() {
+                    break; // EOF.
+                }
+                let new_size = alloc_bytes_mut.len().saturating_add(chunk.len());
+                if new_size > alloc_bytes_mut.capacity() {
+                    let additional_reserve = max_size
+                        .checked_sub(alloc_bytes_mut.len())
+                        .err_tip(|| "More bytes received than stated in memory store")?
+                        .min(MEMORY_ALLOC_CHUNK_SIZE);
+                    loop {
+                        match alloc_bytes_mut.reserve(additional_reserve) {
+                            Ok(()) => break,
+                            Err(AllocBytesError::FailedToRealloc) => {
+                                let evict_bytes = u64::try_from(chunk.len())
+                                    .err_tip(|| "Could not convert chunk.len() to u64")?;
+                                if self.evicting_map.force_eviction_bytes(evict_bytes).await == 0 {
+                                    event!(
+                                        Level::WARN,
+                                        "FailedToRealloc: Object too large ({max_size}) to fit in memory store even after evicting. {}",
+                                        "Suggest using a size_partitioning store to ensure big files don't get sent to this store.",
+                                    );
+                                    return Ok(());
+                                }
+                            }
+                            Err(AllocBytesError::ReserveTooLarge) => {
+                                event!(
+                                    Level::WARN,
+                                    "ReserveTooLarge: Object too large ({max_size}) to fit in memory store even after evicting. {}",
+                                    "Suggest using a size_partitioning store to ensure big files don't get sent to this store.",
+                                );
+                                return Ok(());
+                            }
+                            Err(AllocBytesError::Layout(e)) => {
+                                return Err(make_err!(
+                                    Code::Internal,
+                                    "Memory store Invalid layout. This should never happen - {e:?}"
+                                ));
+                            }
+                        }
+                    }
+                }
+                alloc_bytes_mut
+                    .extend_from_slice(&chunk)
+                    .map_err(|e| make_err!(
+                        Code::Internal,
+                        "Could not allocate bytes from slice in memory store. This should never happen - {e:?}")
+                    )?;
+            }
+            Bytes::from_owner(alloc_bytes_mut.freeze())
         };
 
         self.evicting_map

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -26,7 +26,7 @@ use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-const MEGABYTE_SZ: usize = 1024 * 1024;
+const KILOBYTE_SZ: usize = 1024;
 
 fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<MemoryStore>>) {
     let memory_store_config = MemorySpec::default();
@@ -69,7 +69,7 @@ async fn verify_weights(
     print_results: bool,
 ) -> Result<(), Error> {
     let (shard_store, stores) = make_stores(weights);
-    let data = make_random_data(MEGABYTE_SZ);
+    let data = make_random_data(KILOBYTE_SZ);
 
     for counter in 0..rounds {
         let mut hasher = DigestHasherFunc::Blake3.hasher();
@@ -101,13 +101,13 @@ const STORE1_HASH: &str = "00000000EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
 async fn has_with_one_digest() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data = make_random_data(MEGABYTE_SZ);
+    let original_data = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
     stores[0]
         .update_oneshot(digest1, original_data.clone().into())
         .await?;
 
-    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(KILOBYTE_SZ as u64)));
     Ok(())
 }
 
@@ -131,7 +131,7 @@ async fn has_with_many_digests_both_missing() -> Result<(), Error> {
 async fn has_with_many_digests_one_missing() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data = make_random_data(MEGABYTE_SZ);
+    let original_data = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
     let missing_digest = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
     stores[0]
@@ -142,7 +142,7 @@ async fn has_with_many_digests_one_missing() -> Result<(), Error> {
         shard_store
             .has_many(&[digest1.into(), missing_digest.into()])
             .await,
-        Ok(vec![Some(MEGABYTE_SZ as u64), None])
+        Ok(vec![Some(KILOBYTE_SZ as u64), None])
     );
     Ok(())
 }
@@ -151,8 +151,8 @@ async fn has_with_many_digests_one_missing() -> Result<(), Error> {
 async fn has_with_many_digests_both_exist() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
-    let original_data2 = make_random_data(2 * MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
+    let original_data2 = make_random_data(2 * KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
     let digest2 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
     stores[0]
@@ -178,7 +178,7 @@ async fn has_with_many_digests_both_exist() -> Result<(), Error> {
 async fn get_part_reads_store0() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
     stores[0]
         .update_oneshot(digest1, original_data1.clone().into())
@@ -195,7 +195,7 @@ async fn get_part_reads_store0() -> Result<(), Error> {
 async fn get_part_reads_store1() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
     stores[1]
         .update_oneshot(digest1, original_data1.clone().into())
@@ -212,7 +212,7 @@ async fn get_part_reads_store1() -> Result<(), Error> {
 async fn upload_store0() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE0_HASH, 100).unwrap();
     shard_store
         .update_oneshot(digest1, original_data1.clone().into())
@@ -229,7 +229,7 @@ async fn upload_store0() -> Result<(), Error> {
 async fn upload_store1() -> Result<(), Error> {
     let (shard_store, stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
     shard_store
         .update_oneshot(digest1, original_data1.clone().into())
@@ -246,7 +246,7 @@ async fn upload_store1() -> Result<(), Error> {
 async fn upload_download_has_check() -> Result<(), Error> {
     let (shard_store, _stores) = make_stores(&[1, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
 
     assert_eq!(shard_store.has(digest1).await, Ok(None));
@@ -257,7 +257,7 @@ async fn upload_download_has_check() -> Result<(), Error> {
         shard_store.get_part_unchunked(digest1, 0, None).await,
         Ok(original_data1.into())
     );
-    assert_eq!(shard_store.has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
+    assert_eq!(shard_store.has(digest1).await, Ok(Some(KILOBYTE_SZ as u64)));
     Ok(())
 }
 
@@ -266,13 +266,13 @@ async fn weights_send_to_proper_store() -> Result<(), Error> {
     // Very low chance anything will ever go to second store due to weights being so much diff.
     let (shard_store, stores) = make_stores(&[100_000, 1]);
 
-    let original_data1 = make_random_data(MEGABYTE_SZ);
+    let original_data1 = make_random_data(KILOBYTE_SZ);
     let digest1 = DigestInfo::try_new(STORE1_HASH, 100).unwrap();
     shard_store
         .update_oneshot(digest1, original_data1.clone().into())
         .await?;
 
-    assert_eq!(stores[0].has(digest1).await, Ok(Some(MEGABYTE_SZ as u64)));
+    assert_eq!(stores[0].has(digest1).await, Ok(Some(KILOBYTE_SZ as u64)));
     assert_eq!(stores[1].has(digest1).await, Ok(None));
     Ok(())
 }


### PR DESCRIPTION
MemoryStore now pre-allocates max_bytes from the eviction policy,
then installs a custom allocator in that pool that the store will
use. In testing, memory fragmentation appears to have dropped
significantly, significantly decreased the number of sys-calls
managing memory and slightly reduced user time.

In addition, we remove two full copies of our data when we store
it in the memory store.

This PR also adds two new crates (likely to be published).

"Heap Allocator"
  Fixed heap allocator based on the TLSF (Two-Level Segregated
  Fit) algorithm. TLSF is a fast, constant-time memory allocation
  algorithm designed for real-time applications. It organizes free
  memory into segregated lists based on block sizes, allowing for
  quick allocation and deallocation with minimal fragmentation.

"Alloc Bytes"
  Provides custom byte buffers allocated using a user-provided
  allocator. It offers both mutable and immutable byte buffers,
  enabling efficient memory allocation strategies in systems with
  custom memory requirements.

closes: #289

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1588)
<!-- Reviewable:end -->
