### PR TITLE
Use selector function for stdenv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,10 +95,10 @@
         in
           {
             inherit src;
-            stdenv =
-              if isLinuxTarget
-              then p.pkgsMusl.stdenv
-              else p.stdenv;
+            stdenv = q:
+              if q.stdenv.targetPlatform.isLinux
+              then q.pkgsMusl.stdenv
+              else q.stdenv;
             strictDeps = true;
             buildInputs =
               [p.cacert]


### PR DESCRIPTION
# Description

Nix issues an evaluation warning if `stdenv` isn't defined as a function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1642)
<!-- Reviewable:end -->
