### PR TITLE
Refactor GitHub actions

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -1,0 +1,56 @@
+---
+name: Prepare Nix
+description: "Common setup for all runs using Nix."
+runs:
+  using: "composite"
+  steps:
+    - name: Free disk space
+      uses: >- # v2.0.0
+        endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
+      with:
+        remove_android: false # Takes too long.
+        remove_dotnet: true
+        remove_haskell: true
+        remove_tool_cache: false # TODO(aaronmondal): Do we really need this?
+        # Note: Not deleting google-cloud-cli because it takes too long.
+        remove_packages: >
+          azure-cli
+          microsoft-edge-stable
+          google-chrome-stable
+          firefox
+          postgresql*
+          temurin-*
+          *llvm*
+          mysql*
+          dotnet-sdk-*
+        remove_packages_one_command: true
+        remove_folders: >
+          /usr/share/swift
+          /usr/share/miniconda
+          /usr/share/az*
+          /usr/share/glade*
+          /usr/local/lib/node_modules
+          /usr/local/share/chromium
+          /usr/local/share/powershell
+
+    - name: Delete platform specific items to free up disk space
+      shell: bash
+      run: |
+        if [ "$(uname)" = "Darwin" ]; then
+          echo "Deleting Applications"
+          sudo rm -rf ~/Applications/*
+          echo "Deleting all iOS simulators"
+          xcrun simctl delete all
+          echo "Deleting iOS Simulator caches"
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+        else
+          echo "Nothing to do here."
+        fi
+
+    - name: Install Nix
+      uses: >- # v16
+        DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d
+
+    - name: Cache Nix derivations
+      uses: >- # v9
+        DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     permissions:
       security-events: write
@@ -31,17 +31,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: >- # v4.1.1
-        actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: >- # v4.2.2
+        actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Initialize CodeQL
-      uses: >- # v3.22.11
-        github/codeql-action/init@b374143c1149a9115d881581d29b8390bbcbb59c
+      uses: >- # v3.28.9
+        github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: >- # v3.22.11
-        github/codeql-action/analyze@b374143c1149a9115d881581d29b8390bbcbb59c
+      uses: >- # v3.28.9
+        github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,25 +20,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Generate coverage
         run: |
@@ -46,7 +32,8 @@ jobs:
 
       - name: Upload coverage artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: >- # v3.0.1
+          actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: result/html
 
@@ -64,4 +51,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: >- # v4.0.5
+          actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,25 +23,19 @@ jobs:
       matrix:
         image: [image, nativelink-worker-init, nativelink-worker-lre-cc]
     name: Publish ${{ matrix.image }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       id-token: write
       security-events: write
     timeout-minutes: 30
     steps:
-
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Test image
         run: |

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -20,35 +20,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, macos-15]
         toolchain: [lre-cc, lre-rs]
         exclude:
-          - os: macos-14
+          - os: macos-15
             toolchain: lre-cc
     name: Local / ${{ matrix.toolchain }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Build example with ${{ matrix.toolchain }} toolchain
         env:
@@ -70,25 +56,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Start Kubernetes cluster
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,17 +17,18 @@ concurrency:
 
 jobs:
   nativelink-dot-com-cloud-rbe-main-legacy-dockerfile-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: production
     name: NativeLink.com Cloud / RBE on Main (Legacy Dockerfile Test)
     if: github.ref == 'refs/heads/main'
     steps:
     - name: Checkout
-      uses: >- # v4.1.1
-        actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: >- # v4.2.2
+        actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Set up AWS CLI
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      uses: >- # v4.1.0
+        aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
       with:
         aws-access-key-id: ${{ secrets.RBE_ECR_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.RBE_ECR_AWS_SECRET_ACCESS_KEY }}
@@ -42,11 +43,12 @@ jobs:
         fi
         echo "RBE_IMAGE=${{ secrets.RBE_ECR_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.RBE_ECR_AWS_ACCOUNT_REGION }}.amazonaws.com/${{ secrets.RBE_ECR_REPOSITORY_NAME }}:$DOCKERFILE_HASH" >> $GITHUB_ENV
 
-    - name: Setup Bazelisk
-      uses: >- # v0.8.1
-        bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+    - name: Setup Bazel
+      uses: >- # v0.13.0
+        bazel-contrib/setup-bazel@663f88d97adf17db2523a5b385d9407a562e5551
       with:
         bazelisk-cache: true
+        repository-cache: true
 
     - name: Run Bazel tests
       shell: bash
@@ -69,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.os }}
     environment: production
     name: NativeLink.com Cloud / Remote Cache / ${{ matrix.os }}
@@ -77,25 +79,11 @@ jobs:
       NL_COM_API_KEY: ${{ secrets.NATIVELINK_COM_API_HEADER || '065f02f53f26a12331d5cfd00a778fb243bfb4e857b8fcd4c99273edfb15deae' }}
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Run Bazel tests
         run: >
@@ -108,89 +96,90 @@ jobs:
             ${{ github.ref == 'refs/heads/main' && '--remote_upload_local_results=true' || '--nogenerate_json_trace_profile --remote_upload_local_results=false' }} \
             //..."
 
-  docker-compose-compiles-nativelink:
-    # The type of runner that the job will run on.
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        # Which OS versions we will test on.
-        os_version: [ 22.04 ]
-    steps:
-    - name: Checkout
-      uses: >- # v4.1.1
-        actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+  # TODO(aaronmondal): Flaky. Fix.
+  # docker-compose-compiles-nativelink:
+  #   # The type of runner that the job will run on.
+  #   runs-on: ubuntu-24.04
+  #   strategy:
+  #     matrix:
+  #       # Which OS versions we will test on.
+  #       os_version: [ 24.04 ]
+  #   steps:
+  #   - name: Checkout
+  #     uses: >- # v4.2.2
+  #       actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - name: Set up Docker Buildx
-      uses: >- # v3.2.0
-        docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
+  #   - name: Set up Docker Buildx
+  #     uses: >- # v3.9.0
+  #       docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
 
-    - name: Build Nativelink image
-      uses: >- # v5.3.0
-        docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
-      with:
-        context: .
-        file: ./deployment-examples/docker-compose/Dockerfile
-        build-args: |
-          OPT_LEVEL=opt
-          OS_VERSION=${{ matrix.os_version }}
-          ADDITIONAL_SETUP_WORKER_CMD=apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gcc g++ lld pkg-config python3
-        load: true # This brings the build into `docker images` from buildx.
-        tags: trace_machina/nativelink:latest
+  #   - name: Build Nativelink image
+  #     uses: >- # v6.13.0
+  #       docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
+  #     with:
+  #       context: .
+  #       file: ./deployment-examples/docker-compose/Dockerfile
+  #       build-args: |
+  #         OPT_LEVEL=opt
+  #         OS_VERSION=${{ matrix.os_version }}
+  #         ADDITIONAL_SETUP_WORKER_CMD=apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gcc g++ lld pkg-config python3
+  #       load: true # This brings the build into `docker images` from buildx.
+  #       tags: trace_machina/nativelink:latest
 
-    - name: Build builder image
-      uses: >- # v5.3.0
-        docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
-      with:
-        context: .
-        file: ./deployment-examples/docker-compose/Dockerfile
-        build-args: |
-          OPT_LEVEL=opt
-          OS_VERSION=${{ matrix.os_version }}
-        load: true # This brings the build into `docker images` from buildx.
-        tags: trace_machina/nativelink:builder
-        target: builder
+  #   - name: Build builder image
+  #     uses: >- # v6.13.0
+  #       docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
+  #     with:
+  #       context: .
+  #       file: ./deployment-examples/docker-compose/Dockerfile
+  #       build-args: |
+  #         OPT_LEVEL=opt
+  #         OS_VERSION=${{ matrix.os_version }}
+  #       load: true # This brings the build into `docker images` from buildx.
+  #       tags: trace_machina/nativelink:builder
+  #       target: builder
 
-    - name: Compile NativeLink with NativeLink
-      run: |
-        mkdir -p ~/.cache && \
-        cd deployment-examples/docker-compose && \
-        (docker-compose up -d || docker compose up -d) && \
-        cd ../../ && \
-        docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
-          bazel clean && \
-          bazel test //... \
-          --extra_toolchains=@rust_toolchains//:all \
-          --remote_cache=grpc://127.0.0.1:50051 \
-          --remote_executor=grpc://127.0.0.1:50052 \
-          --remote_default_exec_properties=cpu_count=1 \
-        ' && \
-        docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
-          bazel clean && \
-          bazel test //... \
-          --extra_toolchains=@rust_toolchains//:all \
-          --remote_cache=grpc://127.0.0.1:50051 \
-          --remote_executor=grpc://127.0.0.1:50052 \
-          --remote_default_exec_properties=cpu_count=1 \
-        ' 2>&1 | ( ! grep '         PASSED in ' ) # If we get PASSED without (cache) it means there's a cache issue.
+  #   - name: Compile NativeLink with NativeLink
+  #     run: |
+  #       mkdir -p ~/.cache && \
+  #       cd deployment-examples/docker-compose && \
+  #       (docker-compose up -d || docker compose up -d) && \
+  #       cd ../../ && \
+  #       docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
+  #         bazel clean && \
+  #         bazel test //... \
+  #         --extra_toolchains=@rust_toolchains//:all \
+  #         --remote_cache=grpc://127.0.0.1:50051 \
+  #         --remote_executor=grpc://127.0.0.1:50052 \
+  #         --remote_default_exec_properties=cpu_count=2 \
+  #       ' && \
+  #       docker run --rm --net=host -w /root/nativelink -v $PWD:/root/nativelink trace_machina/nativelink:builder sh -c ' \
+  #         bazel clean && \
+  #         bazel test //... \
+  #         --extra_toolchains=@rust_toolchains//:all \
+  #         --remote_cache=grpc://127.0.0.1:50051 \
+  #         --remote_executor=grpc://127.0.0.1:50052 \
+  #         --remote_default_exec_properties=cpu_count=2 \
+  #       ' 2>&1 | ( ! grep '         PASSED in ' ) # If we get PASSED without (cache) it means there's a cache issue.
 
   integration-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         # Which OS versions we will test on.
-        os_version: [ 22.04 ]
+        os_version: [ 24.04 ]
     steps:
     - name: Checkout
-      uses: >- # v4.1.1
-        actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: >- # v4.2.2
+        actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Set up Docker Buildx
-      uses: >- # v3.2.0
-        docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
+      uses: >- # v3.9.0
+        docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
 
     - name: Build image
-      uses: >- # v5.3.0
-        docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+      uses: >- # v6.13.0
+        docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
       with:
         context: .
         file: ./deployment-examples/docker-compose/Dockerfile

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -20,54 +20,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-24.04, macos-15]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Setup Bazelisk
-        uses: >- # v0.8.1
-          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+      - name: Setup Bazel
+        uses: >- # v0.13.0
+          bazel-contrib/setup-bazel@663f88d97adf17db2523a5b385d9407a562e5551
         with:
           bazelisk-cache: true
-
-      - name: Delete Applications and Simulators to free up disk space
-        if: contains(matrix.os, 'macos')
-        run: |
-          echo "Deleting Applications"
-          sudo rm -rf ~/Applications/*
-          echo "Deleting all iOS simulators"
-          xcrun simctl delete all
-          echo "Deleting iOS Simulator caches"
-          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-
-      - name: Determine Bazel cache mountpoint
-        id: bazel-cache
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "macOS" ]; then
-            echo "mountpoint=~/.cache/bazel" >> "$GITHUB_OUTPUT"
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            echo "mountpoint=C:/tmp" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unknown runner OS: $RUNNER_OS"
-            exit 1
-          fi
-        shell: bash
-
-      - name: Mount bazel cache
-        uses: >- # v4.0.1
-          actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
-        with:
-          path: |
-            ${{ steps.bazel-cache.outputs.mountpoint }}
-          key: |
-            ${{ matrix.os }}-bazel-native-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ matrix.os }}-bazel-native-
+          repository-cache: true
+          disk-cache: ${{ github.workflow }}-${{ matrix.os }}
 
       - name: Run Bazel tests
         run: |

--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -20,16 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
         toolchain: [stable]
     name: ${{ matrix.os }} / ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Rust toolchain
         run: rustup update && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -20,40 +20,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-15]
     name: Bazel Dev / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
-
-      # TODO(aaronmondal): Figure out why this cache breaks CI.
-      # See: https://github.com/TraceMachina/nativelink/issues/772
-      # - name: Mount bazel cache
-      #   uses: >- # v4.0.1
-      #     actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
-      #   with:
-      #     path: "~/.cache/bazel"
-      #     key: ${{ runner.os }}-bazel-nix
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Invoke Bazel build in Nix shell
         run: |
@@ -73,41 +50,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-24.04, macos-15]
     name: Cargo Dev / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Delete Applications and Simulators to free up disk space
-        if: contains(matrix.os, 'macos')
-        run: |
-          echo "Deleting Applications"
-          sudo rm -rf ~/Applications/*
-          echo "Deleting all iOS simulators"
-          xcrun simctl delete all
-          echo "Deleting iOS Simulator caches"
-          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Invoke Cargo build in Nix shell
         run: >
@@ -118,41 +71,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - macos-13
+          - macos-14
+          - macos-15
     name: Installation / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Delete Applications and Simulators to free up disk space
-        if: contains(matrix.os, 'macos')
-        run: |
-          echo "Deleting Applications"
-          sudo rm -rf ~/Applications/*
-          echo "Deleting all iOS simulators"
-          xcrun simctl delete all
-          echo "Deleting iOS Simulator caches"
-          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Test nix run
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,20 +16,15 @@ concurrency:
 
 jobs:
   pre-commit-checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Run pre-commit hooks
         run: nix flake check

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -20,18 +20,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         sanitizer: [asan]
     name: ${{ matrix.sanitizer }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Setup Bazelisk
-        uses: >- # v0.8.1
-          bazel-contrib/setup-bazel@b388b84bb637e50cdae241d0f255670d4bd79f29
+      - name: Setup Bazel
+        uses: >- # v0.13.0
+          bazel-contrib/setup-bazel@663f88d97adf17db2523a5b385d9407a562e5551
         with:
           bazelisk-cache: true
           repository-cache: true

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -23,8 +23,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: >- # v4.1.7
-          actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
@@ -37,15 +37,15 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: >- # v4.4.0
-          actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        uses: >- # v4.6.0
+          actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: >- # v3.26.6
-          github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93
+        uses: >- # v3.28.9
+          github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -17,24 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         image: [image, nativelink-worker-init, nativelink-worker-lre-cc]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       id-token: write
     timeout-minutes: 60
     steps:
-
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Test image
         run: |

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -12,12 +12,12 @@ concurrency:
 jobs:
   vale:
     name: vale
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Run Vale
         uses: >- # Custom commit, last pinned 2024.06.06.

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -31,7 +31,7 @@ jobs:
           - ubuntu-24.04
           # TODO(aaronmondal): Re-enable after:
           #                    https://github.com/NixOS/nixpkgs/pull/371501
-          # - macos-14
+          # - macos-15
     name: Web Platform Deployment / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     environment: production
@@ -42,35 +42,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: >- # v4.1.1
-          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: >- # v4.2.2
+          actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Free disk space
-        uses: >- # v2.0.0
-          endersonmenezes/free-disk-space@3f9ec39ebae520864ac93467ee395f5237585c21
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: false
-
-      - name: Delete Applications and Simulators to free up disk space
-        if: contains(matrix.os, 'macos')
-        run: |
-          echo "Deleting Applications"
-          sudo rm -rf ~/Applications/*
-          echo "Deleting all iOS simulators"
-          xcrun simctl delete all
-          echo "Deleting iOS Simulator caches"
-          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-
-      - name: Install Nix
-        uses: >- # v10
-          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
-
-      - name: Cache Nix derivations
-        uses: >- # v4
-          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
 
       - name: Test Build
         if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,15 +2864,14 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3284,12 +3283,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -25,7 +25,16 @@ ARG ADDITIONAL_SETUP_WORKER_CMD=
 FROM ubuntu:${OS_VERSION} AS dependencies
 ARG OS_VERSION
 RUN apt-get update \
-    && if [ "${OS_VERSION}" = "22.04" ]; then \
+    && if [ "${OS_VERSION}" = "24.04" ]; then \
+        DEBIAN_FRONTEND=noninteractive \
+        apt-get install --no-install-recommends -y \
+            npm=9.2.0~ds1-2 \
+            git=1:2.43.0-1ubuntu7.2 \
+            gcc=4:13.2.0-7ubuntu1 \
+            g++=4:13.2.0-7ubuntu1 \
+            python3=3.12.3-0ubuntu2 \
+            ca-certificates=20240203; \
+    elif [ "${OS_VERSION}" = "22.04" ]; then \
         DEBIAN_FRONTEND=noninteractive \
         apt-get install --no-install-recommends -y \
             npm=8.5.1~ds-1 \
@@ -34,22 +43,13 @@ RUN apt-get update \
             g++=4:11.2.0-1ubuntu1 \
             python3=3.10.6-1~22.04.1 \
             ca-certificates=20240203~22.04.1; \
-    elif [ "${OS_VERSION}" = "20.04" ]; then \
-        DEBIAN_FRONTEND=noninteractive \
-        apt-get install --no-install-recommends -y \
-            npm=6.14.4+ds-1ubuntu2 \
-            git=1:2.25.1-1ubuntu3.13 \
-            gcc=4:9.3.0-1ubuntu2 \
-            g++=4:9.3.0-1ubuntu2 \
-            python3=3.8.2-0ubuntu2 \
-            ca-certificates=20240203~20.04.1; \
     else \
         echo "Unsupported OS version: ${OS_VERSION}" >&2; \
         exit 1; \
     fi \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g @bazel/bazelisk@1.19.0
+    && npm install -g @bazel/bazelisk@1.25.0
 
 # Build the binary.
 FROM dependencies AS builder

--- a/flake.nix
+++ b/flake.nix
@@ -490,11 +490,15 @@
               export PATH=$HOME/.deno/bin:$PATH
               deno types > web/platform/utils/deno.d.ts
             ''
-            + (pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+            + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
               # On Darwin generate darwin.bazelrc which configures
               # darwin libs & frameworks when running in the nix environment.
               ${config.darwin.installationScript}
-            '');
+            ''
+            # TODO(aaronmondal): Generalize this.
+            + pkgs.lib.optionalString (system == "x86_64-linux") ''
+              export CC_x86_64_unknown_linux_gnu=customClang
+            '';
         };
       };
     }


### PR DESCRIPTION
- Unify the nix setup across actions
- Bump most workflows to run on Ubuntu 24.04 and MacOS 15 by default
- Remove Ubuntu 20.04 as it's reaching EOL
- Fix outdated bazel setups
- Fix ring crate build missing clang on x86_64-linux
- Bump workflow versions
- Temporarily disable docker compose workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1589)
<!-- Reviewable:end -->
