### PR TITLE
Handle slashes in instance name of `WaitExecutionRequest`

### DIFF
--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -82,6 +83,25 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tonic",
         "@crates//:tower",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-service",
+    proc_macro_deps = [
+        "//nativelink-macro",
+        "@crates//:async-trait",
+    ],
+    deps = [
+        "//nativelink-metric",
+        "@crates//:async-lock",
+        "@crates//:hyper",
+        "@crates//:hyper-util",
+        "@crates//:maplit",
+        "@crates//:pretty_assertions",
+        "@crates//:prost-types",
     ],
 )
 

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -62,7 +62,7 @@ impl NativelinkOperationId {
 
     fn from_name(name: &str) -> Result<Self, Error> {
         let (instance_name, name) = name
-            .split_once('/')
+            .rsplit_once('/')
             .err_tip(|| "Expected instance_name and name to be separated by '/'")?;
         Ok(NativelinkOperationId::new(
             instance_name.to_string(),
@@ -382,4 +382,17 @@ impl Execution for ExecutionServer {
         }
         resp
     }
+}
+
+#[cfg(test)]
+#[test]
+fn test_nl_op_id_from_name() -> Result<(), Box<dyn std::error::Error>> {
+    let examples = [("foo/bar", "foo"), ("a/b/c/d", "a/b/c")];
+
+    for (input, expected) in examples {
+        let id = NativelinkOperationId::from_name(input)?;
+        assert_eq!(id.instance_name, expected);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
# Description

Request parsing for `ExecutionServer` splits instance name from operation ID  incorrectly when the former contains a slash.

Fixes #1688

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit test for `NativelinkOperationId::from_name`.

Manually tested with chromium siso v1.1.27.
```json
"instance_name": "projects/rbe-chromium-untrusted/instances/default_instance",
```

```sh
autoninja base -reapi_address 127.0.0.1:50051 -reapi_insecure -project rbe-chromium-untrusted
```
## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1689)
<!-- Reviewable:end -->
