### PR TITLE
Fix admin router syntax for axum 0.8

### DIFF
--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -670,7 +670,7 @@ async fn inner_main(
             svc = svc.nest_service(
                 path,
                 Router::new().route(
-                    "/scheduler/:instance_name/set_drain_worker/:worker_id/:is_draining",
+                    "/scheduler/{instance_name}/set_drain_worker/{worker_id}/{is_draining}",
                     axum::routing::post(
                         move |params: axum::extract::Path<(String, String, String)>| async move {
                             let (instance_name, worker_id, is_draining) = params.0;


### PR DESCRIPTION
# Description

Right now, if you run `nix run -L .#nativelink -- ./nativelink-config/examples/basic_cas.json5` you get 

```
thread 'main' panicked at src/bin/nativelink.rs:672:31:
Path segments must not start with `:`. For capture groups, use `{capture}`. If you meant to literally match a segment starting with a colon, call `without_v07_checks` on the router.
```

because https://github.com/TraceMachina/nativelink/pull/1674 upgraded axum to 0.8.x [and they changed the router syntax](https://github.com/tokio-rs/axum/pull/2645), but there's no tests that run a config with the admin enabled. https://github.com/TraceMachina/nativelink/pull/1646 does do this, and hence a) why I've hit it and b) why I haven't added a test yet, as that PR will do the testing.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`nix run -L .#nativelink -- ./nativelink-config/examples/basic_cas.json5` from current `main`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1675)
<!-- Reviewable:end -->
