### PR TITLE
[WIP] Ramp up clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ debug = false
 name = "nativelink"
 
 [features]
-nix = [
-  "nativelink-worker/nix"
-]
+nix = ["nativelink-worker/nix"]
 
 [dependencies]
 nativelink-error = { path = "nativelink-error" }
@@ -44,14 +42,24 @@ hyper = "1.6.0"
 hyper-util = "0.1.11"
 mimalloc = "0.1.44"
 parking_lot = "0.12.3"
-rustls-pemfile = { version = "2.2.0", features = ["std"], default-features = false }
+rustls-pemfile = { version = "2.2.0", features = [
+  "std",
+], default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
 serde_json5 = "0.2.1"
-tokio = { version = "1.44.1", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio = { version = "1.44.1", features = [
+  "fs",
+  "rt-multi-thread",
+  "signal",
+  "io-util",
+], default-features = false }
 tokio-rustls = { version = "0.26.2", default-features = false, features = [
   "ring",
 ] }
-tonic = { version = "0.13.0", features = ["transport", "tls-ring"], default-features = false }
+tonic = { version = "0.13.0", features = [
+  "transport",
+  "tls-ring",
+], default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 opentelemetry_sdk = { version = "0.29.0", default-features = false }
@@ -117,4 +125,36 @@ unused-qualifications = "warn"
 variant-size-differences = "warn"
 
 [workspace.lints.clippy]
+alloc-instead-of-core = "deny"
+std-instead-of-core = "deny"
+undocumented-unsafe-blocks = "deny"
+
 all = { level = "warn", priority = -1 }
+as-underscore = "warn"
+dbg-macro = "warn"
+decimal-literal-representation = "warn"
+explicit-auto-deref = "warn"
+# get-unwrap = "warn" # TODO(jhpratt) temporary
+manual-let-else = "warn"
+missing-enforced-import-renames = "warn"
+nursery = { level = "warn", priority = -1 }
+obfuscated-if-else = "warn"
+print-stdout = "warn"
+semicolon-outside-block = "warn"
+todo = "warn"
+unimplemented = "warn"
+uninlined-format-args = "warn"
+unnested-or-patterns = "warn"
+# unwrap-in-result = "warn" # TODO(jhpratt) temporary
+# unwrap-used = "warn" # TODO(jhpratt) temporary
+use-debug = "warn"
+
+option-if-let-else = "allow" # suggests terrible code, overrides #![warn(clippy::nursery)]
+redundant-pub-crate = "allow" # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
+uninhabited-references = "allow" # rust-lang/rust-clippy#11984
+significant-drop-tightening = "allow" # too many false positives
+too-long-first-doc-paragraph = "allow" # TODO(jhpratt) temporary
+
+[workspace.lints.rustdoc]
+private-doc-tests = "warn"
+unescaped-backticks = "warn"

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -306,6 +306,7 @@ pub struct TlsConfig {
 }
 
 /// Advanced Http configurations. These are generally should not be set.
+///
 /// For documentation on what each of these do, see the hyper documentation:
 /// See: <https://docs.rs/hyper/latest/hyper/server/conn/struct.Http.html>
 ///

--- a/nativelink-config/src/lib.rs
+++ b/nativelink-config/src/lib.rs
@@ -17,10 +17,10 @@ pub mod schedulers;
 pub mod serde_utils;
 pub mod stores;
 
-use std::any::type_name;
+use core::any::type_name;
+use core::marker::PhantomData;
 use std::collections::HashMap;
 use std::fmt;
-use std::marker::PhantomData;
 
 use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -44,7 +44,7 @@ pub type SchedulerConfigs = NamedConfigs<schedulers::SchedulerSpec>;
 pub struct NamedConfigs<T>(pub Vec<NamedConfig<T>>);
 
 impl<T> NamedConfigs<T> {
-    pub fn iter(&self) -> std::slice::Iter<'_, NamedConfig<T>> {
+    pub fn iter(&self) -> core::slice::Iter<'_, NamedConfig<T>> {
         self.0.iter()
     }
 }
@@ -60,7 +60,7 @@ impl<T> IntoIterator for NamedConfigs<T> {
 
 impl<'a, T> IntoIterator for &'a NamedConfigs<T> {
     type Item = &'a NamedConfig<T>;
-    type IntoIter = std::slice::Iter<'a, NamedConfig<T>>;
+    type IntoIter = core::slice::Iter<'a, NamedConfig<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -73,7 +73,7 @@ struct NamedConfigsVisitor<T> {
 
 impl<T> NamedConfigsVisitor<T> {
     const fn new() -> Self {
-        NamedConfigsVisitor {
+        Self {
             phantom: PhantomData,
         }
     }

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -148,10 +148,11 @@ pub struct ExperimentalRedisSchedulerBackend {
     pub redis_store: StoreRefName,
 }
 
-/// A scheduler that simply forwards requests to an upstream scheduler.  This
-/// is useful to use when doing some kind of local action cache or CAS away from
-/// the main cluster of workers.  In general, it's more efficient to point the
-/// build at the main scheduler directly though.
+/// A scheduler that simply forwards requests to an upstream scheduler.
+///
+/// This is useful to use when doing some kind of local action cache or CAS away from the main
+/// cluster of workers.  In general, it's more efficient to point the build at the main scheduler
+/// directly though.
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GrpcSpec {

--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::marker::PhantomData;
 use std::borrow::Cow;
 use std::fmt;
-use std::marker::PhantomData;
 
 use byte_unit::Byte;
 use humantime::parse_duration;

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -641,7 +641,7 @@ pub struct CompletenessCheckingSpec {
     pub cas_store: StoreSpec,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 pub struct Lz4Config {
     /// Size of the blocks to compress.
@@ -664,7 +664,7 @@ pub struct Lz4Config {
     pub max_decode_block_size: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum CompressionAlgorithm {
     /// LZ4 compression algorithm is extremely fast for compression and
@@ -851,7 +851,7 @@ pub struct GrpcSpec {
 }
 
 /// The possible error codes that might occur on an upstream request.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ErrorCode {
     Cancelled = 1,
     Unknown = 2,

--- a/nativelink-config/tests/backwards_compat_test.rs
+++ b/nativelink-config/tests/backwards_compat_test.rs
@@ -36,7 +36,7 @@ fn test_configs_deserialization() {
         }
     ]);
 
-    let config: NamedConfigs<DummySpec> = serde_json::from_value(expected.clone()).unwrap();
+    let config: NamedConfigs<DummySpec> = serde_json::from_value(expected).unwrap();
     let mut new_stores: Vec<_> = config.into_iter().collect();
     new_stores.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/nativelink-config/tests/deserialization_test.rs
+++ b/nativelink-config/tests/deserialization_test.rs
@@ -63,8 +63,7 @@ mod duration_tests {
             // Large numbers
             (r#"{"duration": 0}"#, 0),
             (r#"{"duration": 1000}"#, 1000),
-            // u32::MAX
-            (r#"{"duration": 4294967295}"#, 4_294_967_295),
+            (r#"{"duration": 4294967295}"#, u32::MAX),
         ];
 
         for (input, expected) in examples {
@@ -118,8 +117,7 @@ mod duration_tests {
     #[test]
     fn test_large_duration_numbers() {
         let examples = [
-            // u32::MAX
-            (r#"{"duration": 4294967295}"#, 4_294_967_295),
+            (r#"{"duration": 4294967295}"#, u32::MAX),
             // u64::MAX - this will fail to parse as usize on 64-bit systems
             // (r#"{"duration": 18446744073709551615}"#, 18_446_744_073_709_551_615),
         ];

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::Into;
+use core::convert::Into;
 
 use nativelink_metric::{
     MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
@@ -116,7 +116,7 @@ impl Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<Error> for nativelink_proto::google::rpc::Status {
     fn from(val: Error) -> Self {
@@ -137,8 +137,8 @@ impl From<nativelink_proto::google::rpc::Status> for Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // A manual impl to reduce the noise of frequently empty fields.
         let mut builder = f.debug_struct("Error");
 
@@ -170,8 +170,8 @@ impl From<prost::UnknownEnumValue> for Error {
     }
 }
 
-impl From<std::num::TryFromIntError> for Error {
-    fn from(err: std::num::TryFromIntError) -> Self {
+impl From<core::num::TryFromIntError> for Error {
+    fn from(err: core::num::TryFromIntError) -> Self {
         make_err!(Code::InvalidArgument, "{}", err.to_string())
     }
 }
@@ -182,14 +182,14 @@ impl From<tokio::task::JoinError> for Error {
     }
 }
 
-impl From<std::num::ParseIntError> for Error {
-    fn from(err: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for Error {
+    fn from(err: core::num::ParseIntError) -> Self {
         make_err!(Code::InvalidArgument, "{}", err.to_string())
     }
 }
 
-impl From<std::convert::Infallible> for Error {
-    fn from(_err: std::convert::Infallible) -> Self {
+impl From<core::convert::Infallible> for Error {
+    fn from(_err: core::convert::Infallible) -> Self {
         // Infallible is an error type that can never happen.
         unreachable!();
     }
@@ -333,13 +333,13 @@ trait CodeExt {
 impl CodeExt for Code {
     fn into_error_kind(self) -> std::io::ErrorKind {
         match self {
-            Code::Aborted => std::io::ErrorKind::Interrupted,
-            Code::AlreadyExists => std::io::ErrorKind::AlreadyExists,
-            Code::DeadlineExceeded => std::io::ErrorKind::TimedOut,
-            Code::InvalidArgument => std::io::ErrorKind::InvalidInput,
-            Code::NotFound => std::io::ErrorKind::NotFound,
-            Code::PermissionDenied => std::io::ErrorKind::PermissionDenied,
-            Code::Unavailable => std::io::ErrorKind::ConnectionRefused,
+            Self::Aborted => std::io::ErrorKind::Interrupted,
+            Self::AlreadyExists => std::io::ErrorKind::AlreadyExists,
+            Self::DeadlineExceeded => std::io::ErrorKind::TimedOut,
+            Self::InvalidArgument => std::io::ErrorKind::InvalidInput,
+            Self::NotFound => std::io::ErrorKind::NotFound,
+            Self::PermissionDenied => std::io::ErrorKind::PermissionDenied,
+            Self::Unavailable => std::io::ErrorKind::ConnectionRefused,
             _ => std::io::ErrorKind::Other,
         }
     }

--- a/nativelink-metric-collector/src/metrics_collection.rs
+++ b/nativelink-metric-collector/src/metrics_collection.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::{Deref, DerefMut};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 use serde::Serialize;
 

--- a/nativelink-metric-collector/src/metrics_visitors.rs
+++ b/nativelink-metric-collector/src/metrics_visitors.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
 use std::borrow::Cow;
-use std::fmt::Debug;
 
 use nativelink_metric::MetricKind;
 use serde::Serialize;
@@ -32,10 +32,8 @@ pub enum CollectionKind {
 impl From<MetricKind> for CollectionKind {
     fn from(kind: MetricKind) -> Self {
         match kind {
-            MetricKind::Counter => CollectionKind::Counter,
-            MetricKind::Default | MetricKind::String | MetricKind::Component => {
-                CollectionKind::String
-            }
+            MetricKind::Counter => Self::Counter,
+            MetricKind::Default | MetricKind::String | MetricKind::Component => Self::String,
         }
     }
 }
@@ -49,7 +47,7 @@ enum ValueWithPrimitiveType {
 
 impl Default for ValueWithPrimitiveType {
     fn default() -> Self {
-        ValueWithPrimitiveType::U64(0)
+        Self::U64(0)
     }
 }
 
@@ -78,7 +76,7 @@ impl From<MetricDataVisitor> for CollectedMetricPrimitive {
                 CollectionKind::Counter,
             ),
         };
-        CollectedMetricPrimitive {
+        Self {
             value: Some(value),
             help: visitor.help,
             value_type: visitor.value_type.unwrap_or(derived_type),
@@ -140,7 +138,7 @@ impl Visit for MetricDataVisitor {
             field => panic!("UNKNOWN FIELD {field}"),
         }
     }
-    fn record_error(&mut self, _field: &Field, _value: &(dyn std::error::Error + 'static)) {}
+    fn record_error(&mut self, _field: &Field, _value: &(dyn core::error::Error + 'static)) {}
 }
 
 /// An intermediate structed that will have it's contents populated

--- a/nativelink-metric-collector/src/otel_exporter.rs
+++ b/nativelink-metric-collector/src/otel_exporter.rs
@@ -54,7 +54,7 @@ fn process_children(prefix: &mut String, meter: &Meter, children: &CollectedMetr
     }
 }
 
-fn process_primitive(prefix: &mut String, meter: &Meter, primitive: &CollectedMetricPrimitive) {
+fn process_primitive(prefix: &str, meter: &Meter, primitive: &CollectedMetricPrimitive) {
     match &primitive.value {
         Some(CollectedMetricPrimitiveValue::Counter(value)) => {
             if prefix.len() > MAX_METRIC_NAME_LENGTH {
@@ -62,7 +62,7 @@ fn process_primitive(prefix: &mut String, meter: &Meter, primitive: &CollectedMe
                 return;
             }
             let counter = meter
-                .u64_counter(prefix.clone())
+                .u64_counter(prefix.to_owned())
                 .with_description(primitive.help.clone())
                 .build();
             counter.add(*value, &[]);

--- a/nativelink-metric-collector/src/tracing_layers.rs
+++ b/nativelink-metric-collector/src/tracing_layers.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::marker::PhantomData;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -47,7 +47,7 @@ impl<S> MetricsCollectorLayer<S> {
     pub fn new() -> (Self, Arc<Mutex<RootMetricCollectedMetrics>>) {
         let root_collected_metrics = Arc::new(Mutex::new(RootMetricCollectedMetrics::default()));
         (
-            MetricsCollectorLayer {
+            Self {
                 spans: Mutex::new(HashMap::new()),
                 root_collected_metrics: root_collected_metrics.clone(),
                 _subscriber: PhantomData,

--- a/nativelink-metric-collector/tests/metric_collector_test.rs
+++ b/nativelink-metric-collector/tests/metric_collector_test.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::marker::PhantomData;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use nativelink_metric::{MetricFieldData, MetricKind, MetricsComponent};
 use nativelink_metric_collector::MetricsCollectorLayer;

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::ops::Bound;
 use std::string::ToString;
 use std::sync::{Arc, Weak};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use async_lock::Mutex;
 use async_trait::async_trait;

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use bytes::BytesMut;
@@ -42,7 +42,7 @@ async fn insert_into_store<T: Message>(
     hash: &str,
     action_size: i64,
     action_result: &T,
-) -> Result<i64, Box<dyn std::error::Error>> {
+) -> Result<i64, Box<dyn core::error::Error>> {
     let mut store_data = BytesMut::new();
     action_result.encode(&mut store_data)?;
     let data_len = store_data.len();
@@ -107,7 +107,7 @@ async fn get_action_result(
 }
 
 #[nativelink_test]
-async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
+async fn empty_store() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
 
@@ -120,7 +120,7 @@ async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn has_single_item() -> Result<(), Box<dyn std::error::Error>> {
+async fn has_single_item() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();
@@ -142,7 +142,7 @@ async fn has_single_item() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error>> {
+async fn single_item_wrong_digest_size() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();
@@ -161,7 +161,7 @@ async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
-fn get_encoded_proto_size<T: Message>(proto: &T) -> Result<usize, Box<dyn std::error::Error>> {
+fn get_encoded_proto_size<T: Message>(proto: &T) -> Result<usize, Box<dyn core::error::Error>> {
     let mut store_data = Vec::new();
     proto.encode(&mut store_data)?;
     Ok(store_data.len())
@@ -184,7 +184,7 @@ async fn update_action_result(
 }
 
 #[nativelink_test]
-async fn one_item_update_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn one_item_update_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -82,7 +82,7 @@ fn get_bep_store(store_manager: &StoreManager) -> Result<Store, Error> {
 
 /// Asserts that a gRPC request for a [`PublishLifecycleEventRequest`] is correctly dumped into a [`Store`]
 #[nativelink_test]
-async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn publish_lifecycle_event_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bep_server = make_bep_server(&store_manager)?;
     let bep_store = get_bep_store(&store_manager)?;
@@ -156,7 +156,7 @@ async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[nativelink_test]
-async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bep_server = make_bep_server(&store_manager)?;
     let bep_store = get_bep_store(&store_manager)?;
@@ -172,7 +172,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error
             .err_tip(|| "While invoking publish_build_tool_event_stream")?
             .into_inner();
 
-        Ok::<_, Box<dyn std::error::Error>>((tx, stream))
+        Ok::<_, Box<dyn core::error::Error>>((tx, stream))
     }
     .await?;
 
@@ -276,7 +276,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error
                     }),
                 }),
                 notification_keywords: vec!["testing".to_string()],
-                project_id: project_id.clone(),
+                project_id,
                 check_preceding_lifecycle_events_present: false,
             },
         ];

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -71,7 +71,7 @@ fn make_cas_server(store_manager: &StoreManager) -> Result<CasServer, Error> {
 }
 
 #[nativelink_test]
-async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
+async fn empty_store() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
 
@@ -92,7 +92,7 @@ async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn store_one_item_existence() -> Result<(), Box<dyn std::error::Error>> {
+async fn store_one_item_existence() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE: &str = "1";
 
     let store_manager = make_store_manager().await?;
@@ -119,7 +119,7 @@ async fn store_one_item_existence() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn std::error::Error>> {
+async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE: &str = "1";
 
     let store_manager = make_store_manager().await?;
@@ -158,7 +158,7 @@ async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn std::error::Err
 }
 
 #[nativelink_test]
-async fn update_existing_item() -> Result<(), Box<dyn std::error::Error>> {
+async fn update_existing_item() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "2";
 
@@ -214,8 +214,8 @@ async fn update_existing_item() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn batch_read_blobs_read_two_blobs_success_one_fail() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn batch_read_blobs_read_two_blobs_success_one_fail()
+-> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "23";
 
@@ -240,8 +240,8 @@ async fn batch_read_blobs_read_two_blobs_success_one_fail() -> Result<(), Box<dy
         store
             .update_oneshot(DigestInfo::try_new(HASH2, VALUE2.len())?, VALUE2.into())
             .await
-            .expect("Update should have succeeded");
-    }
+            .expect("Update should have succeeded")
+    };
     {
         // Read two blobs and additional blob should come back not found.
         let digest3 = Digest {
@@ -296,8 +296,8 @@ async fn batch_read_blobs_read_two_blobs_success_one_fail() -> Result<(), Box<dy
                     }
                 ],
             }
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -367,7 +367,7 @@ async fn setup_directory_structure(
 }
 
 #[nativelink_test]
-async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::error::Error>> {
+async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
     let store = store_manager.get_store("main_cas").unwrap();
@@ -413,8 +413,8 @@ async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::e
                 ],
                 next_page_token: String::new()
             }]
-        );
-    }
+        )
+    };
 
     // Also verify that sending the root digest returns the entire tree as well.
     {
@@ -445,14 +445,14 @@ async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::e
                 ],
                 next_page_token: String::new()
             }]
-        );
-    }
+        )
+    };
 
     Ok(())
 }
 
 #[nativelink_test]
-async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::error::Error>> {
+async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
     let store = store_manager.get_store("main_cas").unwrap();
@@ -493,8 +493,8 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
                 directories: vec![root_directory.clone(), sub_directories[0].clone()],
                 next_page_token: format!("{}", sub_directory_digest_infos[1]),
             }]
-        );
-    }
+        )
+    };
 
     // Also verify that sending the root digest as the page token is treated as paging from the
     // beginning and respects page size.
@@ -519,8 +519,8 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
                 directories: vec![root_directory.clone(), sub_directories[0].clone()],
                 next_page_token: format!("{}", sub_directory_digest_infos[1]),
             }]
-        );
-    }
+        )
+    };
 
     // Verify that paging from a non-initial page token will return the expected content.
     {
@@ -566,15 +566,15 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
                 directories: vec![sub_directories[3].clone(), sub_directories[4].clone()],
                 next_page_token: String::new(),
             }]
-        );
-    }
+        )
+    };
 
     Ok(())
 }
 
 #[nativelink_test]
 async fn batch_update_blobs_two_items_existence_with_third_missing()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "23";
 
@@ -633,8 +633,8 @@ async fn batch_update_blobs_two_items_existence_with_third_missing()
                     }
                 ],
             }
-        );
-    }
+        )
+    };
     {
         // Query the backend for inserted entries plus one that is not
         // present and ensure it only returns the one that is missing.
@@ -661,7 +661,7 @@ async fn batch_update_blobs_two_items_existence_with_third_missing()
             .await;
         assert!(raw_response.is_ok());
         let response = raw_response.unwrap().into_inner();
-        assert_eq!(response.missing_blob_digests, vec![missing_digest]);
-    }
+        assert_eq!(response.missing_blob_digests, vec![missing_digest])
+    };
     Ok(())
 }

--- a/nativelink-store/src/ac_utils.rs
+++ b/nativelink-store/src/ac_utils.rs
@@ -17,7 +17,7 @@
 //                    THREADSAFETY. FIGURE OUT WHY AND MOVE IT TO UTILS.
 // @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-use std::pin::Pin;
+use core::pin::Pin;
 
 use bytes::BytesMut;
 use futures::TryFutureExt;

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::pin::Pin;
+use core::cmp;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -42,7 +42,7 @@ const DEFAULT_NORM_SIZE: u64 = 256 * 1024;
 const DEFAULT_MAX_SIZE: u64 = 512 * 1024;
 const DEFAULT_MAX_CONCURRENT_FETCH_PER_GET: usize = 10;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
 pub struct DedupIndex {
     pub entries: Vec<DigestInfo>,
 }
@@ -59,8 +59,8 @@ pub struct DedupStore {
     bincode_options: WithOtherIntEncoding<DefaultOptions, FixintEncoding>,
 }
 
-impl std::fmt::Debug for DedupStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DedupStore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DedupStore")
             .field("index_store", &self.index_store)
             .field("content_store", &self.content_store)
@@ -369,11 +369,11 @@ impl StoreDriver for DedupStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
 use std::borrow::Cow;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -121,7 +121,7 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
                 })
                 .collect::<Vec<_>>();
             drop(self.existence_cache.insert_many(inserts).await);
