### PR TITLE
Fix formatting in configuration-intro

### DIFF
--- a/web/platform/utils/md_to_mdx.ts
+++ b/web/platform/utils/md_to_mdx.ts
@@ -299,13 +299,18 @@ function closeList(inList: boolean, processedLines: string[]): boolean {
 
 function escapeHtml(line: string): string {
   const htmlTagPattern = /^[<\s][^>]*>/g;
-  return htmlTagPattern.test(line)
-    ? line
-    : line
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/{/g, "[")
-        .replace(/}/g, "]");
+
+  if (htmlTagPattern.test(line)) {
+    return line;
+  }
+
+  let escapedLine = line.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  if (escapedLine.includes("//") || escapedLine.includes("/*")) {
+    escapedLine = escapedLine.replace(/{/g, "[").replace(/}/g, "]");
+  }
+
+  return escapedLine;
 }
 
 export async function transformMarkdownToMdx(


### PR DESCRIPTION
Restrict replacing curly brackets in the `md` to `mdx` conversion to comments in `js` codeblocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1742)
<!-- Reviewable:end -->
