### PR TITLE
Throw error on generate docs fail

### DIFF
--- a/web/platform/utils/metaphase_aot.ts
+++ b/web/platform/utils/metaphase_aot.ts
@@ -17,6 +17,7 @@ export async function generateDocs(config: {
     console.info(`Generated: ${outputPath}`);
   } catch (error) {
     console.error("An error occurred during generation:", error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Now `bun run build.docs` raises an error if it fails. In particular `.github/workflows/web.yaml` fails if the auto generated Rust documentation fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1710)
<!-- Reviewable:end -->