-        }
+        };
 
         // Merge the results from the cache and the query.
         {
@@ -140,7 +140,7 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
                 inner_results_iter.next().is_some(),
                 "has_with_results returned more results than expected"
             );
-        }
+        };
 
         Ok(())
     }
@@ -221,11 +221,11 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::BorrowMut;
-use std::cmp::{max, min};
+use core::borrow::BorrowMut;
+use core::cmp::{max, min};
+use core::ops::Range;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::ffi::OsString;
-use std::ops::Range;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
@@ -385,11 +385,11 @@ impl StoreDriver for FastSlowStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::{Debug, Formatter};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{Debug, Formatter};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
@@ -230,7 +230,7 @@ impl FileEntry for FileEntryImpl {
     async fn make_and_open_file(
         block_size: u64,
         encoded_file_path: EncodedFilePath,
-    ) -> Result<(FileEntryImpl, fs::FileSlot, OsString), Error> {
+    ) -> Result<(Self, fs::FileSlot, OsString), Error> {
         let temp_full_path = encoded_file_path.get_file_path().to_os_string();
         let temp_file_result = fs::create_file(temp_full_path.clone())
             .or_else(|mut err| async {
@@ -253,7 +253,7 @@ impl FileEntry for FileEntryImpl {
             .await?;
 
         Ok((
-            <FileEntryImpl as FileEntry>::create(
+            <Self as FileEntry>::create(
                 0, /* Unknown yet, we will fill it in later */
                 block_size,
                 RwLock::new(encoded_file_path),
@@ -304,7 +304,7 @@ impl FileEntry for FileEntryImpl {
 }
 
 impl Debug for FileEntryImpl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("FileEntryImpl")
             .field("data_size", &self.data_size)
             .field("encoded_file_path", &"<behind mutex>")
@@ -971,11 +971,11 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::time::Duration;
 use std::borrow::Cow;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::BytesMut;
@@ -102,7 +102,7 @@ impl GrpcStore {
         }
 
         let jitter_fn = Arc::new(jitter_fn);
-        Ok(Arc::new(GrpcStore {
+        Ok(Arc::new(Self {
             instance_name: spec.instance_name.clone(),
             store_type: spec.store_type,
             retrier: Retrier::new(
@@ -774,11 +774,11 @@ impl StoreDriver for GrpcStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
-use std::fmt::Debug;
-use std::ops::Bound;
-use std::pin::Pin;
+use core::borrow::Borrow;
+use core::fmt::Debug;
+use core::ops::Bound;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -37,7 +37,7 @@ use crate::cas_utils::is_zero_digest;
 pub struct BytesWrapper(Bytes);
 
 impl Debug for BytesWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("BytesWrapper { -- Binary data -- }")
     }
 }
@@ -189,11 +189,11 @@ impl StoreDriver for MemoryStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -39,7 +39,7 @@ impl MetricsComponent for NoopStore {
 
 impl NoopStore {
     pub fn new() -> Arc<Self> {
-        Arc::new(NoopStore {})
+        Arc::new(Self)
     }
 }
 
@@ -85,11 +85,11 @@ impl StoreDriver for NoopStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::cmp;
+use core::pin::Pin;
+use core::time::Duration;
 use std::borrow::Cow;
-use std::cmp;
-use std::pin::Pin;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -574,11 +574,11 @@ impl StoreDriver for RedisStore {
         self
     }
 
-    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send) {
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send> {
         self
     }
 
@@ -787,7 +787,7 @@ struct RedisSubscriptionPublisher {
 impl RedisSubscriptionPublisher {
     fn new(
         key: String,
-        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<RedisSubscriptionPublisher>>>,
+        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<Self>>>,
     ) -> (Self, RedisSubscription) {
         let (sender, receiver) = tokio::sync::watch::channel(key);
         let publisher = Self {
@@ -802,7 +802,7 @@ impl RedisSubscriptionPublisher {
 
     fn subscribe(
         &self,
-        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<RedisSubscriptionPublisher>>>,
+        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<Self>>>,
     ) -> RedisSubscription {
         let receiver = self.sender.lock().subscribe();
         RedisSubscription {

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::UnsafeCell;
-use std::pin::Pin;
+use core::cell::UnsafeCell;
+use core::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
 
 use async_trait::async_trait;
@@ -49,7 +49,7 @@ pub struct RefStore {
 
 impl RefStore {
     pub fn new(spec: &RefSpec, store_manager: Weak<StoreManager>) -> Arc<Self> {
-        Arc::new(RefStore {
+        Arc::new(Self {
             name: spec.name.clone(),
             store_manager,
             inner: StoreReference {
@@ -141,11 +141,11 @@ impl StoreDriver for RefStore {
         }
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::cmp;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::borrow::Cow;
-use std::cmp;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use aws_config::default_provider::credentials;
@@ -130,8 +130,8 @@ impl TlsClient {
     }
 }
 
-impl std::fmt::Debug for TlsClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Debug for TlsClient {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TlsClient").finish_non_exhaustive()
     }
 }
@@ -960,11 +960,11 @@ where
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::hash::{DefaultHasher, Hasher};
-use std::ops::BitXor;
-use std::pin::Pin;
+use core::hash::Hasher;
+use core::pin::Pin;
+use std::hash::DefaultHasher;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -93,32 +93,16 @@ impl ShardStore {
                 //     the slice length, e.g. <[u8; 4]>::try_from(&slice[4..8]).unwrap(). Array implements
                 //     TryFrom returning.
                 let size_bytes = digest.size_bytes().to_le_bytes();
-                0.bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[0..4].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[4..8].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[8..12].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[12..16].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[16..20].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[20..24].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[24..28].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(
-                    digest.packed_hash()[28..32].try_into().unwrap(),
-                ))
-                .bitxor(u32::from_le_bytes(size_bytes[0..4].try_into().unwrap()))
-                .bitxor(u32::from_le_bytes(size_bytes[4..8].try_into().unwrap()))
+                u32::from_le_bytes(digest.packed_hash()[0..4].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[4..8].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[8..12].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[12..16].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[16..20].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[20..24].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[24..28].try_into().unwrap())
+                    ^ u32::from_le_bytes(digest.packed_hash()[28..32].try_into().unwrap())
+                    ^ u32::from_le_bytes(size_bytes[0..4].try_into().unwrap())
+                    ^ u32::from_le_bytes(size_bytes[4..8].try_into().unwrap())
             }
             StoreKey::Str(s) => {
                 let mut hasher = DefaultHasher::new();
@@ -229,11 +213,11 @@ impl StoreDriver for ShardStore {
         self.weights_and_stores[index].store.inner_store(Some(key))
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -36,7 +36,7 @@ pub struct SizePartitioningStore {
 
 impl SizePartitioningStore {
     pub fn new(spec: &SizePartitioningSpec, lower_store: Store, upper_store: Store) -> Arc<Self> {
-        Arc::new(SizePartitioningStore {
+        Arc::new(Self {
             partition_size: spec.size,
             lower_store,
             upper_store,
@@ -152,11 +152,11 @@ impl StoreDriver for SizePartitioningStore {
         self.upper_store.inner_store(Some(digest))
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/store_manager.rs
+++ b/nativelink-store/src/store_manager.rs
@@ -25,8 +25,8 @@ pub struct StoreManager {
 }
 
 impl StoreManager {
-    pub fn new() -> StoreManager {
-        StoreManager {
+    pub fn new() -> Self {
+        Self {
             stores: RwLock::new(HashMap::new()),
         }
     }

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -49,7 +49,7 @@ pub struct VerifyStore {
 
 impl VerifyStore {
     pub fn new(spec: &VerifySpec, inner_store: Store) -> Arc<Self> {
-        Arc::new(VerifyStore {
+        Arc::new(Self {
             inner_store,
             verify_size: spec.verify_size,
             verify_hash: spec.verify_hash,
@@ -77,7 +77,7 @@ impl VerifyStore {
             // Ensure if a user sends us too much data we fail quickly.
             if let Some(expected_size) = maybe_expected_digest_size {
                 match sum_size.cmp(&expected_size) {
-                    std::cmp::Ordering::Greater => {
+                    core::cmp::Ordering::Greater => {
                         self.size_verification_failures.inc();
                         return Err(make_input_err!(
                             "Expected size {} but already received {} on insert",
@@ -85,7 +85,7 @@ impl VerifyStore {
                             sum_size
                         ));
                     }
-                    std::cmp::Ordering::Equal => {
+                    core::cmp::Ordering::Equal => {
                         // Ensure our next chunk is the EOF chunk.
                         // If this was an error it'll be caught on the .recv()
                         // on next cycle.
@@ -99,7 +99,7 @@ impl VerifyStore {
                             }
                         }
                     }
-                    std::cmp::Ordering::Less => {}
+                    core::cmp::Ordering::Less => {}
                 }
             }
 
@@ -223,11 +223,11 @@ impl StoreDriver for VerifyStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -58,8 +58,8 @@ async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
             .await
             .err_tip(|| "Could not write to file")?;
         file.flush().await.err_tip(|| "Could not flush file")?;
-        file.sync_all().await.err_tip(|| "Could not sync file")?;
-    }
+        file.sync_all().await.err_tip(|| "Could not sync file")?
+    };
     {
         // Upload our file.
         let file = fs::open_file(&filepath, 0, u64::MAX)
@@ -73,13 +73,13 @@ async fn upload_file_to_store_with_large_file() -> Result<(), Error> {
                 file,
                 UploadSizeInfo::ExactSize(expected_data.len() as u64),
             )
-            .await?;
-    }
+            .await?
+    };
     {
         // Check to make sure the file was saved correctly to the store.
         let store_data = store.get_part_unchunked(digest, 0, None).await?;
         assert_eq!(store_data.len(), expected_data.len());
-        assert_eq!(store_data, expected_data);
-    }
+        assert_eq!(store_data, expected_data)
+    };
     Ok(())
 }

--- a/nativelink-store/tests/completeness_checking_store_test.rs
+++ b/nativelink-store/tests/completeness_checking_store_test.rs
@@ -125,7 +125,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_some(),
             "Results should be some with all items in CAS."
         );
-    }
+    };
 
     {
         // Completeness check should fail when root file digest is missing.
@@ -142,7 +142,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_none(),
             "Results should be none with missing root file."
         );
-    }
+    };
 
     {
         // Completeness check should fail when child file digest is missing.
@@ -158,7 +158,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_none(),
             "Results should be none with missing root file."
         );
-    }
+    };
 
     {
         // Completeness check should fail when output file digest is missing.
@@ -174,7 +174,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_none(),
             "Results should be none with missing root file."
         );
-    }
+    };
 
     {
         // Completeness check should fail when stdout digest is missing.
@@ -190,7 +190,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_none(),
             "Results should be none with missing root file."
         );
-    }
+    };
 
     {
         // Completeness check should fail when stderr digest is missing.
@@ -206,7 +206,7 @@ async fn verify_has_function_call_checks_cas() -> Result<(), Error> {
             res[0].is_none(),
             "Results should be none with missing root file."
         );
-    }
+    };
 
     Ok(())
 }
@@ -225,7 +225,7 @@ async fn verify_completeness_get() -> Result<(), Error> {
                 .is_ok(),
             ".get() should succeed with all items in CAS",
         );
-    }
+    };
 
     {
         // Completeness check in get call should fail when digest is missing in CAS.
@@ -241,7 +241,7 @@ async fn verify_completeness_get() -> Result<(), Error> {
                 .is_err(),
             ".get() should fail with item missing in CAS",
         );
-    }
+    };
 
     Ok(())
 }

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
+use core::cmp;
+use core::pin::Pin;
+use core::str::from_utf8;
 use std::io::Cursor;
-use std::pin::Pin;
-use std::str::from_utf8;
 use std::sync::Arc;
 
 use bincode::{DefaultOptions, Options};
@@ -77,9 +77,7 @@ async fn simple_smoke_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                Default::default(),
             ),
         },
         Store::new(MemoryStore::new(&MemorySpec::default())),
@@ -163,9 +161,7 @@ async fn rand_5mb_smoke_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                Default::default(),
             ),
         },
         Store::new(MemoryStore::new(&MemorySpec::default())),
@@ -196,9 +192,7 @@ async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                Default::default(),
             ),
         },
         Store::new(inner_store.clone()),
@@ -287,13 +281,13 @@ async fn check_header_test() -> Result<(), Error> {
         assert_eq!(
             version, CURRENT_STREAM_FORMAT_VERSION,
             "Expected header version to match current version"
-        );
-    }
+        )
+    };
     {
         // Check block size.
         let block_size = reader.read_u32_le().await?;
-        assert_eq!(block_size, BLOCK_SIZE, "Expected block size to match");
-    }
+        assert_eq!(block_size, BLOCK_SIZE, "Expected block size to match")
+    };
     {
         // Check upload_type and upload_size.
         const MAX_SIZE_OPT_CODE: u32 = 1;
@@ -306,8 +300,8 @@ async fn check_header_test() -> Result<(), Error> {
         assert_eq!(
             upload_size, MAX_SIZE_INPUT as u32,
             "Expected upload size to match"
-        );
-    }
+        )
+    };
 
     // As a sanity check lets check our footer.
     assert_eq!(
@@ -371,8 +365,8 @@ async fn check_footer_test() -> Result<(), Error> {
         assert_eq!(
             version, CURRENT_STREAM_FORMAT_VERSION,
             "Expected footer version to match current version"
-        );
-    }
+        )
+    };
     {
         // Check block size in footer.
         let block_size = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
@@ -380,8 +374,8 @@ async fn check_footer_test() -> Result<(), Error> {
         assert_eq!(
             block_size, BLOCK_SIZE,
             "Expected uncompressed_data_size to match original data size"
-        );
-    }
+        )
+    };
     {
         // Check data size in footer.
         let uncompressed_data_size =
@@ -391,8 +385,8 @@ async fn check_footer_test() -> Result<(), Error> {
             uncompressed_data_size,
             value.len() as u64,
             "Expected uncompressed_data_size to match original data size"
-        );
-    }
+        )
+    };
     let index_count = {
         // Check index count in footer.
         let index_count = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
@@ -429,8 +423,8 @@ async fn check_footer_test() -> Result<(), Error> {
             bincode_index_count,
             u64::from(index_count),
             "Expected index_count and bincode_index_count to match"
-        );
-    }
+        )
+    };
     {
         // Check our footer length.
         let footer_len = u32::from_le_bytes(compressed_data[pos - 4..pos].try_into().unwrap());
@@ -439,16 +433,16 @@ async fn check_footer_test() -> Result<(), Error> {
             footer_len,
             1 + 4 + 8 + 4 + (index_count * 4) + 8,
             "Expected frame type to be footer"
-        );
-    }
+        )
+    };
     {
         // Check our frame type.
         let frame_type = u8::from_le_bytes(compressed_data[pos - 1..pos].try_into().unwrap());
         assert_eq!(
             frame_type, FOOTER_FRAME_TYPE,
             "Expected frame type to be footer"
-        );
-    }
+        )
+    };
 
     // Just as one last sanity check lets check our deserialized footer.
     assert_eq!(

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -239,7 +239,7 @@ async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
                 .await
                 .err_tip(|| "Failed to get_part from dedup store")?;
 
-            let len_fenced = std::cmp::min(len, rt_data.len());
+            let len_fenced = core::cmp::min(len, rt_data.len());
             assert_eq!(
                 rt_data.len(),
                 len_fenced,
@@ -304,7 +304,7 @@ async fn has_checks_content_store() -> Result<(), Error> {
         // Check to ensure we our baseline `.has()` succeeds.
         let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
         assert_eq!(size_info, Some(DATA_SIZE as u64), "Expected sizes to match");
-    }
+    };
     {
         // We now add one more item to the store, which will trigger eviction of one of
         // the existing items because max_bytes will be exceeded.
@@ -323,7 +323,7 @@ async fn has_checks_content_store() -> Result<(), Error> {
                 Some(DATA2.len() as u64),
                 "Expected sizes to match"
             );
-        }
+        };
         {
             // Check our first added entry is now invalid (because part of it was evicted).
             let size_info = store.has(digest1).await.err_tip(|| "Failed to run .has")?;
@@ -331,7 +331,7 @@ async fn has_checks_content_store() -> Result<(), Error> {
                 size_info, None,
                 "Expected .has() to return None (not found)"
             );
-        }
+        };
     }
 
     Ok(())
@@ -366,7 +366,7 @@ async fn has_with_no_existing_index_returns_none_test() -> Result<(), Error> {
             "Expected None to be returned, got {:?}",
             size_info
         );
-    }
+    };
     Ok(())
 }
 
@@ -398,6 +398,6 @@ async fn has_with_zero_digest_returns_some_test() -> Result<(), Error> {
             "Expected Sone(0) to be returned, got {:?}",
             size_info
         );
-    }
+    };
     Ok(())
 }

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use mock_instant::thread_local::MockClock;
 use nativelink_config::stores::{

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -154,76 +154,66 @@ async fn partial_reads_copy_full_to_fast_store_test() -> Result<(), Error> {
 fn calculate_range_test() {
     let test =
         |start_range, end_range| FastSlowStore::calculate_range(&start_range, &end_range).unwrap();
-    {
-        // Exact match.
-        let received_range = 0..1;
-        let send_range = 0..1;
-        let expected_results = Some(0..1);
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Minus one on received_range.
-        let received_range = 1..4;
-        let send_range = 1..5;
-        let expected_results = Some(0..3);
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Minus one on send_range.
-        let received_range = 1..5;
-        let send_range = 1..4;
-        let expected_results = Some(0..3);
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Should have already sent all data (start fence post).
-        let received_range = 1..2;
-        let send_range = 0..1;
-        let expected_results = None;
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Definiltly already sent data.
-        let received_range = 2..3;
-        let send_range = 0..1;
-        let expected_results = None;
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // All data should be sent (inside range).
-        let received_range = 3..4;
-        let send_range = 0..100;
-        let expected_results = Some(0..1); // Note: This is relative received_range.start.
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Subset of received data should be sent.
-        let received_range = 1..100;
-        let send_range = 3..4;
-        let expected_results = Some(2..3); // Note: This is relative received_range.start.
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // We are clearly not at the offset yet.
-        let received_range = 0..1;
-        let send_range = 3..4;
-        let expected_results = None;
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Not at offset yet (fence post).
-        let received_range = 0..1;
-        let send_range = 1..2;
-        let expected_results = None;
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
-    {
-        // Head part of the received data should be sent.
-        let received_range = 1..3;
-        let send_range = 2..5;
-        let expected_results = Some(1..2);
-        assert_eq!(test(received_range, send_range), expected_results);
-    }
+
+    // Exact match.
+    let received_range = 0..1;
+    let send_range = 0..1;
+    let expected_results = Some(0..1);
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Minus one on received_range.
+    let received_range = 1..4;
+    let send_range = 1..5;
+    let expected_results = Some(0..3);
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Minus one on send_range.
+    let received_range = 1..5;
+    let send_range = 1..4;
+    let expected_results = Some(0..3);
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Should have already sent all data (start fence post).
+    let received_range = 1..2;
+    let send_range = 0..1;
+    let expected_results = None;
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Definiltly already sent data.
+    let received_range = 2..3;
+    let send_range = 0..1;
+    let expected_results = None;
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // All data should be sent (inside range).
+    let received_range = 3..4;
+    let send_range = 0..100;
+    let expected_results = Some(0..1); // Note: This is relative received_range.start.
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Subset of received data should be sent.
+    let received_range = 1..100;
+    let send_range = 3..4;
+    let expected_results = Some(2..3); // Note: This is relative received_range.start.
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // We are clearly not at the offset yet.
+    let received_range = 0..1;
+    let send_range = 3..4;
+    let expected_results = None;
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Not at offset yet (fence post).
+    let received_range = 0..1;
+    let send_range = 1..2;
+    let expected_results = None;
+    assert_eq!(test(received_range, send_range), expected_results);
+
+    // Head part of the received data should be sent.
+    let received_range = 1..3;
+    let send_range = 2..5;
+    let expected_results = Some(1..2);
+    assert_eq!(test(received_range, send_range), expected_results);
 }
 
 #[nativelink_test]
@@ -293,11 +283,11 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             self
         }
 
-        fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+        fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
             self
         }
 
-        fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
             self
         }
     }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::{Debug, Formatter};
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::time::Duration;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{Debug, Formatter};
-use std::marker::PhantomData;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
 
 use async_lock::RwLock;
 use bytes::Bytes;
