### PR TITLE
Refactor `write_too_many_bytes_fails` test

### DIFF
--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -1026,42 +1026,30 @@ pub async fn max_decoding_message_size_test() -> Result<(), Box<dyn core::error:
     Ok(())
 }
 
-// This test validates that if we send a write request with a size larger than
-// the expected size, it will fail.
-// This is a regression test for a bug that was found in the past.
-// First, we define a constant for the expected size of the write request.
-// Then, we create a raw data string that is larger than the expected size.
-// We create a store manager and a bytestream server.
-// We kick off the write stream and create a write request with the oversized data.
-// Finally, we send the oversized payload and assert that the server errors out
-// with the expected error message.
-
 #[nativelink_test]
 async fn write_too_many_bytes_fails() -> Result<(), Box<dyn core::error::Error>> {
-    const EXPECTED_SIZE: usize = 3;
-    let raw_data = "abcd".as_bytes(); // length == 4
+    const MAX_MESSAGE_SIZE: usize = 3;
+    const DATA_SIZE: usize = 4;
 
-    let store_manager = make_store_manager().await?;
-    let bs_server = Arc::new(make_bytestream_server(store_manager.as_ref(), None).unwrap());
+    let (tx, join_handle) = make_stream_and_writer_spawn(
+        Arc::new(make_bytestream_server(make_store_manager().await?.as_ref(), None).unwrap()),
+        None,
+    );
 
-    let (tx, join_handle) =
-        make_stream_and_writer_spawn(bs_server, Some(CompressionEncoding::Gzip));
-
-    let resource_name = make_resource_name(EXPECTED_SIZE);
-    let write_request = WriteRequest {
-        resource_name,
+    tx.send(Frame::data(encode_stream_proto(&WriteRequest {
+        resource_name: make_resource_name(MAX_MESSAGE_SIZE),
         write_offset: 0,
         finish_write: true,
-        data: raw_data.into(),
-    };
+        data: vec![0u8; DATA_SIZE].into(),
+    })?))
+    .await?;
 
-    tx.send(Frame::data(encode_stream_proto(&write_request)?))
-        .await?;
     drop(tx);
 
     let err = join_handle
         .await?
         .expect_err("Expected an error for sending too many bytes");
+
     assert!(
         err.to_string().contains("Sent too much data"),
         "Got wrong error: {err:?}"


### PR DESCRIPTION
Make the test self-documenting and remove redundant logic that isn't part of what we intend to cover.

Note that this isn't just a stylistic change, as variable elision influences codegen, especially under lower optimization levels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1726)
<!-- Reviewable:end -->
