### PR TITLE
Add unit tests to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,6 +63,22 @@ filegroup(
 )
 
 test_suite(
+    name = "unit_tests",
+    tests = [
+        "//nativelink-config:unit_test",
+        "//nativelink-error:unit_test",
+        "//nativelink-macro:unit_test",
+        "//nativelink-metric:unit_test",
+        "//nativelink-metric-collector:unit_test",
+        "//nativelink-scheduler:unit_test",
+        "//nativelink-service:unit_test",
+        "//nativelink-store:unit_test",
+        "//nativelink-util:unit_test",
+        "//nativelink-worker:unit_test",
+    ],
+)
+
+test_suite(
     name = "doctests",
     tests = [
         "//nativelink-config:doc_test",

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -43,6 +44,16 @@ rust_test_suite(
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:serde_json5",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-config",
+    deps = [
+        "@crates//:pretty_assertions",
+        "@crates//:serde_json",
     ],
 )
 

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
 )
 
 rust_library(
@@ -14,6 +15,24 @@ rust_library(
     deps = [
         "//nativelink-metric",
         "//nativelink-proto",
+        "@crates//:fred",
+        "@crates//:hex",
+        "@crates//:prost",
+        "@crates//:prost-types",
+        "@crates//:serde",
+        "@crates//:tokio",
+        "@crates//:tonic",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-error",
+    deps = [
+        "//nativelink-metric",
+        "//nativelink-proto",
+        "@crates//:async-lock",
         "@crates//:fred",
         "@crates//:hex",
         "@crates//:prost",

--- a/nativelink-macro/BUILD.bazel
+++ b/nativelink-macro/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_proc_macro",
+    "rust_test",
 )
 
 rust_proc_macro(
@@ -11,6 +12,17 @@ rust_proc_macro(
         "src/lib.rs",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:proc-macro2",
+        "@crates//:quote",
+        "@crates//:syn",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-macro",
     deps = [
         "@crates//:proc-macro2",
         "@crates//:quote",

--- a/nativelink-metric-collector/BUILD.bazel
+++ b/nativelink-metric-collector/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -44,6 +45,17 @@ rust_test_suite(
         "@crates//:serde_json",
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-metric-collector",
+    deps = [
+        "//nativelink-error",
+        "@crates//:opentelemetry_sdk",
+        "@crates//:serde_json",
     ],
 )
 

--- a/nativelink-metric/BUILD.bazel
+++ b/nativelink-metric/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
 )
 
 rust_library(
@@ -14,6 +15,21 @@ rust_library(
         "//nativelink-metric/nativelink-metric-macro-derive",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:async-lock",
+        "@crates//:parking_lot",
+        "@crates//:tokio",
+        "@crates//:tracing",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-metric",
+    proc_macro_deps = [
+        "//nativelink-metric/nativelink-metric-macro-derive",
+    ],
     deps = [
         "@crates//:async-lock",
         "@crates//:parking_lot",

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -91,6 +92,19 @@ rust_test_suite(
         "@crates//:tokio",
         "@crates//:tokio-stream",
         "@crates//:uuid",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-scheduler",
+    proc_macro_deps = [
+        "//nativelink-macro",
+    ],
+    deps = [
+        "@crates//:fred",
+        "@crates//:pretty_assertions",
     ],
 )
 

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -134,6 +135,31 @@ rust_test_suite(
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
         "@crates//:uuid",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-store",
+    proc_macro_deps = [
+        "//nativelink-macro",
+    ],
+    deps = [
+        "//nativelink-metric-collector",
+        "@crates//:aws-sdk-s3",
+        "@crates//:aws-smithy-runtime",
+        "@crates//:aws-smithy-runtime-api",
+        "@crates//:aws-smithy-types",
+        "@crates//:fred",
+        "@crates//:http",
+        "@crates//:memory-stats",
+        "@crates//:mock_instant",
+        "@crates//:pretty_assertions",
+        "@crates//:rand",
+        "@crates//:serde_json",
+        "@crates//:sha2",
+        "@crates//:tracing-subscriber",
     ],
 )
 

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -285,6 +285,7 @@ impl<'a> RequestBuilder<'a> {
     }
 
     #[inline]
+    #[allow(unused_qualifications, reason = "false positive on hyper::http::Error")]
     fn build(&self) -> Result<Request<SdkBody>, hyper::http::Error> {
         let mut req_builder = Request::builder()
             .method(self.components.method.clone())

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -122,6 +123,21 @@ rust_test_suite(
         "@crates//:tokio-util",
         "@crates//:tonic",
         "@crates//:uuid",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-util",
+    proc_macro_deps = [
+        "//nativelink-macro",
+    ],
+    deps = [
+        "@crates//:http-body-util",
+        "@crates//:pretty_assertions",
+        "@crates//:rand",
+        "@crates//:serde_json",
     ],
 )
 

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "rust_doc",
     "rust_doc_test",
     "rust_library",
+    "rust_test",
     "rust_test_suite",
 )
 
@@ -79,6 +80,23 @@ rust_test_suite(
         "@crates//:serial_test",
         "@crates//:tokio",
         "@crates//:tonic",
+    ],
+)
+
+rust_test(
+    name = "unit_test",
+    timeout = "short",
+    crate = ":nativelink-worker",
+    proc_macro_deps = [
+        "//nativelink-macro",
+    ],
+    deps = [
+        "@crates//:hyper",
+        "@crates//:hyper-util",
+        "@crates//:pretty_assertions",
+        "@crates//:prost-types",
+        "@crates//:rand",
+        "@crates//:serial_test",
     ],
 )
 


### PR DESCRIPTION
# Description

This adds the ability to run unit tests to all nativelink crates, with the exception being `nativelink-proto`. It shouldn't be necessary for that crate given that it's codgen'd, plus it causes some errors that appear to be formatting-related (i.e. not at all relevant).

This also includes a drive-by change of adding an `#[allow]` to a false positive of a lint. I've noticed this before but it's now breaking bazel without it, leaving me with no choice but to silence it. This is not `#[expect]` because it's not triggering consistently (varying by build).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1691)
<!-- Reviewable:end -->