@@ -61,7 +61,7 @@ struct TestFileEntry<Hooks: FileEntryHooks + 'static + Sync + Send> {
 }
 
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> Debug for TestFileEntry<Hooks> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("TestFileEntry")
             .field("inner", &self.inner)
             .finish()
@@ -276,8 +276,8 @@ async fn valid_results_after_shutdown_test() -> Result<(), Error> {
             Ok(Some(VALUE1.len() as u64)),
             "Expected filesystem store to have hash: {}",
             HASH1
-        );
-    }
+        )
+    };
     {
         // With a new store ensure content is still readable (ie: restores from shutdown).
         let store = Box::pin(
@@ -293,8 +293,8 @@ async fn valid_results_after_shutdown_test() -> Result<(), Error> {
         let key = StoreKey::Digest(digest);
 
         let content = store.get_part_unchunked(key, 0, None).await?;
-        assert_eq!(content, VALUE1.as_bytes());
-    }
+        assert_eq!(content, VALUE1.as_bytes())
+    };
 
     Ok(())
 }
@@ -336,8 +336,8 @@ async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
             &data[..],
             VALUE1.as_bytes(),
             "Expected file content to match"
-        );
-    }
+        )
+    };
 
     // Replace content.
     store.update_oneshot(digest1, VALUE2.into()).await?;
