### PR TITLE
Implement `StoreDriver::list` for `RedisStore`

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -999,6 +999,13 @@ pub struct RedisSpec {
     #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_chunk_uploads_per_update: usize,
 
+    /// The COUNT value passed when scanning keys in Redis.
+    /// This is used to hint the amount of work that should be done per response.
+    ///
+    /// Default: 10000
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
+    pub scan_count: u32,
+
     /// Retry configuration to use when a network request fails.
     /// See the `Retry` struct for more information.
     ///

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -51,6 +51,7 @@ const TEMP_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
 const SCRIPT_VERSION: &str = "3e762c15";
 const VERSION_SCRIPT_HASH: &str = "fdf1152fd21705c8763752809b86b55c5d4511ce";
 const MAX_CHUNK_UPLOADS_PER_UPDATE: usize = 10;
+const SCAN_COUNT: u32 = 10_000;
 
 fn mock_uuid_generator() -> String {
     uuid::Uuid::parse_str(TEMP_UUID).unwrap().to_string()
@@ -420,6 +421,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
                 String::new(),
                 4064,
                 MAX_CHUNK_UPLOADS_PER_UPDATE,
+                SCAN_COUNT,
             )
             .unwrap(),
         )

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::cmp;
+use core::ops::{Bound, RangeBounds};
 use core::pin::Pin;
 use core::time::Duration;
 use std::borrow::Cow;
@@ -31,6 +32,7 @@ use fred::types::redisearch::{
     AggregateOperation, FtAggregateOptions, FtCreateOptions, IndexKind, Load, SearchField,
     SearchSchema, SearchSchemaKind, WithCursor,
 };
+use fred::types::scan::Scanner;
 use fred::types::scripts::Script;
 use fred::types::{Builder, Key as RedisKey, Map as RedisMap, SortOrder, Value as RedisValue};
 use futures::stream::FuturesUnordered;
@@ -88,6 +90,10 @@ const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 10_000;
 /// Note: If this changes it should be updated in the config documentation.
 const DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE: usize = 10;
 
+/// The default COUNT value passed when scanning keys in Redis.
+/// Note: If this changes it should be updated in the config documentation.
+const DEFAULT_SCAN_COUNT: u32 = 10_000;
+
 #[expect(
     clippy::trivially_copy_pass_by_ref,
     reason = "must match method signature expected"
@@ -136,6 +142,11 @@ pub struct RedisStore {
     /// This is used to limit the number of chunk uploads per update to prevent
     #[metric(help = "The maximum number of chunk uploads per update")]
     max_chunk_uploads_per_update: usize,
+
+    /// The COUNT value passed when scanning keys in Redis.
+    /// This is used to hint the amount of work that should be done per response.
+    #[metric(help = "The COUNT value passed when scanning keys in Redis")]
+    scan_count: u32,
 
     /// Redis script used to update a value in redis if the version matches.
     /// This is done by incrementing the version number and then setting the new data
@@ -216,6 +227,9 @@ impl RedisStore {
             if spec.max_chunk_uploads_per_update == 0 {
                 spec.max_chunk_uploads_per_update = DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE;
             }
+            if spec.scan_count == 0 {
+                spec.scan_count = DEFAULT_SCAN_COUNT;
+            }
         }
         let connection_timeout = Duration::from_millis(spec.connection_timeout_ms);
         let command_timeout = Duration::from_millis(spec.command_timeout_ms);
@@ -257,11 +271,13 @@ impl RedisStore {
             spec.key_prefix.clone(),
             spec.read_chunk_size,
             spec.max_chunk_uploads_per_update,
+            spec.scan_count,
         )
         .map(Arc::new)
     }
 
     /// Used for testing when determinism is required.
