### PR TITLE
Use `alloc`, `core` when possible

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,6 +94,8 @@ build --@rules_rust//:extra_rustc_flag=-Wunused_import_braces
 build --@rules_rust//:extra_rustc_flag=-Wunused_lifetimes
 build --@rules_rust//:extra_rustc_flag=-Wunused_qualifications
 build --@rules_rust//:extra_rustc_flag=-Wvariant_size_differences
+build --@rules_rust//:clippy_flag=-Dclippy::alloc_instead_of_core
+build --@rules_rust//:clippy_flag=-Dclippy::std_instead_of_core
 # TODO(aaronmondal): Extend these flags until we can run with clippy::pedantic.
 build --@rules_rust//:clippy_flags=-Dwarnings,-Dclippy::missing_const_for_fn,-Dclippy::uninlined_format_args,-Dclippy::manual_string_new,-Dclippy::manual_let_else,-Dclippy::single_match_else,-Dclippy::redundant_closure_for_method_calls,-Dclippy::semicolon_if_nothing_returned,-Dclippy::unreadable_literal,-Dclippy::range_plus_one,-Dclippy::inconsistent_struct_constructor,-Dclippy::match_wildcard_for_single_variants,-Dclippy::implicit_clone,-Dclippy::needless_pass_by_value,-Dclippy::explicit_deref_methods,-Dclippy::trivially_copy_pass_by_ref,-Dclippy::unnecessary_wraps,-Dclippy::cast_lossless,-Dclippy::map_unwrap_or,-Dclippy::ref_as_ptr,-Dclippy::inline_always,-Dclippy::redundant_else,-Dclippy::return_self_not_must_use,-Dclippy::match_same_arms,-Dclippy::explicit_iter_loop,-Dclippy::items_after_statements,-Dclippy::explicit_into_iter_loop,-Dclippy::stable_sort_primitive,-Dclippy::ptr_as_ptr,-Dclippy::needless_raw_string_hashes,-Dclippy::default_trait_access,-Dclippy::ignored_unit_patterns,-Dclippy::needless_continue,-Dclippy::wildcard_imports,-Dclippy::doc_markdown,-Dclippy::struct_field_names,-Dclippy::implicit_hasher
 build --@rules_rust//:clippy.toml=//:clippy.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ debug = false
 name = "nativelink"
 
 [features]
-nix = [
-  "nativelink-worker/nix"
-]
+nix = ["nativelink-worker/nix"]
 
 [dependencies]
 nativelink-error = { path = "nativelink-error" }
@@ -44,14 +42,24 @@ hyper = "1.6.0"
 hyper-util = "0.1.11"
 mimalloc = "0.1.44"
 parking_lot = "0.12.3"
