### PR TITLE
Reduce use of monomorphization

### DIFF
--- a/nativelink-store/src/cas_utils.rs
+++ b/nativelink-store/src/cas_utils.rs
@@ -37,9 +37,9 @@ pub const ZERO_BYTE_DIGESTS: [DigestInfo; 2] = [
 ];
 
 #[inline]
-pub fn is_zero_digest<'a>(digest: impl Into<StoreKey<'a>>) -> bool {
-    match digest.into() {
-        StoreKey::Digest(digest) => digest.size_bytes() == 0 && ZERO_BYTE_DIGESTS.contains(&digest),
+pub fn is_zero_digest(digest: &StoreKey<'_>) -> bool {
+    match digest {
+        StoreKey::Digest(digest) => digest.size_bytes() == 0 && ZERO_BYTE_DIGESTS.contains(digest),
         StoreKey::Str(_) => false,
     }
 }

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -394,7 +394,7 @@ impl StoreDriver for CompressionStore {
         offset: u64,
         length: Option<u64>,
     ) -> Result<(), Error> {
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             writer
                 .send_eof()
                 .err_tip(|| "Failed to send zero EOF in filesystem store get_part")?;

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -162,7 +162,7 @@ impl StoreDriver for DedupStore {
             .iter()
             .zip(results.iter_mut())
             .map(|(key, result)| async move {
-                if is_zero_digest(key.borrow()) {
+                if is_zero_digest(key) {
                     *result = Some(0);
                     return Ok(());
                 }

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -829,7 +829,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         // If our results failed and the result was a zero file, we need to
         // create the file by spec.
         for (key, result) in keys.iter().zip(results.iter_mut()) {
-            if result.is_some() || !is_zero_digest(key.borrow()) {
+            if result.is_some() || !is_zero_digest(key) {
                 continue;
             }
             let (mut tx, rx) = make_buf_channel_pair();
@@ -914,7 +914,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         offset: u64,
         length: Option<u64>,
     ) -> Result<(), Error> {
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             self.has(key.borrow())
                 .await
                 .err_tip(|| "Failed to check if zero digest exists in filesystem store")?;

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -98,7 +98,7 @@ impl StoreDriver for MemoryStore {
         keys.iter()
             .zip(results.iter_mut())
             .for_each(|(key, result)| {
-                if is_zero_digest(key.borrow()) {
+                if is_zero_digest(key) {
                     *result = Some(0);
                 }
             });
@@ -157,7 +157,7 @@ impl StoreDriver for MemoryStore {
             .map(|v| usize::try_from(v).err_tip(|| "Could not convert length to usize"))
             .transpose()?;
 
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             writer
                 .send_eof()
                 .err_tip(|| "Failed to send zero EOF in filesystem store get_part")?;

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -326,7 +326,7 @@ impl StoreDriver for RedisStore {
             .zip(results.iter_mut())
             .map(|(key, result)| async move {
                 // We need to do a special pass to ensure our zero key exist.
-                if is_zero_digest(key.borrow()) {
+                if is_zero_digest(key) {
                     *result = Some(0);
                     return Ok::<_, Error>(());
                 }
@@ -384,7 +384,7 @@ impl StoreDriver for RedisStore {
             &final_key
         );
 
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             let chunk = reader
                 .peek()
                 .await
@@ -485,7 +485,7 @@ impl StoreDriver for RedisStore {
 
         // To follow RBE spec we need to consider any digest's with
         // zero size to be existing.
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             return writer
                 .send_eof()
                 .err_tip(|| "Failed to send zero EOF in redis store get_part");

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -571,7 +571,7 @@ where
             .zip(results.iter_mut())
             .map(|(key, result)| async move {
                 // We need to do a special pass to ensure our zero key exist.
-                if is_zero_digest(key.borrow()) {
+                if is_zero_digest(key) {
                     *result = Some(0);
                     return Ok::<_, Error>(());
                 }
@@ -857,7 +857,7 @@ where
         offset: u64,
         length: Option<u64>,
     ) -> Result<(), Error> {
-        if is_zero_digest(key.borrow()) {
+        if is_zero_digest(&key) {
             writer
                 .send_eof()
                 .err_tip(|| "Failed to send zero EOF in filesystem store get_part")?;

--- a/nativelink-store/tests/cas_utils_test.rs
+++ b/nativelink-store/tests/cas_utils_test.rs
@@ -20,7 +20,7 @@ use sha2::{Digest, Sha256};
 #[test]
 fn sha256_is_zero_digest() {
     let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
-    assert!(is_zero_digest(digest));
+    assert!(is_zero_digest(&digest.into()));
 }
 
 #[test]
@@ -28,13 +28,13 @@ fn sha256_is_non_zero_digest() {
     let mut hasher = Sha256::new();
     hasher.update(b"a");
     let digest = DigestInfo::new(hasher.finalize().into(), 1);
-    assert!(!is_zero_digest(digest));
+    assert!(!is_zero_digest(&digest.into()));
 }
 
 #[test]
 fn blake_is_zero_digest() {
     let digest = DigestInfo::new(Blake3::new().finalize().into(), 0);
-    assert!(is_zero_digest(digest));
+    assert!(is_zero_digest(&digest.into()));
 }
 
 #[test]
@@ -42,5 +42,5 @@ fn blake_is_non_zero_digest() {
     let mut hasher = Blake3::new();
     hasher.update(b"a");
     let digest = DigestInfo::new(hasher.finalize().into(), 1);
-    assert!(!is_zero_digest(digest));
+    assert!(!is_zero_digest(&digest.into()));
 }


### PR DESCRIPTION
For reviewing, it's likely best to view without whitespace changes; indentation changed a fair amount.

# Description

While far from perfect, this pattern allows the compiler to build the primary function only once per implementation of the relevant type. We then manually call the method to monomorphize the variable. Note that this does not necessarily result in only a single copy of the function in the final binary, as other types may still be monomorphized.

This pattern isn't usable everywhere due to pre-existing limitations, primarily 'static lifetimes and interactions with async `Drop` handling.

## Type of change

strictly internal

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally — not done; `cargo` is sufficient
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1669)
<!-- Reviewable:end -->
