### PR TITLE
Add key_prefix and db configuration options

### DIFF
--- a/nativelink-config/examples/redis.json5
+++ b/nativelink-config/examples/redis.json5
@@ -5,14 +5,16 @@
       "redis_store": {
         "addresses": ["redis://127.0.0.1:6379/"],
         "mode": "cluster",
-        key_prefix: "my_cas_prefix:"
+        key_prefix: "my_cas_prefix:",
+        db: 1,
       }
     }, {
       "name": "AC_FAST_SLOW_STORE",
       "redis_store": {
         "addresses": ["redis://127.0.0.1:6379/"],
         "mode": "cluster",
-        key_prefix: "my_cas_prefix:"
+        key_prefix: "my_cas_prefix:",
+        db: 1,
       }
     }, {
       "name": "AC_MAIN_STORE",

--- a/nativelink-config/examples/redis.json5
+++ b/nativelink-config/examples/redis.json5
@@ -4,13 +4,15 @@
       "name": "CAS_FAST_SLOW_STORE",
       "redis_store": {
         "addresses": ["redis://127.0.0.1:6379/"],
-        "mode": "cluster"
+        "mode": "cluster",
+        key_prefix: "my_cas_prefix:"
       }
     }, {
       "name": "AC_FAST_SLOW_STORE",
       "redis_store": {
         "addresses": ["redis://127.0.0.1:6379/"],
-        "mode": "cluster"
+        "mode": "cluster",
+        key_prefix: "my_cas_prefix:"
       }
     }, {
       "name": "AC_MAIN_STORE",

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -903,6 +903,12 @@ pub struct RedisSpec {
     #[serde(deserialize_with = "convert_vec_string_with_shellexpand")]
     pub addresses: Vec<String>,
 
+    /// The Redis database number to select.
+    ///
+    /// Defaults to 0.
+    #[serde(default)]
+    pub db: u32,
+
     /// The response timeout for the Redis connection in seconds.
     ///
     /// Default: 10

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -54,7 +54,7 @@ use parking_lot::{Mutex, RwLock};
 use patricia_tree::StringPatriciaMap;
 use tokio::select;
 use tokio::time::sleep;
-use tracing::{Level, error, event, info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::cas_utils::is_zero_digest;

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -409,6 +409,122 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn test_has_with_prefix() -> Result<(), Error> {
+    let prefix = "has_pfx:";
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{prefix}{digest}");
+
+    let real_key = RedisValue::Bytes(packed_hash_hex.into());
+
+    let mocks = Arc::new(MockRedisBackend::new());
+
+    mocks
+        .expect(
+            MockCommand {
+                cmd: Str::from_static("STRLEN"),
+                subcommand: None,
+                args: vec![real_key.clone()],
+            },
+            Ok(RedisValue::Integer(2)),
+        )
+        .expect(
+            MockCommand {
+                cmd: Str::from_static("EXISTS"),
+                subcommand: None,
+                args: vec![real_key],
+            },
+            Ok(RedisValue::Integer(1)),
+        );
+
+    let store = {
+        let mut builder = Builder::default_centralized();
+        builder.set_config(RedisConfig {
+            mocks: Some(mocks),
+            ..Default::default()
+        });
+        let (client_pool, subscriber_client) = make_clients(builder);
+
+        RedisStore::new_from_builder_and_parts(
+            client_pool,
+            subscriber_client,
+            None,
+            mock_uuid_generator,
+            prefix.to_string(),
+            DEFAULT_READ_CHUNK_SIZE,
+            DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
+        )
+        .unwrap()
+    };
+
+    let result = store.has(digest).await.unwrap();
+    assert!(
+        result.is_some(),
+        "Expected has() to return Some when mock indicates existence"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_has_without_prefix() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+
+    let packed_hash_hex = format!("{digest}");
+    let real_key = RedisValue::Bytes(packed_hash_hex.into());
+
+    let mocks = Arc::new(MockRedisBackend::new());
+
+    mocks
+        .expect(
+            MockCommand {
+                cmd: Str::from_static("STRLEN"),
+                subcommand: None,
+                args: vec![real_key.clone()],
+            },
+            Ok(RedisValue::Integer(2)),
+        )
+        .expect(
+            MockCommand {
+                cmd: Str::from_static("EXISTS"),
+                subcommand: None,
+                args: vec![real_key],
+            },
+            Ok(RedisValue::Integer(1)),
+        );
+
+    let store = {
+        let mut builder = Builder::default_centralized();
+        builder.set_config(RedisConfig {
+            mocks: Some(mocks),
+            ..Default::default()
+        });
+        let (client_pool, subscriber_client) = make_clients(builder);
+
+        RedisStore::new_from_builder_and_parts(
+            client_pool,
+            subscriber_client,
+            None,
+            mock_uuid_generator,
+            String::new(),
+            DEFAULT_READ_CHUNK_SIZE,
+            DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE,
+            DEFAULT_SCAN_COUNT,
+        )
+        .unwrap()
+    };
+
+    let result = store.has(digest).await.unwrap();
+    assert!(
+        result.is_some(),
+        "Expected has() to return Some when mock indicates existence (no prefix)"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn upload_empty_data() -> Result<(), Error> {
     let data = Bytes::from_static(b"");
     let digest = ZERO_BYTE_DIGESTS[0];


### PR DESCRIPTION
# Description

This update fixes issues in RedisStore and RedisScheduler from #1585. 

Use key_prefix to add a custom prefix to all keys.
Choose a db number instead of always using 0.

Fixes # (1585)

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Configured nativelink-config/examples/redis.json5 with both key_prefix: "my_test_prefix:" and db: 1.
Started Redis locally using Docker.
Started Nativelink using bazel run //:nativelink -- $(pwd)/nativelink-config/examples/redis.json5
Used redis-cli MONITOR to watch Redis commands.
See Redis commands always using keys with my_test_prefix:.

## Checklist

- [ x ] `bazel test //...`  passes locally
 This PR contains two distinct logical commits (one for key_prefix, one for db selection) for clarity in history

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1728)
<!-- Reviewable:end -->
