### PR TITLE
Standardize flake naming

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,9 +112,7 @@
     },
     "nix2container": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -169,7 +167,6 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs",

--- a/local-remote-execution/README.md
+++ b/local-remote-execution/README.md
@@ -69,7 +69,7 @@ devShells.default = pkgs.mkShell {
   shellHook = ''
     # Generate lre.bazelrc which configures LRE toolchains when running
     # in the nix environment.
-    ${config.local-remote-execution.installationScript}
+    ${config.lre.installationScript}
   '';
 }
 ```
@@ -101,12 +101,12 @@ build --extra_toolchains=@local-remote-execution//generated-cc/config:cc-toolcha
 
 In the snippet above you can see a warning that no local toolchain is
 configured. LRE needs to know the remote toolchain configuration to make it
-available locally. The `local-remote-execution` settings take an `Env` input and
+available locally. The `lre` settings take an `Env` input and
 an optional `prefix` input to configure the generated `lre.bazelrc`:
 
 ```nix
 # This is a top-level field, next to `packages` and `apps`, and `devShells`
-local-remote-execution.settings = {
+lre.settings = {
   # In this example we import the lre-cc environment from nativelink and make it
   # available locally.
   inherit (lre-cc.meta) Env;
@@ -270,7 +270,7 @@ invoke a build against the cluster:
 CACHE=$(kubectl get gtw cache -o=jsonpath='{.status.addresses[0].value}')
 SCHEDULER=$(kubectl get gtw scheduler -o=jsonpath='{.status.addresses[0].value}')
 
-# Note: If you omit setting a `prefix` the `local-remote-execution.settings` you
+# Note: If you omit setting a `prefix` the `lre.settings` you
 #       can omit `--config=lre` here as LRE will be enabled by default.
 bazel build \
     --config=lre \
@@ -300,7 +300,7 @@ bazel clean
 
 CACHE=$(kubectl get gtw cache -o=jsonpath='{.status.addresses[0].value}')
 
-# Note: If you omit setting a `prefix` the `local-remote-execution.settings` you
+# Note: If you omit setting a `prefix` the `lre.settings` you
 #       can omit `--config=lre` here as LRE will be enabled by default.
 bazel build \
     --config=lre \

--- a/local-remote-execution/flake-module.nix
+++ b/local-remote-execution/flake-module.nix
@@ -11,10 +11,10 @@
         pkgs,
         ...
       }: let
-        cfg = config.local-remote-execution;
+        cfg = config.lre;
       in {
         options = {
-          local-remote-execution = {
+          lre = {
             pkgs = lib.mkOption {
               type = lib.types.uniq (lib.types.lazyAttrsOf (lib.types.raw or lib.types.unspecified));
               description = lib.mdDoc ''

--- a/local-remote-execution/modules/lre.nix
+++ b/local-remote-execution/modules/lre.nix
@@ -41,7 +41,7 @@
   # devShells.default = pkgs.mkShell {
   #   shellHook = ''
   #   # Generate the `lre.bazelrc` config file.
-  #   ${config.local-remote-execution.installationScript}
+  #   ${config.lre.installationScript}
   #   '';
   # };
   # ```
@@ -103,7 +103,7 @@
     then ["#" "# WARNING: No environment set. LRE will not work locally."]
     else ["#"] ++ (map (x: "# " + x) (lib.lists.unique config.Env));
 
-  # If the `local-remote-execution.settings.prefix` is set to a nonempty string,
+  # If the `lre.settings.prefix` is set to a nonempty string,
   # prefix the Bazel build commands with that string. This will disable LRE
   # by default and require adding `--config=<prefix>` to Bazel invocations.
   maybePrefixedConfig =


### PR DESCRIPTION
This change is breaking for flake module users:
- Renames `flakeModule` to `flakeModules`
- Renames the flake module `local-remote-execution` to `lre`. In particular import it with `nativelink.flakeModules.lre` and install `lre.bazelrc` with `${config.lre.installationScript}` in your shell hook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1698)
<!-- Reviewable:end -->
