### PR TITLE
[Breaking] Remove support for MacOS 13 on x86_64

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    runs-on: ubuntu-24.04
+    runs-on: xlarge-ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [large-ubuntu-22.04]
+        os: [xlarge-ubuntu-24.04]
         toolchain: [lre-cc, lre-rs]
     name: Remote / ${{ matrix.toolchain }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -74,7 +74,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
           - macos-14
           - macos-15
     name: Installation / ${{ matrix.os }}


### PR DESCRIPTION
This is slowing down CI too much. This change also increases some of the Ubuntu runner corecounts to improve CI runtime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1732)
<!-- Reviewable:end -->
