### PR TITLE
[Breaking] Change S3Store to a generic CloudObjectStore

### DIFF
--- a/nativelink-config/examples/README.md
+++ b/nativelink-config/examples/README.md
@@ -43,7 +43,7 @@ The value of `stores` is an array where each element defines a store. Each shoul
 ### Store Type
 
 Once the store has been named and its object exists,
-the next key to add is the type of store. The options are `filesystem`, `memory`, `compression`, `dedup`, `fast_slow`, `verify`, and `experimental_s3_store`.
+the next key to add is the type of store. The options are `filesystem`, `memory`, `compression`, `dedup`, `fast_slow`, `verify`, and `experimental_cloud_object_store`.
 
 ```json5
 {

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
@@ -23,7 +23,8 @@
                   // }
                 },
                 "slow": {
-                  "experimental_s3_store": {
+                  "experimental_cloud_object_store": {
+                    "provider": "aws",
                     "region": "eu-central-1",
                     "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
                     "key_prefix": "test-prefix-index/",
@@ -58,7 +59,8 @@
                       // }
                     },
                     "slow": {
-                      "experimental_s3_store": {
+                      "experimental_cloud_object_store": {
+                        "provider": "aws",
                         "region": "eu-central-1",
                         "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
                         "key_prefix": "test-prefix-dedup-cas/",
@@ -95,7 +97,8 @@
           // }
         },
         "slow": {
-          "experimental_s3_store": {
+          "experimental_cloud_object_store": {
+            "provider": "aws",
             "region": "eu-central-1",
             "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
             "key_prefix": "test-prefix-ac/",

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 
 use futures::stream::FuturesOrdered;
 use futures::{Future, TryStreamExt};
-use nativelink_config::stores::StoreSpec;
+use nativelink_config::stores::{ExperimentalCloudObjectSpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_util::health_utils::HealthRegistryBuilder;
 use nativelink_util::store_trait::{Store, StoreDriver};
@@ -50,7 +50,11 @@ pub fn store_factory<'a>(
     Box::pin(async move {
         let store: Arc<dyn StoreDriver> = match backend {
             StoreSpec::Memory(spec) => MemoryStore::new(spec),
-            StoreSpec::ExperimentalS3Store(spec) => S3Store::new(spec, SystemTime::now).await?,
+            StoreSpec::ExperimentalCloudObjectStore(spec) => match spec {
+                ExperimentalCloudObjectSpec::Aws(aws_config) => {
+                    S3Store::new(aws_config, SystemTime::now).await?
+                }
+            },
             StoreSpec::RedisStore(spec) => RedisStore::new(spec.clone())?,
             StoreSpec::Verify(spec) => VerifyStore::new(
                 spec,

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -52,7 +52,7 @@ use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::client::legacy::connect::HttpConnector as LegacyHttpConnector;
 use hyper_util::rt::TokioExecutor;
-use nativelink_config::stores::S3Spec;
+use nativelink_config::stores::ExperimentalAwsSpec;
 // Note: S3 store should be very careful about the error codes it returns
 // when in a retryable wrapper. Always prefer Code::Aborted or another
 // retryable code over Code::InvalidArgument or make_input_err!().
@@ -102,16 +102,19 @@ pub struct TlsClient {
 
 impl TlsClient {
     #[must_use]
-    pub fn new(spec: &S3Spec, jitter_fn: Arc<dyn Fn(Duration) -> Duration + Send + Sync>) -> Self {
+    pub fn new(
+        spec: &ExperimentalAwsSpec,
+        jitter_fn: Arc<dyn Fn(Duration) -> Duration + Send + Sync>,
+    ) -> Self {
         let connector_with_roots = HttpsConnectorBuilder::new().with_webpki_roots();
 
-        let connector_with_schemes = if spec.insecure_allow_http {
+        let connector_with_schemes = if spec.common.insecure_allow_http {
             connector_with_roots.https_or_http()
         } else {
             connector_with_roots.https_only()
         };
 
-        let connector = if spec.disable_http2 {
+        let connector = if spec.common.disable_http2 {
             connector_with_schemes.enable_http1().build()
         } else {
             connector_with_schemes.enable_http1().enable_http2().build()
@@ -124,7 +127,7 @@ impl TlsClient {
             retrier: Retrier::new(
                 Arc::new(|duration| Box::pin(sleep(duration))),
                 jitter_fn,
-                spec.retry.clone(),
+                spec.common.retry.clone(),
             ),
         }
     }
@@ -435,8 +438,8 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
-    pub async fn new(spec: &S3Spec, now_fn: NowFn) -> Result<Arc<Self>, Error> {
-        let jitter_amt = spec.retry.jitter;
+    pub async fn new(spec: &ExperimentalAwsSpec, now_fn: NowFn) -> Result<Arc<Self>, Error> {
+        let jitter_amt = spec.common.retry.jitter;
         let jitter_fn = Arc::new(move |delay: Duration| {
             if jitter_amt == 0. {
                 return delay;
@@ -476,7 +479,7 @@ where
     }
 
     pub fn new_with_client_and_jitter(
-        spec: &S3Spec,
+        spec: &ExperimentalAwsSpec,
         s3_client: Client,
         jitter_fn: Arc<dyn Fn(Duration) -> Duration + Send + Sync>,
         now_fn: NowFn,
@@ -485,17 +488,24 @@ where
             s3_client: Arc::new(s3_client),
             now_fn,
             bucket: spec.bucket.to_string(),
-            key_prefix: spec.key_prefix.as_ref().unwrap_or(&String::new()).clone(),
+            key_prefix: spec
+                .common
+                .key_prefix
+                .as_ref()
+                .unwrap_or(&String::new())
+                .clone(),
             retrier: Retrier::new(
                 Arc::new(|duration| Box::pin(sleep(duration))),
                 jitter_fn,
-                spec.retry.clone(),
+                spec.common.retry.clone(),
             ),
-            consider_expired_after_s: i64::from(spec.consider_expired_after_s),
+            consider_expired_after_s: i64::from(spec.common.consider_expired_after_s),
             max_retry_buffer_per_request: spec
+                .common
                 .max_retry_buffer_per_request
                 .unwrap_or(DEFAULT_MAX_RETRY_BUFFER_PER_REQUEST),
             multipart_max_concurrent_uploads: spec
+                .common
                 .multipart_max_concurrent_uploads
                 .map_or(DEFAULT_MULTIPART_MAX_CONCURRENT_UPLOADS, |v| v),
         }))

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -26,7 +26,7 @@ use http::header;
 use http::status::StatusCode;
 use http_body::Frame;
 use mock_instant::thread_local::MockClock;
-use nativelink_config::stores::S3Spec;
+use nativelink_config::stores::{CommonObjectSpec, ExperimentalAwsSpec};
 use nativelink_error::{Code, Error, ResultExt, make_err, make_input_err};
 use nativelink_macro::nativelink_test;
 use nativelink_store::s3_store::S3Store;
@@ -61,7 +61,7 @@ async fn simple_has_object_found() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -96,7 +96,7 @@ async fn simple_has_object_not_found() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -155,12 +155,15 @@ async fn simple_has_retries() -> Result<(), Error> {
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
 
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
-            retry: nativelink_config::stores::Retry {
-                max_retries: 1024,
-                delay: 0.,
-                jitter: 0.,
+            common: CommonObjectSpec {
+                retry: nativelink_config::stores::Retry {
+                    max_retries: 1024,
+                    delay: 0.,
+                    jitter: 0.,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             ..Default::default()
@@ -221,7 +224,7 @@ async fn simple_update_ac() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -314,7 +317,7 @@ async fn simple_get_ac() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -359,7 +362,7 @@ async fn smoke_test_get_part() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -420,12 +423,15 @@ async fn get_part_simple_retries() -> Result<(), Error> {
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
 
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
-            retry: nativelink_config::stores::Retry {
-                max_retries: 1024,
-                delay: 0.,
-                jitter: 0.,
+            common: CommonObjectSpec {
+                retry: nativelink_config::stores::Retry {
+                    max_retries: 1024,
+                    delay: 0.,
+                    jitter: 0.,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             ..Default::default()
@@ -551,7 +557,7 @@ async fn multipart_update_large_cas() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -594,7 +600,7 @@ async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -648,7 +654,7 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = Arc::new(S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -690,7 +696,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
             ..Default::default()
         },
@@ -733,9 +739,12 @@ async fn has_with_expired_result() -> Result<(), Error> {
         .build();
     let s3_client = aws_sdk_s3::Client::from_conf(test_config);
     let store = S3Store::new_with_client_and_jitter(
-        &S3Spec {
+        &ExperimentalAwsSpec {
             bucket: BUCKET_NAME.to_string(),
-            consider_expired_after_s: 2 * 24 * 60 * 60, // 2 days.
+            common: CommonObjectSpec {
+                consider_expired_after_s: 2 * 24 * 60 * 60, // 2 days.
+                ..Default::default()
+            },
             ..Default::default()
         },
         s3_client,


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.
We have made the changes to the S3Store such that it follows a generalised CloudObjectStore that can handle multiple cloud objects like GCS and Azure. This PR is a follow-up to the conversation in the following PR: https://github.com/TraceMachina/nativelink/pull/1645#pullrequestreview-2792790467

Fixes # (issue)

## Type of change
Updating the S3Store to a more generalised ObjectStore [Breaking Change]

Please delete options that aren't relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?
This runs against the standard tests, so it should be fine. 

Please also list any relevant details for your test configuration

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1720)
<!-- Reviewable:end -->