@@ -349,8 +349,8 @@ async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
             &data[..],
             VALUE2.as_bytes(),
             "Expected file content to match"
-        );
-    }
+        )
+    };
 
     loop {
         if DELETES_FINISHED.load(Ordering::Relaxed) == 1 {
@@ -414,8 +414,8 @@ async fn file_continues_to_stream_on_content_replace_test() -> Result<(), Error>
             first_byte[0],
             VALUE1.as_bytes()[0],
             "Expected first byte to match"
-        );
-    }
+        )
+    };
 
     // Replace content.
     store.update_oneshot(digest1, VALUE2.into()).await?;
@@ -444,8 +444,8 @@ async fn file_continues_to_stream_on_content_replace_test() -> Result<(), Error>
         assert_eq!(
             num_files, 1,
             "There should only be one file in the temp directory"
-        );
-    }
+        )
+    };
 
     let remaining_file_data = reader
         .consume(Some(1024))
@@ -544,8 +544,8 @@ async fn file_gets_cleans_up_on_cache_eviction() -> Result<(), Error> {
         assert_eq!(
             num_files, 1,
             "There should only be one file in the temp directory"
-        );
-    }
+        )
+    };
 
     let reader_data = reader
         .consume(Some(1024))
@@ -589,8 +589,8 @@ async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error
         let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
         let mut file_contents = String::new();
         reader.read_to_string(&mut file_contents).await?;
