### PR TITLE
Actualize param for reclient config dir (#1668)

### DIFF
--- a/deploy/chromium-example/build_chromium_tests.sh
+++ b/deploy/chromium-example/build_chromium_tests.sh
@@ -59,7 +59,7 @@ else
 fi
 
 echo "Generating ninja projects"
-gn gen --args="use_remoteexec=true rbe_cfg_dir=\"../../buildtools/reclient_cfgs/linux\"" out/Default
+gn gen --args="use_remoteexec=true reclient_cfg_dir=\"../../buildtools/reclient_cfgs/linux\"" out/Default
 
 # Fetch cache and schedular IP address for passing to ninja
 NATIVELINK=$(kubectl get gtw nativelink-gateway -o=jsonpath='{.status.addresses[0].value}')

--- a/web/platform/src/content/docs/docs/nativelink-cloud/Reclient.mdx
+++ b/web/platform/src/content/docs/docs/nativelink-cloud/Reclient.mdx
@@ -120,7 +120,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   cd $HOME/chromium/src
   source $HOME/nativelink-reclient/.env.local
   rm -rf out
-  gn gen --args="use_remoteexec=true is_debug=false is_component_build=true symbol_level=0 rbe_cfg_dir=\"../../buildtools/reclient_cfgs\"" out/Default
+  gn gen --args="use_remoteexec=true is_debug=false is_component_build=true symbol_level=0 reclient_cfg_dir=\"../../buildtools/reclient_cfgs\"" out/Default
   autoninja -C out/Default chrome
   ```
 
@@ -249,7 +249,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   cd $HOME/chromium/src
   source $HOME/nativelink-reclient/.env.local
   rm -rf out
-  gn gen --args="use_remoteexec=true is_debug=false is_component_build=true symbol_level=0 rbe_cfg_dir=\"../../buildtools/reclient_cfgs\"" out/Default
+  gn gen --args="use_remoteexec=true is_debug=false is_component_build=true symbol_level=0 reclient_cfg_dir=\"../../buildtools/reclient_cfgs\"" out/Default
   autoninja -C out/Default chrome
   ```
 


### PR DESCRIPTION
# Description

`rbe_cfg_dir` is deprecated for Chromium/Reclient usage, adding `reclient_cfg_dir` instead.

Fixes https://github.com/TraceMachina/nativelink/issues/1668

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Made sure that change is appeared in docs.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1679)
<!-- Reviewable:end -->
