### PR TITLE
Largely change from map-based to array-based config

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json5
+++ b/deployment-examples/docker-compose/local-storage-cas.json5
@@ -41,17 +41,13 @@
       }
     },
     "services": {
-      "cas": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "capabilities": {},
+      "cas": [{
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "capabilities": [],
       "bytestream": {
         "cas_stores": {
           "": "CAS_MAIN_STORE"
@@ -76,17 +72,13 @@
     // specified by the invoking tool (e.g. using
     // `--remote_instance_name=` for Bazel)
     "services": {
-      "cas": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "capabilities": {},
+      "cas": [{
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "capabilities": [],
       "bytestream": {
         "cas_stores": {
           "": "CAS_MAIN_STORE"

--- a/deployment-examples/docker-compose/scheduler.json5
+++ b/deployment-examples/docker-compose/scheduler.json5
@@ -48,24 +48,18 @@
     // specified by the invoking tool (e.g. using
     // `--remote_instance_name=` for Bazel)
     "services": {
-      "ac": {
-        "": {
-          "ac_store": "GRPC_LOCAL_AC_STORE"
-        }
-      },
-      "execution": {
-        "": {
-          "cas_store": "GRPC_LOCAL_STORE",
+      "ac": [{
+        "ac_store": "GRPC_LOCAL_AC_STORE"
+      }],
+      "execution": [{
+        "cas_store": "GRPC_LOCAL_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "capabilities": {
-        "": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      }
+      }]
     }
   }, {
     "listener": {

--- a/integration_tests/buildstream/buildstream_cas.json5
+++ b/integration_tests/buildstream/buildstream_cas.json5
@@ -109,33 +109,23 @@
       }
     },
     "services": {
-      "cas": {
-        "": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "fetch": [],
+      "push": [],
+      "capabilities": [{
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "fetch": {
-      },
-      "push": {
-      },
-      "capabilities": {
-        "": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "": "WORKER_FAST_SLOW_STORE"

--- a/kubernetes/nativelink/nativelink-config.json5
+++ b/kubernetes/nativelink/nativelink-config.json5
@@ -79,29 +79,21 @@
       }
     },
     "services": {
-      "cas": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "capabilities": {
-        "": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
-      "execution": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE",
+      "cas": [{
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "capabilities": [{
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
+      }],
+      "execution": [{
+        "cas_store": "CAS_MAIN_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
       "bytestream": {
         "cas_stores": {
           "": "CAS_MAIN_STORE"
@@ -120,29 +112,21 @@
       }
     },
     "services": {
-      "cas": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "capabilities": {
-        "": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
-      "execution": {
-        "": {
-          "cas_store": "CAS_MAIN_STORE",
+      "cas": [{
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "capabilities": [{
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
+      }],
+      "execution": [{
+        "cas_store": "CAS_MAIN_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
       "bytestream": {
         "cas_stores": {
           "": "CAS_MAIN_STORE"

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 rust_library(
     name = "nativelink-config",
     srcs = [
+        "src/backcompat.rs",
         "src/cas_server.rs",
         "src/lib.rs",
         "src/schedulers.rs",

--- a/nativelink-config/README.md
+++ b/nativelink-config/README.md
@@ -42,19 +42,17 @@ A very basic configuration that's a pure in-memory store is:
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "capabilities": {
-        "main": {}
-      },
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "capabilities": [{
+        "instance_name": "main"
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",

--- a/nativelink-config/examples/README.md
+++ b/nativelink-config/examples/README.md
@@ -272,29 +272,25 @@ The `public` server consists of a `listener` object and a `services` object. The
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER",
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER",
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",
@@ -327,29 +323,25 @@ The `private` server consists of a `listener` object and a `services` object. Th
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER",
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER",
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",
@@ -508,29 +500,25 @@ Below, you will find a fully tested example that you can also find in [basic_cas
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER",
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER",
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",

--- a/nativelink-config/examples/basic_cas.json5
+++ b/nativelink-config/examples/basic_cas.json5
@@ -109,29 +109,25 @@
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE"

--- a/nativelink-config/examples/filesystem_cas.json5
+++ b/nativelink-config/examples/filesystem_cas.json5
@@ -124,29 +124,25 @@
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE"

--- a/nativelink-config/examples/gcs_backend.json5
+++ b/nativelink-config/examples/gcs_backend.json5
@@ -129,29 +129,25 @@
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE"

--- a/nativelink-config/examples/redis.json5
+++ b/nativelink-config/examples/redis.json5
@@ -52,17 +52,15 @@
         }
       },
       "services": {
-        "cas": {
-          "main": {
-            "cas_store": "CAS_MAIN_STORE"
-          }
-        },
-        "ac": {
-          "main": {
-            "ac_store": "AC_MAIN_STORE"
-          }
-        },
-        "capabilities": {},
+        "cas": [{
+          "instance_name": "main",
+          "cas_store": "CAS_MAIN_STORE"
+        }],
+        "ac": [{
+          "instance_name": "main",
+          "ac_store": "AC_MAIN_STORE"
+        }],
+        "capabilities": [],
         "bytestream": {
           "cas_stores": {
             "main": "CAS_MAIN_STORE"

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
@@ -146,29 +146,25 @@
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "CAS_MAIN_STORE",
+        "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER"
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE"

--- a/nativelink-config/src/backcompat.rs
+++ b/nativelink-config/src/backcompat.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer};
+
+use crate::cas_server::WithInstanceName;
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum WithInstanceNameBackCompat<T> {
+    Map(HashMap<String, T>),
+    Vec(Vec<WithInstanceName<T>>),
+}
+
+const DEPRECATION_MESSAGE: &str = r#"
+WARNING: Using deprecated map format for services. Please migrate to the new array format:
+    // Old:
+    "cas": {
+        "main": {
+            "cas_store": "STORE_NAME"
+        }
+    }
+    // New:
+    "cas": [
+        {
+            "instance_name": "main",
+            "cas_store": "STORE_NAME"
+        }
+    ]
+"#;
+
+/// Use `#[serde(default, deserialize_with = "backcompat::opt_vec_named_config")]` for backwards
+/// compatibility with map-based access. A deprecation warning will be written to stderr if the
+/// old format is used.
+pub(crate) fn opt_vec_with_instance_name<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<Vec<WithInstanceName<T>>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let Some(back_compat) = Option::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    match back_compat {
+        WithInstanceNameBackCompat::Map(map) => {
+            eprintln!("{DEPRECATION_MESSAGE}");
+            let vec = map
+                .into_iter()
+                .map(|(instance_name, config)| WithInstanceName {
+                    instance_name,
+                    config,
+                })
+                .collect();
+            Ok(Some(vec))
+        }
+        WithInstanceNameBackCompat::Vec(vec) => Ok(Some(vec)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct PartialConfig {
+        store: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct FullConfig {
+        #[serde(default, deserialize_with = "opt_vec_with_instance_name")]
+        cas: Option<Vec<WithInstanceName<PartialConfig>>>,
+    }
+
+    #[test]
+    fn test_configs_deserialization() {
+        let old_format = json!({
+            "cas": {
+                "foo": { "store": "foo_store" },
+                "bar": { "store": "bar_store" }
+            }
+        });
+
+        let new_format = json!({
+            "cas": [
+                {
+                    "instance_name": "foo",
+                    "store": "foo_store"
+                },
+                {
+                    "instance_name": "bar",
+                    "store": "bar_store"
+                }
+            ]
+        });
+
+        let mut old_format: FullConfig = serde_json::from_value(old_format).unwrap();
+        let mut new_format: FullConfig = serde_json::from_value(new_format).unwrap();
+
+        // Ensure deterministic ordering.
+        if let Some(vec) = old_format.cas.as_mut() {
+            vec.sort_by(|a, b| a.instance_name.cmp(&b.instance_name));
+        }
+        if let Some(vec) = new_format.cas.as_mut() {
+            vec.sort_by(|a, b| a.instance_name.cmp(&b.instance_name));
+        }
+
+        assert_eq!(old_format, new_format);
+    }
+
+    #[test]
+    fn test_deserialize_none() {
+        let json = json!({});
+
+        let value: FullConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(value.cas, None);
+    }
+}

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -32,6 +32,29 @@ pub type SchedulerRefName = String;
 /// Used when the config references `instance_name` in the protocol.
 pub type InstanceName = String;
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+pub struct WithInstanceName<T> {
+    #[serde(default)]
+    pub instance_name: InstanceName,
+    #[serde(flatten)]
+    pub config: T,
+}
+
+impl<T> core::ops::Deref for WithInstanceName<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct NamedConfig<Spec> {
+    pub name: String,
+    #[serde(flatten)]
+    pub spec: Spec,
+}
+
 #[derive(Deserialize, Debug, Default, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum HttpCompressionAlgorithm {
@@ -247,22 +270,38 @@ pub struct ServicesConfig {
     /// The Content Addressable Storage (CAS) backend config.
     /// The key is the `instance_name` used in the protocol and the
     /// value is the underlying CAS store config.
-    pub cas: Option<HashMap<InstanceName, CasStoreConfig>>,
+    #[serde(
+        default,
+        deserialize_with = "super::backcompat::opt_vec_with_instance_name"
+    )]
+    pub cas: Option<Vec<WithInstanceName<CasStoreConfig>>>,
 
     /// The Action Cache (AC) backend config.
     /// The key is the `instance_name` used in the protocol and the
     /// value is the underlying AC store config.
-    pub ac: Option<HashMap<InstanceName, AcStoreConfig>>,
+    #[serde(
+        default,
+        deserialize_with = "super::backcompat::opt_vec_with_instance_name"
+    )]
+    pub ac: Option<Vec<WithInstanceName<AcStoreConfig>>>,
 
     /// Capabilities service is required in order to use most of the
     /// bazel protocol. This service is used to provide the supported
     /// features and versions of this bazel GRPC service.
-    pub capabilities: Option<HashMap<InstanceName, CapabilitiesConfig>>,
+    #[serde(
+        default,
+        deserialize_with = "super::backcompat::opt_vec_with_instance_name"
+    )]
+    pub capabilities: Option<Vec<WithInstanceName<CapabilitiesConfig>>>,
 
     /// The remote execution service configuration.
     /// NOTE: This service is under development and is currently just a
     /// place holder.
-    pub execution: Option<HashMap<InstanceName, ExecutionConfig>>,
+    #[serde(
+        default,
+        deserialize_with = "super::backcompat::opt_vec_with_instance_name"
+    )]
+    pub execution: Option<Vec<WithInstanceName<ExecutionConfig>>>,
 
     /// This is the service used to stream data to and from the CAS.
     /// Bazel's protocol strongly encourages users to use this streaming
@@ -727,13 +766,6 @@ pub struct GlobalConfig {
     /// Default: 1024*1024 (1MiB)
     #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
     pub default_digest_size_health_check: usize,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct NamedConfig<Spec> {
-    pub name: String,
-    #[serde(flatten)]
-    pub spec: Spec,
 }
 
 pub type StoreConfig = NamedConfig<StoreSpec>;

--- a/nativelink-config/src/lib.rs
+++ b/nativelink-config/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod backcompat;
 pub mod cas_server;
 pub mod schedulers;
 pub mod serde_utils;

--- a/nativelink-service/src/capabilities_server.rs
+++ b/nativelink-service/src/capabilities_server.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use nativelink_config::cas_server::{CapabilitiesConfig, InstanceName};
+use nativelink_config::cas_server::{CapabilitiesConfig, InstanceName, WithInstanceName};
 use nativelink_error::{Error, ResultExt};
 use nativelink_proto::build::bazel::remote::execution::v2::capabilities_server::{
     Capabilities, CapabilitiesServer as Server,
@@ -43,13 +43,13 @@ pub struct CapabilitiesServer {
 
 impl CapabilitiesServer {
     pub async fn new(
-        config: &HashMap<InstanceName, CapabilitiesConfig>,
+        configs: &[WithInstanceName<CapabilitiesConfig>],
         scheduler_map: &HashMap<String, Arc<dyn ClientStateManager>>,
     ) -> Result<Self, Error> {
         let mut supported_node_properties_for_instance = HashMap::new();
-        for (instance_name, cfg) in config {
+        for config in configs {
             let mut properties = Vec::new();
-            if let Some(remote_execution_cfg) = &cfg.remote_execution {
+            if let Some(remote_execution_cfg) = &config.remote_execution {
                 let scheduler =
                     scheduler_map
                         .get(&remote_execution_cfg.scheduler)
@@ -61,10 +61,13 @@ impl CapabilitiesServer {
                         })?;
                 if let Some(props_provider) = scheduler.as_known_platform_property_provider() {
                     for platform_key in props_provider
-                        .get_known_properties(instance_name)
+                        .get_known_properties(&config.instance_name)
                         .await
                         .err_tip(|| {
-                            format!("Failed to get platform properties for {instance_name}")
+                            format!(
+                                "Failed to get platform properties for {}",
+                                config.instance_name
+                            )
                         })?
                     {
                         properties.push(platform_key.clone());
@@ -76,7 +79,7 @@ impl CapabilitiesServer {
                     );
                 }
             }
-            supported_node_properties_for_instance.insert(instance_name.clone(), properties);
+            supported_node_properties_for_instance.insert(config.instance_name.clone(), properties);
         }
         Ok(Self {
             supported_node_properties_for_instance,

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -16,7 +16,7 @@ use core::pin::Pin;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use maplit::hashmap;
+use nativelink_config::cas_server::WithInstanceName;
 use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
@@ -77,12 +77,13 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
 
 fn make_ac_server(store_manager: &StoreManager) -> Result<AcServer, Error> {
     AcServer::new(
-        &hashmap! {
-            "foo_instance_name".to_string() => nativelink_config::cas_server::AcStoreConfig{
+        &[WithInstanceName {
+            instance_name: "foo_instance_name".to_string(),
+            config: nativelink_config::cas_server::AcStoreConfig {
                 ac_store: "main_ac".to_string(),
                 read_only: false,
-            }
-        },
+            },
+        }],
         store_manager,
     )
 }

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -16,7 +16,7 @@ use core::pin::Pin;
 use std::sync::Arc;
 
 use futures::StreamExt;
-use maplit::hashmap;
+use nativelink_config::cas_server::WithInstanceName;
 use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
@@ -62,11 +62,12 @@ async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
 
 fn make_cas_server(store_manager: &StoreManager) -> Result<CasServer, Error> {
     CasServer::new(
-        &hashmap! {
-            "foo_instance_name".to_string() => nativelink_config::cas_server::CasStoreConfig{
+        &[WithInstanceName {
+            instance_name: "foo_instance_name".to_string(),
+            config: nativelink_config::cas_server::CasStoreConfig {
                 cas_store: "main_cas".to_string(),
-            }
-        },
+            },
+        }],
         store_manager,
     )
 }

--- a/toolchain-examples/nativelink-config.json5
+++ b/toolchain-examples/nativelink-config.json5
@@ -89,29 +89,21 @@
       }
     },
     "services": {
-      "cas": {
-        "": {
+     "cas": [{
           "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "": {
+      }],
+      "ac": [{
           "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "": {
+      }],
+      "execution": [{
           "cas_store": "WORKER_FAST_SLOW_STORE",
-          "scheduler": "MAIN_SCHEDULER",
-        }
-      },
-      "capabilities": {
-        "": {
+          "scheduler": "MAIN_SCHEDULER"
+      }],
+      "capabilities": [{
           "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
+            "scheduler": "MAIN_SCHEDULER"
           }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "": "WORKER_FAST_SLOW_STORE",

--- a/web/platform/src/content/docs/docs/config/basic-configs.mdx
+++ b/web/platform/src/content/docs/docs/config/basic-configs.mdx
@@ -129,29 +129,25 @@ memory and filesystem stores instead of S3 and Redis.
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER",
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER",
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",
@@ -305,29 +301,25 @@ memory and filesystem stores instead of S3 and Redis.
       }
     },
     "services": {
-      "cas": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-        }
-      },
-      "ac": {
-        "main": {
-          "ac_store": "AC_MAIN_STORE"
-        }
-      },
-      "execution": {
-        "main": {
-          "cas_store": "WORKER_FAST_SLOW_STORE",
+      "cas": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE"
+      }],
+      "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_MAIN_STORE"
+      }],
+      "execution": [{
+        "instance_name": "main",
+        "cas_store": "WORKER_FAST_SLOW_STORE",
+        "scheduler": "MAIN_SCHEDULER",
+      }],
+      "capabilities": [{
+        "instance_name": "main",
+        "remote_execution": {
           "scheduler": "MAIN_SCHEDULER",
         }
-      },
-      "capabilities": {
-        "main": {
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER",
-          }
-        }
-      },
+      }],
       "bytestream": {
         "cas_stores": {
           "main": "WORKER_FAST_SLOW_STORE",

--- a/web/platform/src/content/docs/docs/config/production-config.mdx
+++ b/web/platform/src/content/docs/docs/config/production-config.mdx
@@ -25,64 +25,57 @@ At the top level of the CAS Config, we've stores and servers. Each server define
 Specifically, under servers, we've two separate servers defined:
 
 ```json
-"servers": [
- {
-   "listener": {
-     "http": {
-       "socket_address": "0.0.0.0:50051"
-     }
-   },
-   "services": {
-     "cas": {
-       "main": {
-         "cas_store": "cas_STORE"
-       }
-     },
-     "ac": {
-       "main": {
-         "ac_store": "AC_STORE"
-       }
-     },
-     "capabilities": {},
-     "bytestream": {
-       "cas_stores": {
-         "main": "cas_STORE",
-         "": "cas_STORE"
-       }
-     }
-   }
- }
-]
-
+"servers": [{
+  "listener": {
+    "http": {
+      "socket_address": "0.0.0.0:50051"
+    }
+  },
+  "services": {
+    "cas": [{
+        "instance_name": "main",
+        "cas_store": "cas_STORE"
+    }],
+    "ac": [{
+        "instance_name": "main",
+        "ac_store": "AC_STORE"
+    }],
+    "capabilities": [],
+    "bytestream": {
+      "cas_stores": {
+        "main": "cas_STORE",
+        "": "cas_STORE"
+      }
+    }
+  }
+}]
 ```
 
 Let’s focus on the main server that exposes the CAS and ActionCache services.
 ```json
- {
-   "listener": {
-     "http": {
-       "socket_address": "0.0.0.0:50051"
-     }
-   },
-   "services": {
-     "cas": {
-       "main": {
-         "cas_store": "cas_STORE"
-       }
-     },
-     "ac": {
-       "main": {
-         "ac_store": "AC_STORE"
-       }
-     },
-     "capabilities": {},
+{
+  "listener": {
+    "http": {
+      "socket_address": "0.0.0.0:50051"
+    }
+  },
+  "services": {
+    "cas": [{
+      "instance_name": "main",
+      "cas_store": "cas_STORE"
+    }],
+    "ac": [{
+      "instance_name": "main",
+      "ac_store": "AC_STORE"
+    }],
+    "capabilities": [],
      "bytestream": {
        "cas_stores": {
          "main": "cas_STORE"
        }
      }
-   }
- }
+  }
+}
 ```
 
 From this definition, we see that an HTTP listener binds to port 50051 on all network interfaces on the server. You can also Configure advanced HTTP settings on the listener, such as TLS, compression, and timeouts. In our cloud, we terminate TLS in our ingress controller, so we don't define a TLS listener, but NativeLink can be Configured to terminate TLS if so desired.
@@ -91,16 +84,12 @@ This server hosts four services: CAS, ac, capabilities, and bytestream. The capa
 
 You might be wondering what the “main” object under "CAS" and “AC” services means. In this case, it indicates the instance name, which means you need to pass --remote_instance_name=main. Alternatively, you can use the following Configuration so your Bazel clients don’t have to pass the --remote_instance_name parameter:
 ```json
-     "cas": {
-       "": {
-         "cas_store": "cas_STORE"
-       }
-     },
-     "ac": {
-       "": {
-         "ac_store": "AC_STORE"
-       }
-     }
+"cas": [{
+  "cas_store": "cas_STORE"
+}],
+"ac": [{
+  "ac_store": "AC_STORE"
+}]
 ```
 
 Now let’s turn our attention to the stores section of the CAS Configuration, starting with the ActionCache.
@@ -119,18 +108,18 @@ If we look at the ac service, we see it references a store named ac_STORE. The A
 
 ```json5
 "AC_STORE": {
- "completeness_checking": {
-   "backend": {
-     "ref_store": {
-       "name": "AC_FAST_SLOW_STORE"
-     }
-   },
-   "cas_store": {
-     "ref_store": {
-       "name": "cas_STORE"
-     }
-   }
- }
+  "completeness_checking": {
+    "backend": {
+      "ref_store": {
+        "name": "AC_FAST_SLOW_STORE"
+      }
+    },
+    "cas_store": {
+      "ref_store": {
+        "name": "cas_STORE"
+      }
+    }
+  }
 }
 ```
 
@@ -297,172 +286,170 @@ Here is the final CAS Config JSON without the 99 extra shards for writing to S3.
 ## Production CAS JSON
 ```json
 {
- "stores": {
-   "AC_FAST_SLOW_STORE": {
-     "fast_slow": {
-       "fast": {
-         "size_partitioning": {
-           "size": 1000,
-           "lower_store": {
-             "memory": {
-               "eviction_policy": {
-                 "max_bytes": 100000000,
-                 "max_count": 150000
-               }
-             }
-           },
-           "upper_store": {
-             "noop": {}
-           }
-         }
-       },
-       "slow": {
-         "redis_store": {
-           "addresses": [
-             "${REDIS_STORE_URL:-redis://redis-headless:6379}"
-           ]
-         }
-       }
-     }
-   },
-   "AC_STORE": {
-     "completeness_checking": {
-       "backend": {
-         "ref_store": {
-           "name": "AC_FAST_SLOW_STORE"
-         }
-       },
-       "cas_store": {
-         "ref_store": {
-           "name": "cas_STORE"
-         }
-       }
-     }
-   },
-   "cas_FAST_SLOW_STORE": {
-     "verify": {
-       "backend": {
-         "fast_slow": {
-           "fast": {
-             "size_partitioning": {
-               "size": 64000,
-               "upper_store": {
-                 "noop": {}
-               },
-               "lower_store": {
-                 "memory": {
-                   "eviction_policy": {
-                     "max_bytes": 1000000000,
-                     "max_count": 100000
-                   }
-                 }
-               }
-             }
-           },
-           "slow": {
-             "size_partitioning": {
-               "size": 1500000,
-               "lower_store": {
-                 "redis_store": {
-                   "addresses": [
-                     "${SHARED_REDIS_URL}"
-                   ]
-                 }
-               },
-               "upper_store": {
-                 "shard": {
-                   "stores": [
-                     {
-                       "store": {
-                         "experimental_s3_store": {
-                           "region": "${NATIVE_LINK_AWS_REGION:-us-east-1}",
-                           "bucket": "${SHARED_cas_BUCKET:-not_set}",
-                           "key_prefix": "cas/0/",
-                           "retry": {
-                             "max_retries": 10,
-                             "delay": 0.3,
-                             "jitter": 0.5
-                           }
-                         }
-                       }
-                     }
-                   ]
-                 }
-               }
-             }
-           }
-         }
-       }
-     },
-     "verify_size": true,
-     "hash_verification_function": "sha256"
-   },
-   "cas_STORE": {
-     "existence_cache": {
-       "backend": {
-         "ref_store": {
-           "name": "cas_FAST_SLOW_STORE"
-         }
-       },
-       "eviction_policy": {
-         "max_count": 10000000,
-         "max_seconds": 1800
-       }
-     }
-   },
-   "BEP_STORE": {
-     "redis_store": {
-       "addresses": [
-         "${BEP_REDIS_STORE_URL:-redis://redis-headless:6379/2}"
-       ]
-     }
-   }
- },
- "servers": [
-   {
-     "listener": {
-       "http": {
-         "socket_address": "0.0.0.0:50051",
-         "compression": {
-           "send_compression_algorithm": "gzip",
-           "accepted_compression_algorithms": [
-             "gzip"
-           ]
-         },
-         "advanced_http": {
-           "experimental_http2_keep_alive_timeout": 1200
-         }
-       }
-     },
-     "services": {
-       "cas": {
-         "main": {
-           "cas_store": "cas_STORE"
-         }
-       },
-       "ac": {
-         "main": {
-           "ac_store": "AC_STORE"
-         }
-       },
-       "capabilities": {},
-       "bytestream": {
-         "cas_stores": {
-           "main": "cas_STORE"
-         }
-       }
-     }
-   },
-   {
-     "listener": {
-       "http": {
-         "socket_address": "0.0.0.0:50061"
-       }
-     },
-     "services": {
-       "health": {}
-     }
-   }
- ]
+  "stores": {
+    "AC_FAST_SLOW_STORE": {
+      "fast_slow": {
+        "fast": {
+          "size_partitioning": {
+            "size": 1000,
+            "lower_store": {
+              "memory": {
+                "eviction_policy": {
+                  "max_bytes": 100000000,
+                  "max_count": 150000
+                }
+              }
+            },
+            "upper_store": {
+              "noop": {}
+            }
+          }
+        },
+        "slow": {
+          "redis_store": {
+            "addresses": [
+              "${REDIS_STORE_URL:-redis://redis-headless:6379}"
+            ]
+          }
+        }
+      }
+    },
+    "AC_STORE": {
+      "completeness_checking": {
+        "backend": {
+          "ref_store": {
+            "name": "AC_FAST_SLOW_STORE"
+          }
+        },
+        "cas_store": {
+          "ref_store": {
+            "name": "cas_STORE"
+          }
+        }
+      }
+    },
+    "cas_FAST_SLOW_STORE": {
+      "verify": {
+        "backend": {
+          "fast_slow": {
+            "fast": {
+              "size_partitioning": {
+                "size": 64000,
+                "upper_store": {
+                  "noop": {}
+                },
+                "lower_store": {
+                  "memory": {
+                    "eviction_policy": {
+                      "max_bytes": 1000000000,
+                      "max_count": 100000
+                    }
+                  }
+                }
+              }
+            },
+            "slow": {
+              "size_partitioning": {
+                "size": 1500000,
+                "lower_store": {
+                  "redis_store": {
+                    "addresses": [
+                      "${SHARED_REDIS_URL}"
+                    ]
+                  }
+                },
+                "upper_store": {
+                  "shard": {
+                    "stores": [
+                      {
+                        "store": {
+                          "experimental_s3_store": {
+                            "region": "${NATIVE_LINK_AWS_REGION:-us-east-1}",
+                            "bucket": "${SHARED_cas_BUCKET:-not_set}",
+                            "key_prefix": "cas/0/",
+                            "retry": {
+                              "max_retries": 10,
+                              "delay": 0.3,
+                              "jitter": 0.5
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "verify_size": true,
+      "hash_verification_function": "sha256"
+    },
+    "cas_STORE": {
+      "existence_cache": {
+        "backend": {
+          "ref_store": {
+            "name": "cas_FAST_SLOW_STORE"
+          }
+        },
+        "eviction_policy": {
+          "max_count": 10000000,
+          "max_seconds": 1800
+        }
+      }
+    },
+    "BEP_STORE": {
+      "redis_store": {
+        "addresses": [
+          "${BEP_REDIS_STORE_URL:-redis://redis-headless:6379/2}"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "listener": {
+        "http": {
+          "socket_address": "0.0.0.0:50051",
+          "compression": {
+            "send_compression_algorithm": "gzip",
+            "accepted_compression_algorithms": [
+              "gzip"
+            ]
+          },
+          "advanced_http": {
+            "experimental_http2_keep_alive_timeout": 1200
+          }
+        }
+      },
+      "services": {
+        "cas": [{
+          "instance_name": "main",
+          "cas_store": "cas_STORE"
+        }],
+        "ac": [{
+          "instance_name": "main",
+          "ac_store": "AC_STORE"
+        }],
+        "capabilities": [],
+        "bytestream": {
+          "cas_stores": {
+            "main": "cas_STORE"
+          }
+        }
+      }
+    },
+    {
+      "listener": {
+        "http": {
+          "socket_address": "0.0.0.0:50061"
+        }
+      },
+      "services": {
+        "health": {}
+      }
+    }
+  ]
 }
 ```


### PR DESCRIPTION
# Description

This includes a backwards-compatibility layer to avoid breaking anything. When the old format is fully removed, this can be trivially accomplished by removing `backcompat.rs` and removing the `#[serde(deserialize_with)]` annotations from the fields.

This does not change the config for bytestream, as it is far more involved than the other fields.

Part of #1649

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1712)
<!-- Reviewable:end -->
