### PR TITLE
Change Astro.site config for new URL

### DIFF
--- a/web/platform/astro.config.ts
+++ b/web/platform/astro.config.ts
@@ -17,7 +17,7 @@ import { starlightConfig } from "./starlight.conf";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://nativelink.com",
+  site: "https://docs.nativelink.com",
   output: "server",
   image: {
     service: passthroughImageService(),


### PR DESCRIPTION
Updates the `Astro.site` configuration value to `docs.nativelink.com`, the new home domain for the documentation site now that the main site at <https://nativelink.com> has relaunched.