### PR TITLE
Rename variants to Rust standards

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -32,15 +32,15 @@ pub type SchedulerRefName = String;
 /// Used when the config references `instance_name` in the protocol.
 pub type InstanceName = String;
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Default, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
 pub enum HttpCompressionAlgorithm {
     /// No compression.
     #[default]
-    none,
+    None,
 
     /// Zlib compression.
-    gzip,
+    Gzip,
 }
 
 /// Note: Compressing data in the cloud rarely has a benefit, since most
@@ -61,7 +61,7 @@ pub struct HttpCompressionConfig {
     /// latency.
     /// see: <https://github.com/tracemachina/nativelink/issues/109>
     ///
-    /// Default: `HttpCompressionAlgorithm::none`
+    /// Default: `HttpCompressionAlgorithm::None`
     pub send_compression_algorithm: Option<HttpCompressionAlgorithm>,
 
     /// The compression algorithm that the server will accept from clients.
@@ -394,11 +394,11 @@ pub struct HttpServerConfig {
     pub experimental_http2_max_header_list_size: Option<u32>,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum ListenerConfig {
     /// Listener for HTTP/HTTPS/HTTP2 sockets.
-    http(HttpListener),
+    Http(HttpListener),
 }
 
 #[derive(Deserialize, Debug)]
@@ -447,18 +447,18 @@ pub struct ServerConfig {
     pub experimental_identity_header: IdentityHeaderSpec,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum WorkerProperty {
     /// List of static values.
     /// Note: Generally there should only ever be 1 value, but if the platform
     /// property key is `PropertyType::Priority` it may have more than one value.
     #[serde(deserialize_with = "convert_vec_string_with_shellexpand")]
-    values(Vec<String>),
+    Values(Vec<String>),
 
     /// A dynamic configuration. The string will be executed as a command
     /// (not sell) and will be split by "\n" (new line character).
-    query_cmd(String),
+    QueryCmd(String),
 }
 
 /// Generic config for an endpoint and associated configs.
@@ -477,35 +477,35 @@ pub struct EndpointConfig {
     pub tls_config: Option<ClientTlsConfig>,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Deserialize, Debug, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum UploadCacheResultsStrategy {
     /// Only upload action results with an exit code of 0.
     #[default]
-    success_only,
+    SuccessOnly,
 
     /// Don't upload any action results.
-    never,
+    Never,
 
     /// Upload all action results that complete.
-    everything,
+    Everything,
 
     /// Only upload action results that fail.
-    failures_only,
+    FailuresOnly,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum EnvironmentSource {
     /// The name of the platform property in the action to get the value from.
-    property(String),
+    Property(String),
 
     /// The raw value to set.
-    value(#[serde(deserialize_with = "convert_string_with_shellexpand")] String),
+    Value(#[serde(deserialize_with = "convert_string_with_shellexpand")] String),
 
     /// The max amount of time in milliseconds the command is allowed to run
     /// (requested by the client).
-    timeout_millis,
+    TimeoutMillis,
 
     /// A special file path will be provided that can be used to communicate
     /// with the parent process about out-of-band information. This file
@@ -523,7 +523,7 @@ pub enum EnvironmentSource {
     ///
     /// All fields are optional, file does not need to be created and may be
     /// empty.
-    side_channel_file,
+    SideChannelFile,
 
     /// A "root" directory for the action. This directory can be used to
     /// store temporary files that are not needed after the action has
@@ -538,7 +538,7 @@ pub enum EnvironmentSource {
     /// variable, `mkdir $ENV_VAR_NAME/tmp` and `export TMPDIR=$ENV_VAR_NAME/tmp`.
     /// Another example might be to bind-mount the `/tmp` path in a container to
     /// this path in `entrypoint`.
-    action_directory,
+    ActionDirectory,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -693,11 +693,11 @@ pub struct LocalWorkerConfig {
     pub additional_environment: Option<HashMap<String, EnvironmentSource>>,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum WorkerConfig {
     /// A worker type that executes jobs locally on this machine.
-    local(LocalWorkerConfig),
+    Local(LocalWorkerConfig),
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -19,50 +19,50 @@ use serde::Deserialize;
 use crate::serde_utils::{convert_duration_with_shellexpand, convert_numeric_with_shellexpand};
 use crate::stores::{GrpcEndpoint, Retry, StoreRefName};
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum SchedulerSpec {
-    simple(SimpleSpec),
-    grpc(GrpcSpec),
-    cache_lookup(CacheLookupSpec),
-    property_modifier(PropertyModifierSpec),
+    Simple(SimpleSpec),
+    Grpc(GrpcSpec),
+    CacheLookup(CacheLookupSpec),
+    PropertyModifier(PropertyModifierSpec),
 }
 
 /// When the scheduler matches tasks to workers that are capable of running
 /// the task, this value will be used to determine how the property is treated.
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum PropertyType {
     /// Requires the platform property to be a u64 and when the scheduler looks
     /// for appropriate worker nodes that are capable of executing the task,
     /// the task will not run on a node that has less than this value.
-    minimum,
+    Minimum,
 
     /// Requires the platform property to be a string and when the scheduler
     /// looks for appropriate worker nodes that are capable of executing the
     /// task, the task will not run on a node that does not have this property
     /// set to the value with exact string match.
-    exact,
+    Exact,
 
     /// Does not restrict on this value and instead will be passed to the worker
     /// as an informational piece.
     /// TODO(allada) In the future this will be used by the scheduler and worker
     /// to cause the scheduler to prefer certain workers over others, but not
     /// restrict them based on these values.
-    priority,
+    Priority,
 }
 
 /// When a worker is being searched for to run a job, this will be used
 /// on how to choose which worker should run the job when multiple
 /// workers are able to run the task.
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Deserialize, Debug, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum WorkerAllocationStrategy {
     /// Prefer workers that have been least recently used to run a job.
     #[default]
-    least_recently_used,
+    LeastRecentlyUsed,
     /// Prefer workers that have been most recently used to run a job.
-    most_recently_used,
+    MostRecentlyUsed,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -131,13 +131,13 @@ pub struct SimpleSpec {
     pub experimental_backend: Option<ExperimentalSimpleSchedulerBackend>,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum ExperimentalSimpleSchedulerBackend {
     /// Use an in-memory store for the scheduler.
-    memory,
+    Memory,
     /// Use a redis store for the scheduler.
-    redis(ExperimentalRedisSchedulerBackend),
+    Redis(ExperimentalRedisSchedulerBackend),
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -195,13 +195,13 @@ pub struct PlatformPropertyAddition {
     pub value: String,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum PropertyModification {
     /// Add a property to the action properties.
-    add(PlatformPropertyAddition),
+    Add(PlatformPropertyAddition),
     /// Remove a named property from the action.
-    remove(String),
+    Remove(String),
 }
 
 #[derive(Deserialize, Debug)]

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -24,20 +24,20 @@ use crate::serde_utils::{
 /// in the `CasConfig::stores`'s map key.
 pub type StoreRefName = String;
 
-#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
 pub enum ConfigDigestHashFunction {
     /// Use the sha256 hash function.
     /// <https://en.wikipedia.org/wiki/SHA-2>
-    sha256,
+    Sha256,
 
     /// Use the blake3 hash function.
     /// <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
-    blake3,
+    Blake3,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum StoreSpec {
     /// Memory store will store all data in a hashmap in memory.
     ///
@@ -52,7 +52,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    memory(MemorySpec),
+    Memory(MemorySpec),
 
     /// S3 store will use Amazon's S3 service as a backend to store
     /// the files. This configuration can be used to share files
@@ -76,7 +76,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    experimental_s3_store(S3Spec),
+    ExperimentalS3Store(S3Spec),
 
     /// Verify store is used to apply verifications to an underlying
     /// store implementation. It is strongly encouraged to validate
@@ -100,7 +100,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    verify(Box<VerifySpec>),
+    Verify(Box<VerifySpec>),
 
     /// Completeness checking store verifies if the
     /// output files & folders exist in the CAS before forwarding
@@ -128,7 +128,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    completeness_checking(Box<CompletenessCheckingSpec>),
+    CompletenessChecking(Box<CompletenessCheckingSpec>),
 
     /// A compression store that will compress the data inbound and
     /// outbound. There will be a non-trivial cost to compress and
@@ -156,7 +156,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    compression(Box<CompressionSpec>),
+    Compression(Box<CompressionSpec>),
 
     /// A dedup store will take the inputs and run a rolling hash
     /// algorithm on them to slice the input into smaller parts then
@@ -221,7 +221,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    dedup(Box<DedupSpec>),
+    Dedup(Box<DedupSpec>),
 
     /// Existence store will wrap around another store and cache calls
     /// to has so that subsequent `has_with_results` calls will be
@@ -248,7 +248,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    existence_cache(Box<ExistenceCacheSpec>),
+    ExistenceCache(Box<ExistenceCacheSpec>),
 
     /// `FastSlow` store will first try to fetch the data from the `fast`
     /// store and then if it does not exist try the `slow` store.
@@ -291,7 +291,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    fast_slow(Box<FastSlowSpec>),
+    FastSlow(Box<FastSlowSpec>),
 
     /// Shards the data to multiple stores. This is useful for cases
     /// when you want to distribute the load across multiple stores.
@@ -313,7 +313,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    shard(ShardSpec),
+    Shard(ShardSpec),
 
     /// Stores the data on the filesystem. This store is designed for
     /// local persistent storage. Restarts of this program should restore
@@ -332,7 +332,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    filesystem(FilesystemSpec),
+    Filesystem(FilesystemSpec),
 
     /// Store used to reference a store in the root store manager.
     /// This is useful for cases when you want to share a store in different
@@ -347,7 +347,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    ref_store(RefSpec),
+    RefStore(RefSpec),
 
     /// Uses the size field of the digest to separate which store to send the
     /// data. This is useful for cases when you'd like to put small objects
@@ -375,7 +375,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    size_partitioning(Box<SizePartitioningSpec>),
+    SizePartitioning(Box<SizePartitioningSpec>),
 
     /// This store will pass-through calls to another GRPC store. This store
     /// is not designed to be used as a sub-store of another store, but it
@@ -398,7 +398,7 @@ pub enum StoreSpec {
     ///   }
     /// ```
     ///
-    grpc(GrpcSpec),
+    Grpc(GrpcSpec),
 
     /// Stores data in any stores compatible with Redis APIs.
     ///
@@ -415,7 +415,7 @@ pub enum StoreSpec {
     /// }
     /// ```
     ///
-    redis_store(RedisSpec),
+    RedisStore(RedisSpec),
 
     /// Noop store is a store that sends streams into the void and all data
     /// retrieval will return 404 (`NotFound`). This can be useful for cases
@@ -427,7 +427,7 @@ pub enum StoreSpec {
     /// "noop": {}
     /// ```
     ///
-    noop(NoopSpec),
+    Noop(NoopSpec),
 }
 
 /// Configuration for an individual shard of the store.
@@ -664,8 +664,8 @@ pub struct Lz4Config {
     pub max_decode_block_size: u32,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum CompressionAlgorithm {
     /// LZ4 compression algorithm is extremely fast for compression and
     /// decompression, however does not perform very well in compression
@@ -674,7 +674,7 @@ pub enum CompressionAlgorithm {
     /// compressible.
     ///
     /// see: <https://lz4.github.io/lz4/>
-    lz4(Lz4Config),
+    Lz4(Lz4Config),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -785,13 +785,13 @@ pub struct S3Spec {
     pub disable_http2: bool,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
 pub enum StoreType {
     /// The store is content addressable storage.
-    cas,
+    Cas,
     /// The store is an action cache.
-    ac,
+    Ac,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -992,7 +992,7 @@ pub struct RedisSpec {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum RedisMode {
     Cluster,
     Sentinel,

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -181,11 +181,11 @@ impl ApiWorkerSchedulerImpl {
         let mut workers_iter = self.workers.iter();
         let workers_iter = match self.allocation_strategy {
             // Use rfind to get the least recently used that satisfies the properties.
-            WorkerAllocationStrategy::least_recently_used => workers_iter.rfind(|(_, w)| {
+            WorkerAllocationStrategy::LeastRecentlyUsed => workers_iter.rfind(|(_, w)| {
                 w.can_accept_work() && platform_properties.is_satisfied_by(&w.platform_properties)
             }),
             // Use find to get the most recently used that satisfies the properties.
-            WorkerAllocationStrategy::most_recently_used => workers_iter.find(|(_, w)| {
+            WorkerAllocationStrategy::MostRecentlyUsed => workers_iter.find(|(_, w)| {
                 w.can_accept_work() && platform_properties.is_satisfied_by(&w.platform_properties)
             }),
         };

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -58,11 +58,11 @@ fn inner_scheduler_factory(
     maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
 ) -> Result<SchedulerFactoryResults, Error> {
     let scheduler: SchedulerFactoryResults = match spec {
-        SchedulerSpec::simple(spec) => {
+        SchedulerSpec::Simple(spec) => {
             simple_scheduler_factory(spec, store_manager, SystemTime::now, maybe_origin_event_tx)?
         }
-        SchedulerSpec::grpc(spec) => (Some(Arc::new(GrpcScheduler::new(spec)?)), None),
-        SchedulerSpec::cache_lookup(spec) => {
+        SchedulerSpec::Grpc(spec) => (Some(Arc::new(GrpcScheduler::new(spec)?)), None),
+        SchedulerSpec::CacheLookup(spec) => {
             let ac_store = store_manager
                 .get_store(&spec.ac_store)
                 .err_tip(|| format!("'ac_store': '{}' does not exist", spec.ac_store))?;
@@ -75,7 +75,7 @@ fn inner_scheduler_factory(
             )?);
             (Some(cache_lookup_scheduler), worker_scheduler)
         }
-        SchedulerSpec::property_modifier(spec) => {
+        SchedulerSpec::PropertyModifier(spec) => {
             let (action_scheduler, worker_scheduler) =
                 inner_scheduler_factory(&spec.scheduler, store_manager, maybe_origin_event_tx)
                     .err_tip(|| "In nested PropertyModifierScheduler construction")?;
@@ -99,9 +99,9 @@ fn simple_scheduler_factory(
     match spec
         .experimental_backend
         .as_ref()
-        .unwrap_or(&ExperimentalSimpleSchedulerBackend::memory)
+        .unwrap_or(&ExperimentalSimpleSchedulerBackend::Memory)
     {
-        ExperimentalSimpleSchedulerBackend::memory => {
+        ExperimentalSimpleSchedulerBackend::Memory => {
             let task_change_notify = Arc::new(Notify::new());
             let awaited_action_db = memory_awaited_action_db_factory(
                 spec.retain_completed_for_s,
@@ -116,7 +116,7 @@ fn simple_scheduler_factory(
             );
             Ok((Some(action_scheduler), Some(worker_scheduler)))
         }
-        ExperimentalSimpleSchedulerBackend::redis(redis_config) => {
+        ExperimentalSimpleSchedulerBackend::Redis(redis_config) => {
             let store = store_manager
                 .get_store(redis_config.redis_store.as_ref())
                 .err_tip(|| {

--- a/nativelink-scheduler/src/platform_property_manager.rs
+++ b/nativelink-scheduler/src/platform_property_manager.rs
@@ -77,7 +77,7 @@ impl PlatformPropertyManager {
     pub fn make_prop_value(&self, key: &str, value: &str) -> Result<PlatformPropertyValue, Error> {
         if let Some(prop_type) = self.known_properties.get(key) {
             return match prop_type {
-                PropertyType::minimum => Ok(PlatformPropertyValue::Minimum(
+                PropertyType::Minimum => Ok(PlatformPropertyValue::Minimum(
                     value.parse::<u64>().err_tip_with_code(|e| {
                         (
                             Code::InvalidArgument,
@@ -85,8 +85,8 @@ impl PlatformPropertyManager {
                         )
                     })?,
                 )),
-                PropertyType::exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
-                PropertyType::priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
+                PropertyType::Exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
+                PropertyType::Priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
             };
         }
         Err(make_input_err!("Unknown platform property '{}'", key))

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -62,10 +62,10 @@ impl PropertyModifierScheduler {
         );
         for modification in &self.modifications {
             match modification {
-                PropertyModification::remove(name) => {
+                PropertyModification::Remove(name) => {
                     known_properties.insert(name.clone());
                 }
-                PropertyModification::add(_) => (),
+                PropertyModification::Add(_) => (),
             }
         }
         let final_known_properties: Vec<String> = known_properties.into_iter().collect();
@@ -84,10 +84,10 @@ impl PropertyModifierScheduler {
         let action_info_mut = Arc::make_mut(&mut action_info);
         for modification in &self.modifications {
             match modification {
-                PropertyModification::add(addition) => action_info_mut
+                PropertyModification::Add(addition) => action_info_mut
                     .platform_properties
                     .insert(addition.name.clone(), addition.value.clone()),
-                PropertyModification::remove(name) => {
+                PropertyModification::Remove(name) => {
                     action_info_mut.platform_properties.remove(name)
                 }
             };

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -46,7 +46,7 @@ fn make_modifier_scheduler(modifications: Vec<PropertyModification>) -> TestCont
     let mock_scheduler = Arc::new(MockActionScheduler::new());
     let config = PropertyModifierSpec {
         modifications,
-        scheduler: Box::new(SchedulerSpec::simple(SimpleSpec::default())),
+        scheduler: Box::new(SchedulerSpec::Simple(SimpleSpec::default())),
     };
     let modifier_scheduler = PropertyModifierScheduler::new(&config, mock_scheduler.clone());
     TestContext {
@@ -60,7 +60,7 @@ async fn add_action_adds_property() -> Result<(), Error> {
     let name = "name".to_string();
     let value = "value".to_string();
     let context =
-        make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
+        make_modifier_scheduler(vec![PropertyModification::Add(PlatformPropertyAddition {
             name: name.clone(),
             value: value.clone(),
         })]);
@@ -98,7 +98,7 @@ async fn add_action_overwrites_property() -> Result<(), Error> {
     let original_value = "value".to_string();
     let replaced_value = "replaced".to_string();
     let context =
-        make_modifier_scheduler(vec![PropertyModification::add(PlatformPropertyAddition {
+        make_modifier_scheduler(vec![PropertyModification::Add(PlatformPropertyAddition {
             name: name.clone(),
             value: replaced_value.clone(),
         })]);
@@ -141,8 +141,8 @@ async fn add_action_property_added_after_remove() -> Result<(), Error> {
     let name = "name".to_string();
     let value = "value".to_string();
     let context = make_modifier_scheduler(vec![
-        PropertyModification::remove(name.clone()),
-        PropertyModification::add(PlatformPropertyAddition {
+        PropertyModification::Remove(name.clone()),
+        PropertyModification::Add(PlatformPropertyAddition {
             name: name.clone(),
             value: value.clone(),
         }),
@@ -180,11 +180,11 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
     let name = "name".to_string();
     let value = "value".to_string();
     let context = make_modifier_scheduler(vec![
-        PropertyModification::add(PlatformPropertyAddition {
+        PropertyModification::Add(PlatformPropertyAddition {
             name: name.clone(),
             value: value.clone(),
         }),
-        PropertyModification::remove(name.clone()),
+        PropertyModification::Remove(name.clone()),
     ]);
     let action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest());
     let (_forward_watch_channel_tx, forward_watch_channel_rx) =
@@ -215,7 +215,7 @@ async fn add_action_property_remove_after_add() -> Result<(), Error> {
 async fn add_action_property_remove() -> Result<(), Error> {
     let name = "name".to_string();
     let value = "value".to_string();
-    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
     let mut action_info = make_base_action_info(UNIX_EPOCH, DigestInfo::zero_digest())
         .as_ref()
         .clone();
@@ -275,7 +275,7 @@ async fn find_by_client_operation_id_call_passed() -> Result<(), Error> {
 #[nativelink_test]
 async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
     let name = "name".to_string();
-    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
     let known_properties = Vec::new();
     let instance_name_fut = context
         .mock_scheduler
@@ -292,7 +292,7 @@ async fn remove_adds_to_underlying_manager() -> Result<(), Error> {
 #[nativelink_test]
 async fn remove_retains_type_in_underlying_manager() -> Result<(), Error> {
     let name = "name".to_string();
-    let context = make_modifier_scheduler(vec![PropertyModification::remove(name.clone())]);
+    let context = make_modifier_scheduler(vec![PropertyModification::Remove(name.clone())]);
     let known_properties = vec![name.clone()];
     let instance_name_fut = context
         .mock_scheduler

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -656,7 +656,7 @@ async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), E
     let worker_id2 = WorkerId("worker2".to_string());
 
     let mut prop_defs = HashMap::new();
-    prop_defs.insert("prop".to_string(), PropertyType::exact);
+    prop_defs.insert("prop".to_string(), PropertyType::Exact);
 
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
@@ -1729,7 +1729,7 @@ async fn run_two_jobs_on_same_worker_with_platform_properties_restrictions() -> 
     let worker_id = WorkerId("worker_id".to_string());
 
     let mut supported_props = HashMap::new();
-    supported_props.insert("prop1".to_string(), PropertyType::minimum);
+    supported_props.insert("prop1".to_string(), PropertyType::Minimum);
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &SimpleSpec {
@@ -1895,7 +1895,7 @@ async fn run_jobs_in_the_order_they_were_queued() -> Result<(), Error> {
     let worker_id = WorkerId("worker_id".to_string());
 
     let mut supported_props = HashMap::new();
-    supported_props.insert("prop1".to_string(), PropertyType::minimum);
+    supported_props.insert("prop1".to_string(), PropertyType::Minimum);
     let task_change_notify = Arc::new(Notify::new());
     let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
         &SimpleSpec {

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -56,7 +56,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &StoreSpec::memory(MemorySpec::default()),
+            &StoreSpec::Memory(MemorySpec::default()),
             &store_manager,
             None,
         )
@@ -65,7 +65,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_ac",
         store_factory(
-            &StoreSpec::memory(MemorySpec::default()),
+            &StoreSpec::Memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -55,7 +55,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         BEP_STORE_NAME,
         store_factory(
-            &StoreSpec::memory(MemorySpec::default()),
+            &StoreSpec::Memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -61,7 +61,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &StoreSpec::memory(MemorySpec::default()),
+            &StoreSpec::Memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -50,7 +50,7 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     store_manager.add_store(
         "main_cas",
         store_factory(
-            &StoreSpec::memory(MemorySpec::default()),
+            &StoreSpec::Memory(MemorySpec::default()),
             &store_manager,
             None,
         )

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -221,7 +221,7 @@ pub struct CompressionStore {
 impl CompressionStore {
     pub fn new(spec: &CompressionSpec, inner_store: Store) -> Result<Arc<Self>, Error> {
         let lz4_config = match spec.compression_algorithm {
-            nativelink_config::stores::CompressionAlgorithm::lz4(mut lz4_config) => {
+            nativelink_config::stores::CompressionAlgorithm::Lz4(mut lz4_config) => {
                 if lz4_config.block_size == 0 {
                     lz4_config.block_size = DEFAULT_BLOCK_SIZE;
                 }

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -49,45 +49,45 @@ pub fn store_factory<'a>(
 ) -> Pin<FutureMaybeStore<'a>> {
     Box::pin(async move {
         let store: Arc<dyn StoreDriver> = match backend {
-            StoreSpec::memory(spec) => MemoryStore::new(spec),
-            StoreSpec::experimental_s3_store(spec) => S3Store::new(spec, SystemTime::now).await?,
-            StoreSpec::redis_store(spec) => RedisStore::new(spec.clone())?,
-            StoreSpec::verify(spec) => VerifyStore::new(
+            StoreSpec::Memory(spec) => MemoryStore::new(spec),
+            StoreSpec::ExperimentalS3Store(spec) => S3Store::new(spec, SystemTime::now).await?,
+            StoreSpec::RedisStore(spec) => RedisStore::new(spec.clone())?,
+            StoreSpec::Verify(spec) => VerifyStore::new(
                 spec,
                 store_factory(&spec.backend, store_manager, None).await?,
             ),
-            StoreSpec::compression(spec) => CompressionStore::new(
+            StoreSpec::Compression(spec) => CompressionStore::new(
                 &spec.clone(),
                 store_factory(&spec.backend, store_manager, None).await?,
             )?,
-            StoreSpec::dedup(spec) => DedupStore::new(
+            StoreSpec::Dedup(spec) => DedupStore::new(
                 spec,
                 store_factory(&spec.index_store, store_manager, None).await?,
                 store_factory(&spec.content_store, store_manager, None).await?,
             )?,
-            StoreSpec::existence_cache(spec) => ExistenceCacheStore::new(
+            StoreSpec::ExistenceCache(spec) => ExistenceCacheStore::new(
                 spec,
                 store_factory(&spec.backend, store_manager, None).await?,
             ),
-            StoreSpec::completeness_checking(spec) => CompletenessCheckingStore::new(
+            StoreSpec::CompletenessChecking(spec) => CompletenessCheckingStore::new(
                 store_factory(&spec.backend, store_manager, None).await?,
                 store_factory(&spec.cas_store, store_manager, None).await?,
             ),
-            StoreSpec::fast_slow(spec) => FastSlowStore::new(
+            StoreSpec::FastSlow(spec) => FastSlowStore::new(
                 spec,
                 store_factory(&spec.fast, store_manager, None).await?,
                 store_factory(&spec.slow, store_manager, None).await?,
             ),
-            StoreSpec::filesystem(spec) => <FilesystemStore>::new(spec).await?,
-            StoreSpec::ref_store(spec) => RefStore::new(spec, Arc::downgrade(store_manager)),
-            StoreSpec::size_partitioning(spec) => SizePartitioningStore::new(
+            StoreSpec::Filesystem(spec) => <FilesystemStore>::new(spec).await?,
+            StoreSpec::RefStore(spec) => RefStore::new(spec, Arc::downgrade(store_manager)),
+            StoreSpec::SizePartitioning(spec) => SizePartitioningStore::new(
                 spec,
                 store_factory(&spec.lower_store, store_manager, None).await?,
                 store_factory(&spec.upper_store, store_manager, None).await?,
             ),
-            StoreSpec::grpc(spec) => GrpcStore::new(spec).await?,
-            StoreSpec::noop(_) => NoopStore::new(),
-            StoreSpec::shard(spec) => {
+            StoreSpec::Grpc(spec) => GrpcStore::new(spec).await?,
+            StoreSpec::Noop(_) => NoopStore::new(),
+            StoreSpec::Shard(spec) => {
                 let stores = spec
                     .stores
                     .iter()

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -145,7 +145,7 @@ impl GrpcStore {
         grpc_request: Request<FindMissingBlobsRequest>,
     ) -> Result<Response<FindMissingBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -170,7 +170,7 @@ impl GrpcStore {
         grpc_request: Request<BatchUpdateBlobsRequest>,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -195,7 +195,7 @@ impl GrpcStore {
         grpc_request: Request<BatchReadBlobsRequest>,
     ) -> Result<Response<BatchReadBlobsResponse>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -220,7 +220,7 @@ impl GrpcStore {
         grpc_request: Request<GetTreeRequest>,
     ) -> Result<Response<Streaming<GetTreeResponse>>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -276,7 +276,7 @@ impl GrpcStore {
         grpc_request: impl IntoRequest<ReadRequest>,
     ) -> Result<impl Stream<Item = Result<ReadResponse, Status>>, Error> {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -296,7 +296,7 @@ impl GrpcStore {
         E: Into<Error> + 'static,
     {
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -360,7 +360,7 @@ impl GrpcStore {
         const IS_UPLOAD_TRUE: bool = true;
 
         error_if!(
-            matches!(self.store_type, nativelink_config::stores::StoreType::ac),
+            matches!(self.store_type, nativelink_config::stores::StoreType::Ac),
             "CAS operation on AC store"
         );
 
@@ -513,7 +513,7 @@ impl StoreDriver for GrpcStore {
         keys: &[StoreKey<'_>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
-        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::Ac) {
             keys.iter()
                 .zip(results.iter_mut())
                 .map(|(key, result)| async move {
@@ -580,7 +580,7 @@ impl StoreDriver for GrpcStore {
         _size_info: UploadSizeInfo,
     ) -> Result<(), Error> {
         let digest = key.into_digest();
-        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::Ac) {
             return self.update_action_result_from_bytes(digest, reader).await;
         }
 
@@ -667,7 +667,7 @@ impl StoreDriver for GrpcStore {
         length: Option<u64>,
     ) -> Result<(), Error> {
         let digest = key.into_digest();
-        if matches!(self.store_type, nativelink_config::stores::StoreType::ac) {
+        if matches!(self.store_type, nativelink_config::stores::StoreType::Ac) {
             let offset = usize::try_from(offset).err_tip(|| "Could not convert offset to usize")?;
             let length = length
                 .map(|v| usize::try_from(v).err_tip(|| "Could not convert length to usize"))

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -75,8 +75,8 @@ async fn simple_smoke_test() -> Result<(), Error> {
 
     let store = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
                 },
@@ -112,8 +112,8 @@ async fn partial_reads_test() -> Result<(), Error> {
 
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: 10,
                     ..Default::default()
@@ -161,8 +161,8 @@ async fn partial_reads_test() -> Result<(), Error> {
 async fn rand_5mb_smoke_test() -> Result<(), Error> {
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
                 },
@@ -194,8 +194,8 @@ async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     ..Default::default()
                 },
@@ -249,8 +249,8 @@ async fn check_header_test() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,
                     ..Default::default()
@@ -335,8 +335,8 @@ async fn check_footer_test() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,
                     ..Default::default()
@@ -481,8 +481,8 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
         &CompressionSpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
-            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::lz4(
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
                 nativelink_config::stores::Lz4Config {
                     block_size: BLOCK_SIZE,
                     ..Default::default()

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -26,8 +26,8 @@ use rand::{Rng, SeedableRng};
 
 fn make_default_config() -> DedupSpec {
     DedupSpec {
-        index_store: StoreSpec::memory(MemorySpec::default()),
-        content_store: StoreSpec::memory(MemorySpec::default()),
+        index_store: StoreSpec::Memory(MemorySpec::default()),
+        content_store: StoreSpec::Memory(MemorySpec::default()),
         min_size: 8 * 1024,
         normal_size: 32 * 1024,
         max_size: 128 * 1024,
@@ -161,8 +161,8 @@ async fn check_length_not_set_with_chunk_read_beyond_first_chunk_regression_test
 
     let store = DedupStore::new(
         &DedupSpec {
-            index_store: StoreSpec::memory(MemorySpec::default()),
-            content_store: StoreSpec::memory(MemorySpec::default()),
+            index_store: StoreSpec::Memory(MemorySpec::default()),
+            content_store: StoreSpec::Memory(MemorySpec::default()),
             min_size: 5,
             normal_size: 6,
             max_size: 7,
@@ -206,8 +206,8 @@ async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
 
     let store = DedupStore::new(
         &DedupSpec {
-            index_store: StoreSpec::memory(MemorySpec::default()),
-            content_store: StoreSpec::memory(MemorySpec::default()),
+            index_store: StoreSpec::Memory(MemorySpec::default()),
+            content_store: StoreSpec::Memory(MemorySpec::default()),
             min_size: 5,
             normal_size: 6,
             max_size: 7,

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -33,7 +33,7 @@ const VALID_HASH1: &str = "0123456789abcdef0000000000000000000100000000000001234
 async fn simple_exist_cache_test() -> Result<(), Error> {
     const VALUE: &str = "123";
     let spec = ExistenceCacheSpec {
-        backend: StoreSpec::noop(NoopSpec::default()), // Note: Not used.
+        backend: StoreSpec::Noop(NoopSpec::default()), // Note: Not used.
         eviction_policy: Option::default(),
     };
     let inner_store = Store::new(MemoryStore::new(&MemorySpec::default()));
@@ -71,7 +71,7 @@ async fn simple_exist_cache_test() -> Result<(), Error> {
 async fn update_flags_existance_cache_test() -> Result<(), Error> {
     const VALUE: &str = "123";
     let spec = ExistenceCacheSpec {
-        backend: StoreSpec::noop(NoopSpec::default()),
+        backend: StoreSpec::Noop(NoopSpec::default()),
         eviction_policy: Option::default(),
     };
     let inner_store = Store::new(MemoryStore::new(&MemorySpec::default()));
@@ -94,7 +94,7 @@ async fn update_flags_existance_cache_test() -> Result<(), Error> {
 async fn get_part_caches_if_exact_size_set() -> Result<(), Error> {
     const VALUE: &str = "123";
     let spec = ExistenceCacheSpec {
-        backend: StoreSpec::noop(NoopSpec::default()),
+        backend: StoreSpec::Noop(NoopSpec::default()),
         eviction_policy: Option::default(),
     };
     let inner_store = Store::new(MemoryStore::new(&MemorySpec::default()));
@@ -129,7 +129,7 @@ async fn ensure_has_requests_eventually_do_let_evictions_happen() -> Result<(), 
         .err_tip(|| "Failed to update store")?;
     let store = ExistenceCacheStore::new_with_time(
         &ExistenceCacheSpec {
-            backend: StoreSpec::noop(NoopSpec::default()),
+            backend: StoreSpec::Noop(NoopSpec::default()),
             eviction_policy: Some(EvictionPolicy {
                 max_seconds: 10,
                 ..Default::default()

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -40,8 +40,8 @@ fn make_stores() -> (Store, Store, Store) {
     let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let fast_slow_store = Store::new(FastSlowStore::new(
         &FastSlowSpec {
-            fast: StoreSpec::memory(MemorySpec::default()),
-            slow: StoreSpec::memory(MemorySpec::default()),
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
         },
         fast_store.clone(),
         slow_store.clone(),
@@ -330,8 +330,8 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
 
     let fast_slow_store = FastSlowStore::new(
         &FastSlowSpec {
-            fast: StoreSpec::memory(MemorySpec::default()),
-            slow: StoreSpec::memory(MemorySpec::default()),
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
         },
         fast_store,
         slow_store,
@@ -371,8 +371,8 @@ async fn ignore_value_in_fast_store() -> Result<(), Error> {
     let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let fast_slow_store = Arc::new(FastSlowStore::new(
         &FastSlowSpec {
-            fast: StoreSpec::memory(MemorySpec::default()),
-            slow: StoreSpec::memory(MemorySpec::default()),
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
         },
         fast_store.clone(),
         slow_store,
@@ -394,8 +394,8 @@ async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
     let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let slow_store = Store::new(NoopStore::new());
     let fast_slow_store_config = FastSlowSpec {
-        fast: StoreSpec::memory(MemorySpec::default()),
-        slow: StoreSpec::noop(NoopSpec::default()),
+        fast: StoreSpec::Memory(MemorySpec::default()),
+        slow: StoreSpec::Noop(NoopSpec::default()),
     };
     let fast_slow_store = Arc::new(FastSlowStore::new(
         &fast_slow_store_config,

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -30,7 +30,7 @@ const MEGABYTE_SZ: usize = 1024 * 1024;
 
 fn make_stores(weights: &[u32]) -> (Arc<ShardStore>, Vec<Arc<MemoryStore>>) {
     let memory_store_config = MemorySpec::default();
-    let store_config = StoreSpec::memory(memory_store_config.clone());
+    let store_config = StoreSpec::Memory(memory_store_config.clone());
     let stores: Vec<_> = weights
         .iter()
         .map(|_| MemoryStore::new(&memory_store_config))

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -44,8 +44,8 @@ fn setup_stores(
     let size_part_store = SizePartitioningStore::new(
         &SizePartitioningSpec {
             size,
-            lower_store: StoreSpec::memory(MemorySpec::default()),
-            upper_store: StoreSpec::memory(MemorySpec::default()),
+            lower_store: StoreSpec::Memory(MemorySpec::default()),
+            upper_store: StoreSpec::Memory(MemorySpec::default()),
         },
         Store::new(lower_memory_store.clone()),
         Store::new(upper_memory_store.clone()),

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -38,7 +38,7 @@ async fn verify_size_false_passes_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: false,
         },
@@ -69,7 +69,7 @@ async fn verify_size_true_fails_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -107,7 +107,7 @@ async fn verify_size_true_suceeds_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -130,7 +130,7 @@ async fn verify_size_true_suceeds_on_multi_chunk_stream_update() -> Result<(), E
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -170,7 +170,7 @@ async fn verify_sha256_hash_true_suceeds_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -198,7 +198,7 @@ async fn verify_sha256_hash_true_fails_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -231,7 +231,7 @@ async fn verify_blake3_hash_true_suceeds_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -265,7 +265,7 @@ async fn verify_blake3_hash_true_fails_on_update() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: false,
             verify_hash: true,
         },
@@ -308,7 +308,7 @@ async fn verify_fails_immediately_on_too_much_data_sent_update() -> Result<(), E
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: false,
         },
@@ -352,7 +352,7 @@ async fn verify_size_and_hash_suceeds_on_small_data() -> Result<(), Error> {
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store = VerifyStore::new(
         &VerifySpec {
-            backend: StoreSpec::memory(MemorySpec::default()),
+            backend: StoreSpec::Memory(MemorySpec::default()),
             verify_size: true,
             verify_hash: true,
         },

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -98,8 +98,8 @@ impl DigestHasherFunc {
 impl From<ConfigDigestHashFunction> for DigestHasherFunc {
     fn from(value: ConfigDigestHashFunction) -> Self {
         match value {
-            ConfigDigestHashFunction::sha256 => Self::Sha256,
-            ConfigDigestHashFunction::blake3 => Self::Blake3,
+            ConfigDigestHashFunction::Sha256 => Self::Sha256,
+            ConfigDigestHashFunction::Blake3 => Self::Blake3,
         }
     }
 }

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -34,7 +34,7 @@ pub async fn make_connect_worker_request<S: BuildHasher>(
     for (property_name, worker_property) in worker_properties {
         futures.push(async move {
             match worker_property {
-                WorkerProperty::values(values) => {
+                WorkerProperty::Values(values) => {
                     let mut props = Vec::with_capacity(values.len());
                     for value in values {
                         props.push(Property {
@@ -44,7 +44,7 @@ pub async fn make_connect_worker_request<S: BuildHasher>(
                     }
                     Ok(props)
                 }
-                WorkerProperty::query_cmd(cmd) => {
+                WorkerProperty::QueryCmd(cmd) => {
                     let maybe_split_cmd = shlex::split(cmd);
                     let (command, args) = match &maybe_split_cmd {
                         Some(split_cmd) => (&split_cmd[0], &split_cmd[1..]),

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -79,15 +79,15 @@ async fn platform_properties_smoke_test() -> Result<(), Error> {
     let mut platform_properties = HashMap::new();
     platform_properties.insert(
         "foo".to_string(),
-        WorkerProperty::values(vec!["bar1".to_string(), "bar2".to_string()]),
+        WorkerProperty::Values(vec!["bar1".to_string(), "bar2".to_string()]),
     );
     platform_properties.insert(
         "baz".to_string(),
         // Note: new lines will result in two entries for same key.
         #[cfg(target_family = "unix")]
-        WorkerProperty::query_cmd("printf 'hello\ngoodbye'".to_string()),
+        WorkerProperty::QueryCmd("printf 'hello\ngoodbye'".to_string()),
         #[cfg(target_family = "windows")]
-        WorkerProperty::query_cmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
+        WorkerProperty::QueryCmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
     );
     let mut test_context = setup_local_worker(platform_properties).await;
     let streaming_response = test_context.maybe_streaming_response.take().unwrap();
@@ -428,8 +428,8 @@ async fn new_local_worker_creates_work_directory_test() -> Result<(), Error> {
     let cas_store = Store::new(FastSlowStore::new(
         &FastSlowSpec {
             // Note: These are not needed for this test, so we put dummy memory stores here.
-            fast: StoreSpec::memory(MemorySpec::default()),
-            slow: StoreSpec::memory(MemorySpec::default()),
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
         },
         Store::new(
             <FilesystemStore>::new(&FilesystemSpec {
@@ -467,8 +467,8 @@ async fn new_local_worker_removes_work_directory_before_start_test() -> Result<(
     let cas_store = Store::new(FastSlowStore::new(
         &FastSlowSpec {
             // Note: These are not needed for this test, so we put dummy memory stores here.
-            fast: StoreSpec::memory(MemorySpec::default()),
-            slow: StoreSpec::memory(MemorySpec::default()),
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
         },
         Store::new(
             <FilesystemStore>::new(&FilesystemSpec {

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -102,8 +102,8 @@ async fn setup_stores() -> Result<
     let ac_store = MemoryStore::new(&slow_config);
     let cas_store = FastSlowStore::new(
         &FastSlowSpec {
-            fast: StoreSpec::filesystem(fast_config),
-            slow: StoreSpec::memory(slow_config),
+            fast: StoreSpec::Filesystem(fast_config),
+            slow: StoreSpec::Memory(slow_config),
         },
         Store::new(fast_store.clone()),
         Store::new(slow_store.clone()),
@@ -438,7 +438,7 @@ async fn ensure_output_files_full_directories_are_created_no_working_directory_t
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -560,7 +560,7 @@ async fn ensure_output_files_full_directories_are_created_test(
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -684,7 +684,7 @@ async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -864,7 +864,7 @@ async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Er
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1045,7 +1045,7 @@ async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>>
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1252,7 +1252,7 @@ async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Erro
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1386,7 +1386,7 @@ async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1587,7 +1587,7 @@ exit 0
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1740,19 +1740,19 @@ exit 0
                 additional_environment: Some(HashMap::from([
                     (
                         "PROPERTY".to_string(),
-                        EnvironmentSource::property("property_name".to_string()),
+                        EnvironmentSource::Property("property_name".to_string()),
                     ),
                     (
                         "VALUE".to_string(),
-                        EnvironmentSource::value("raw_value".to_string()),
+                        EnvironmentSource::Value("raw_value".to_string()),
                     ),
                     (
                         "INNER_TIMEOUT".to_string(),
-                        EnvironmentSource::timeout_millis,
+                        EnvironmentSource::TimeoutMillis,
                     ),
                     (
                         "PATH".to_string(),
-                        EnvironmentSource::value(std::env::var("PATH").unwrap()),
+                        EnvironmentSource::Value(std::env::var("PATH").unwrap()),
                     ),
                 ])),
             },
@@ -1761,7 +1761,7 @@ exit 0
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -1919,7 +1919,7 @@ exit 1
                 entrypoint: Some(test_wrapper_script.into_string().unwrap()),
                 additional_environment: Some(HashMap::from([(
                     "SIDE_CHANNEL_FILE".to_string(),
-                    EnvironmentSource::side_channel_file,
+                    EnvironmentSource::SideChannelFile,
                 )])),
             },
             cas_store: cas_store.clone(),
@@ -1927,7 +1927,7 @@ exit 1
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -2010,7 +2010,7 @@ async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -2082,7 +2082,7 @@ async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn st
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::everything,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Everything,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -2154,7 +2154,7 @@ async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::e
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
                 ),
                 #[allow(clippy::literal_string_with_formatting_args)]
                 success_message_template: "{historical_results_hash}-{historical_results_size}"
@@ -2255,7 +2255,7 @@ async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn st
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
                 ),
                 #[allow(clippy::literal_string_with_formatting_args)]
                 success_message_template: "{historical_results_hash}-{historical_results_size}"
@@ -2297,7 +2297,7 @@ async fn infra_failure_does_cache_in_historical_results() -> Result<(), Box<dyn 
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_historical_results_strategy: Some(
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::failures_only,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::FailuresOnly,
                 ),
                 #[allow(clippy::literal_string_with_formatting_args)]
                 failure_message_template: "{historical_results_hash}-{historical_results_size}"
@@ -2366,7 +2366,7 @@ async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::E
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::success_only,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::SuccessOnly,
                 #[allow(clippy::literal_string_with_formatting_args)]
                 success_message_template: "{action_digest_hash}-{action_digest_size}".to_string(),
                 ..Default::default()
@@ -2484,7 +2484,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                 upload_action_result_config:
                     &nativelink_config::cas_server::UploadActionResultConfig {
                         upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                            nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                         ..Default::default()
                     },
                 max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2566,7 +2566,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                 upload_action_result_config:
                     &nativelink_config::cas_server::UploadActionResultConfig {
                         upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                            nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                         ..Default::default()
                     },
                 max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2648,7 +2648,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
                 upload_action_result_config:
                     &nativelink_config::cas_server::UploadActionResultConfig {
                         upload_ac_results_strategy:
-                            nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                            nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                         ..Default::default()
                     },
                 max_action_timeout: MAX_TIMEOUT_DURATION,
@@ -2727,7 +2727,7 @@ async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -2858,7 +2858,7 @@ async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::err
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -3026,7 +3026,7 @@ async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -3125,7 +3125,7 @@ async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::erro
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -3238,7 +3238,7 @@ async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,
@@ -3417,7 +3417,7 @@ async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn
             historical_store: Store::new(cas_store.clone()),
             upload_action_result_config: &nativelink_config::cas_server::UploadActionResultConfig {
                 upload_ac_results_strategy:
-                    nativelink_config::cas_server::UploadCacheResultsStrategy::never,
+                    nativelink_config::cas_server::UploadCacheResultsStrategy::Never,
                 ..Default::default()
             },
             max_action_timeout: Duration::MAX,

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -178,8 +178,8 @@ async fn inner_main(
 ) -> Result<(), Error> {
     const fn into_encoding(from: HttpCompressionAlgorithm) -> Option<CompressionEncoding> {
         match from {
-            HttpCompressionAlgorithm::gzip => Some(CompressionEncoding::Gzip),
-            HttpCompressionAlgorithm::none => None,
+            HttpCompressionAlgorithm::Gzip => Some(CompressionEncoding::Gzip),
+            HttpCompressionAlgorithm::None => None,
         }
     }
 
@@ -279,7 +279,7 @@ async fn inner_main(
             .err_tip(|| "'services' must be configured")?;
 
         // Currently we only support http as our socket type.
-        let ListenerConfig::http(http_config) = server_cfg.listener;
+        let ListenerConfig::Http(http_config) = server_cfg.listener;
 
         let tonic_services = TonicServer::builder()
             .add_optional_service(
@@ -290,7 +290,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -316,7 +316,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -342,7 +342,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -368,7 +368,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -408,7 +408,7 @@ async fn inner_main(
                     let mut service = v.into_service();
                     let send_algo = &http_config.compression.send_compression_algorithm;
                     if let Some(encoding) =
-                        into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                        into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                     {
                         service = service.send_compressed(encoding);
                     }
@@ -432,7 +432,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -458,7 +458,7 @@ async fn inner_main(
                             let mut service = v.into_service();
                             let send_algo = &http_config.compression.send_compression_algorithm;
                             if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::none))
+                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
                             {
                                 service = service.send_compressed(encoding);
                             }
@@ -921,7 +921,7 @@ async fn inner_main(
         let mut worker_metrics: HashMap<String, Arc<dyn RootMetricsComponent>> = HashMap::new();
         for (i, worker_cfg) in worker_cfgs.into_iter().enumerate() {
             let spawn_fut = match worker_cfg {
-                WorkerConfig::local(local_worker_cfg) => {
+                WorkerConfig::Local(local_worker_cfg) => {
                     let fast_slow_store = store_manager
                         .get_store(&local_worker_cfg.cas_fast_slow_store)
                         .err_tip(|| {
@@ -1036,7 +1036,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_default_digest_hasher_func(DigestHasherFunc::from(
             global_cfg
                 .default_digest_hash_function
-                .unwrap_or(ConfigDigestHashFunction::sha256),
+                .unwrap_or(ConfigDigestHashFunction::Sha256),
         ))?;
         set_default_digest_size_health_check(global_cfg.default_digest_size_health_check)?;
         !global_cfg.disable_metrics


### PR DESCRIPTION
# Description

`non_camel_case_types` has been changed to use `serde`'s renaming functionality, with the variants being renamed

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
  - Renaming variants to follow Rust's naming conventions is inherently breaking. This only affects the Rust API, as `serde` attributes are used to maintain compatibility with snake case names.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally — not done; `cargo` should be sufficient
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1666)
<!-- Reviewable:end -->
