### PR TITLE
Remove redundant settings in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,6 @@ rust-version = "1.85.0"
 
 [profile.release]
 lto = true
-opt-level = 3
-
-[profile.dev]
-lto = false
-opt-level = 0
-strip = false
-debug = true
 
 # Prefer this profile in CI, for instance via `cargo test --all --profile=smol`.
 # It reduces the size of the `target` directory from ~12GB to ~1GB.


### PR DESCRIPTION
All of these settings are the default, so there is no reason to set them explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1659)
<!-- Reviewable:end -->