-        assert_eq!(file_contents, VALUE1);
-    }
+        assert_eq!(file_contents, VALUE1)
+    };
 
     // Now replace the data.
     store.update_oneshot(digest, VALUE2.into()).await?;
@@ -600,8 +600,8 @@ async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error
         let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
         let mut file_contents = String::new();
         reader.read_to_string(&mut file_contents).await?;
-        assert_eq!(file_contents, VALUE1);
-    }
+        assert_eq!(file_contents, VALUE1)
+    };
 
     Ok(())
 }
@@ -660,8 +660,8 @@ async fn eviction_on_insert_calls_unref_once() -> Result<(), Error> {
             1,
             "Expected exactly 1 unrefed digest"
         );
-        assert_eq!(unrefed_digests[0], small_digest, "Expected digest to match");
-    }
+        assert_eq!(unrefed_digests[0], small_digest, "Expected digest to match")
+    };
 
     Ok(())
 }
@@ -694,8 +694,8 @@ async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens()
                         .await
                         .err_tip(|| "Failed to open temp file")?;
                     // We don't care if it fails, this is only best attempt.
-                    drop(file_handle.get_ref().as_ref().sync_all().await);
-                }
+                    drop(file_handle.get_ref().as_ref().sync_all().await)
+                };
                 // Ensure we have written to the file too. This ensures we have an open file handle.
                 // Failing to do this may result in the file existing, but the `update_fut` not actually
                 // sending data to it yet.
@@ -783,9 +783,7 @@ async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens()
     FILE_DELETED_BARRIER.wait().await;
 
     // Now it should have cleaned up its temp files.
-    {
-        check_temp_empty(&temp_path).await?;
-    }
+    check_temp_empty(&temp_path).await?;
 
     // Finally ensure that our entry is not in the store.
     assert_eq!(
@@ -937,7 +935,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
             .await
             .err_tip(|| "Failed to get_part"),
     );
-    assert_eq!(results, vec!(Some(0)));
+    assert_eq!(results, vec![Some(0)]);
 
     wait_for_empty_content_file(&content_path, digest, || async move {
         tokio::task::yield_now().await;
@@ -1012,8 +1010,8 @@ async fn update_file_future_drops_before_rename() -> Result<(), Error> {
         // Writing these out explicitly so users know this is what we are testing.
         // Note: The order they are dropped matters.
         drop(update_fut);
-        drop(rename_pause_request_lock);
-    }
+        drop(rename_pause_request_lock)
+    };
     // Grab the newly inserted item in our store.
     let new_file_entry = store.get_file_entry_for_digest(&digest).await?;
     assert!(
@@ -1132,8 +1130,8 @@ async fn update_with_whole_file_closes_file() -> Result<(), Error> {
             fs::OPEN_FILE_SEMAPHORE.available_permits(),
             1,
             "Expected 1 permit to be available"
-        );
-    }
+        )
+    };
     let content_path = make_temp_path("content_path");
     let temp_path = make_temp_path("temp_path");
 
@@ -1157,8 +1155,8 @@ async fn update_with_whole_file_closes_file() -> Result<(), Error> {
     {
         file.write_all(value.as_bytes()).await?;
         file.as_mut().sync_all().await?;
-        file.seek(tokio::io::SeekFrom::Start(0)).await?;
-    }
+        file.seek(tokio::io::SeekFrom::Start(0)).await?
+    };
 
     store
         .update_with_whole_file(

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::RangeBounds;
-use std::pin::Pin;
+use core::ops::RangeBounds;
+use core::pin::Pin;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use memory_stats::memory_stats;
@@ -188,8 +188,8 @@ async fn errors_with_invalid_inputs() -> Result<(), Error> {
         }
         has_should_fail(store, TOO_LONG_HASH, VALUE1.len()).await;
         has_should_fail(store, TOO_SHORT_HASH, VALUE1.len()).await;
-        has_should_fail(store, INVALID_HASH, VALUE1.len()).await;
-    }
+        has_should_fail(store, INVALID_HASH, VALUE1.len()).await
+    };
     {
         // .update() tests.
         async fn update_should_fail<'a>(
@@ -210,8 +210,8 @@ async fn errors_with_invalid_inputs() -> Result<(), Error> {
         }
         update_should_fail(store, TOO_LONG_HASH, VALUE1.len(), VALUE1).await;
         update_should_fail(store, TOO_SHORT_HASH, VALUE1.len(), VALUE1).await;
-        update_should_fail(store, INVALID_HASH, VALUE1.len(), VALUE1).await;
-    }
+        update_should_fail(store, INVALID_HASH, VALUE1.len(), VALUE1).await
+    };
     {
         // .update() tests.
         async fn get_should_fail<'a>(
@@ -234,8 +234,8 @@ async fn errors_with_invalid_inputs() -> Result<(), Error> {
         get_should_fail(store, TOO_SHORT_HASH, 1).await;
         get_should_fail(store, INVALID_HASH, 1).await;
         // With an empty store .get() should fail too.
-        get_should_fail(store, VALID_HASH1, 1).await;
-    }
+        get_should_fail(store, VALID_HASH1, 1).await
+    };
     Ok(())
 }
 
@@ -283,7 +283,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
             .await
             .err_tip(|| "Failed to get_part"),
     );
-    assert_eq!(results, vec!(Some(0)));
+    assert_eq!(results, vec![Some(0)]);
 
     Ok(())
 }