-rustls-pemfile = { version = "2.2.0", features = ["std"], default-features = false }
+rustls-pemfile = { version = "2.2.0", features = [
+  "std",
+], default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
 serde_json5 = "0.2.1"
-tokio = { version = "1.44.1", features = ["fs", "rt-multi-thread", "signal", "io-util"], default-features = false }
+tokio = { version = "1.44.1", features = [
+  "fs",
+  "rt-multi-thread",
+  "signal",
+  "io-util",
+], default-features = false }
 tokio-rustls = { version = "0.26.2", default-features = false, features = [
   "ring",
 ] }
-tonic = { version = "0.13.0", features = ["transport", "tls-ring"], default-features = false }
+tonic = { version = "0.13.0", features = [
+  "transport",
+  "tls-ring",
+], default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 opentelemetry_sdk = { version = "0.29.0", default-features = false }
@@ -117,4 +125,7 @@ unused-qualifications = "warn"
 variant-size-differences = "warn"
 
 [workspace.lints.clippy]
+alloc-instead-of-core = "deny"
+std-instead-of-core = "deny"
+
 all = { level = "warn", priority = -1 }

--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::marker::PhantomData;
 use std::borrow::Cow;
 use std::fmt;
-use std::marker::PhantomData;
 
 use byte_unit::Byte;
 use humantime::parse_duration;

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::Into;
+use core::convert::Into;
 
 use nativelink_metric::{
     MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
@@ -116,7 +116,7 @@ impl Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<Error> for nativelink_proto::google::rpc::Status {
     fn from(val: Error) -> Self {
@@ -137,8 +137,8 @@ impl From<nativelink_proto::google::rpc::Status> for Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // A manual impl to reduce the noise of frequently empty fields.
         let mut builder = f.debug_struct("Error");
 
@@ -170,8 +170,8 @@ impl From<prost::UnknownEnumValue> for Error {
     }
 }
 
-impl From<std::num::TryFromIntError> for Error {
-    fn from(err: std::num::TryFromIntError) -> Self {
+impl From<core::num::TryFromIntError> for Error {
+    fn from(err: core::num::TryFromIntError) -> Self {
         make_err!(Code::InvalidArgument, "{}", err.to_string())
     }
 }
@@ -182,14 +182,14 @@ impl From<tokio::task::JoinError> for Error {
     }
 }
 
-impl From<std::num::ParseIntError> for Error {
-    fn from(err: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for Error {
+    fn from(err: core::num::ParseIntError) -> Self {
         make_err!(Code::InvalidArgument, "{}", err.to_string())
     }
 }
 
-impl From<std::convert::Infallible> for Error {
-    fn from(_err: std::convert::Infallible) -> Self {
+impl From<core::convert::Infallible> for Error {
+    fn from(_err: core::convert::Infallible) -> Self {
         // Infallible is an error type that can never happen.
         unreachable!();
     }

--- a/nativelink-metric-collector/src/metrics_collection.rs
+++ b/nativelink-metric-collector/src/metrics_collection.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::{Deref, DerefMut};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 use serde::Serialize;
 

--- a/nativelink-metric-collector/src/metrics_visitors.rs
+++ b/nativelink-metric-collector/src/metrics_visitors.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
 use std::borrow::Cow;
-use std::fmt::Debug;
 
 use nativelink_metric::MetricKind;
 use serde::Serialize;
@@ -140,7 +140,7 @@ impl Visit for MetricDataVisitor {
             field => panic!("UNKNOWN FIELD {field}"),
         }
     }
-    fn record_error(&mut self, _field: &Field, _value: &(dyn std::error::Error + 'static)) {}
+    fn record_error(&mut self, _field: &Field, _value: &(dyn core::error::Error + 'static)) {}
 }
 
 /// An intermediate structed that will have it's contents populated

--- a/nativelink-metric-collector/src/tracing_layers.rs
+++ b/nativelink-metric-collector/src/tracing_layers.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::marker::PhantomData;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use parking_lot::Mutex;

--- a/nativelink-metric-collector/tests/metric_collector_test.rs
+++ b/nativelink-metric-collector/tests/metric_collector_test.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::marker::PhantomData;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use nativelink_metric::{MetricFieldData, MetricKind, MetricsComponent};
 use nativelink_metric_collector::MetricsCollectorLayer;

--- a/nativelink-metric/src/lib.rs
+++ b/nativelink-metric/src/lib.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::hash::BuildHasher;
+use core::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use core::time::Duration;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::BuildHasher;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub use nativelink_metric_macro_derive::MetricsComponent;
 pub use tracing::{error as __metric_error, info as __metric_event, info_span as __metric_span};
@@ -29,13 +30,13 @@ pub use tracing::{error as __metric_error, info as __metric_event, info_span as 
 #[derive(Debug)]
 pub struct Error(String);
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 /// Holds metadata about the field that is being published.
 #[derive(Debug, Default, Clone)]

--- a/nativelink-proto/gen_lib_rs_tool.py
+++ b/nativelink-proto/gen_lib_rs_tool.py
@@ -39,12 +39,14 @@ _HEADER = """\
 #![allow(
     unknown_lints,
     unused_qualifications,
+    clippy::alloc_instead_of_core,
     clippy::default_trait_access,
     clippy::doc_lazy_continuation,
     clippy::doc_markdown,
+    clippy::doc_overindented_list_items,
     clippy::large_enum_variant,
     clippy::missing_const_for_fn,
-    clippy::doc_overindented_list_items,
+    clippy::std_instead_of_core,
     rustdoc::invalid_html_tags
 )]
 """

--- a/nativelink-proto/genproto/lib.rs
+++ b/nativelink-proto/genproto/lib.rs
@@ -19,12 +19,14 @@
 #![allow(
     unknown_lints,
     unused_qualifications,
+    clippy::alloc_instead_of_core,
     clippy::default_trait_access,
     clippy::doc_lazy_continuation,
     clippy::doc_markdown,
+    clippy::doc_overindented_list_items,
     clippy::large_enum_variant,
     clippy::missing_const_for_fn,
-    clippy::doc_overindented_list_items,
+    clippy::std_instead_of_core,
     rustdoc::invalid_html_tags
 )]
 

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -89,8 +89,8 @@ struct ApiWorkerSchedulerImpl {
     operation_keep_alive_tx: UnboundedSender<(OperationId, WorkerId)>,
 }
 
-impl std::fmt::Debug for ApiWorkerSchedulerImpl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ApiWorkerSchedulerImpl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ApiWorkerSchedulerImpl")
             .field("workers", &self.workers)
             .field("allocation_strategy", &self.allocation_strategy)

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -190,7 +190,7 @@ impl AwaitedAction {
 
     /// Sets the current state of the action and updates the last worker updated timestamp.
     pub fn worker_set_state(&mut self, mut state: Arc<ActionState>, now: SystemTime) {
-        std::mem::swap(&mut self.state, &mut state);
+        core::mem::swap(&mut self.state, &mut state);
         self.worker_keep_alive(now);
     }
 }

--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::ops::Bound;
+use core::cmp;
+use core::ops::Bound;
+use core::time::Duration;
 use std::sync::Arc;
-use std::time::Duration;
 
 pub use awaited_action::{AwaitedAction, AwaitedActionSortKey};
 use futures::{Future, Stream};
@@ -89,9 +89,9 @@ impl Ord for SortedAwaitedAction {
     }
 }
 
-impl std::fmt::Display for SortedAwaitedAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::write(
+impl core::fmt::Display for SortedAwaitedAction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::write(
             f,
             format_args!("{}-{}", self.sort_key.as_u64(), self.operation_id),
         )

--- a/nativelink-scheduler/src/cache_lookup_scheduler.rs
+++ b/nativelink-scheduler/src/cache_lookup_scheduler.rs
@@ -67,8 +67,8 @@ pub struct CacheLookupScheduler {
     inflight_cache_checks: Arc<Mutex<CheckActions>>,
 }
 
-impl std::fmt::Debug for CacheLookupScheduler {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CacheLookupScheduler {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("CacheLookupScheduler")
             .field("ac_store", &self.ac_store)
             .finish_non_exhaustive()

--- a/nativelink-scheduler/src/grpc_scheduler.rs
+++ b/nativelink-scheduler/src/grpc_scheduler.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::future::Future;
+use core::time::Duration;
 use std::collections::HashMap;
-use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream::unfold;
@@ -125,7 +125,7 @@ impl GrpcScheduler {
                 spec.retry.clone(),
             ),
             connection_manager: ConnectionManager::new(
-                std::iter::once(endpoint),
+                core::iter::once(endpoint),
                 spec.connections_per_endpoint,
                 spec.max_concurrent_requests,
                 spec.retry.clone(),

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::{Bound, RangeBounds};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
 use async_lock::Mutex;

--- a/nativelink-scheduler/src/property_modifier_scheduler.rs
+++ b/nativelink-scheduler/src/property_modifier_scheduler.rs
@@ -35,8 +35,8 @@ pub struct PropertyModifierScheduler {
     known_properties: Mutex<HashMap<String, Vec<String>>>,
 }
 
-impl std::fmt::Debug for PropertyModifierScheduler {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PropertyModifierScheduler {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PropertyModifierScheduler")
             .field("modifications", &self.modifications)
             .field("known_properties", &self.known_properties)

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -138,8 +138,8 @@ pub struct SimpleScheduler {
     _task_worker_matching_spawn: JoinHandleDropGuard<()>,
 }
 
-impl std::fmt::Debug for SimpleScheduler {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SimpleScheduler {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SimpleScheduler")
             .field("platform_property_manager", &self.platform_property_manager)
             .field("worker_scheduler", &self.worker_scheduler)

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Bound;
+use core::ops::Bound;
+use core::time::Duration;
 use std::string::ToString;
 use std::sync::{Arc, Weak};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use async_lock::Mutex;
 use async_trait::async_trait;

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::Bound;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
 use std::borrow::Cow;
-use std::ops::Bound;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
@@ -62,14 +62,14 @@ pub struct OperationSubscriber<S: SchedulerStore, I: InstantWrapper, NowFn: Fn()
     now_fn: NowFn,
 }
 
-impl<S: SchedulerStore, I: InstantWrapper, NowFn: Fn() -> I + std::fmt::Debug> std::fmt::Debug
+impl<S: SchedulerStore, I: InstantWrapper, NowFn: Fn() -> I + core::fmt::Debug> core::fmt::Debug
     for OperationSubscriber<S, I, NowFn>
 where
     OperationSubscriberState<
         <S::SubscriptionManager as SchedulerSubscriptionManager>::Subscription,
-    >: std::fmt::Debug,
+    >: core::fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OperationSubscriber")
             .field("maybe_client_operation_id", &self.maybe_client_operation_id)
             .field("subscription_key", &self.subscription_key)

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::hash::{Hash, Hasher};
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
 use std::thread::panicking;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use bytes::Bytes;
 use fred::bytes_utils::string::Str;
@@ -112,7 +113,7 @@ impl Mocks for MockRedisBackend {
             args: Vec::new(),
         };
 
-        let results = std::iter::once(MULTI.clone())
+        let results = core::iter::once(MULTI.clone())
             .chain(commands)
             .chain([EXEC.clone()])
             .map(|command| self.process_command(command))

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::future::Future;
+use core::ops::Bound;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::time::Duration;
 use std::collections::HashMap;
-use std::future::Future;
-use std::ops::Bound;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_lock::Mutex;
 use futures::task::Poll;

--- a/nativelink-scheduler/tests/utils/mock_scheduler.rs
+++ b/nativelink-scheduler/tests/utils/mock_scheduler.rs
@@ -70,7 +70,10 @@ impl MockActionScheduler {
     }
 
     #[allow(dead_code, reason = "https://github.com/rust-lang/rust/issues/46379")]
-    pub(crate) async fn expect_get_known_properties(&self, result: Result<Vec<String>, Error>) -> String {
+    pub(crate) async fn expect_get_known_properties(
+        &self,
+        result: Result<Vec<String>, Error>,
+    ) -> String {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::GetGetKnownProperties(req) = rx_call_lock
             .recv()

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use nativelink_error::{Code, Error, make_err};

--- a/nativelink-service/src/ac_server.rs
+++ b/nativelink-service/src/ac_server.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::Into;
+use core::fmt::Debug;
 use std::collections::HashMap;
-use std::convert::Into;
-use std::fmt::Debug;
 
 use bytes::BytesMut;
 use nativelink_config::cas_server::{AcStoreConfig, InstanceName};
@@ -47,7 +47,7 @@ pub struct AcServer {
 }
 
 impl Debug for AcServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("AcServer").finish()
     }
 }

--- a/nativelink-service/src/bep_server.rs
+++ b/nativelink-service/src/bep_server.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
 use std::borrow::Cow;
-use std::pin::Pin;
 
 use bytes::BytesMut;
 use futures::Stream;

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::Into;
+use core::fmt::{Debug, Formatter};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::convert::Into;
-use std::fmt::{Debug, Formatter};
-use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
 
 use futures::future::{BoxFuture, pending};
 use futures::stream::unfold;
@@ -72,7 +72,7 @@ struct StreamState {
 }
 
 impl Debug for StreamState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("StreamState")
             .field("uuid", &self.uuid)
             .finish()
@@ -167,7 +167,7 @@ pub struct ByteStreamServer {
 }
 
 impl Debug for ByteStreamServer {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ByteStreamServer")
             .field("stores", &self.stores)
             .field("max_bytes_per_stream", &self.max_bytes_per_stream)

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::Into;
+use core::pin::Pin;
 use std::collections::{HashMap, VecDeque};
-use std::convert::Into;
-use std::pin::Pin;
 
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, Stream};

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::Into;
+use core::pin::Pin;
+use core::time::Duration;
 use std::collections::HashMap;
-use std::convert::Into;
 use std::fmt;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::stream::unfold;
 use futures::{Stream, StreamExt};
@@ -386,7 +387,7 @@ impl Execution for ExecutionServer {
 
 #[cfg(test)]
 #[test]
-fn test_nl_op_id_from_name() -> Result<(), Box<dyn std::error::Error>> {
+fn test_nl_op_id_from_name() -> Result<(), Box<dyn core::error::Error>> {
     let examples = [("foo/bar", "foo"), ("a/b/c/d", "a/b/c")];
 
     for (input, expected) in examples {

--- a/nativelink-service/src/fetch_server.rs
+++ b/nativelink-service/src/fetch_server.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::Into;
+use core::convert::Into;
 
 use nativelink_config::cas_server::FetchConfig;
 use nativelink_error::{Code, Error, ResultExt, make_err};

--- a/nativelink-service/src/health_server.rs
+++ b/nativelink-service/src/health_server.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::Infallible;
-use std::future::Future;
-use std::pin::Pin;
+use core::convert::Infallible;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use axum::body::Body;
 use bytes::Bytes;

--- a/nativelink-service/src/push_server.rs
+++ b/nativelink-service/src/push_server.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::Into;
+use core::convert::Into;
 
 use nativelink_config::cas_server::PushConfig;
 use nativelink_error::{Error, ResultExt};

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::Into;
+use core::pin::Pin;
+use core::time::Duration;
 use std::collections::HashMap;
-use std::convert::Into;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::stream::unfold;
 use futures::Stream;
@@ -52,8 +53,8 @@ pub struct WorkerApiServer {
     node_id: [u8; 6],
 }
 
-impl std::fmt::Debug for WorkerApiServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for WorkerApiServer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("WorkerApiServer")
             .field("node_id", &self.node_id)
             .finish_non_exhaustive()

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use bytes::BytesMut;
@@ -42,7 +42,7 @@ async fn insert_into_store<T: Message>(
     hash: &str,
     action_size: i64,
     action_result: &T,
-) -> Result<i64, Box<dyn std::error::Error>> {
+) -> Result<i64, Box<dyn core::error::Error>> {
     let mut store_data = BytesMut::new();
     action_result.encode(&mut store_data)?;
     let data_len = store_data.len();
@@ -107,7 +107,7 @@ async fn get_action_result(
 }
 
 #[nativelink_test]
-async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
+async fn empty_store() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
 
@@ -120,7 +120,7 @@ async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn has_single_item() -> Result<(), Box<dyn std::error::Error>> {
+async fn has_single_item() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();
@@ -142,7 +142,7 @@ async fn has_single_item() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error>> {
+async fn single_item_wrong_digest_size() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();
@@ -161,7 +161,7 @@ async fn single_item_wrong_digest_size() -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
-fn get_encoded_proto_size<T: Message>(proto: &T) -> Result<usize, Box<dyn std::error::Error>> {
+fn get_encoded_proto_size<T: Message>(proto: &T) -> Result<usize, Box<dyn core::error::Error>> {
     let mut store_data = Vec::new();
     proto.encode(&mut store_data)?;
     Ok(store_data.len())
@@ -184,7 +184,7 @@ async fn update_action_result(
 }
 
 #[nativelink_test]
-async fn one_item_update_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn one_item_update_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let ac_server = make_ac_server(&store_manager)?;
     let ac_store = store_manager.get_store("main_ac").unwrap();

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -82,7 +82,7 @@ fn get_bep_store(store_manager: &StoreManager) -> Result<Store, Error> {
 
 /// Asserts that a gRPC request for a [`PublishLifecycleEventRequest`] is correctly dumped into a [`Store`]
 #[nativelink_test]
-async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn publish_lifecycle_event_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bep_server = make_bep_server(&store_manager)?;
     let bep_store = get_bep_store(&store_manager)?;
@@ -156,7 +156,7 @@ async fn publish_lifecycle_event_test() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[nativelink_test]
-async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bep_server = make_bep_server(&store_manager)?;
     let bep_store = get_bep_store(&store_manager)?;
@@ -172,7 +172,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn std::error
             .err_tip(|| "While invoking publish_build_tool_event_stream")?
             .into_inner();
 
-        Ok::<_, Box<dyn std::error::Error>>((tx, stream))
+        Ok::<_, Box<dyn core::error::Error>>((tx, stream))
     }
     .await?;
 

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -107,7 +107,7 @@ fn make_stream_and_writer_spawn(
     (tx, join_handle)
 }
 
-fn make_resource_name(data_len: impl std::fmt::Display) -> String {
+fn make_resource_name(data_len: impl core::fmt::Display) -> String {
     format!(
         "{}/uploads/{}/blobs/{}/{}",
         INSTANCE_NAME,
@@ -184,7 +184,7 @@ async fn server_and_client_stub(
 }
 
 #[nativelink_test]
-pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bs_server = Arc::new(
         make_bytestream_server(store_manager.as_ref(), None).expect("Failed to make server"),
@@ -260,8 +260,8 @@ pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error
             .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None)
             .await?;
         assert_eq!(
-            std::str::from_utf8(&store_data),
-            std::str::from_utf8(raw_data),
+            core::str::from_utf8(&store_data),
+            core::str::from_utf8(raw_data),
             "Expected store to have been updated to new value"
         );
     }
@@ -269,7 +269,7 @@ pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn std::error
 }
 
 #[nativelink_test]
-pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn resume_write_success() -> Result<(), Box<dyn core::error::Error>> {
     const WRITE_DATA: &str = "12456789abcdefghijk";
 
     // Chunk our data into two chunks to simulate something a client
@@ -343,7 +343,7 @@ pub async fn resume_write_success() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn restart_write_success() -> Result<(), Box<dyn core::error::Error>> {
     const WRITE_DATA: &str = "12456789abcdefghijk";
 
     // Chunk our data into two chunks to simulate something a client
@@ -422,7 +422,7 @@ pub async fn restart_write_success() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn core::error::Error>> {
     const WRITE_DATA: &str = "12456789abcdefghijk";
 
     // Chunk our data into two chunks to simulate something a client
@@ -502,7 +502,7 @@ pub async fn restart_mid_stream_write_success() -> Result<(), Box<dyn std::error
 
 #[nativelink_test]
 pub async fn ensure_write_is_not_done_until_write_request_is_set()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const WRITE_DATA: &str = "12456789abcdefghijk";
 
     let store_manager = make_store_manager().await?;
@@ -579,7 +579,7 @@ pub async fn ensure_write_is_not_done_until_write_request_is_set()
 }
 
 #[nativelink_test]
-pub async fn out_of_order_data_fails() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn out_of_order_data_fails() -> Result<(), Box<dyn core::error::Error>> {
     const WRITE_DATA: &str = "12456789abcdefghijk";
 
     // Chunk our data into two chunks to simulate something a client
@@ -634,7 +634,7 @@ pub async fn out_of_order_data_fails() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[nativelink_test]
-pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bs_server = Arc::new(
         make_bytestream_server(store_manager.as_ref(), None).expect("Failed to make server"),
@@ -673,7 +673,7 @@ pub async fn upload_zero_byte_chunk() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[nativelink_test]
-pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bs_server = Arc::new(
         make_bytestream_server(store_manager.as_ref(), None).expect("Failed to make server"),
@@ -701,7 +701,7 @@ pub async fn disallow_negative_write_offset() -> Result<(), Box<dyn std::error::
 }
 
 #[nativelink_test]
-pub async fn out_of_sequence_write() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn out_of_sequence_write() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let bs_server = Arc::new(
         make_bytestream_server(store_manager.as_ref(), None).expect("Failed to make server"),
@@ -729,7 +729,7 @@ pub async fn out_of_sequence_write() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "12456789abcdefghijk";
 
     let store_manager = make_store_manager().await?;
@@ -765,7 +765,7 @@ pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn std:
 }
 
 #[nativelink_test]
-pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn chunked_stream_reads_10mb_of_data() -> Result<(), Box<dyn core::error::Error>> {
     const DATA_SIZE: usize = 10_000_000;
 
     let store_manager = make_store_manager().await?;
@@ -860,7 +860,7 @@ pub async fn read_with_not_found_does_not_deadlock() -> Result<(), Error> {
 }
 
 #[nativelink_test]
-pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn core::error::Error>> {
     const BYTE_SPLIT_OFFSET: usize = 8;
 
     let store_manager = make_store_manager()
@@ -954,7 +954,7 @@ pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn std::err
 }
 
 #[nativelink_test]
-pub async fn max_decoding_message_size_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn max_decoding_message_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const MAX_MESSAGE_SIZE: usize = 1024 * 1024; // 1MB.
 
     // This is the size of the wrapper proto around the data.

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -71,7 +71,7 @@ fn make_cas_server(store_manager: &StoreManager) -> Result<CasServer, Error> {
 }
 
 #[nativelink_test]
-async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
+async fn empty_store() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
 
@@ -92,7 +92,7 @@ async fn empty_store() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn store_one_item_existence() -> Result<(), Box<dyn std::error::Error>> {
+async fn store_one_item_existence() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE: &str = "1";
 
     let store_manager = make_store_manager().await?;
@@ -119,7 +119,7 @@ async fn store_one_item_existence() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn std::error::Error>> {
+async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE: &str = "1";
 
     let store_manager = make_store_manager().await?;
@@ -158,7 +158,7 @@ async fn has_three_requests_one_bad_hash() -> Result<(), Box<dyn std::error::Err
 }
 
 #[nativelink_test]
-async fn update_existing_item() -> Result<(), Box<dyn std::error::Error>> {
+async fn update_existing_item() -> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "2";
 
@@ -214,8 +214,8 @@ async fn update_existing_item() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn batch_read_blobs_read_two_blobs_success_one_fail() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn batch_read_blobs_read_two_blobs_success_one_fail()
+-> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "23";
 
@@ -367,7 +367,7 @@ async fn setup_directory_structure(
 }
 
 #[nativelink_test]
-async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::error::Error>> {
+async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
     let store = store_manager.get_store("main_cas").unwrap();
@@ -452,7 +452,7 @@ async fn get_tree_read_directories_without_paging() -> Result<(), Box<dyn std::e
 }
 
 #[nativelink_test]
-async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::error::Error>> {
+async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn core::error::Error>> {
     let store_manager = make_store_manager().await?;
     let cas_server = make_cas_server(&store_manager)?;
     let store = store_manager.get_store("main_cas").unwrap();
@@ -574,7 +574,7 @@ async fn get_tree_read_directories_with_paging() -> Result<(), Box<dyn std::erro
 
 #[nativelink_test]
 async fn batch_update_blobs_two_items_existence_with_third_missing()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const VALUE1: &str = "1";
     const VALUE2: &str = "23";
 

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
@@ -207,8 +208,8 @@ async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestCont
 }
 
 #[nativelink_test]
-pub async fn connect_worker_adds_worker_to_scheduler_test() -> Result<(), Box<dyn std::error::Error>>
-{
+pub async fn connect_worker_adds_worker_to_scheduler_test()
+-> Result<(), Box<dyn core::error::Error>> {
     let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
     let worker_exists = test_context
@@ -221,7 +222,7 @@ pub async fn connect_worker_adds_worker_to_scheduler_test() -> Result<(), Box<dy
 }
 
 #[nativelink_test]
-pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn server_times_out_workers_test() -> Result<(), Box<dyn core::error::Error>> {
     let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
     let mut now_timestamp = BASE_NOW_S;
@@ -256,7 +257,7 @@ pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::E
 }
 
 #[nativelink_test]
-pub async fn server_does_not_timeout_if_keep_alive_test() -> Result<(), Box<dyn std::error::Error>>
+pub async fn server_does_not_timeout_if_keep_alive_test() -> Result<(), Box<dyn core::error::Error>>
 {
     let now_timestamp = Arc::new(Mutex::new(BASE_NOW_S));
     let now_timestamp_clone = now_timestamp.clone();
@@ -312,7 +313,7 @@ pub async fn server_does_not_timeout_if_keep_alive_test() -> Result<(), Box<dyn 
 }
 
 #[nativelink_test]
-pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn core::error::Error>> {
     let mut test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
     // Send keep alive to client.
@@ -345,7 +346,7 @@ pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std
 }
 
 #[nativelink_test]
-pub async fn going_away_removes_worker_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn going_away_removes_worker_test() -> Result<(), Box<dyn core::error::Error>> {
     let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
     let worker_exists = test_context
@@ -377,7 +378,7 @@ fn make_system_time(time: u64) -> SystemTime {
 }
 
 #[nativelink_test]
-pub async fn execution_response_success_test() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn execution_response_success_test() -> Result<(), Box<dyn core::error::Error>> {
     let mut test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
 
     let action_digest = DigestInfo::new([7u8; 32], 123);

--- a/nativelink-store/src/ac_utils.rs
+++ b/nativelink-store/src/ac_utils.rs
@@ -17,7 +17,7 @@
 //                    THREADSAFETY. FIGURE OUT WHY AND MOVE IT TO UTILS.
 // @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-use std::pin::Pin;
+use core::pin::Pin;
 
 use bytes::BytesMut;
 use futures::TryFutureExt;

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::{iter, mem};
 use std::sync::Arc;
-use std::{iter, mem};
 
 use async_trait::async_trait;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -380,11 +380,11 @@ impl StoreDriver for CompletenessCheckingStore {
         self
     }
 
-    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::pin::Pin;
+use core::cmp;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -221,8 +221,8 @@ pub struct CompressionStore {
     bincode_options: BincodeOptions,
 }
 
-impl std::fmt::Debug for CompressionStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CompressionStore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("CompressionStore")
             .field("inner_store", &self.inner_store)
             .field("config", &self.config)
@@ -332,7 +332,7 @@ impl StoreDriver for CompressionStore {
                 // For efficiency reasons we do some raw slice manipulation so we can write directly
                 // into our buffer instead of having to do another allocation.
                 let raw_compressed_data = unsafe {
-                    std::slice::from_raw_parts_mut(
+                    core::slice::from_raw_parts_mut(
                         compressed_data_buf.chunk_mut().as_mut_ptr(),
                         max_output_size,
                     )
@@ -512,7 +512,7 @@ impl StoreDriver for CompressionStore {
                     // For efficiency reasons we do some raw slice manipulation so we can write directly
                     // into our buffer instead of having to do another allocation.
                     let raw_decompressed_data = unsafe {
-                        std::slice::from_raw_parts_mut(
+                        core::slice::from_raw_parts_mut(
                             uncompressed_data.chunk_mut().as_mut_ptr(),
                             max_output_size,
                         )
@@ -624,11 +624,11 @@ impl StoreDriver for CompressionStore {
         self
     }
 
-    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::pin::Pin;
+use core::cmp;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -59,8 +59,8 @@ pub struct DedupStore {
     bincode_options: WithOtherIntEncoding<DefaultOptions, FixintEncoding>,
 }
 
-impl std::fmt::Debug for DedupStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DedupStore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DedupStore")
             .field("index_store", &self.index_store)
             .field("content_store", &self.content_store)
@@ -369,11 +369,11 @@ impl StoreDriver for DedupStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
 use std::borrow::Cow;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -221,11 +221,11 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::BorrowMut;
-use std::cmp::{max, min};
+use core::borrow::BorrowMut;
+use core::cmp::{max, min};
+use core::ops::Range;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::ffi::OsString;
-use std::ops::Range;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
@@ -385,11 +385,11 @@ impl StoreDriver for FastSlowStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::{Debug, Formatter};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{Debug, Formatter};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
@@ -304,7 +304,7 @@ impl FileEntry for FileEntryImpl {
 }
 
 impl Debug for FileEntryImpl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("FileEntryImpl")
             .field("data_size", &self.data_size)
             .field("encoded_file_path", &"<behind mutex>")
@@ -971,11 +971,11 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::time::Duration;
 use std::borrow::Cow;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::BytesMut;
@@ -774,11 +774,11 @@ impl StoreDriver for GrpcStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
-use std::fmt::Debug;
-use std::ops::Bound;
-use std::pin::Pin;
+use core::borrow::Borrow;
+use core::fmt::Debug;
+use core::ops::Bound;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -37,7 +37,7 @@ use crate::cas_utils::is_zero_digest;
 pub struct BytesWrapper(Bytes);
 
 impl Debug for BytesWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("BytesWrapper { -- Binary data -- }")
     }
 }
@@ -189,11 +189,11 @@ impl StoreDriver for MemoryStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -85,11 +85,11 @@ impl StoreDriver for NoopStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::cmp;
+use core::pin::Pin;
+use core::time::Duration;
 use std::borrow::Cow;
-use std::cmp;
-use std::pin::Pin;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -574,11 +574,11 @@ impl StoreDriver for RedisStore {
         self
     }
 
-    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send) {
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send> {
         self
     }
 

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::UnsafeCell;
-use std::pin::Pin;
+use core::cell::UnsafeCell;
+use core::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
 
 use async_trait::async_trait;
@@ -141,11 +141,11 @@ impl StoreDriver for RefStore {
         }
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::cmp;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::borrow::Cow;
-use std::cmp;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use aws_config::default_provider::credentials;
@@ -130,8 +130,8 @@ impl TlsClient {
     }
 }
 
-impl std::fmt::Debug for TlsClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Debug for TlsClient {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("TlsClient").finish_non_exhaustive()
     }
 }
@@ -960,11 +960,11 @@ where
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::hash::{DefaultHasher, Hasher};
-use std::ops::BitXor;
-use std::pin::Pin;
+use core::hash::Hasher;
+use core::ops::BitXor;
+use core::pin::Pin;
+use std::hash::DefaultHasher;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -229,11 +230,11 @@ impl StoreDriver for ShardStore {
         self.weights_and_stores[index].store.inner_store(Some(key))
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -152,11 +152,11 @@ impl StoreDriver for SizePartitioningStore {
         self.upper_store.inner_store(Some(digest))
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -77,7 +77,7 @@ impl VerifyStore {
             // Ensure if a user sends us too much data we fail quickly.
             if let Some(expected_size) = maybe_expected_digest_size {
                 match sum_size.cmp(&expected_size) {
-                    std::cmp::Ordering::Greater => {
+                    core::cmp::Ordering::Greater => {
                         self.size_verification_failures.inc();
                         return Err(make_input_err!(
                             "Expected size {} but already received {} on insert",
@@ -85,7 +85,7 @@ impl VerifyStore {
                             sum_size
                         ));
                     }
-                    std::cmp::Ordering::Equal => {
+                    core::cmp::Ordering::Equal => {
                         // Ensure our next chunk is the EOF chunk.
                         // If this was an error it'll be caught on the .recv()
                         // on next cycle.
@@ -99,7 +99,7 @@ impl VerifyStore {
                             }
                         }
                     }
-                    std::cmp::Ordering::Less => {}
+                    core::cmp::Ordering::Less => {}
                 }
             }
 
@@ -223,11 +223,11 @@ impl StoreDriver for VerifyStore {
         self
     }
 
-    fn as_any<'a>(&'a self) -> &'a (dyn std::any::Any + Sync + Send + 'static) {
+    fn as_any<'a>(&'a self) -> &'a (dyn core::any::Any + Sync + Send + 'static) {
         self
     }
 
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
     }
 }

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
+use core::cmp;
+use core::pin::Pin;
+use core::str::from_utf8;
 use std::io::Cursor;
-use std::pin::Pin;
-use std::str::from_utf8;
 use std::sync::Arc;
 
 use bincode::{DefaultOptions, Options};

--- a/nativelink-store/tests/dedup_store_test.rs
+++ b/nativelink-store/tests/dedup_store_test.rs
@@ -239,7 +239,7 @@ async fn check_chunk_boundary_reads_test() -> Result<(), Error> {
                 .await
                 .err_tip(|| "Failed to get_part from dedup store")?;
 
-            let len_fenced = std::cmp::min(len, rt_data.len());
+            let len_fenced = core::cmp::min(len, rt_data.len());
             assert_eq!(
                 rt_data.len(),
                 len_fenced,

--- a/nativelink-store/tests/existence_store_test.rs
+++ b/nativelink-store/tests/existence_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use mock_instant::thread_local::MockClock;
 use nativelink_config::stores::{

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -293,11 +293,11 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             self
         }
 
-        fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static) {
+        fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
             self
         }
 
-        fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static> {
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
             self
         }
     }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::{Debug, Formatter};
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::time::Duration;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{Debug, Formatter};
-use std::marker::PhantomData;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
 
 use async_lock::RwLock;
 use bytes::Bytes;
@@ -61,7 +61,7 @@ struct TestFileEntry<Hooks: FileEntryHooks + 'static + Sync + Send> {
 }
 
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> Debug for TestFileEntry<Hooks> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("TestFileEntry")
             .field("inner", &self.inner)
             .finish()

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::RangeBounds;
-use std::pin::Pin;
+use core::ops::RangeBounds;
+use core::pin::Pin;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use memory_stats::memory_stats;

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::panicking;
 
@@ -137,7 +137,7 @@ impl Mocks for MockRedisBackend {
             args: Vec::new(),
         };
 
-        let results = std::iter::once(MULTI.clone())
+        let results = core::iter::once(MULTI.clone())
             .chain(commands)
             .chain([EXEC.clone()])
             .map(|command| self.process_command(command))

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ptr::from_ref;
+use core::ptr::from_ref;
 use std::sync::Arc;
 
 use nativelink_config::stores::{MemorySpec, RefSpec};

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::sync::Arc;
-use std::time::Duration;
 
 use aws_sdk_s3::config::{BehaviorVersion, Builder, Region};
 use aws_sdk_s3::primitives::ByteStream;
@@ -184,7 +184,7 @@ async fn simple_has_retries() -> Result<(), Error> {
 // As of `BehaviorVersion::v2025_01_17` responses contain checksums. This helper
 // function removes them for easier comparison.
 fn extract_payload_from_chunked_data(chunked_data: &[u8]) -> Result<Bytes, Error> {
-    let data_str = std::str::from_utf8(chunked_data)
+    let data_str = core::str::from_utf8(chunked_data)
         .map_err(|e| make_input_err!("Invalid UTF-8 in chunked data: {e:?}"))?;
     let parts: Vec<&str> = data_str.split("\r\n").collect();
     if parts.len() > 1 {

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 
 use futures::future::pending;
 use futures::try_join;

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
+use core::convert::Into;
+use core::hash::Hash;
+use core::time::Duration;
 use std::collections::HashMap;
-use std::convert::Into;
-use std::hash::Hash;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use nativelink_error::{Error, ResultExt, error_if, make_input_err};
 use nativelink_metric::{
@@ -68,8 +69,8 @@ impl Default for OperationId {
     }
 }
 
-impl std::fmt::Display for OperationId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for OperationId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Uuid(uuid) => uuid.fmt(f),
             Self::String(name) => f.write_str(name),
@@ -124,7 +125,7 @@ impl TryFrom<Bytes> for OperationId {
             }
             // We could not take ownership of the Bytes, so we may need to copy our data.
             Err(value) => {
-                let value = std::str::from_utf8(&value).map_err(|e| {
+                let value = core::str::from_utf8(&value).map_err(|e| {
                     make_input_err!(
                         "Failed to convert bytes to string in try_from<Bytes> for OperationId : {e:?}"
                     )
@@ -149,15 +150,15 @@ impl MetricsComponent for WorkerId {
     }
 }
 
-impl std::fmt::Display for WorkerId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("{}", self.0))
     }
 }
 
-impl std::fmt::Debug for WorkerId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self, f)
+impl core::fmt::Debug for WorkerId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self, f)
     }
 }
 
@@ -228,8 +229,8 @@ impl ActionUniqueQualifier {
     }
 }
 
-impl std::fmt::Display for ActionUniqueQualifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ActionUniqueQualifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let (cachable, unique_key) = match self {
             Self::Cachable(action) => (true, action),
             Self::Uncachable(action) => (false, action),
@@ -262,8 +263,8 @@ pub struct ActionUniqueKey {
     pub digest: DigestInfo,
 }
 
-impl std::fmt::Display for ActionUniqueKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ActionUniqueKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!(
             "{}/{}/{}",
             self.instance_name, self.digest_function, self.digest,

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
 use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::Poll;
 
 use bytes::{Bytes, BytesMut};
 use futures::task::Context;

--- a/nativelink-util/src/channel_body_for_tests.rs
+++ b/nativelink-util/src/channel_body_for_tests.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::task::{Context, ready};
+use core::pin::Pin;
+use core::task::{Context, ready};
 
 use bytes::Bytes;
 use futures::task::Poll;

--- a/nativelink-util/src/chunked_stream.rs
+++ b/nativelink-util/src/chunked_stream.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::Bound;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::VecDeque;
-use std::ops::Bound;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use futures::{Future, Stream};
 use pin_project::pin_project;
@@ -85,7 +85,7 @@ where
                         Ok(Some(((start, end), mut buffer))) => {
                             *this.start_key = Some(start);
                             *this.end_key = Some(end);
-                            std::mem::swap(&mut buffer, this.buffer);
+                            core::mem::swap(&mut buffer, this.buffer);
                         }
                         Ok(None) => return Poll::Ready(None), // End of stream.
                         Err(err) => return Poll::Ready(Some(Err(err))),
@@ -96,7 +96,7 @@ where
                 StreamStateProj::Next => {
                     this.buffer.clear();
                     // This trick is used to recycle capacity.
-                    let buffer = std::mem::take(this.buffer);
+                    let buffer = core::mem::take(this.buffer);
                     let start_key = this
                         .start_key
                         .take()

--- a/nativelink-util/src/common.rs
+++ b/nativelink-util/src/common.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::{Eq, Ordering};
+use core::cmp::{Eq, Ordering};
+use core::hash::{BuildHasher, Hash};
+use core::ops::{Deref, DerefMut};
 use std::collections::HashMap;
 use std::fmt;
-use std::hash::{BuildHasher, Hash};
 use std::io::{Cursor, Write};
-use std::ops::{Deref, DerefMut};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use nativelink_error::{Error, ResultExt, make_input_err};
@@ -163,7 +163,7 @@ impl<'a> DigestStackStringifier<'a> {
             cursor.position() as usize
         };
         // Convert the buffer into utf8 string.
-        std::str::from_utf8(&self.buf[..len]).map_err(|e| {
+        core::str::from_utf8(&self.buf[..len]).map_err(|e| {
             make_input_err!(
                 "Could not convert [u8] to string - {} - {:?} - {:?}",
                 self.digest,
@@ -381,7 +381,7 @@ impl PackedHash {
 impl fmt::Display for PackedHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let hash = self.to_hex()?;
-        match std::str::from_utf8(&hash) {
+        match core::str::from_utf8(&hash) {
             Ok(hash) => f.write_str(hash)?,
             Err(_) => f.write_str(&format!("Could not convert hash to utf8 {:?}", self.0))?,
         }
@@ -451,9 +451,9 @@ impl<K: Eq + Hash, T, S: BuildHasher + Clone> HashMapExt<K, T, S> for HashMap<K,
 }
 
 // Utility to encode our proto into GRPC stream format.
-pub fn encode_stream_proto<T: Message>(proto: &T) -> Result<Bytes, Box<dyn std::error::Error>> {
+pub fn encode_stream_proto<T: Message>(proto: &T) -> Result<Bytes, Box<dyn core::error::Error>> {
     // See below comment on spec.
-    use std::mem::size_of;
+    use core::mem::size_of;
     const PREFIX_BYTES: usize = size_of::<u8>() + size_of::<u32>();
 
     let mut buf = BytesMut::new();

--- a/nativelink-util/src/connection_manager.rs
+++ b/nativelink-util/src/connection_manager.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use futures::Future;
 use futures::stream::{FuturesUnordered, StreamExt, unfold};
@@ -425,8 +425,8 @@ pub struct ResponseFuture {
     identifier: ChannelIdentifier,
 }
 
-impl std::fmt::Debug for ResponseFuture {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ResponseFuture {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ResponseFuture")
             .field("inner", &self.inner)
             .field("connection_tx", &self.connection_tx)

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -133,8 +133,8 @@ impl TryFrom<&str> for DigestHasherFunc {
     }
 }
 
-impl std::fmt::Display for DigestHasherFunc {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for DigestHasherFunc {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             DigestHasherFunc::Sha256 => write!(f, "SHA256"),
             DigestHasherFunc::Blake3 => write!(f, "BLAKE3"),

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
-use std::cmp::Eq;
+use core::borrow::Borrow;
+use core::cmp::Eq;
+use core::fmt::Debug;
+use core::future::Future;
+use core::hash::Hash;
+use core::ops::RangeBounds;
 use std::collections::BTreeSet;
-use std::fmt::Debug;
-use std::future::Future;
-use std::hash::Hash;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -64,7 +64,7 @@ pub trait LenEntry: 'static {
     /// the `EvictionMap` globally (including inside `unref()`).
     #[inline]
     fn unref(&self) -> impl Future<Output = ()> + Send {
-        std::future::ready(())
+        core::future::ready(())
     }
 }
 

--- a/nativelink-util/src/fastcdc.rs
+++ b/nativelink-util/src/fastcdc.rs
@@ -95,7 +95,7 @@ impl Decoder for FastCDC {
         // Zero means not found.
         let mut split_point = 0;
 
-        let start_point = std::cmp::max(self.state.position, self.min_size);
+        let start_point = core::cmp::max(self.state.position, self.min_size);
 
         // Note: We use this kind of loop because it improved performance of this loop by 20%.
         let mut i = start_point;

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::task::{Context, Poll};
 use std::fs::Metadata;
 use std::io::{IoSlice, Seek};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::task::{Context, Poll};
 
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use rlimit::increase_nofile_limit;

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::pin::Pin;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -107,7 +107,7 @@ pub trait HealthStatusIndicator: Sync + Send + Unpin {
 
     /// Returns the name of the struct implementing the trait.
     fn struct_name(&self) -> &'static str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
 
     /// Check the health status of the component. This function should be
@@ -124,7 +124,7 @@ pub struct HealthRegistryBuilder {
 }
 
 impl Debug for HealthRegistryBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("HealthRegistryBuilder")
             .field("namespace", &self.namespace)
             .finish_non_exhaustive()
@@ -172,7 +172,7 @@ pub struct HealthRegistry {
 }
 
 impl Debug for HealthRegistry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("HealthRegistry")
             .field(
                 "indicators",

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use core::future::Future;
+use core::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use mock_instant::thread_local::{Instant as MockInstant, MockClock};
 

--- a/nativelink-util/src/metrics_utils.rs
+++ b/nativelink-util/src/metrics_utils.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem::forget;
-use std::sync::atomic::{AtomicU64, Ordering};
+use core::mem::forget;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use futures::Future;

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/nativelink-util/src/origin_context.rs
+++ b/nativelink-util/src/origin_context.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::any::Any;
+use core::cell::RefCell;
+use core::clone::Clone;
+use core::mem::ManuallyDrop;
 use core::panic;
-use std::any::Any;
-use std::cell::RefCell;
-use std::clone::Clone;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::mem::ManuallyDrop;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use futures::Future;
 use nativelink_error::{Code, Error, make_err};
@@ -49,7 +49,7 @@ macro_rules! unsafe_make_symbol {
         pub static $name: $crate::origin_context::NLSymbol<$type> =
             $crate::origin_context::NLSymbol {
                 name: concat!(module_path!(), "::", stringify!($name)),
-                _phantom: std::marker::PhantomData {},
+                _phantom: core::marker::PhantomData {},
             };
     };
 }
@@ -62,7 +62,7 @@ unsafe_make_symbol!(ORIGIN_IDENTITY, String);
 #[derive(Debug)]
 pub struct NLSymbol<T: Send + Sync + 'static> {
     pub name: &'static str,
-    pub _phantom: std::marker::PhantomData<T>,
+    pub _phantom: core::marker::PhantomData<T>,
 }
 
 impl<T: Send + Sync + 'static> Symbol for NLSymbol<T> {
@@ -77,7 +77,7 @@ pub trait Symbol {
     type Type: 'static;
 
     fn name(&self) -> &'static str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
 }
 
@@ -300,7 +300,7 @@ impl ContextDropGuard {
     #[inline]
     fn release(mut self) -> Arc<OriginContext> {
         let new_ctx = self.restore_global_context();
-        std::mem::forget(self); // Prevent the destructor from being called.
+        core::mem::forget(self); // Prevent the destructor from being called.
         new_ctx
     }
 }

--- a/nativelink-util/src/origin_event.rs
+++ b/nativelink-util/src/origin_event.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
-use std::pin::Pin;
+use core::marker::PhantomData;
+use core::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
@@ -297,8 +297,8 @@ pub struct OriginEventContext<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<T> std::fmt::Debug for OriginEventContext<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T> core::fmt::Debug for OriginEventContext<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OriginEventContext")
             .field("inner", &self.inner)
             .field("_phantom", &self._phantom)

--- a/nativelink-util/src/origin_event_middleware.rs
+++ b/nativelink-util/src/origin_event_middleware.rs
@@ -84,7 +84,7 @@ impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for OriginEventMiddlew
 where
     S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    ReqBody: std::fmt::Debug + Send + 'static,
+    ReqBody: core::fmt::Debug + Send + 'static,
     ResBody: From<String> + Send + 'static,
 {
     type Response = S::Response;
@@ -99,7 +99,7 @@ where
         // We must take the current `inner` and not the clone.
         // See: https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
         let clone = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let mut inner = core::mem::replace(&mut self.inner, clone);
 
         let mut context = ActiveOriginContext::fork().unwrap_or_default();
         let identity = {

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::borrow::Cow;
-use std::fmt::Debug;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use futures::{Stream, StreamExt};
 use nativelink_error::{Error, ResultExt, error_if, make_input_err};
@@ -35,7 +35,7 @@ pub struct WriteRequestStreamWrapper<T> {
 }
 
 impl<T> Debug for WriteRequestStreamWrapper<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("WriteRequestStreamWrapper")
             .field("resource_info", &self.resource_info)
             .field("bytes_received", &self.bytes_received)

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::AsRef;
 use std::borrow::Cow;
-use std::convert::AsRef;
 
 use nativelink_error::{Error, ResultExt, error_if, make_input_err};
 

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::time::Duration;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::future::Future;
 use futures::stream::StreamExt;
@@ -59,8 +59,8 @@ pub struct Retrier {
     config: Retry,
 }
 
-impl std::fmt::Debug for Retrier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Retrier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Retrier")
             .field("config", &self.config)
             .finish_non_exhaustive()

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::{Borrow, BorrowMut, Cow};
+use core::borrow::{Borrow, BorrowMut};
+use core::convert::Into;
+use core::hash::{Hash, Hasher};
+use core::ops::{Bound, RangeBounds};
+use core::pin::Pin;
+use core::ptr::addr_eq;
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher as StdHasher;
-use std::convert::Into;
 use std::ffi::OsString;
-use std::hash::{Hash, Hasher};
-use std::ops::{Bound, RangeBounds};
-use std::pin::Pin;
-use std::ptr::addr_eq;
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
@@ -243,18 +244,18 @@ impl Clone for StoreKey<'static> {
 }
 
 impl PartialOrd for StoreKey<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for StoreKey<'_> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         match (self, other) {
             (StoreKey::Str(a), StoreKey::Str(b)) => a.cmp(b),
             (StoreKey::Digest(a), StoreKey::Digest(b)) => a.cmp(b),
-            (StoreKey::Str(_), StoreKey::Digest(_)) => std::cmp::Ordering::Less,
-            (StoreKey::Digest(_), StoreKey::Str(_)) => std::cmp::Ordering::Greater,
+            (StoreKey::Str(_), StoreKey::Digest(_)) => core::cmp::Ordering::Less,
+            (StoreKey::Digest(_), StoreKey::Str(_)) => core::cmp::Ordering::Greater,
         }
     }
 }
@@ -322,8 +323,8 @@ pub struct Store {
     inner: Arc<dyn StoreDriver>,
 }
 
-impl std::fmt::Debug for Store {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Store {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Store").finish_non_exhaustive()
     }
 }
@@ -804,8 +805,8 @@ pub trait StoreDriver:
     fn inner_store(&self, _digest: Option<StoreKey<'_>>) -> &dyn StoreDriver;
 
     /// Returns an Any variation of whatever Self is.
-    fn as_any(&self) -> &(dyn std::any::Any + Sync + Send + 'static);
-    fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Sync + Send + 'static>;
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static);
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static>;
 
     // Register health checks used to monitor the store.
     fn register_health(self: Arc<Self>, _registry: &mut HealthRegistryBuilder) {}

--- a/nativelink-util/src/task.rs
+++ b/nativelink-util/src/task.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use futures::Future;
 use hyper::rt::Executor;

--- a/nativelink-util/src/write_counter.rs
+++ b/nativelink-util/src/write_counter.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use tokio::io::AsyncWrite;

--- a/nativelink-util/tests/buf_channel_test.rs
+++ b/nativelink-util/tests/buf_channel_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::task::Poll;
+use core::task::Poll;
 
 use bytes::{Bytes, BytesMut};
 use futures::poll;
@@ -226,7 +226,7 @@ async fn send_and_take_fuzz_test() -> Result<(), Error> {
 
                 let tx_fut = async move {
                     for i in (0..data_size).step_by(write_size) {
-                        tx.send(tx_data.slice(i..std::cmp::min(data_size, i + write_size)))
+                        tx.send(tx_data.slice(i..core::cmp::min(data_size, i + write_size)))
                             .await?;
                     }
                     tx.send_eof()?;

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::time::Duration;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use bytes::Bytes;
 use mock_instant::thread_local::MockClock;
@@ -585,7 +585,7 @@ async fn remove_evicts_on_time() -> Result<(), Error> {
 async fn range_multiple_items_test() -> Result<(), Error> {
     async fn get_map_range(
         evicting_map: &EvictingMap<String, BytesWrapper, MockInstantWrapped>,
-        range: impl std::ops::RangeBounds<String> + Send,
+        range: impl core::ops::RangeBounds<String> + Send,
     ) -> Vec<(String, Bytes)> {
         let mut found_values = Vec::new();
         evicting_map

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -57,7 +57,7 @@ async fn test_all_zeros() -> Result<(), std::io::Error> {
 }
 
 #[nativelink_test]
-async fn test_sekien_16k_chunks() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_sekien_16k_chunks() -> Result<(), Box<dyn core::error::Error>> {
     let contents = include_bytes!("data/SekienAkashita.jpg");
     let mut cursor = Cursor::new(&contents);
     let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(8192, 16384, 32768));

--- a/nativelink-util/tests/resource_info_test.rs
+++ b/nativelink-util/tests/resource_info_test.rs
@@ -20,7 +20,7 @@ use pretty_assertions::assert_eq;
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -40,7 +40,7 @@ async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -56,7 +56,7 @@ async fn read_instance_name_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -75,7 +75,7 @@ async fn read_instance_name_blobs_digest_function_hash_size_optional_metadata_te
 
 #[nativelink_test]
 async fn read_instance_name_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -91,7 +91,7 @@ async fn read_instance_name_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -110,7 +110,7 @@ async fn read_compressed_blobs_compressor_digest_function_hash_size_optional_met
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -125,7 +125,7 @@ async fn read_compressed_blobs_compressor_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn read_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -143,7 +143,7 @@ async fn read_blobs_digest_function_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -159,7 +159,7 @@ async fn read_blobs_digest_function_hash_size_test() -> Result<(), Box<dyn std::
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -178,7 +178,7 @@ async fn read_instance_name_compressed_blobs_compressor_hash_size_optional_metad
 
 #[nativelink_test]
 async fn read_instance_name_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -194,7 +194,7 @@ async fn read_instance_name_compressed_blobs_compressor_hash_size_test()
 
 #[nativelink_test]
 async fn read_instance_name_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -212,7 +212,7 @@ async fn read_instance_name_blobs_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -228,7 +228,7 @@ async fn read_instance_name_blobs_hash_size_test() -> Result<(), Box<dyn std::er
 
 #[nativelink_test]
 async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -246,7 +246,7 @@ async fn read_compressed_blobs_compressor_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn std::error::Error>>
+async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn core::error::Error>>
 {
     const RESOURCE_NAME: &str = "compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
@@ -262,7 +262,7 @@ async fn read_compressed_blobs_compressor_hash_size_test() -> Result<(), Box<dyn
 }
 
 #[nativelink_test]
-async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -280,7 +280,7 @@ async fn read_blobs_hash_size_optional_metadata_test() -> Result<(), Box<dyn std
 }
 
 #[nativelink_test]
-async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "");
@@ -295,7 +295,7 @@ async fn read_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[nativelink_test]
-async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "my/instance/name/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "my/instance/name");
@@ -310,7 +310,7 @@ async fn read_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::e
 }
 
 #[nativelink_test]
-async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, false)?;
     assert_eq!(resource_info.instance_name, "blobs");
@@ -325,21 +325,21 @@ async fn read_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error
 }
 
 #[nativelink_test]
-async fn read_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn read_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_blobs_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "BLOBS/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, false).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn read_too_short_test() -> Result<(), Box<dyn core::error::Error>> {
     assert!(ResourceInfo::new("", false).is_err());
     assert!(ResourceInfo::new("/", false).is_err());
     assert!(ResourceInfo::new("//", false).is_err());
@@ -354,7 +354,7 @@ async fn read_too_short_test() -> Result<(), Box<dyn std::error::Error>> {
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -374,7 +374,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_fun
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -391,7 +391,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_digest_fun
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -411,7 +411,7 @@ async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_option
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -427,7 +427,7 @@ async fn write_instance_name_uploads_uuid_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -447,7 +447,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -463,7 +463,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_digest_function_hash_siz
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -482,7 +482,7 @@ async fn write_uploads_uuid_blobs_digest_function_hash_size_optional_metadata_te
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_digest_function_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/blake3/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -498,7 +498,7 @@ async fn write_uploads_uuid_blobs_digest_function_hash_size_test()
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str =
         "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
@@ -518,7 +518,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -534,7 +534,7 @@ async fn write_instance_name_uploads_uuid_compressed_blobs_compressor_hash_size_
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -553,7 +553,7 @@ async fn write_instance_name_uploads_uuid_blobs_hash_size_optional_metadata_test
 
 #[nativelink_test]
 async fn write_instance_name_uploads_uuid_blobs_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "instance_name/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "instance_name");
@@ -569,7 +569,7 @@ async fn write_instance_name_uploads_uuid_blobs_hash_size_test()
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -588,7 +588,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_optional_metad
 
 #[nativelink_test]
 async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/zstd/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -603,7 +603,7 @@ async fn write_uploads_uuid_compressed_blobs_compressor_hash_size_test()
 }
 
 #[nativelink_test]
-async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std::error::Error>> {
+async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/compressed-blobs/INVALID/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
@@ -611,7 +611,7 @@ async fn compressed_blob_invalid_compression_format() -> Result<(), Box<dyn std:
 
 #[nativelink_test]
 async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345/optional_metadata";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -629,7 +629,7 @@ async fn write_uploads_uuid_blobs_hash_size_optional_metadata_test()
 }
 
 #[nativelink_test]
-async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "");
@@ -644,7 +644,7 @@ async fn write_uploads_uuid_blobs_hash_size_test() -> Result<(), Box<dyn std::er
 }
 
 #[nativelink_test]
-async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "my/instance/name/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "my/instance/name");
@@ -659,7 +659,7 @@ async fn write_instance_name_can_have_slashes_test() -> Result<(), Box<dyn std::
 }
 
 #[nativelink_test]
-async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "blobs/uploads/uuid/blobs/hash/12345";
     let resource_info = ResourceInfo::new(RESOURCE_NAME, true)?;
     assert_eq!(resource_info.instance_name, "blobs");
@@ -674,35 +674,35 @@ async fn write_instance_name_can_be_blobs_test() -> Result<(), Box<dyn std::erro
 }
 
 #[nativelink_test]
-async fn write_uploads_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uuid/compressed-blobs/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "UPLOADS/uuid/compressed-blobs/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_blobs_missing() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_blobs_missing() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_uploads_blobs_invalid() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/BLOBS/hash/12345";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())
 }
 
 #[nativelink_test]
-async fn write_invalid_size_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn write_invalid_size_test() -> Result<(), Box<dyn core::error::Error>> {
     const RESOURCE_NAME: &str = "uploads/uuid/blobs/hash/INVALID";
     assert!(ResourceInfo::new(RESOURCE_NAME, true).is_err());
     Ok(())

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI32, Ordering};
 
 use futures::future::ready;
 use futures::stream::repeat_with;

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
+use core::pin::Pin;
+use core::str;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
 use std::process::Stdio;
-use std::str;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
@@ -383,10 +383,10 @@ pub struct LocalWorker<T: WorkerApiClientTrait, U: RunningActionsManager> {
     metrics: Arc<Metrics>,
 }
 
-impl<T: WorkerApiClientTrait + std::fmt::Debug, U: RunningActionsManager + std::fmt::Debug>
-    std::fmt::Debug for LocalWorker<T, U>
+impl<T: WorkerApiClientTrait + core::fmt::Debug, U: RunningActionsManager + core::fmt::Debug>
+    core::fmt::Debug for LocalWorker<T, U>
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("LocalWorker")
             .field("config", &self.config)
             .field("running_actions_manager", &self.running_actions_manager)

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::cmp::min;
+use core::convert::Into;
+use core::fmt::Debug;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::time::Duration;
 use std::borrow::Cow;
-use std::cmp::min;
 use std::collections::HashMap;
 use std::collections::vec_deque::VecDeque;
-use std::convert::Into;
 use std::ffi::{OsStr, OsString};
-use std::fmt::Debug;
 #[cfg(target_family = "unix")]
 use std::fs::Permissions;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
-use std::pin::Pin;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use bytes::{Bytes, BytesMut};
 use filetime::{FileTime, set_file_mtime};
@@ -768,7 +769,7 @@ impl RunningActionImpl {
             .execution_configuration
             .entrypoint
         {
-            std::iter::once(entrypoint.as_ref())
+            core::iter::once(entrypoint.as_ref())
                 .chain(command_proto.arguments.iter().map(AsRef::as_ref))
                 .collect()
         } else {
@@ -1148,8 +1149,8 @@ impl RunningActionImpl {
         if execution_result.exit_code != 0 {
             // Don't convert our stdout/stderr to strings unless we are need too.
             if enabled!(Level::ERROR) {
-                let stdout = std::str::from_utf8(&execution_result.stdout).unwrap_or("<no-utf8>");
-                let stderr = std::str::from_utf8(&execution_result.stderr).unwrap_or("<no-utf8>");
+                let stdout = core::str::from_utf8(&execution_result.stdout).unwrap_or("<no-utf8>");
+                let stderr = core::str::from_utf8(&execution_result.stderr).unwrap_or("<no-utf8>");
                 event!(
                     Level::ERROR,
                     exit_code = ?execution_result.exit_code,
@@ -1369,7 +1370,7 @@ pub struct Callbacks {
 }
 
 impl Debug for Callbacks {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Callbacks").finish_non_exhaustive()
     }
 }

--- a/nativelink-worker/src/worker_api_client_wrapper.rs
+++ b/nativelink-worker/src/worker_api_client_wrapper.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
+use core::future::Future;
 
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::hash::BuildHasher;
+use core::str::from_utf8;
 use std::collections::HashMap;
-use std::hash::BuildHasher;
 use std::io::{BufRead, BufReader, Cursor};
 use std::process::Stdio;
-use std::str::from_utf8;
 
 use futures::future::try_join_all;
 use nativelink_config::cas_server::WorkerProperty;

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
@@ -20,7 +21,7 @@ use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 mod utils {
     pub(crate) mod local_worker_test_utils;

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::str::from_utf8;
+use core::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use core::task::Poll;
+use core::time::Duration;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
 use std::io::{Cursor, Write};
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-use std::str::from_utf8;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
-use std::task::Poll;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, poll};
 use nativelink_config::cas_server::EnvironmentSource;
@@ -146,7 +147,7 @@ fn increment_clock(time: &mut SystemTime) -> SystemTime {
 
 #[serial]
 #[nativelink_test]
-async fn download_to_directory_file_download_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn download_to_directory_file_download_test() -> Result<(), Box<dyn core::error::Error>> {
     const FILE1_NAME: &str = "file1.txt";
     const FILE1_CONTENT: &str = "HELLOFILE1";
     const FILE2_NAME: &str = "file2.exec";
@@ -245,7 +246,7 @@ async fn download_to_directory_file_download_test() -> Result<(), Box<dyn std::e
 
 #[serial]
 #[nativelink_test]
-async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn core::error::Error>> {
     const DIRECTORY1_NAME: &str = "folder1";
     const FILE1_NAME: &str = "file1.txt";
     const FILE1_CONTENT: &str = "HELLOFILE1";
@@ -344,7 +345,7 @@ async fn download_to_directory_folder_download_test() -> Result<(), Box<dyn std:
 #[cfg(not(target_family = "windows"))]
 #[serial]
 #[nativelink_test]
-async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn core::error::Error>> {
     const FILE_NAME: &str = "file.txt";
     const FILE_CONTENT: &str = "HELLOFILE";
     const SYMLINK_NAME: &str = "symlink_file.txt";
@@ -417,7 +418,7 @@ async fn download_to_directory_symlink_download_test() -> Result<(), Box<dyn std
 #[serial]
 #[nativelink_test]
 async fn ensure_output_files_full_directories_are_created_no_working_directory_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -539,7 +540,7 @@ async fn ensure_output_files_full_directories_are_created_no_working_directory_t
 #[serial]
 #[nativelink_test]
 async fn ensure_output_files_full_directories_are_created_test()
--> Result<(), Box<dyn std::error::Error>> {
+-> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -663,7 +664,7 @@ async fn ensure_output_files_full_directories_are_created_test()
 
 #[serial]
 #[nativelink_test]
-async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
+async fn blake3_upload_files() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -843,7 +844,7 @@ async fn blake3_upload_files() -> Result<(), Box<dyn std::error::Error>> {
 
 #[serial]
 #[nativelink_test]
-async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -1024,7 +1025,7 @@ async fn upload_files_from_above_cwd_test() -> Result<(), Box<dyn std::error::Er
 #[cfg(not(target_family = "windows"))]
 #[serial]
 #[nativelink_test]
-async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -1231,7 +1232,7 @@ async fn upload_dir_and_symlink_test() -> Result<(), Box<dyn std::error::Error>>
 
 #[serial]
 #[nativelink_test]
-async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Error>> {
+async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -1370,7 +1371,7 @@ async fn cleanup_happens_on_job_failure() -> Result<(), Box<dyn std::error::Erro
 
 #[serial]
 #[nativelink_test]
-async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
+async fn kill_ends_action() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     let (_, _, cas_store, ac_store) = setup_stores().await?;
@@ -1515,7 +1516,7 @@ async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg_attr(feature = "nix", ignore)]
 #[serial]
 #[nativelink_test]
-async fn entrypoint_does_invoke_if_set() -> Result<(), Box<dyn std::error::Error>> {
+async fn entrypoint_does_invoke_if_set() -> Result<(), Box<dyn core::error::Error>> {
     #[cfg(target_family = "unix")]
     const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
 #!/usr/bin/env bash
@@ -1671,7 +1672,7 @@ exit 0
 #[cfg_attr(feature = "nix", ignore)]
 #[serial]
 #[nativelink_test]
-async fn entrypoint_injects_properties() -> Result<(), Box<dyn std::error::Error>> {
+async fn entrypoint_injects_properties() -> Result<(), Box<dyn core::error::Error>> {
     #[cfg(target_family = "unix")]
     const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
 #!/usr/bin/env bash
@@ -1863,7 +1864,7 @@ exit 0
 #[cfg_attr(feature = "nix", ignore)]
 #[serial]
 #[nativelink_test]
-async fn entrypoint_sends_timeout_via_side_channel() -> Result<(), Box<dyn std::error::Error>> {
+async fn entrypoint_sends_timeout_via_side_channel() -> Result<(), Box<dyn core::error::Error>> {
     #[cfg(target_family = "unix")]
     const TEST_WRAPPER_SCRIPT_CONTENT: &str = "\
 #!/bin/bash
@@ -1998,7 +1999,7 @@ exit 1
 
 #[serial]
 #[nativelink_test]
-async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error::Error>> {
+async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn core::error::Error>> {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
     let running_actions_manager =
@@ -2070,7 +2071,7 @@ async fn caches_results_in_action_cache_store() -> Result<(), Box<dyn std::error
 
 #[serial]
 #[nativelink_test]
-async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn std::error::Error>> {
+async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn core::error::Error>> {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
     let running_actions_manager =
@@ -2142,7 +2143,7 @@ async fn failed_action_does_not_cache_in_action_cache() -> Result<(), Box<dyn st
 
 #[serial]
 #[nativelink_test]
-async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
+async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn core::error::Error>> {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
     let running_actions_manager =
@@ -2246,7 +2247,7 @@ async fn success_does_cache_in_historical_results() -> Result<(), Box<dyn std::e
 
 #[serial]
 #[nativelink_test]
-async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>> {
+async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn core::error::Error>> {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
     let running_actions_manager =
@@ -2286,7 +2287,7 @@ async fn failure_does_not_cache_in_historical_results() -> Result<(), Box<dyn st
 
 #[serial]
 #[nativelink_test]
-async fn infra_failure_does_cache_in_historical_results() -> Result<(), Box<dyn std::error::Error>>
+async fn infra_failure_does_cache_in_historical_results() -> Result<(), Box<dyn core::error::Error>>
 {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
@@ -2359,7 +2360,7 @@ async fn infra_failure_does_cache_in_historical_results() -> Result<(), Box<dyn 
 
 #[serial]
 #[nativelink_test]
-async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::Error>> {
+async fn action_result_has_used_in_message() -> Result<(), Box<dyn core::error::Error>> {
     let (_, _, cas_store, ac_store) = setup_stores().await?;
 
     let running_actions_manager =
@@ -2410,7 +2411,7 @@ async fn action_result_has_used_in_message() -> Result<(), Box<dyn std::error::E
 
 #[serial]
 #[nativelink_test]
-async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn std::error::Error>> {
+async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -2705,7 +2706,7 @@ async fn ensure_worker_timeout_chooses_correct_values() -> Result<(), Box<dyn st
 
 #[serial]
 #[nativelink_test]
-async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
+async fn worker_times_out() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -2841,7 +2842,7 @@ async fn worker_times_out() -> Result<(), Box<dyn std::error::Error>> {
 
 #[serial]
 #[nativelink_test]
-async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::error::Error>> {
+async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -3008,7 +3009,7 @@ async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::err
 #[cfg(target_family = "unix")]
 #[serial]
 #[nativelink_test]
-async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
+async fn unix_executable_file_test() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
     const FILE_1_NAME: &str = "file1";
 
@@ -3111,7 +3112,7 @@ async fn unix_executable_file_test() -> Result<(), Box<dyn std::error::Error>> {
 
 #[serial]
 #[nativelink_test]
-async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::error::Error>> {
+async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     let (_, _, cas_store, ac_store) = setup_stores().await?;
@@ -3214,7 +3215,7 @@ async fn action_directory_contents_are_cleaned() -> Result<(), Box<dyn std::erro
 #[serial]
 #[nativelink_test]
 #[cfg(target_family = "unix")]
-async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
+async fn upload_with_single_permit() -> Result<(), Box<dyn core::error::Error>> {
     const WORKER_ID: &str = "foo_worker_id";
 
     fn test_monotonic_clock() -> SystemTime {
@@ -3397,7 +3398,7 @@ async fn upload_with_single_permit() -> Result<(), Box<dyn std::error::Error>> {
 
 #[serial]
 #[nativelink_test]
-async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn std::error::Error>>
+async fn running_actions_manager_respects_action_timeout() -> Result<(), Box<dyn core::error::Error>>
 {
     const WORKER_ID: &str = "foo_worker_id";
 

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -194,7 +194,9 @@ pub(crate) fn setup_grpc_stream() -> (
     (tx, Response::new(stream))
 }
 
-pub(crate) async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConfig) -> TestContext {
+pub(crate) async fn setup_local_worker_with_config(
+    local_worker_config: LocalWorkerConfig,
+) -> TestContext {
     let mock_worker_api_client = MockWorkerApiClient::new();
     let mock_worker_api_client_clone = mock_worker_api_client.clone();
     let actions_manager = Arc::new(MockRunningActionsManager::new());

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future;
+use core::future;
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -97,7 +97,9 @@ impl MockRunningActionsManager {
         req
     }
 
-    pub(crate) async fn expect_cache_action_result(&self) -> (DigestInfo, ActionResult, DigestHasherFunc) {
+    pub(crate) async fn expect_cache_action_result(
+        &self,
+    ) -> (DigestInfo, ActionResult, DigestHasherFunc) {
         let mut rx_call_lock = self.rx_call.lock().await;
         match rx_call_lock
             .recv()
@@ -270,7 +272,10 @@ impl MockRunningAction {
         Ok(())
     }
 
-    pub(crate) async fn expect_execute(self: &Arc<Self>, result: Result<(), Error>) -> Result<(), Error> {
+    pub(crate) async fn expect_execute(
+        self: &Arc<Self>,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
         let mut rx_call_lock = self.rx_call.lock().await;
         match rx_call_lock
             .recv()
@@ -290,7 +295,10 @@ impl MockRunningAction {
         Ok(())
     }
 
-    pub(crate) async fn upload_results(self: &Arc<Self>, result: Result<(), Error>) -> Result<(), Error> {
+    pub(crate) async fn upload_results(
+        self: &Arc<Self>,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
         let mut rx_call_lock = self.rx_call.lock().await;
         match rx_call_lock
             .recv()

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::net::SocketAddr;
+use core::time::Duration;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_lock::Mutex as AsyncMutex;
 use axum::Router;
@@ -165,8 +166,10 @@ impl RootMetricsComponent for ConnectedClientsMetrics {}
 trait RoutesExt {
     fn add_optional_service<S>(self, svc: Option<S>) -> Self
     where
-        S: tower::Service<axum::http::Request<tonic::body::Body>, Error = std::convert::Infallible>
-            + tonic::server::NamedService
+        S: tower::Service<
+                axum::http::Request<tonic::body::Body>,
+                Error = core::convert::Infallible,
+            > + tonic::server::NamedService
             + Clone
             + Send
             + Sync
@@ -178,8 +181,10 @@ trait RoutesExt {
 impl RoutesExt for Routes {
     fn add_optional_service<S>(mut self, svc: Option<S>) -> Self
     where
-        S: tower::Service<axum::http::Request<tonic::body::Body>, Error = std::convert::Infallible>
-            + tonic::server::NamedService
+        S: tower::Service<
+                axum::http::Request<tonic::body::Body>,
+                Error = core::convert::Infallible,
+            > + tonic::server::NamedService
             + Clone
             + Send
             + Sync
@@ -939,7 +944,7 @@ async fn inner_main(
     Ok(())
 }
 
-fn get_config() -> Result<CasConfig, Box<dyn std::error::Error>> {
+fn get_config() -> Result<CasConfig, Box<dyn core::error::Error>> {
     let args = Args::parse();
     let json_contents = String::from_utf8(
         std::fs::read(&args.config_file)
@@ -948,7 +953,7 @@ fn get_config() -> Result<CasConfig, Box<dyn std::error::Error>> {
     Ok(serde_json5::from_str(&json_contents)?)
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn core::error::Error>> {
     init_tracing()?;
 
     let mut cfg = get_config()?;


### PR DESCRIPTION
# Description

This changes uses of `std` to be `core` or `alloc` as appropriate whenever possible. Such usage is enforced by clippy.

The unrelated changes to `Cargo.toml` are a result of formatting.

## Type of change

strictly internal

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1704)
<!-- Reviewable:end -->