+    #[expect(clippy::too_many_arguments)]
     pub fn new_from_builder_and_parts(
         client_pool: RedisPool,
         subscriber_client: SubscriberClient,
@@ -270,6 +286,7 @@ impl RedisStore {
         key_prefix: String,
         read_chunk_size: usize,
         max_chunk_uploads_per_update: usize,
+        scan_count: u32,
     ) -> Result<Self, Error> {
         // Start connection pool (this will retry forever by default).
         client_pool.connect();
@@ -284,6 +301,7 @@ impl RedisStore {
             key_prefix,
             read_chunk_size,
             max_chunk_uploads_per_update,
+            scan_count,
             update_if_version_matches_script: Script::from_lua(LUA_VERSION_SET_SCRIPT),
             subscription_manager: Mutex::new(None),
         })
@@ -363,6 +381,58 @@ impl StoreDriver for RedisStore {
             .collect::<FuturesUnordered<_>>()
             .try_collect()
             .await
+    }
+
+    async fn list(
+        self: Pin<&Self>,
+        range: (Bound<StoreKey<'_>>, Bound<StoreKey<'_>>),
+        handler: &mut (dyn for<'a> FnMut(&'a StoreKey) -> bool + Send + Sync + '_),
+    ) -> Result<u64, Error> {
+        let range = (
+            range.0.map(StoreKey::into_owned),
+            range.1.map(StoreKey::into_owned),
+        );
+        let pattern = match range.0 {
+            Bound::Included(ref start) | Bound::Excluded(ref start) => match range.1 {
+                Bound::Included(ref end) | Bound::Excluded(ref end) => {
+                    let start = start.as_str();
+                    let end = end.as_str();
+                    let max_length = start.len().min(end.len());
+                    let length = start
+                        .chars()
+                        .zip(end.chars())
+                        .position(|(a, b)| a != b)
+                        .unwrap_or(max_length);
+                    format!("{}{}*", self.key_prefix, &start[..length])
+                }
+                Bound::Unbounded => format!("{}*", self.key_prefix),
+            },
+            Bound::Unbounded => format!("{}*", self.key_prefix),
+        };
+        let client = self.client_pool.next();
+        let mut scan_stream = client.scan(pattern, Some(self.scan_count), None);
+        let mut iterations = 0;
+        'outer: while let Some(mut page) = scan_stream.try_next().await? {
+            if let Some(keys) = page.take_results() {
+                for key in keys {
+                    // TODO: Notification of conversion errors
+                    // Any results that do not conform to expectations are ignored.
+                    if let Some(key) = key.as_str() {
+                        if let Some(key) = key.strip_prefix(&self.key_prefix) {
+                            let key = StoreKey::new_str(key);
+                            if range.contains(&key) {
+                                iterations += 1;
+                                if !handler(&key) {
+                                    break 'outer;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            page.next();
+        }
+        Ok(iterations)
     }
 
     async fn update(

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::RangeBounds;
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -34,7 +35,7 @@ use nativelink_store::redis_store::RedisStore;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
-use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
+use nativelink_util::store_trait::{Store, StoreKey, StoreLike, UploadSizeInfo};
 use parking_lot::RwLock;
 use pretty_assertions::assert_eq;
 use serde_json::{Value, from_str, to_string};
@@ -46,6 +47,7 @@ const TEMP_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
 const DEFAULT_READ_CHUNK_SIZE: usize = 1024;
 const DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE: usize = 10;
+const DEFAULT_SCAN_COUNT: u32 = 10_000;
 
 fn mock_uuid_generator() -> String {
     uuid::Uuid::parse_str(TEMP_UUID).unwrap().to_string()
@@ -277,6 +279,7 @@ async fn upload_and_get_data() -> Result<(), Error> {
             String::new(),
             DEFAULT_READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
@@ -382,6 +385,7 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
             prefix.to_string(),
             DEFAULT_READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
@@ -419,6 +423,7 @@ async fn upload_empty_data() -> Result<(), Error> {
         String::new(),
         DEFAULT_READ_CHUNK_SIZE,
         DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+        DEFAULT_SCAN_COUNT,
     )
     .unwrap();
 
@@ -448,6 +453,7 @@ async fn upload_empty_data_with_prefix() -> Result<(), Error> {
         prefix.to_string(),
         DEFAULT_READ_CHUNK_SIZE,
         DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+        DEFAULT_SCAN_COUNT,
     )
     .unwrap();
 
@@ -562,6 +568,7 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
             String::new(),
             READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
@@ -716,6 +723,7 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
             String::new(),
             DEFAULT_READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
@@ -806,12 +814,132 @@ async fn zero_len_items_exist_check() -> Result<(), Error> {
             String::new(),
             DEFAULT_READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
 
     let result = store.get_part_unchunked(digest, 0, None).await;
     assert_eq!(result.unwrap_err().code, Code::NotFound);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn list_test() -> Result<(), Error> {
+    async fn get_list(
+        store: &RedisStore,
+        range: impl RangeBounds<StoreKey<'static>> + Send + Sync + 'static,
+    ) -> Vec<StoreKey<'static>> {
+        let mut found_keys = vec![];
+        store
+            .list(range, |key| {
+                found_keys.push(key.borrow().into_owned());
+                true
+            })
+            .await
+            .unwrap();
+        found_keys
+    }
+
+    const KEY1: StoreKey = StoreKey::new_str("key1");
+    const KEY2: StoreKey = StoreKey::new_str("key2");
+    const KEY3: StoreKey = StoreKey::new_str("key3");
+
+    let command = MockCommand {
+        cmd: Str::from_static("SCAN"),
+        subcommand: None,
+        args: vec![
+            RedisValue::String(Str::from_static("0")),
+            RedisValue::String(Str::from_static("MATCH")),
+            RedisValue::String(Str::from_static("key*")),
+            RedisValue::String(Str::from_static("COUNT")),
+            RedisValue::Integer(10000),
+        ],
+    };
+    let command_open = MockCommand {
+        cmd: Str::from_static("SCAN"),
+        subcommand: None,
+        args: vec![
+            RedisValue::String(Str::from_static("0")),
+            RedisValue::String(Str::from_static("MATCH")),
+            RedisValue::String(Str::from_static("*")),
+            RedisValue::String(Str::from_static("COUNT")),
+            RedisValue::Integer(10000),
+        ],
+    };
+    let result = Ok(RedisValue::Array(vec![
+        RedisValue::String(Str::from_static("0")),
+        RedisValue::Array(vec![
+            RedisValue::String(Str::from_static("key1")),
+            RedisValue::String(Str::from_static("key2")),
+            RedisValue::String(Str::from_static("key3")),
+        ]),
+    ]));
+
+    let mocks = Arc::new(MockRedisBackend::new());
+    mocks
+        .expect(command_open.clone(), result.clone())
+        .expect(command_open.clone(), result.clone())
+        .expect(command.clone(), result.clone())
+        .expect(command.clone(), result.clone())
+        .expect(command.clone(), result.clone())
+        .expect(command_open.clone(), result.clone())
+        .expect(command.clone(), result.clone())
+        .expect(command_open, result);
+
+    let store = {
+        let mut builder = Builder::default_centralized();
+        builder.set_config(RedisConfig {
+            mocks: Some(mocks),
+            ..Default::default()
+        });
+
+        let (client_pool, subscriber_client) = make_clients(builder);
+        RedisStore::new_from_builder_and_parts(
+            client_pool,
+            subscriber_client,
+            None,
+            mock_uuid_generator,
+            String::new(),
+            DEFAULT_READ_CHUNK_SIZE,
+            DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
+        )
+        .unwrap()
+    };
+
+    // Test listing all keys.
+    let keys = get_list(&store, ..).await;
+    assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
+
+    // Test listing from key1 to all.
+    let keys = get_list(&store, KEY1..).await;
+    assert_eq!(keys, vec![KEY1, KEY2, KEY3]);
+
+    // Test listing from key1 to key2.
+    let keys = get_list(&store, KEY1..KEY2).await;
+    assert_eq!(keys, vec![KEY1]);
+
+    // Test listing from key1 including key2.
+    let keys = get_list(&store, KEY1..=KEY2).await;
+    assert_eq!(keys, vec![KEY1, KEY2]);
+
+    // Test listing from key1 to key3.
+    let keys = get_list(&store, KEY1..KEY3).await;
+    assert_eq!(keys, vec![KEY1, KEY2]);
+
+    // Test listing from all to key2.
+    let keys = get_list(&store, ..KEY2).await;
+    assert_eq!(keys, vec![KEY1]);
+
+    // Test listing from key2 to key3.
+    let keys = get_list(&store, KEY2..KEY3).await;
+    assert_eq!(keys, vec![KEY2]);
+
+    // Test listing with reversed bounds.
+    let keys = get_list(&store, KEY3..=KEY1).await;
+    assert_eq!(keys, vec![]);
 
     Ok(())
 }
@@ -836,6 +964,7 @@ async fn dont_loop_forever_on_empty() -> Result<(), Error> {
             String::new(),
             DEFAULT_READ_CHUNK_SIZE,
             DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
         )
         .unwrap()
     };
@@ -883,6 +1012,7 @@ async fn test_redis_fingerprint_metric() -> Result<(), Error> {
                     String::new(),
                     DEFAULT_READ_CHUNK_SIZE,
                     DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+                    DEFAULT_SCAN_COUNT,
                 )
                 .unwrap(),
             ))


### PR DESCRIPTION
# Description

Advances #901 by enabling the locality-sensitive-hash store to be persisted and queried in Redis.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Adapted unit tests from the implementation for `MemoryStore`.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1697)
<!-- Reviewable:end -->
