### PR TITLE
Add remote execution example using resilient client for issue #1684

### DIFF
--- a/deployment-examples/remote-resilient-example/README.md
+++ b/deployment-examples/remote-resilient-example/README.md
@@ -1,0 +1,19 @@
+# Remote Execution Example with Resilient Client
+
+This example demonstrates using NativeLink's resilient client for remote execution.
+
+## Steps
+
+1. Ensure NativeLink server is running remotely or locally.
+2. Edit `client-config.json` with the appropriate remote URL and mTLS settings.
+3. Run the resilient client using the provided config.
+
+## Files Included
+
+- `client-config.json` – Example configuration for remote execution
+- `run.bat` – Script to launch the resilient client using the config
+
+## Notes
+
+- Assumes secure (mTLS) connection setup.
+- This example is minimal and intended to demonstrate basic remote execution flow.

--- a/deployment-examples/remote-resilient-example/client-config.json
+++ b/deployment-examples/remote-resilient-example/client-config.json
@@ -1,0 +1,16 @@
+{
+  "remote_execution": {
+    "execution_address": "grpcs://your-remote-server.com:443",
+    "use_tls": true,
+    "cert_file": "certs/client.crt",
+    "key_file": "certs/client.key",
+    "ca_file": "certs/ca.crt"
+  },
+  "cache": {
+    "address": "grpcs://your-remote-cas.com:443",
+    "use_tls": true,
+    "cert_file": "certs/client.crt",
+    "key_file": "certs/client.key",
+    "ca_file": "certs/ca.crt"
+  }
+}

--- a/deployment-examples/remote-resilient-example/run.bat
+++ b/deployment-examples/remote-resilient-example/run.bat
@@ -1,0 +1,4 @@
+@echo off
+echo Running NativeLink resilient client with remote execution...
+resilient-client.exe --config=client-config.json --target=//myapp:hello_world
+pause


### PR DESCRIPTION
This PR adds a new example in `deployment-examples/remote-resilient-example` to demonstrate how to use the resilient client for remote execution.

It includes:
- `README.md` with setup and usage instructions
- `client-config.json` showing example mTLS configuration
- `run.bat` script to launch the resilient client with the config

This is in response to issue #1684 and provides a minimal but complete example that can be extended further as needed.

Let me know if you'd like me to make any updates or refinements!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1701)
<!-- Reviewable:end -->