@@ -315,41 +315,33 @@ async fn list_test() -> Result<(), Error> {
     store.update_oneshot(KEY2, VALUE.into()).await?;
     store.update_oneshot(KEY3, VALUE.into()).await?;
 
-    {
-        // Test listing all keys.
-        let keys = get_list(&store, ..).await;
-        assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
-    }
-    {
-        // Test listing from key1 to all.
-        let keys = get_list(&store, KEY1..).await;
-        assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
-    }
-    {
-        // Test listing from key1 to key2.
-        let keys = get_list(&store, KEY1..KEY2).await;
-        assert_eq!(keys, vec![KEY1]);
-    }
-    {
-        // Test listing from key1 including key2.
-        let keys = get_list(&store, KEY1..=KEY2).await;
-        assert_eq!(keys, vec![KEY1, KEY2]);
-    }
-    {
-        // Test listing from key1 to key3.
-        let keys = get_list(&store, KEY1..KEY3).await;
-        assert_eq!(keys, vec![KEY1, KEY2]);
-    }
-    {
-        // Test listing from all to key2.
-        let keys = get_list(&store, ..KEY2).await;
-        assert_eq!(keys, vec![KEY1]);
-    }
-    {
-        // Test listing from key2 to key3.
-        let keys = get_list(&store, KEY2..KEY3).await;
-        assert_eq!(keys, vec![KEY2]);
-    }
+    // Test listing all keys.
+    let keys = get_list(&store, ..).await;
+    assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
+
+    // Test listing from key1 to all.
+    let keys = get_list(&store, KEY1..).await;
+    assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
+
+    // Test listing from key1 to key2.
+    let keys = get_list(&store, KEY1..KEY2).await;
+    assert_eq!(keys, vec![KEY1]);
+
+    // Test listing from key1 including key2.
+    let keys = get_list(&store, KEY1..=KEY2).await;
+    assert_eq!(keys, vec![KEY1, KEY2]);
+
+    // Test listing from key1 to key3.
+    let keys = get_list(&store, KEY1..KEY3).await;
+    assert_eq!(keys, vec![KEY1, KEY2]);
+
+    // Test listing from all to key2.
+    let keys = get_list(&store, ..KEY2).await;
+    assert_eq!(keys, vec![KEY1]);
+
+    // Test listing from key2 to key3.
+    let keys = get_list(&store, KEY2..KEY3).await;
+    assert_eq!(keys, vec![KEY2]);
 
     Ok(())
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::panicking;
 
@@ -137,7 +137,7 @@ impl Mocks for MockRedisBackend {
             args: Vec::new(),
         };
 
-        let results = std::iter::once(MULTI.clone())
+        let results = core::iter::once(MULTI.clone())
             .chain(commands)
             .chain([EXEC.clone()])
             .map(|command| self.process_command(command))
@@ -892,7 +892,7 @@ async fn test_redis_fingerprint_metric() -> Result<(), Error> {
     };
 
     let root_metrics = Arc::new(RwLock::new(RootMetricsTest {
-        stores: store_manager.clone(),
+        stores: store_manager,
     }));
 
     let (layer, output_metrics) = MetricsCollectorLayer::new();

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ptr::from_ref;
+use core::ptr::from_ref;
 use std::sync::Arc;
 
 use nativelink_config::stores::{MemorySpec, RefSpec};
@@ -49,15 +49,13 @@ async fn has_test() -> Result<(), Error> {
 
     let (_store_manager, memory_store, ref_store) = setup_stores();
 
-    {
-        // Insert data into memory store.
-        memory_store
-            .update_oneshot(
-                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                VALUE1.into(),
-            )
-            .await?;
-    }
+    // Insert data into memory store.
+    memory_store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+            VALUE1.into(),
+        )
+        .await?;
     {
         // Now check if we check of ref_store has the data.
         let has_result = ref_store
@@ -68,8 +66,8 @@ async fn has_test() -> Result<(), Error> {
             Ok(Some(VALUE1.len() as u64)),
             "Expected ref store to have data in ref store : {}",
             VALID_HASH1
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -79,15 +77,13 @@ async fn get_test() -> Result<(), Error> {
 
     let (_store_manager, memory_store, ref_store) = setup_stores();
 
-    {
-        // Insert data into memory store.
-        memory_store
-            .update_oneshot(
-                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                VALUE1.into(),
-            )
-            .await?;
-    }
+    // Insert data into memory store.
+    memory_store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+            VALUE1.into(),
+        )
+        .await?;
     {
         // Now check if we read it from ref_store it has same data.
         let data = ref_store
@@ -99,8 +95,8 @@ async fn get_test() -> Result<(), Error> {
             VALUE1.as_bytes(),
             "Expected ref store to have data in ref store : {}",
             VALID_HASH1
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -110,15 +106,13 @@ async fn update_test() -> Result<(), Error> {
 
     let (_store_manager, memory_store, ref_store) = setup_stores();
 
-    {
-        // Insert data into ref_store.
-        ref_store
-            .update_oneshot(
-                DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
-                VALUE1.into(),
-            )
-            .await?;
-    }
+    // Insert data into ref_store.
+    ref_store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, VALUE1.len())?,
+            VALUE1.into(),
+        )
+        .await?;
     {
         // Now check if we read it from memory_store it has same data.
         let data = memory_store
@@ -130,8 +124,8 @@ async fn update_test() -> Result<(), Error> {
             VALUE1.as_bytes(),
             "Expected ref store to have data in memory store : {}",
             VALID_HASH1
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -148,7 +142,7 @@ async fn inner_store_test() -> Result<(), Error> {
         },
         Arc::downgrade(&store_manager),
     ));
-    store_manager.add_store("ref_store_inner", ref_store_inner.clone());
+    store_manager.add_store("ref_store_inner", ref_store_inner);
 
     let ref_store_outer = Store::new(RefStore::new(
         &RefSpec {

--- a/nativelink-store/tests/size_partitioning_store_test.rs
+++ b/nativelink-store/tests/size_partitioning_store_test.rs
@@ -72,8 +72,8 @@ async fn has_test() -> Result<(), Error> {
                 DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
                 BIG_VALUE.into(),
             )
-            .await?;
-    }
+            .await?
+    };
     {
         // Check if our partition store has small data.
         let small_has_result = size_part_store
@@ -84,8 +84,8 @@ async fn has_test() -> Result<(), Error> {
             Ok(Some(SMALL_VALUE.len() as u64)),
             "Expected size part store to have data in ref store : {}",
             SMALL_HASH
-        );
-    }
+        )
+    };
     {
         // Check if our partition store has big data.
         let small_has_result = size_part_store
@@ -96,8 +96,8 @@ async fn has_test() -> Result<(), Error> {
             Ok(Some(BIG_VALUE.len() as u64)),
             "Expected size part store to have data in ref store : {}",
             BIG_HASH
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -120,8 +120,8 @@ async fn get_test() -> Result<(), Error> {
                 DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
                 BIG_VALUE.into(),
             )
-            .await?;
-    }
+            .await?
+    };
     {
         // Read the partition store small data.
         let data = size_part_store
@@ -133,8 +133,8 @@ async fn get_test() -> Result<(), Error> {
             SMALL_VALUE.as_bytes(),
             "Expected size part store to have data in ref store : {}",
             SMALL_HASH
-        );
-    }
+        )
+    };
     {
         // Read the partition store big data.
         let data = size_part_store
@@ -146,8 +146,8 @@ async fn get_test() -> Result<(), Error> {
             BIG_VALUE.as_bytes(),
             "Expected size part store to have data in ref store : {}",
             BIG_HASH
-        );
-    }
+        )
+    };
     Ok(())
 }
 
@@ -170,8 +170,8 @@ async fn update_test() -> Result<(), Error> {
                 DigestInfo::try_new(BIG_HASH, BIG_VALUE.len())?,
                 BIG_VALUE.into(),
             )
-            .await?;
-    }
+            .await?
+    };
     {
         // Check if we read small data from size_partition_store it has same data.
         let data = lower_memory_store
@@ -183,8 +183,8 @@ async fn update_test() -> Result<(), Error> {
             SMALL_VALUE.as_bytes(),
             "Expected size part store to have data in memory store : {}",
             SMALL_HASH
-        );
-    }
+        )
+    };
     {
         // Check if we read big data from size_partition_store it has same data.
         let data = upper_memory_store
@@ -196,7 +196,7 @@ async fn update_test() -> Result<(), Error> {
             BIG_VALUE.as_bytes(),
             "Expected size part store to have data in memory store : {}",
             BIG_HASH
-        );
-    }
+        )
+    };
     Ok(())
 }

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 
 use futures::future::pending;
 use futures::try_join;

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
 use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::Poll;
 
 use bytes::{Bytes, BytesMut};
 use futures::task::Context;
@@ -27,11 +27,12 @@ use tracing::{Level, event};
 
 const ZERO_DATA: Bytes = Bytes::new();
 
-/// Create a channel pair that can be used to transport buffer objects around to
-/// different components. This wrapper is used because the streams give some
-/// utility like managing EOF in a more friendly way, ensure if no EOF is received
-/// it will send an error to the receiver channel before shutting down and count
-/// the number of bytes sent.
+/// Create a channel pair that can be used to transport buffer objects around to different
+/// components.
+///
+/// This wrapper is used because the streams give some utility like managing EOF in a more friendly
+/// way, ensure if no EOF is received it will send an error to the receiver channel before shutting
+/// down and count the number of bytes sent.
 #[must_use]
 pub fn make_buf_channel_pair() -> (DropCloserWriteHalf, DropCloserReadHalf) {
     // We allow up to 2 items in the buffer at any given time. There is no major
@@ -364,7 +365,7 @@ impl DropCloserReadHalf {
                     }
                 }
                 Err(e) => {
-                    return Err(e.clone()).err_tip(|| "Failed to check if next chunk is EOF")?;
+                    return Err(e).err_tip(|| "Failed to check if next chunk is EOF")?;
                 }
             }
             chunk

--- a/nativelink-util/src/channel_body_for_tests.rs
+++ b/nativelink-util/src/channel_body_for_tests.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::task::{Context, ready};
+use core::pin::Pin;
+use core::task::{Context, ready};
 
 use bytes::Bytes;
 use futures::task::Poll;

--- a/nativelink-util/src/chunked_stream.rs
+++ b/nativelink-util/src/chunked_stream.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::Bound;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::VecDeque;
-use std::ops::Bound;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use futures::{Future, Stream};
 use pin_project::pin_project;
@@ -85,7 +85,7 @@ where
                         Ok(Some(((start, end), mut buffer))) => {
                             *this.start_key = Some(start);
                             *this.end_key = Some(end);
-                            std::mem::swap(&mut buffer, this.buffer);
+                            core::mem::swap(&mut buffer, this.buffer);
                         }
                         Ok(None) => return Poll::Ready(None), // End of stream.
                         Err(err) => return Poll::Ready(Some(Err(err))),
@@ -96,7 +96,7 @@ where
                 StreamStateProj::Next => {
                     this.buffer.clear();
                     // This trick is used to recycle capacity.
-                    let buffer = std::mem::take(this.buffer);
+                    let buffer = core::mem::take(this.buffer);
                     let start_key = this
                         .start_key
                         .take()

--- a/nativelink-util/src/connection_manager.rs
+++ b/nativelink-util/src/connection_manager.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use futures::Future;
 use futures::stream::{FuturesUnordered, StreamExt, unfold};
@@ -386,6 +386,7 @@ impl ConnectionManagerWorker {
 /// service.  This handles the permit for limiting concurrency, and also
 /// re-connecting the underlying channel on error.  It depends on users
 /// reporting all errors.
+///
 /// NOTE: This should never be cloneable because its lifetime is linked to the
 ///       `ConnectionManagerWorker::available_connections`.
 #[derive(Debug)]
@@ -425,8 +426,8 @@ pub struct ResponseFuture {
     identifier: ChannelIdentifier,
 }
 
-impl std::fmt::Debug for ResponseFuture {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ResponseFuture {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ResponseFuture")
             .field("inner", &self.inner)
             .field("connection_tx", &self.connection_tx)

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -133,11 +133,11 @@ impl TryFrom<&str> for DigestHasherFunc {
     }
 }
 
-impl std::fmt::Display for DigestHasherFunc {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for DigestHasherFunc {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            DigestHasherFunc::Sha256 => write!(f, "SHA256"),
-            DigestHasherFunc::Blake3 => write!(f, "BLAKE3"),
+            Self::Sha256 => write!(f, "SHA256"),
+            Self::Blake3 => write!(f, "BLAKE3"),
         }
     }
 }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
-use std::cmp::Eq;
+use core::borrow::Borrow;
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::ops::RangeBounds;
 use std::collections::BTreeSet;
-use std::fmt::Debug;
-use std::future::Future;
-use std::hash::Hash;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -31,7 +29,7 @@ use tracing::{Level, event};
 use crate::instant_wrapper::InstantWrapper;
 use crate::metrics_utils::{Counter, CounterWithTime};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct SerializedLRU<K> {
     pub data: Vec<(K, i32)>,
     pub anchor_time: u64,
@@ -64,7 +62,7 @@ pub trait LenEntry: 'static {
     /// the `EvictionMap` globally (including inside `unref()`).
     #[inline]
     fn unref(&self) -> impl Future<Output = ()> + Send {
-        std::future::ready(())
+        core::future::ready(())
     }
 }
 
@@ -168,7 +166,7 @@ where
     I: InstantWrapper,
 {
     pub fn new(config: &EvictionPolicy, anchor_time: I) -> Self {
-        EvictingMap {
+        Self {
             // We use unbounded because if we use the bounded version we can't call the delete
             // function on the LenEntry properly.
             state: Mutex::new(State {

--- a/nativelink-util/src/fastcdc.rs
+++ b/nativelink-util/src/fastcdc.rs
@@ -95,7 +95,7 @@ impl Decoder for FastCDC {
         // Zero means not found.
         let mut split_point = 0;
 
-        let start_point = std::cmp::max(self.state.position, self.min_size);
+        let start_point = core::cmp::max(self.state.position, self.min_size);
 
         // Note: We use this kind of loop because it improved performance of this loop by 20%.
         let mut i = start_point;

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::task::{Context, Poll};
 use std::fs::Metadata;
 use std::io::{IoSlice, Seek};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::task::{Context, Poll};
 
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use rlimit::increase_nofile_limit;
@@ -32,7 +32,7 @@ use tracing::{Level, event};
 use crate::spawn_blocking;
 
 /// Default read buffer size when reading to/from disk.
-pub const DEFAULT_READ_BUFF_SIZE: usize = 16384;
+pub const DEFAULT_READ_BUFF_SIZE: usize = 0x4000;
 
 #[derive(Debug)]
 pub struct FileSlot {

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::pin::Pin;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -63,7 +63,7 @@ impl HealthStatus {
     pub fn new_initializing(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Initializing {
             struct_name: component.struct_name(),
             message,
@@ -73,7 +73,7 @@ impl HealthStatus {
     pub fn new_warning(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Warning {
             struct_name: component.struct_name(),
             message,
@@ -83,7 +83,7 @@ impl HealthStatus {
     pub fn new_failed(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Failed {
             struct_name: component.struct_name(),
             message,
@@ -107,7 +107,7 @@ pub trait HealthStatusIndicator: Sync + Send + Unpin {
 
     /// Returns the name of the struct implementing the trait.
     fn struct_name(&self) -> &'static str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
 
     /// Check the health status of the component. This function should be
@@ -124,7 +124,7 @@ pub struct HealthRegistryBuilder {
 }
 
 impl Debug for HealthRegistryBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("HealthRegistryBuilder")
             .field("namespace", &self.namespace)
             .finish_non_exhaustive()
@@ -151,8 +151,8 @@ impl HealthRegistryBuilder {
 
     /// Create a sub builder for a namespace.
     #[must_use]
-    pub fn sub_builder(&mut self, namespace: &str) -> HealthRegistryBuilder {
-        HealthRegistryBuilder {
+    pub fn sub_builder(&mut self, namespace: &str) -> Self {
+        Self {
             namespace: format!("{}/{}", self.namespace, namespace).into(),
             state: self.state.clone(),
         }
@@ -172,7 +172,7 @@ pub struct HealthRegistry {
 }
 
 impl Debug for HealthRegistry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("HealthRegistry")
             .field(
                 "indicators",

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use core::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use mock_instant::thread_local::{Instant as MockInstant, MockClock};
 
@@ -28,8 +28,8 @@ pub trait InstantWrapper: Send + Sync + Unpin + 'static {
 }
 
 impl InstantWrapper for SystemTime {
-    fn from_secs(secs: u64) -> SystemTime {
-        SystemTime::UNIX_EPOCH
+    fn from_secs(secs: u64) -> Self {
+        Self::UNIX_EPOCH
             .checked_add(Duration::from_secs(secs))
             .unwrap()
     }
@@ -39,11 +39,11 @@ impl InstantWrapper for SystemTime {
     }
 
     fn now(&self) -> SystemTime {
-        SystemTime::now()
+        Self::now()
     }
 
     fn elapsed(&self) -> Duration {
-        <SystemTime>::elapsed(self).unwrap()
+        Self::elapsed(self).unwrap()
     }
 
     async fn sleep(self, duration: Duration) {
@@ -67,7 +67,7 @@ impl Default for MockInstantWrapped {
 
 impl InstantWrapper for MockInstantWrapped {
     fn from_secs(_secs: u64) -> Self {
-        MockInstantWrapped(MockInstant::now())
+        Self(MockInstant::now())
     }
 
     fn unix_timestamp(&self) -> u64 {

--- a/nativelink-util/src/metrics_utils.rs
+++ b/nativelink-util/src/metrics_utils.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem::forget;
-use std::sync::atomic::{AtomicU64, Ordering};
+use core::mem::forget;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use futures::Future;
@@ -115,7 +115,8 @@ impl AsyncTimer<'_> {
 }
 
 /// Tracks the number of calls, successes, failures, and drops of an async function.
-/// call `.wrap(future)` to wrap a future and stats about the future are automatically
+///
+/// Call `.wrap(future)` to wrap a future and stats about the future are automatically
 /// tracked and can be published to a `CollectorState`.
 #[derive(Debug, Default)]
 pub struct AsyncCounterWrapper {
@@ -133,6 +134,10 @@ pub struct AsyncCounterWrapper {
 // can attach multiple values on the same group, so we need to
 // manually implement the `MetricsComponent` trait to do so.
 impl MetricsComponent for AsyncCounterWrapper {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "complexity arises from macro usage"
+    )]
     fn publish(
         &self,
         _kind: MetricKind,

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/nativelink-util/src/origin_event.rs
+++ b/nativelink-util/src/origin_event.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
-use std::pin::Pin;
+use core::marker::PhantomData;
+use core::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
@@ -290,8 +290,8 @@ pub struct OriginEventContext<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<T> std::fmt::Debug for OriginEventContext<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T> core::fmt::Debug for OriginEventContext<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OriginEventContext")
             .field("inner", &self.inner)
             .field("_phantom", &self._phantom)

--- a/nativelink-util/src/origin_event_middleware.rs
+++ b/nativelink-util/src/origin_event_middleware.rs
@@ -84,7 +84,7 @@ impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for OriginEventMiddlew
 where
     S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    ReqBody: std::fmt::Debug + Send + 'static,
+    ReqBody: core::fmt::Debug + Send + 'static,
     ResBody: From<String> + Send + 'static,
 {
     type Response = S::Response;
@@ -99,7 +99,7 @@ where
         // We must take the current `inner` and not the clone.
         // See: https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
         let clone = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let mut inner = core::mem::replace(&mut self.inner, clone);
 
         let mut context = ActiveOriginContext::fork().unwrap_or_default();
         let identity = {

--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -22,11 +22,11 @@ use nativelink_proto::build::bazel::remote::execution::v2::Platform as ProtoPlat
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property as ProtoProperty;
 use serde::{Deserialize, Serialize};
 
-/// `PlatformProperties` helps manage the configuration of platform properties to
-/// keys and types. The scheduler uses these properties to decide what jobs
-/// can be assigned to different workers. For example, if a job states it needs
-/// a specific key, it will never be run on a worker that does not have at least
-/// all the platform property keys configured on the worker.
+/// `PlatformProperties` helps manage the configuration of platform properties to keys and types.
+///
+/// The scheduler uses these properties to decide what jobs can be assigned to different workers.
+/// For example, if a job states it needs a specific key, it will never be run on a worker that does
+/// not have at least all the platform property keys configured on the worker.
 ///
 /// Additional rules may be applied based on `PlatfromPropertyValue`.
 #[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, MetricsComponent)]
@@ -72,7 +72,7 @@ impl From<ProtoPlatform> for PlatformProperties {
 
 impl From<&PlatformProperties> for ProtoPlatform {
     fn from(val: &PlatformProperties) -> Self {
-        ProtoPlatform {
+        Self {
             properties: val
                 .properties
                 .iter()

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::borrow::Cow;
-use std::fmt::Debug;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use futures::{Stream, StreamExt};
 use nativelink_error::{Error, ResultExt, error_if, make_input_err};
@@ -35,7 +35,7 @@ pub struct WriteRequestStreamWrapper<T> {
 }
 
 impl<T> Debug for WriteRequestStreamWrapper<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("WriteRequestStreamWrapper")
             .field("resource_info", &self.resource_info)
             .field("bytes_received", &self.bytes_received)
@@ -50,7 +50,7 @@ where
     T: Stream<Item = Result<WriteRequest, E>> + Unpin,
     E: Into<Error>,
 {
-    pub async fn from(mut stream: T) -> Result<WriteRequestStreamWrapper<T>, Error> {
+    pub async fn from(mut stream: T) -> Result<Self, Error> {
         let first_msg = stream
             .next()
             .await
@@ -66,7 +66,7 @@ where
             })?
             .to_owned();
 
-        Ok(WriteRequestStreamWrapper {
+        Ok(Self {
             resource_info,
             bytes_received: 0,
             stream,

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::convert::AsRef;
 
 use nativelink_error::{Error, ResultExt, error_if, make_input_err};
 
@@ -93,7 +92,7 @@ pub struct ResourceInfo<'a> {
 }
 
 impl<'a> ResourceInfo<'a> {
-    pub fn new(resource_name: &'a str, is_upload: bool) -> Result<ResourceInfo<'a>, Error> {
+    pub fn new(resource_name: &'a str, is_upload: bool) -> Result<Self, Error> {
         // The most amount of slashes there can be to get to "(compressed-)blobs" section is 7.
         let mut rparts = resource_name.rsplitn(7, '/');
         let mut output = ResourceInfo::default();
@@ -131,16 +130,15 @@ impl<'a> ResourceInfo<'a> {
                 .next()
                 .err_tip(|| format!("{ERROR_MSG} in {resource_name}"))?,
         ));
-        {
-            // Sanity check that our next item is "uploads".
-            let uploads = parts
-                .next()
-                .err_tip(|| format!("{ERROR_MSG} in {resource_name}"))?;
-            error_if!(
-                uploads != "uploads",
-                "Expected part to be 'uploads'. Got: {uploads} for {resource_name} is_upload: {is_upload}"
-            );
-        }
+
+        // Sanity check that our next item is "uploads".
+        let uploads = parts
+            .next()
+            .err_tip(|| format!("{ERROR_MSG} in {resource_name}"))?;
+        error_if!(
+            uploads != "uploads",
+            "Expected part to be 'uploads'. Got: {uploads} for {resource_name} is_upload: {is_upload}"
+        );
 
         // `instance_name` is optional.
         if let Some(instance_name) = parts.next() {

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::time::Duration;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::future::Future;
 use futures::stream::StreamExt;
@@ -28,7 +28,7 @@ struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     const fn new(base: Duration) -> Self {
-        ExponentialBackoff { current: base }
+        Self { current: base }
     }
 }
 
@@ -59,8 +59,8 @@ pub struct Retrier {
     config: Retry,
 }
 
-impl std::fmt::Debug for Retrier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Retrier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Retrier")
             .field("config", &self.config)
             .finish_non_exhaustive()
@@ -90,7 +90,7 @@ const fn to_error_code(code: Code) -> ErrorCode {
 
 impl Retrier {
     pub fn new(sleep_fn: SleepFn, jitter_fn: JitterFn, config: Retry) -> Self {
-        Retrier {
+        Self {
             sleep_fn,
             jitter_fn,
             config,
@@ -168,7 +168,7 @@ impl Retrier {
                         }
                         (self.sleep_fn)(
                             iter.next()
-                                .ok_or(err.append(format!("On attempt {attempt}")))?,
+                                .ok_or_else(|| err.append(format!("On attempt {attempt}")))?,
                         )
                         .await;
                     }

--- a/nativelink-util/src/shutdown_guard.rs
+++ b/nativelink-util/src/shutdown_guard.rs
@@ -29,15 +29,15 @@ pub enum Priority {
 impl From<usize> for Priority {
     fn from(value: usize) -> Self {
         match value {
-            0 => Priority::P0,
-            1 => Priority::P1,
-            _ => Priority::LeastImportant,
+            0 => Self::P0,
+            1 => Self::P1,
+            _ => Self::LeastImportant,
         }
     }
 }
 
 impl From<Priority> for usize {
-    fn from(priority: Priority) -> usize {
+    fn from(priority: Priority) -> Self {
         match priority {
             Priority::P0 => 0,
             Priority::P1 => 1,

--- a/nativelink-util/src/task.rs
+++ b/nativelink-util/src/task.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use futures::Future;
 use hyper::rt::Executor;

--- a/nativelink-util/src/write_counter.rs
+++ b/nativelink-util/src/write_counter.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use tokio::io::AsyncWrite;
@@ -31,7 +31,7 @@ pin_project! {
 
 impl<T: AsyncWrite> WriteCounter<T> {
     pub const fn new(inner: T) -> Self {
-        WriteCounter {
+        Self {
             inner,
             bytes_written: 0,
             failed: false,

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -57,10 +57,10 @@ async fn test_all_zeros() -> Result<(), std::io::Error> {
 }
 
 #[nativelink_test]
-async fn test_sekien_16k_chunks() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_sekien_16k_chunks() -> Result<(), Box<dyn core::error::Error>> {
     let contents = include_bytes!("data/SekienAkashita.jpg");
     let mut cursor = Cursor::new(&contents);
-    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(8192, 16384, 32768));
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(0x2000, 0x4000, 0x8000));
 
     let mut frames = vec![];
     let mut sum_frame_len = 0;
@@ -123,12 +123,10 @@ async fn insert_garbage_check_boundaries_recover_test() -> Result<(), std::io::E
         frames_map
     };
 
-    {
-        // Replace 2k of bytes and append one byte to middle.
-        let mut rng = SmallRng::seed_from_u64(2);
-        rng.fill(&mut rand_data[0..4097]);
-        rand_data.insert(rand_data.len() / 2, 0x71);
-    }
+    // Replace 2k of bytes and append one byte to middle.
+    let mut rng = SmallRng::seed_from_u64(2);
+    rng.fill(&mut rand_data[0..4097]);
+    rand_data.insert(rand_data.len() / 2, 0x71);
 
     let mut right_frames = {
         let mut frame_reader = FramedRead::new(Cursor::new(&rand_data), fast_cdc.clone());

--- a/nativelink-util/tests/operation_id_tests.rs
+++ b/nativelink-util/tests/operation_id_tests.rs
@@ -30,14 +30,11 @@ async fn parse_operation_id() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn parse_empty_failure() -> Result<(), Error> {
-    {
-        let operation_id = OperationId::from("");
-        assert_eq!(operation_id, OperationId::String(String::new()));
-    }
-    {
-        let operation_id = OperationId::from("foobar");
-        assert_eq!(operation_id, OperationId::String("foobar".to_string()));
-    }
+    let operation_id = OperationId::from("");
+    assert_eq!(operation_id, OperationId::String(String::new()));
+
+    let operation_id = OperationId::from("foobar");
+    assert_eq!(operation_id, OperationId::String("foobar".to_string()));
 
     Ok(())
 }

--- a/nativelink-util/tests/proto_stream_utils_test.rs
+++ b/nativelink-util/tests/proto_stream_utils_test.rs
@@ -60,12 +60,10 @@ async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Resul
         data: Bytes::from_static(&RAW_DATA.as_bytes()[8..]),
     };
 
-    {
-        tx.send(Ok(message1.clone())).unwrap();
-        tx.send(Ok(message2.clone())).unwrap();
-        tx.send(Ok(message3.clone())).unwrap();
-        drop(tx); // Close the channel.
-    }
+    tx.send(Ok(message1.clone())).unwrap();
+    tx.send(Ok(message2.clone())).unwrap();
+    tx.send(Ok(message3.clone())).unwrap();
+    drop(tx); // Close the channel.
 
     let local_state = Arc::new(Mutex::new(WriteState::new(
         INSTANCE_NAME.to_string(),
@@ -73,16 +71,14 @@ async fn ensure_no_errors_if_only_first_message_has_resource_name_set() -> Resul
     )));
     let mut write_state_wrapper = WriteStateWrapper::new(local_state.clone());
 
-    {
-        // Ensure we transported our data properly.
-        assert_eq!(write_state_wrapper.next().await, Some(message1));
-        assert_eq!(write_state_wrapper.next().await, Some(message2));
-        assert_eq!(write_state_wrapper.next().await, Some(message3));
-        assert_eq!(write_state_wrapper.next().await, None);
+    // Ensure we transported our data properly.
+    assert_eq!(write_state_wrapper.next().await, Some(message1));
+    assert_eq!(write_state_wrapper.next().await, Some(message2));
+    assert_eq!(write_state_wrapper.next().await, Some(message3));
+    assert_eq!(write_state_wrapper.next().await, None);
 
-        // Ensure no stream errors were set.
-        assert_eq!(local_state.lock().take_read_stream_error(), None);
-    }
+    // Ensure no stream errors were set.
+    assert_eq!(local_state.lock().take_read_stream_error(), None);
 
     Ok(())
 }

--- a/nativelink-util/tests/resource_info_test.rs
+++ b/nativelink-util/tests/resource_info_test.rs
@@ -20,7 +20,7 @@ use pretty_assertions::assert_eq;
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -40,7 +40,7 @@ async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -56,7 +56,7 @@ async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -75,7 +75,7 @@ async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_te
 
 #[nativelink_test]
 async fn read_instance_name_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -91,7 +91,7 @@ async fn read_instance_name_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -110,7 +110,7 @@ async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_met
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -125,7 +125,7 @@ async fn read_compressed_blobs_compressor_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn read_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -143,7 +143,7 @@ async fn read_blobs_digest_function_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -159,7 +159,7 @@ async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -178,7 +178,7 @@ async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metad
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -194,7 +194,7 @@ async fn read_instance_name_compressed_blobs_compressor_hash_size_test()
 
 #[nativelink_test]
 async fn read_instance_name_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -212,7 +212,7 @@ async fn read_instance_name_blobs_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -228,7 +228,7 @@ async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::er
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -246,7 +246,7 @@ async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn std::error::Error>>
+async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn core::error::Error>>
 {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -262,7 +262,7 @@ async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn
 }
 
 #[nativelink_test]
-async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -280,7 +280,7 @@ async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std
 }
 
 #[nativelink_test]
-async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -295,7 +295,7 @@ async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "my/instance/name/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "my/instance/name");
@@ -310,7 +310,7 @@ async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::e
 }
 
 #[nativelink_test]
-async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "blobs");
@@ -325,21 +325,21 @@ async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error
 }
 
 #[nativelink_test]
-async fn read_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn read_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "BLOBS/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_too_short_test() -> Result<(), Box<dyn core::error::Error>> {
     assert!(ResourceInfo::new("", false).is_err());
     assert!(ResourceInfo::new("/", false).is_err());
     assert!(ResourceInfo::new("//", false).is_err());
@@ -354,7 +354,7 @@ async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -374,7 +374,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_fun
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -391,7 +391,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_fun
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -411,7 +411,7 @@ async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_option
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -427,7 +427,7 @@ async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -447,7 +447,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -463,7 +463,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -482,7 +482,7 @@ async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_te
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -498,7 +498,7 @@ async fn write_uploads_uuid_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -518,7 +518,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -534,7 +534,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -553,7 +553,7 @@ async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -569,7 +569,7 @@ async fn write_instance_name_uploads_uuid_blobs_hash_size_test()
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -588,7 +588,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metad
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -603,7 +603,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test()
 }
 
 #[nativelink_test]
-async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std::error::Error>> {
+async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/INVALID/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
@@ -611,7 +611,7 @@ async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std:
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -629,7 +629,7 @@ async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -644,7 +644,7 @@ async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::er
 }
 
 #[nativelink_test]
-async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "my/instance/name");
@@ -659,7 +659,7 @@ async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::
 }
 
 #[nativelink_test]
-async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "blobs");
@@ -674,35 +674,35 @@ async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::erro
 }
 
 #[nativelink_test]
-async fn write_uploads_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uuid/compressed-blobs/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "UPLOADS/uuid/compressed-blobs/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_blobs_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/BLOBS/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_invalid_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_invalid_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/INVALID";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -431,12 +431,14 @@ fn upload_directory<'a, P: AsRef<Path> + Debug + Send + Sync + Clone + 'a>(
                             .await
                             .err_tip(|| format!("Could not open file {full_path:?}"))?;
                         upload_file(cas_store, &full_path, hasher, metadata)
-                            .map_ok(Into::into)
+                            .map(|res| res.and_then(TryInto::try_into))
                             .await
                     });
                 } else if file_type.is_symlink() {
-                    symlink_futures
-                        .push(upload_symlink(full_path, &full_work_directory).map_ok(Into::into));
+                    symlink_futures.push(
+                        upload_symlink(full_path, &full_work_directory)
+                            .map(|res| res.and_then(TryInto::try_into)),
+                    );
                 }
             }
         }


### PR DESCRIPTION
# Description

This applies relatively strict clippy lints, enforcing a variety of preferences to ensure best practices, warn about possible bugs, and ensure the programmer is aware of less-than-ideal practices.

# Remaining work

- [ ] update lints in `BUILD.bazel`
- [ ] fix, document, or (temporarily) silence remaining lint violations
  - most of this is only a handful of lints, though some will require nontrivial analysis (namely those involving `unsafe`)
- [ ] document necessity of using clippy in `CONTRIBUTING.md`
  - not a bad idea to link to how to configure rust-analyzer to use clippy by default

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1696)
<!-- Reviewable:end -->
