### PR TITLE
More clippy lints

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,11 @@ build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 
 # Keep this in sync with the top-level Cargo.toml
+
+# rustc lints with negative (low) priority
+build --@rules_rust//:extra_rustc_flag=-Wunused
+
+# rustc denies with default priority
 build --@rules_rust//:extra_rustc_flag=-Dambiguous_glob_reexports
 build --@rules_rust//:extra_rustc_flag=-Dclashing_extern_declarations
 build --@rules_rust//:extra_rustc_flag=-Dconst_item_mutation
@@ -77,6 +82,8 @@ build --@rules_rust//:extra_rustc_flag=-Dunexpected_cfgs
 build --@rules_rust//:extra_rustc_flag=-Dunnameable_test_items
 build --@rules_rust//:extra_rustc_flag=-Dunsafe_op_in_unsafe_fn
 build --@rules_rust//:extra_rustc_flag=-Dunstable_syntax_pre_expansion
+
+# rustc warnings with default priority
 build --@rules_rust//:extra_rustc_flag=-Wkeyword_idents
 build --@rules_rust//:extra_rustc_flag=-Wlet_underscore
 build --@rules_rust//:extra_rustc_flag=-Wmacro_use_extern_crate
@@ -89,14 +96,20 @@ build --@rules_rust//:extra_rustc_flag=-Wsingle_use_lifetimes
 build --@rules_rust//:extra_rustc_flag=-Wtrivial_casts
 build --@rules_rust//:extra_rustc_flag=-Wtrivial_numeric_casts
 build --@rules_rust//:extra_rustc_flag=-Wunreachable_pub
-build --@rules_rust//:extra_rustc_flag=-Wunused
 build --@rules_rust//:extra_rustc_flag=-Wunused_import_braces
 build --@rules_rust//:extra_rustc_flag=-Wunused_lifetimes
 build --@rules_rust//:extra_rustc_flag=-Wunused_qualifications
 build --@rules_rust//:extra_rustc_flag=-Wvariant_size_differences
 
 # TODO(aaronmondal): Extend these flags until we can run with clippy::pedantic.
+
+# clippy lints with negative (low) priority
+build --@rules_rust//:clippy_flag=-Wall
+build --@rules_rust//:clippy_flag=-Wnursery
+
+# clippy denies with default priority
 build --@rules_rust//:clippy_flag=-Dclippy::alloc_instead_of_core
+build --@rules_rust//:clippy_flag=-Das_underscore
 build --@rules_rust//:clippy_flag=-Dclippy::cast_lossless
 build --@rules_rust//:clippy_flag=-Dclippy::default_trait_access
 build --@rules_rust//:clippy_flag=-Dclippy::doc_markdown
@@ -135,8 +148,28 @@ build --@rules_rust//:clippy_flag=-Dclippy::unnecessary_wraps
 build --@rules_rust//:clippy_flag=-Dclippy::unreadable_literal
 build --@rules_rust//:clippy_flag=-Dclippy::wildcard_imports
 
-build --@rules_rust//:clippy.toml=//:clippy.toml
+# clippy warnings with default priority
+build --@rules_rust//:clippy_flag=-Wdbg_macro
+build --@rules_rust//:clippy_flag=-Wdecimal_literal_representation
+build --@rules_rust//:clippy_flag=-Wexplicit_auto_deref
+build --@rules_rust//:clippy_flag=-Wmissing_enforced_import_renames
+build --@rules_rust//:clippy_flag=-Wobfuscated_if_else
+build --@rules_rust//:clippy_flag=-Wprint_stdout
+build --@rules_rust//:clippy_flag=-Wtodo
+build --@rules_rust//:clippy_flag=-Wunimplemented
+build --@rules_rust//:clippy_flag=-Wunnested_or_patterns
+build --@rules_rust//:clippy_flag=-Wuse_debug
 
+# clippy lints with positive (high) priority
+build --@rules_rust//:clippy_flag=-Wclippy::fallible_impl_from
+build --@rules_rust//:clippy_flag=-Wclippy::iter_with_drain
+build --@rules_rust//:clippy_flag=-Wclippy::option_if_let_else
+build --@rules_rust//:clippy_flag=-Wclippy::redundant_pub_crate
+build --@rules_rust//:clippy_flag=-Wclippy::significant_drop_tightening
+build --@rules_rust//:clippy_flag=-Wclippy::too_long_first_doc_paragraph
+build --@rules_rust//:clippy_flag=-Wclippy::uninhabited_references
+
+build --@rules_rust//:clippy.toml=//:clippy.toml
 test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml
 
 # This will make rustfmt and clippy only run on `bazel test`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ variant-size-differences = "warn"
 
 [workspace.lints.clippy]
 alloc-instead-of-core = "deny"
+as-underscore = "deny"
 cast-lossless = "deny"
 default-trait-access = "deny"
 doc-markdown = "deny"
@@ -166,3 +167,26 @@ unreadable-literal = "deny"
 wildcard-imports = "deny"
 
 all = { level = "warn", priority = -1 }
+dbg-macro = "warn"
+decimal-literal-representation = "warn"
+explicit-auto-deref = "warn"
+# get-unwrap = "warn" # TODO(jhpratt) uncomment this
+# missing-docs-in-private-items = "warn" # TODO(jhpratt) uncomment this
+missing-enforced-import-renames = "warn"
+nursery = { level = "warn", priority = -1 }
+obfuscated-if-else = "warn"
+print-stdout = "warn"
+todo = "warn"
+unimplemented = "warn"
+unnested-or-patterns = "warn"
+# unwrap-in-result = "warn" # TODO(jhpratt) uncomment this
+# unwrap-used = "warn" # TODO(jhpratt) uncomment this
+use-debug = "warn"
+
+fallible-impl-from = { level = "allow", priority = 1 }          # TODO(jhpratt) remove this
+iter-with-drain = { level = "allow", priority = 1 }             # TODO(jhpratt) remove this
+option-if-let-else = { level = "allow", priority = 1 }          # suggests terrible code, overrides #![warn(clippy::nursery)]
+redundant-pub-crate = { level = "allow", priority = 1 }         # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
+significant-drop-tightening = { level = "allow", priority = 1 } # TODO(jhpratt) remove this
+too-long-first-doc-paragraph = { level = "allow" }              # TODO(jhpratt) remove this
+uninhabited-references = { level = "allow", priority = 1 }      # rust-lang/rust-clippy#11984

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -665,7 +665,7 @@ pub struct CompletenessCheckingSpec {
     pub cas_store: StoreSpec,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 pub struct Lz4Config {
     /// Size of the blocks to compress.
@@ -688,7 +688,7 @@ pub struct Lz4Config {
     pub max_decode_block_size: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum CompressionAlgorithm {
     /// LZ4 compression algorithm is extremely fast for compression and
@@ -912,7 +912,7 @@ pub struct GrpcSpec {
 }
 
 /// The possible error codes that might occur on an upstream request.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ErrorCode {
     Cancelled = 1,
     Unknown = 2,

--- a/nativelink-config/tests/deserialization_test.rs
+++ b/nativelink-config/tests/deserialization_test.rs
@@ -63,8 +63,7 @@ mod duration_tests {
             // Large numbers
             (r#"{"duration": 0}"#, 0),
             (r#"{"duration": 1000}"#, 1000),
-            // u32::MAX
-            (r#"{"duration": 4294967295}"#, 4_294_967_295),
+            (r#"{"duration": 4294967295}"#, u32::MAX as usize),
         ];
 
         for (input, expected) in examples {
@@ -118,8 +117,7 @@ mod duration_tests {
     #[test]
     fn test_large_duration_numbers() {
         let examples = [
-            // u32::MAX
-            (r#"{"duration": 4294967295}"#, 4_294_967_295),
+            (r#"{"duration": 4294967295}"#, u32::MAX as usize),
             // u64::MAX - this will fail to parse as usize on 64-bit systems
             // (r#"{"duration": 18446744073709551615}"#, 18_446_744_073_709_551_615),
         ];
@@ -139,10 +137,10 @@ mod data_size_tests {
         let examples = [
             // Basic size tests
             (r#"{"data_size": "1KiB"}"#, 1024),
-            (r#"{"data_size": "1MiB"}"#, 1_048_576),
+            (r#"{"data_size": "1MiB"}"#, 0x10_0000),
             (r#"{"data_size": "1MB"}"#, 1_000_000),
             (r#"{"data_size": "1M"}"#, 1_000_000),
-            (r#"{"data_size": "1Mi"}"#, 1_048_576),
+            (r#"{"data_size": "1Mi"}"#, 0x10_0000),
             // Large sizes
             (r#"{"data_size": "9EiB"}"#, 10_376_293_541_461_622_784),
             (r#"{"data_size": 10}"#, 10),
@@ -237,7 +235,7 @@ mod optional_values_tests {
         // Test i64::MAX for optional numeric
         let input = r#"{"value": "9223372036854775807"}"#;
         let result: OptionalNumericEntity = serde_json5::from_str(input).unwrap();
-        assert_eq!(result.value, Some(9_223_372_036_854_775_807));
+        assert_eq!(result.value, Some(i64::MAX as usize));
     }
 
     #[test]

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -333,13 +333,13 @@ trait CodeExt {
 impl CodeExt for Code {
     fn into_error_kind(self) -> std::io::ErrorKind {
         match self {
-            Code::Aborted => std::io::ErrorKind::Interrupted,
-            Code::AlreadyExists => std::io::ErrorKind::AlreadyExists,
-            Code::DeadlineExceeded => std::io::ErrorKind::TimedOut,
-            Code::InvalidArgument => std::io::ErrorKind::InvalidInput,
-            Code::NotFound => std::io::ErrorKind::NotFound,
-            Code::PermissionDenied => std::io::ErrorKind::PermissionDenied,
-            Code::Unavailable => std::io::ErrorKind::ConnectionRefused,
+            Self::Aborted => std::io::ErrorKind::Interrupted,
+            Self::AlreadyExists => std::io::ErrorKind::AlreadyExists,
+            Self::DeadlineExceeded => std::io::ErrorKind::TimedOut,
+            Self::InvalidArgument => std::io::ErrorKind::InvalidInput,
+            Self::NotFound => std::io::ErrorKind::NotFound,
+            Self::PermissionDenied => std::io::ErrorKind::PermissionDenied,
+            Self::Unavailable => std::io::ErrorKind::ConnectionRefused,
             _ => std::io::ErrorKind::Other,
         }
     }

--- a/nativelink-metric-collector/src/metrics_visitors.rs
+++ b/nativelink-metric-collector/src/metrics_visitors.rs
@@ -32,10 +32,8 @@ pub enum CollectionKind {
 impl From<MetricKind> for CollectionKind {
     fn from(kind: MetricKind) -> Self {
         match kind {
-            MetricKind::Counter => CollectionKind::Counter,
-            MetricKind::Default | MetricKind::String | MetricKind::Component => {
-                CollectionKind::String
-            }
+            MetricKind::Counter => Self::Counter,
+            MetricKind::Default | MetricKind::String | MetricKind::Component => Self::String,
         }
     }
 }
@@ -49,7 +47,7 @@ enum ValueWithPrimitiveType {
 
 impl Default for ValueWithPrimitiveType {
     fn default() -> Self {
-        ValueWithPrimitiveType::U64(0)
+        Self::U64(0)
     }
 }
 
@@ -78,7 +76,7 @@ impl From<MetricDataVisitor> for CollectedMetricPrimitive {
                 CollectionKind::Counter,
             ),
         };
-        CollectedMetricPrimitive {
+        Self {
             value: Some(value),
             help: visitor.help,
             value_type: visitor.value_type.unwrap_or(derived_type),

--- a/nativelink-metric-collector/src/otel_exporter.rs
+++ b/nativelink-metric-collector/src/otel_exporter.rs
@@ -54,7 +54,7 @@ fn process_children(prefix: &mut String, meter: &Meter, children: &CollectedMetr
     }
 }
 
-fn process_primitive(prefix: &mut String, meter: &Meter, primitive: &CollectedMetricPrimitive) {
+fn process_primitive(prefix: &str, meter: &Meter, primitive: &CollectedMetricPrimitive) {
     match &primitive.value {
         Some(CollectedMetricPrimitiveValue::Counter(value)) => {
             if prefix.len() > MAX_METRIC_NAME_LENGTH {
@@ -62,7 +62,7 @@ fn process_primitive(prefix: &mut String, meter: &Meter, primitive: &CollectedMe
                 return;
             }
             let counter = meter
-                .u64_counter(prefix.clone())
+                .u64_counter(prefix.to_owned())
                 .with_description(primitive.help.clone())
                 .build();
             counter.add(*value, &[]);

--- a/nativelink-metric-collector/src/tracing_layers.rs
+++ b/nativelink-metric-collector/src/tracing_layers.rs
@@ -47,7 +47,7 @@ impl<S> MetricsCollectorLayer<S> {
     pub fn new() -> (Self, Arc<Mutex<RootMetricCollectedMetrics>>) {
         let root_collected_metrics = Arc::new(Mutex::new(RootMetricCollectedMetrics::default()));
         (
-            MetricsCollectorLayer {
+            Self {
                 spans: Mutex::new(HashMap::new()),
                 root_collected_metrics: root_collected_metrics.clone(),
                 _subscriber: PhantomData,

--- a/nativelink-metric/src/lib.rs
+++ b/nativelink-metric/src/lib.rs
@@ -72,25 +72,26 @@ pub enum MetricKind {
 impl From<u64> for MetricKind {
     fn from(value: u64) -> Self {
         match value {
-            0 | 4_u64..=u64::MAX => MetricKind::Default,
-            1 => MetricKind::Counter,
-            2 => MetricKind::String,
-            3 => MetricKind::Component,
+            0 | 4_u64..=u64::MAX => Self::Default,
+            1 => Self::Counter,
+            2 => Self::String,
+            3 => Self::Component,
         }
     }
 }
 
 impl MetricKind {
-    pub fn into_known_kind(&self, default_kind: MetricKind) -> MetricPublishKnownKindData {
-        let mut this = *self;
-        if matches!(self, MetricKind::Default) {
-            this = default_kind;
-        }
+    pub fn into_known_kind(&self, default_kind: Self) -> MetricPublishKnownKindData {
+        let this = if matches!(self, Self::Default) {
+            default_kind
+        } else {
+            *self
+        };
         match this {
-            MetricKind::Counter => MetricPublishKnownKindData::Counter(0),
-            MetricKind::String => MetricPublishKnownKindData::String(String::new()),
-            MetricKind::Component => MetricPublishKnownKindData::Component,
-            MetricKind::Default => unreachable!("Default should have been handled"),
+            Self::Counter => MetricPublishKnownKindData::Counter(0),
+            Self::String => MetricPublishKnownKindData::String(String::new()),
+            Self::Component => MetricPublishKnownKindData::Component,
+            Self::Default => unreachable!("Default should have been handled"),
         }
     }
 }
@@ -300,7 +301,7 @@ impl MetricsComponent for SystemTime {
         kind: MetricKind,
         field_metadata: MetricFieldData,
     ) -> Result<MetricPublishKnownKindData, Error> {
-        match SystemTime::now().duration_since(UNIX_EPOCH) {
+        match Self::now().duration_since(UNIX_EPOCH) {
             Ok(n) => n.as_secs().publish(kind, field_metadata),
             Err(_) => Err(Error("SystemTime before UNIX EPOCH!".to_string())),
         }

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -237,7 +237,7 @@ impl AwaitedActionSortKey {
         // This makes timestamp descending order instead of ascending.
         let timestamp = (insert_timestamp ^ u32::MAX).to_be_bytes();
 
-        AwaitedActionSortKey(u64::from_be_bytes([
+        Self(u64::from_be_bytes([
             priority[0], priority[1], priority[2], priority[3],
             timestamp[0], timestamp[1], timestamp[2], timestamp[3],
         ]))

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -105,7 +105,7 @@ fn simple_scheduler_factory(
             let task_change_notify = Arc::new(Notify::new());
             let awaited_action_db = memory_awaited_action_db_factory(
                 spec.retain_completed_for_s,
-                &task_change_notify.clone(),
+                &task_change_notify,
                 SystemTime::now,
             );
             let (action_scheduler, worker_scheduler) = SimpleScheduler::new(

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -443,7 +443,7 @@ impl SimpleScheduler {
                     }
                     // Unreachable.
                 });
-            SimpleScheduler {
+            Self {
                 matching_engine_state_manager: state_manager.clone(),
                 client_state_manager: state_manager.clone(),
                 worker_scheduler,

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -130,6 +130,7 @@ where
         Ok(awaited_action)
     }
 
+    #[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
     async fn get_awaited_action(&self) -> Result<AwaitedAction, Error> {
         let store = self
             .weak_store
@@ -481,6 +482,7 @@ where
         })
     }
 
+    #[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
     async fn try_subscribe(
         &self,
         client_operation_id: &ClientOperationId,
@@ -537,6 +539,7 @@ where
         }
     }
 
+    #[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
     async fn inner_get_awaited_action_by_id(
         &self,
         client_operation_id: &ClientOperationId,

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -100,7 +100,7 @@ pub struct Worker {
 }
 
 fn send_msg_to_worker(
-    tx: &mut UnboundedSender<UpdateForWorker>,
+    tx: &UnboundedSender<UpdateForWorker>,
     msg: update_for_worker::Update,
 ) -> Result<(), Error> {
     tx.send(UpdateForWorker { update: Some(msg) })
@@ -159,7 +159,7 @@ impl Worker {
     /// This should only be sent once and should always be the first item in the stream.
     pub fn send_initial_connection_result(&mut self) -> Result<(), Error> {
         send_msg_to_worker(
-            &mut self.tx,
+            &self.tx,
             update_for_worker::Update::ConnectionResult(ConnectionResult {
                 worker_id: self.id.clone().into(),
             }),
@@ -175,7 +175,7 @@ impl Worker {
             }
             WorkerUpdate::Disconnect => {
                 self.metrics.notify_disconnect.inc();
-                send_msg_to_worker(&mut self.tx, update_for_worker::Update::Disconnect(()))
+                send_msg_to_worker(&self.tx, update_for_worker::Update::Disconnect(()))
             }
         }
     }

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -214,6 +214,10 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         2000.into(),
     ];
     let mocks = Arc::new(MockRedisBackend::new());
+    #[expect(
+        clippy::string_lit_as_bytes,
+        reason = r#"avoids `b"foo".as_slice()`, which is hardly better"#
+    )]
     mocks
         .expect(
             MockCommand {

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -854,7 +854,7 @@ async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         let mut client3_action_listener =
             setup_action(&scheduler, action_digest, HashMap::new(), insert_timestamp3).await?;
         let (action_state, _maybe_origin_metadata) =
-            client3_action_listener.changed().await.unwrap().clone();
+            client3_action_listener.changed().await.unwrap();
         expected_action_state.client_operation_id = action_state.client_operation_id.clone();
         assert_eq!(action_state.as_ref(), &expected_action_state);
     }

--- a/nativelink-service/src/ac_server.rs
+++ b/nativelink-service/src/ac_server.rs
@@ -70,12 +70,12 @@ impl AcServer {
                 },
             );
         }
-        Ok(AcServer {
+        Ok(Self {
             stores: stores.clone(),
         })
     }
 
-    pub fn into_service(self) -> Server<AcServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/src/bep_server.rs
+++ b/nativelink-service/src/bep_server.rs
@@ -63,7 +63,7 @@ impl BepServer {
         Ok(Self { store })
     }
 
-    pub fn into_service(self) -> PublishBuildEventServer<BepServer> {
+    pub fn into_service(self) -> PublishBuildEventServer<Self> {
         PublishBuildEventServer::new(self)
     }
 

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -178,11 +178,12 @@ impl Debug for ByteStreamServer {
 
 impl ByteStreamServer {
     pub fn new(config: &ByteStreamConfig, store_manager: &StoreManager) -> Result<Self, Error> {
-        let mut persist_stream_on_disconnect_timeout =
-            Duration::from_secs(config.persist_stream_on_disconnect_timeout as u64);
-        if config.persist_stream_on_disconnect_timeout == 0 {
-            persist_stream_on_disconnect_timeout = DEFAULT_PERSIST_STREAM_ON_DISCONNECT_TIMEOUT;
-        }
+        let persist_stream_on_disconnect_timeout =
+            if config.persist_stream_on_disconnect_timeout == 0 {
+                DEFAULT_PERSIST_STREAM_ON_DISCONNECT_TIMEOUT
+            } else {
+                Duration::from_secs(config.persist_stream_on_disconnect_timeout as u64)
+            };
         Self::new_with_sleep_fn(
             config,
             store_manager,
@@ -212,7 +213,7 @@ impl ByteStreamServer {
         } else {
             config.max_decoding_message_size
         };
-        Ok(ByteStreamServer {
+        Ok(Self {
             stores,
             max_bytes_per_stream,
             max_decoding_message_size,

--- a/nativelink-service/src/capabilities_server.rs
+++ b/nativelink-service/src/capabilities_server.rs
@@ -78,12 +78,12 @@ impl CapabilitiesServer {
             }
             supported_node_properties_for_instance.insert(instance_name.clone(), properties);
         }
-        Ok(CapabilitiesServer {
+        Ok(Self {
             supported_node_properties_for_instance,
         })
     }
 
-    pub fn into_service(self) -> Server<CapabilitiesServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 }

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -60,10 +60,10 @@ impl CasServer {
             })?;
             stores.insert(instance_name.to_string(), store);
         }
-        Ok(CasServer { stores })
+        Ok(Self { stores })
     }
 
-    pub fn into_service(self) -> Server<CasServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -65,7 +65,7 @@ impl NativelinkOperationId {
         let (instance_name, name) = name
             .rsplit_once('/')
             .err_tip(|| "Expected instance_name and name to be separated by '/'")?;
-        Ok(NativelinkOperationId::new(
+        Ok(Self::new(
             instance_name.to_string(),
             OperationId::from(name),
         ))
@@ -202,7 +202,7 @@ impl ExecutionServer {
         Ok(Self { instance_infos })
     }
 
-    pub fn into_service(self) -> Server<ExecutionServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/src/fetch_server.rs
+++ b/nativelink-service/src/fetch_server.rs
@@ -33,10 +33,10 @@ pub struct FetchServer {}
 
 impl FetchServer {
     pub const fn new(_config: &FetchConfig, _store_manager: &StoreManager) -> Result<Self, Error> {
-        Ok(FetchServer {})
+        Ok(Self {})
     }
 
-    pub fn into_service(self) -> Server<FetchServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/src/push_server.rs
+++ b/nativelink-service/src/push_server.rs
@@ -31,10 +31,10 @@ pub struct PushServer {}
 
 impl PushServer {
     pub const fn new(_config: &PushConfig, _store_manager: &StoreManager) -> Result<Self, Error> {
-        Ok(PushServer {})
+        Ok(Self {})
     }
 
-    pub fn into_service(self) -> Server<PushServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -134,7 +134,7 @@ impl WorkerApiServer {
         })
     }
 
-    pub fn into_service(self) -> Server<WorkerApiServer> {
+    pub fn into_service(self) -> Server<Self> {
         Server::new(self)
     }
 

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -51,6 +51,7 @@ async fn insert_into_store<T: Message>(
     Ok(data_len.try_into().unwrap())
 }
 
+#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -50,6 +50,7 @@ use tonic::{Request, Streaming};
 const BEP_STORE_NAME: &str = "main_bep";
 
 /// Utility function to construct a [`StoreManager`]
+#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(
@@ -276,7 +277,7 @@ async fn publish_build_tool_event_stream_test() -> Result<(), Box<dyn core::erro
                     }),
                 }),
                 notification_keywords: vec!["testing".to_string()],
-                project_id: project_id.clone(),
+                project_id,
                 check_preceding_lifecycle_events_present: false,
             },
         ];

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -56,6 +56,7 @@ use tower::service_fn;
 const INSTANCE_NAME: &str = "foo_instance_name";
 const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
 
+#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(
@@ -74,7 +75,7 @@ fn make_bytestream_server(
     store_manager: &StoreManager,
     config: Option<ByteStreamConfig>,
 ) -> Result<ByteStreamServer, Error> {
-    let config = config.unwrap_or(ByteStreamConfig {
+    let config = config.unwrap_or_else(|| ByteStreamConfig {
         cas_stores: hashmap! {
             "foo_instance_name".to_string() => "main_cas".to_string(),
         },
@@ -201,7 +202,7 @@ pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn core::erro
         // might do.
         const BYTE_SPLIT_OFFSET: usize = 8;
 
-        let raw_data = "12456789abcdefghijk".as_bytes();
+        let raw_data = b"12456789abcdefghijk";
 
         let resource_name = format!(
             "{}/uploads/{}/blobs/{}/{}",
@@ -870,7 +871,7 @@ pub async fn test_query_write_status_smoke_test() -> Result<(), Box<dyn core::er
         make_bytestream_server(store_manager.as_ref(), None).expect("Failed to make server"),
     );
 
-    let raw_data = "12456789abcdefghijk".as_bytes();
+    let raw_data = b"12456789abcdefghijk";
     let resource_name = make_resource_name(raw_data.len());
 
     {

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -45,6 +45,7 @@ const HASH2: &str = "9993456789abcdef000000000000000000000000000000000123456789a
 const HASH3: &str = "7773456789abcdef000000000000000000000000000000000123456789abc777";
 const BAD_HASH: &str = "BAD_HASH";
 
+#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -60,6 +60,7 @@ fn get_digests_and_output_dirs(
 /// Given a list of output directories recursively get all digests
 /// that need to be checked and pass them into `handle_digest_infos_fn`
 /// as they are found.
+#[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
 async fn check_output_directories<'a>(
     cas_store: &Store,
     output_directories: Vec<ProtoOutputDirectory>,
@@ -117,7 +118,7 @@ pub struct CompletenessCheckingStore {
 
 impl CompletenessCheckingStore {
     pub fn new(ac_store: Store, cas_store: Store) -> Arc<Self> {
-        Arc::new(CompletenessCheckingStore {
+        Arc::new(Self {
             cas_store,
             ac_store,
             incomplete_entries_counter: CounterWithTime::default(),

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -42,7 +42,7 @@ const DEFAULT_NORM_SIZE: u64 = 256 * 1024;
 const DEFAULT_MAX_SIZE: u64 = 512 * 1024;
 const DEFAULT_MAX_CONCURRENT_FETCH_PER_GET: usize = 10;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
 pub struct DedupIndex {
     pub entries: Vec<DigestInfo>,
 }

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -230,7 +230,7 @@ impl FileEntry for FileEntryImpl {
     async fn make_and_open_file(
         block_size: u64,
         encoded_file_path: EncodedFilePath,
-    ) -> Result<(FileEntryImpl, fs::FileSlot, OsString), Error> {
+    ) -> Result<(Self, fs::FileSlot, OsString), Error> {
         let temp_full_path = encoded_file_path.get_file_path().to_os_string();
         let temp_file_result = fs::create_file(temp_full_path.clone())
             .or_else(|mut err| async {
@@ -247,7 +247,7 @@ impl FileEntry for FileEntryImpl {
             .await?;
 
         Ok((
-            <FileEntryImpl as FileEntry>::create(
+            <Self as FileEntry>::create(
                 0, /* Unknown yet, we will fill it in later */
                 block_size,
                 RwLock::new(encoded_file_path),

--- a/nativelink-store/src/gcs_client/client.rs
+++ b/nativelink-store/src/gcs_client/client.rs
@@ -563,7 +563,7 @@ impl GcsOperations for GcsClient {
                     retry_delay = core::cmp::min(retry_delay * 2, MAX_UPLOAD_RETRY_DELAY_MS);
 
                     let mut rng = rand::rng();
-                    let jitter_factor = 0.8 + (rng.random::<f64>() * 0.4);
+                    let jitter_factor = rng.random::<f64>().mul_add(0.4, 0.8);
                     retry_delay = (retry_delay as f64 * jitter_factor) as u64;
 
                     retry_count += 1;

--- a/nativelink-store/src/gcs_client/mocks.rs
+++ b/nativelink-store/src/gcs_client/mocks.rs
@@ -59,7 +59,7 @@ pub struct CallCounts {
 
 impl Clone for CallCounts {
     fn clone(&self) -> Self {
-        CallCounts {
+        Self {
             metadata_calls: AtomicUsize::new(self.metadata_calls.load(Ordering::Relaxed)),
             read_calls: AtomicUsize::new(self.read_calls.load(Ordering::Relaxed)),
             write_calls: AtomicUsize::new(self.write_calls.load(Ordering::Relaxed)),
@@ -110,7 +110,7 @@ pub enum MockRequest {
     },
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FailureMode {
     #[default]
     None,
@@ -216,7 +216,8 @@ impl MockGcsOperations {
     /// Helper method to handle failures based on current settings
     async fn handle_failure(&self) -> Result<(), Error> {
         if self.should_fail.load(Ordering::Relaxed) {
-            match *self.failure_mode.read().await {
+            let value = *self.failure_mode.read().await;
+            match value {
                 FailureMode::None => Err(make_err!(Code::Internal, "Simulated generic failure")),
                 FailureMode::NotFound => {
                     Err(make_err!(Code::NotFound, "Simulated not found error"))

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -86,7 +86,7 @@ where
             if jitter_amt == 0.0 {
                 return delay;
             }
-            delay.mul_f32(1. + jitter_amt * (rand::rng().random::<f32>() - 0.5))
+            delay.mul_f32(jitter_amt.mul_add(rand::rng().random::<f32>() - 0.5, 1.))
         });
 
         Ok(Arc::new(Self {

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -102,7 +102,7 @@ impl GrpcStore {
         }
 
         let jitter_fn = Arc::new(jitter_fn);
-        Ok(Arc::new(GrpcStore {
+        Ok(Arc::new(Self {
             instance_name: spec.instance_name.clone(),
             store_type: spec.store_type,
             retrier: Retrier::new(

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -39,7 +39,7 @@ impl MetricsComponent for NoopStore {
 
 impl NoopStore {
     pub fn new() -> Arc<Self> {
-        Arc::new(NoopStore {})
+        Arc::new(Self {})
     }
 }
 

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -853,7 +853,7 @@ struct RedisSubscriptionPublisher {
 impl RedisSubscriptionPublisher {
     fn new(
         key: String,
-        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<RedisSubscriptionPublisher>>>,
+        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<Self>>>,
     ) -> (Self, RedisSubscription) {
         let (sender, receiver) = tokio::sync::watch::channel(key);
         let publisher = Self {
@@ -868,7 +868,7 @@ impl RedisSubscriptionPublisher {
 
     fn subscribe(
         &self,
-        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<RedisSubscriptionPublisher>>>,
+        weak_subscribed_keys: Weak<RwLock<StringPatriciaMap<Self>>>,
     ) -> RedisSubscription {
         let receiver = self.sender.lock().subscribe();
         RedisSubscription {

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -49,7 +49,7 @@ pub struct RefStore {
 
 impl RefStore {
     pub fn new(spec: &RefSpec, store_manager: Weak<StoreManager>) -> Arc<Self> {
-        Arc::new(RefStore {
+        Arc::new(Self {
             name: spec.name.clone(),
             store_manager,
             inner: StoreReference {

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -444,7 +444,7 @@ where
             if jitter_amt == 0. {
                 return delay;
             }
-            delay.mul_f32(1. + jitter_amt * (rand::rng().random::<f32>() - 0.5))
+            delay.mul_f32(jitter_amt.mul_add(rand::rng().random::<f32>() - 0.5, 1.))
         });
         let s3_client = {
             let http_client = TlsClient::new(&spec.clone(), jitter_fn.clone());

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -36,7 +36,7 @@ pub struct SizePartitioningStore {
 
 impl SizePartitioningStore {
     pub fn new(spec: &SizePartitioningSpec, lower_store: Store, upper_store: Store) -> Arc<Self> {
-        Arc::new(SizePartitioningStore {
+        Arc::new(Self {
             partition_size: spec.size,
             lower_store,
             upper_store,

--- a/nativelink-store/src/store_manager.rs
+++ b/nativelink-store/src/store_manager.rs
@@ -25,8 +25,8 @@ pub struct StoreManager {
 }
 
 impl StoreManager {
-    pub fn new() -> StoreManager {
-        StoreManager {
+    pub fn new() -> Self {
+        Self {
             stores: RwLock::new(HashMap::new()),
         }
     }

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -49,7 +49,7 @@ pub struct VerifyStore {
 
 impl VerifyStore {
     pub fn new(spec: &VerifySpec, inner_store: Store) -> Arc<Self> {
-        Arc::new(VerifyStore {
+        Arc::new(Self {
             inner_store,
             verify_size: spec.verify_size,
             verify_hash: spec.verify_hash,

--- a/nativelink-store/tests/ac_utils_test.rs
+++ b/nativelink-store/tests/ac_utils_test.rs
@@ -30,7 +30,7 @@ use tokio::io::AsyncWriteExt;
 async fn make_temp_path(data: &str) -> OsString {
     let dir = format!(
         "{}/{}",
-        env::var("TEST_TMPDIR").unwrap_or(env::temp_dir().to_str().unwrap().to_string()),
+        env::var("TEST_TMPDIR").unwrap_or_else(|_| env::temp_dir().to_str().unwrap().to_string()),
         rand::rng().random::<u64>(),
     );
     fs::create_dir_all(&dir).await.unwrap();

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -77,9 +77,7 @@ async fn simple_smoke_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                nativelink_config::stores::Lz4Config::default(),
             ),
         },
         Store::new(MemoryStore::new(&MemorySpec::default())),
@@ -163,9 +161,7 @@ async fn rand_5mb_smoke_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                nativelink_config::stores::Lz4Config::default(),
             ),
         },
         Store::new(MemoryStore::new(&MemorySpec::default())),
@@ -196,9 +192,7 @@ async fn sanity_check_zero_bytes_test() -> Result<(), Error> {
         &CompressionSpec {
             backend: StoreSpec::Memory(MemorySpec::default()),
             compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
-                nativelink_config::stores::Lz4Config {
-                    ..Default::default()
-                },
+                nativelink_config::stores::Lz4Config::default(),
             ),
         },
         Store::new(inner_store.clone()),

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -283,7 +283,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
         ) -> Result<(), Error> {
             // Gets called in the slow store and we provide the data that's
             // sent to the upstream and the fast store.
-            let bytes = length.unwrap_or(key.into_digest().size_bytes()) - offset;
+            let bytes = length.unwrap_or_else(|| key.into_digest().size_bytes()) - offset;
             let data = vec![0_u8; bytes as usize];
             writer.send(Bytes::copy_from_slice(&data)).await?;
             writer.send_eof()

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -186,7 +186,7 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> Drop for TestFileEntry<Hooks
 fn make_temp_path(data: &str) -> String {
     format!(
         "{}/{}/{}",
-        env::var("TEST_TMPDIR").unwrap_or(env::temp_dir().to_str().unwrap().to_string()),
+        env::var("TEST_TMPDIR").unwrap_or_else(|_| env::temp_dir().to_str().unwrap().to_string()),
         rand::rng().random::<u64>(),
         data
     )
@@ -937,7 +937,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
             .await
             .err_tip(|| "Failed to get_part"),
     );
-    assert_eq!(results, vec!(Some(0)));
+    assert_eq!(results, vec![Some(0)]);
 
     wait_for_empty_content_file(&content_path, digest, || async move {
         tokio::task::yield_now().await;
@@ -1121,6 +1121,7 @@ async fn get_file_size_uses_block_size() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn update_with_whole_file_closes_file() -> Result<(), Error> {
+    #[expect(clippy::collection_is_never_read)] // TODO(jhpratt) investigate
     let mut permits = vec![];
     // Grab all permits to ensure only 1 permit is available.
     {

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -283,7 +283,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
             .await
             .err_tip(|| "Failed to get_part"),
     );
-    assert_eq!(results, vec!(Some(0)));
+    assert_eq!(results, vec![Some(0)]);
 
     Ok(())
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -1022,7 +1022,7 @@ async fn test_redis_fingerprint_metric() -> Result<(), Error> {
     };
 
     let root_metrics = Arc::new(RwLock::new(RootMetricsTest {
-        stores: store_manager.clone(),
+        stores: store_manager,
     }));
 
     let (layer, output_metrics) = MetricsCollectorLayer::new();

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -148,7 +148,7 @@ async fn inner_store_test() -> Result<(), Error> {
         },
         Arc::downgrade(&store_manager),
     ));
-    store_manager.add_store("ref_store_inner", ref_store_inner.clone());
+    store_manager.add_store("ref_store_inner", ref_store_inner);
 
     let ref_store_outer = Store::new(RefStore::new(
         &RefSpec {

--- a/nativelink-store/tests/s3_store_test.rs
+++ b/nativelink-store/tests/s3_store_test.rs
@@ -271,12 +271,15 @@ async fn simple_update_ac() -> Result<(), Error> {
             }
             tx.send_eof()
         })
-        .or_else(|e| {
-            // Printing error to make it easier to debug, since ordering
-            // of futures is not guaranteed.
-            eprintln!("Error updating or sending in spawn: {e:?}");
-            Err(e)
-        })
+        .or_else(
+            #[expect(clippy::use_debug)]
+            |e| {
+                // Printing error to make it easier to debug, since ordering
+                // of futures is not guaranteed.
+                eprintln!("Error updating or sending in spawn: {e:?}");
+                Err(e)
+            },
+        )
     });
 
     // Wait for all the data to be received by the s3 backend server.
@@ -634,8 +637,8 @@ async fn ensure_empty_string_in_stream_works_test() -> Result<(), Error> {
     }
 
     assert_eq!(
-        get_part_result.err_tip(|| "Expected get_part_result to pass")?,
-        "helloworld".as_bytes()
+        *get_part_result.err_tip(|| "Expected get_part_result to pass")?,
+        *b"helloworld"
     );
 
     mock_client.assert_requests_match(&[]);
@@ -706,7 +709,7 @@ async fn has_with_results_on_zero_digests() -> Result<(), Error> {
     )?;
 
     store.has_with_results(&keys, &mut results).await.unwrap();
-    assert_eq!(results, vec!(Some(0)));
+    assert_eq!(results, vec![Some(0)]);
 
     Ok(())
 }

--- a/nativelink-store/tests/shard_store_test.rs
+++ b/nativelink-store/tests/shard_store_test.rs
@@ -82,6 +82,7 @@ async fn verify_weights(
 
     for (index, (store, expected_hit)) in stores.iter().zip(expected_hits.iter()).enumerate() {
         let total_hits = store.len_for_test().await;
+        #[expect(clippy::print_stdout, reason = "improves debugging")]
         if print_results {
             println!("expected_hit: {expected_hit} - total_hits: {total_hits}");
         } else {

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -170,7 +170,7 @@ impl From<WorkerId> for String {
 
 impl From<String> for WorkerId {
     fn from(s: String) -> Self {
-        WorkerId(s)
+        Self(s)
     }
 }
 
@@ -709,7 +709,7 @@ pub struct ActionResult {
 
 impl Default for ActionResult {
     fn default() -> Self {
-        ActionResult {
+        Self {
             output_files: Vec::default(),
             output_folders: Vec::default(),
             output_directory_symlinks: Vec::default(),
@@ -809,12 +809,12 @@ impl MetricsComponent for ActionStage {
         _field_metadata: MetricFieldData,
     ) -> Result<MetricPublishKnownKindData, nativelink_metric::Error> {
         let value = match self {
-            ActionStage::Unknown => "Unknown".to_string(),
-            ActionStage::CacheCheck => "CacheCheck".to_string(),
-            ActionStage::Queued => "Queued".to_string(),
-            ActionStage::Executing => "Executing".to_string(),
-            ActionStage::Completed(_) => "Completed".to_string(),
-            ActionStage::CompletedFromCache(_) => "CompletedFromCache".to_string(),
+            Self::Unknown => "Unknown".to_string(),
+            Self::CacheCheck => "CacheCheck".to_string(),
+            Self::Queued => "Queued".to_string(),
+            Self::Executing => "Executing".to_string(),
+            Self::Completed(_) => "Completed".to_string(),
+            Self::CompletedFromCache(_) => "CompletedFromCache".to_string(),
         };
         Ok(MetricPublishKnownKindData::String(value))
     }

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -363,7 +363,7 @@ impl DropCloserReadHalf {
                     }
                 }
                 Err(e) => {
-                    return Err(e.clone()).err_tip(|| "Failed to check if next chunk is EOF")?;
+                    return Err(e).err_tip(|| "Failed to check if next chunk is EOF")?;
                 }
             }
             chunk

--- a/nativelink-util/src/common.rs
+++ b/nativelink-util/src/common.rs
@@ -55,7 +55,7 @@ impl MetricsComponent for DigestInfo {
 
 impl DigestInfo {
     pub const fn new(packed_hash: [u8; 32], size_bytes: u64) -> Self {
-        DigestInfo {
+        Self {
             size_bytes,
             packed_hash: PackedHash(packed_hash),
         }
@@ -79,14 +79,14 @@ impl DigestInfo {
                 i64::MAX
             ));
         }
-        Ok(DigestInfo {
+        Ok(Self {
             packed_hash,
             size_bytes,
         })
     }
 
-    pub const fn zero_digest() -> DigestInfo {
-        DigestInfo {
+    pub const fn zero_digest() -> Self {
+        Self {
             size_bytes: 0,
             packed_hash: PackedHash::new(),
         }
@@ -278,7 +278,7 @@ impl TryFrom<Digest> for DigestInfo {
             .size_bytes
             .try_into()
             .map_err(|_| make_input_err!("Could not convert {} into u64", digest.size_bytes))?;
-        Ok(DigestInfo {
+        Ok(Self {
             packed_hash,
             size_bytes,
         })
@@ -295,7 +295,7 @@ impl TryFrom<&Digest> for DigestInfo {
             .size_bytes
             .try_into()
             .map_err(|_| make_input_err!("Could not convert {} into u64", digest.size_bytes))?;
-        Ok(DigestInfo {
+        Ok(Self {
             packed_hash,
             size_bytes,
         })
@@ -304,7 +304,7 @@ impl TryFrom<&Digest> for DigestInfo {
 
 impl From<DigestInfo> for Digest {
     fn from(val: DigestInfo) -> Self {
-        Digest {
+        Self {
             hash: val.packed_hash.to_string(),
             size_bytes: val.size_bytes.try_into().unwrap_or_else(|e| {
                 error!("Could not convert {} into u64 - {e:?}", val.size_bytes);
@@ -318,7 +318,7 @@ impl From<DigestInfo> for Digest {
 
 impl From<&DigestInfo> for Digest {
     fn from(val: &DigestInfo) -> Self {
-        Digest {
+        Self {
             hash: val.packed_hash.to_string(),
             size_bytes: val.size_bytes.try_into().unwrap_or_else(|e| {
                 error!("Could not convert {} into u64 - {e:?}", val.size_bytes);
@@ -338,14 +338,14 @@ pub struct PackedHash([u8; 32]);
 const SIZE_OF_PACKED_HASH: usize = 32;
 impl PackedHash {
     const fn new() -> Self {
-        PackedHash([0; SIZE_OF_PACKED_HASH])
+        Self([0; SIZE_OF_PACKED_HASH])
     }
 
     fn from_hex(hash: &str) -> Result<Self, Error> {
         let mut packed_hash = [0u8; 32];
         hex::decode_to_slice(hash, &mut packed_hash)
             .map_err(|e| make_input_err!("Invalid sha256 hash: {hash} - {e:?}"))?;
-        Ok(PackedHash(packed_hash))
+        Ok(Self(packed_hash))
     }
 
     /// Converts the packed hash into a hex string.

--- a/nativelink-util/src/digest_hasher.rs
+++ b/nativelink-util/src/digest_hasher.rs
@@ -136,8 +136,8 @@ impl TryFrom<&str> for DigestHasherFunc {
 impl core::fmt::Display for DigestHasherFunc {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            DigestHasherFunc::Sha256 => write!(f, "SHA256"),
-            DigestHasherFunc::Blake3 => write!(f, "BLAKE3"),
+            Self::Sha256 => write!(f, "SHA256"),
+            Self::Blake3 => write!(f, "BLAKE3"),
         }
     }
 }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -31,7 +31,7 @@ use tracing::info;
 use crate::instant_wrapper::InstantWrapper;
 use crate::metrics_utils::{Counter, CounterWithTime};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct SerializedLRU<K> {
     pub data: Vec<(K, i32)>,
     pub anchor_time: u64,
@@ -168,7 +168,7 @@ where
     I: InstantWrapper,
 {
     pub fn new(config: &EvictionPolicy, anchor_time: I) -> Self {
-        EvictingMap {
+        Self {
             // We use unbounded because if we use the bounded version we can't call the delete
             // function on the LenEntry properly.
             state: Mutex::new(State {

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -32,7 +32,7 @@ use tracing::{error, info, warn};
 use crate::spawn_blocking;
 
 /// Default read buffer size when reading to/from disk.
-pub const DEFAULT_READ_BUFF_SIZE: usize = 16384;
+pub const DEFAULT_READ_BUFF_SIZE: usize = 0x4000;
 
 #[derive(Debug)]
 pub struct FileSlot {

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -63,7 +63,7 @@ impl HealthStatus {
     pub fn new_initializing(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Initializing {
             struct_name: component.struct_name(),
             message,
@@ -73,7 +73,7 @@ impl HealthStatus {
     pub fn new_warning(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Warning {
             struct_name: component.struct_name(),
             message,
@@ -83,7 +83,7 @@ impl HealthStatus {
     pub fn new_failed(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
-    ) -> HealthStatus {
+    ) -> Self {
         Self::Failed {
             struct_name: component.struct_name(),
             message,
@@ -151,8 +151,8 @@ impl HealthRegistryBuilder {
 
     /// Create a sub builder for a namespace.
     #[must_use]
-    pub fn sub_builder(&mut self, namespace: &str) -> HealthRegistryBuilder {
-        HealthRegistryBuilder {
+    pub fn sub_builder(&mut self, namespace: &str) -> Self {
+        Self {
             namespace: format!("{}/{}", self.namespace, namespace).into(),
             state: self.state.clone(),
         }

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -29,8 +29,8 @@ pub trait InstantWrapper: Send + Sync + Unpin + 'static {
 }
 
 impl InstantWrapper for SystemTime {
-    fn from_secs(secs: u64) -> SystemTime {
-        SystemTime::UNIX_EPOCH
+    fn from_secs(secs: u64) -> Self {
+        Self::UNIX_EPOCH
             .checked_add(Duration::from_secs(secs))
             .unwrap()
     }
@@ -40,11 +40,11 @@ impl InstantWrapper for SystemTime {
     }
 
     fn now(&self) -> SystemTime {
-        SystemTime::now()
+        Self::now()
     }
 
     fn elapsed(&self) -> Duration {
-        <SystemTime>::elapsed(self).unwrap()
+        <Self>::elapsed(self).unwrap()
     }
 
     async fn sleep(self, duration: Duration) {
@@ -68,7 +68,7 @@ impl Default for MockInstantWrapped {
 
 impl InstantWrapper for MockInstantWrapped {
     fn from_secs(_secs: u64) -> Self {
-        MockInstantWrapped(MockInstant::now())
+        Self(MockInstant::now())
     }
 
     fn unix_timestamp(&self) -> u64 {

--- a/nativelink-util/src/metrics_utils.rs
+++ b/nativelink-util/src/metrics_utils.rs
@@ -132,6 +132,10 @@ pub struct AsyncCounterWrapper {
 // is now a group with the name of the group as the field so we
 // can attach multiple values on the same group, so we need to
 // manually implement the `MetricsComponent` trait to do so.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "complexity arises from macro expansion"
+)]
 impl MetricsComponent for AsyncCounterWrapper {
     fn publish(
         &self,

--- a/nativelink-util/src/origin_context.rs
+++ b/nativelink-util/src/origin_context.rs
@@ -352,9 +352,9 @@ impl<T> ContextAwareFuture<T> {
     /// active context.
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     #[inline]
-    pub fn new_from_active(inner: Instrumented<T>) -> ContextAwareFuture<T> {
+    pub fn new_from_active(inner: Instrumented<T>) -> Self {
         if let Some(ctx) = ActiveOriginContext::get() {
-            ContextAwareFuture::new(Some(ctx), inner)
+            Self::new(Some(ctx), inner)
         } else {
             // Useful to get tracing stack trace.
             tracing::error!("OriginContext must be set");

--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -72,7 +72,7 @@ impl From<ProtoPlatform> for PlatformProperties {
 
 impl From<&PlatformProperties> for ProtoPlatform {
     fn from(val: &PlatformProperties) -> Self {
-        ProtoPlatform {
+        Self {
             properties: val
                 .properties
                 .iter()

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -50,7 +50,7 @@ where
     T: Stream<Item = Result<WriteRequest, E>> + Unpin,
     E: Into<Error>,
 {
-    pub async fn from(mut stream: T) -> Result<WriteRequestStreamWrapper<T>, Error> {
+    pub async fn from(mut stream: T) -> Result<Self, Error> {
         let first_msg = stream
             .next()
             .await
@@ -66,7 +66,7 @@ where
             })?
             .to_owned();
 
-        Ok(WriteRequestStreamWrapper {
+        Ok(Self {
             resource_info,
             bytes_received: 0,
             stream,

--- a/nativelink-util/src/resource_info.rs
+++ b/nativelink-util/src/resource_info.rs
@@ -93,7 +93,7 @@ pub struct ResourceInfo<'a> {
 }
 
 impl<'a> ResourceInfo<'a> {
-    pub fn new(resource_name: &'a str, is_upload: bool) -> Result<ResourceInfo<'a>, Error> {
+    pub fn new(resource_name: &'a str, is_upload: bool) -> Result<Self, Error> {
         // The most amount of slashes there can be to get to "(compressed-)blobs" section is 7.
         let mut rparts = resource_name.rsplitn(7, '/');
         let mut output = ResourceInfo::default();

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -28,7 +28,7 @@ struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     const fn new(base: Duration) -> Self {
-        ExponentialBackoff { current: base }
+        Self { current: base }
     }
 }
 
@@ -90,7 +90,7 @@ const fn to_error_code(code: Code) -> ErrorCode {
 
 impl Retrier {
     pub fn new(sleep_fn: SleepFn, jitter_fn: JitterFn, config: Retry) -> Self {
-        Retrier {
+        Self {
             sleep_fn,
             jitter_fn,
             config,
@@ -168,7 +168,7 @@ impl Retrier {
                         }
                         (self.sleep_fn)(
                             iter.next()
-                                .ok_or(err.append(format!("On attempt {attempt}")))?,
+                                .ok_or_else(|| err.append(format!("On attempt {attempt}")))?,
                         )
                         .await;
                     }

--- a/nativelink-util/src/shutdown_guard.rs
+++ b/nativelink-util/src/shutdown_guard.rs
@@ -29,15 +29,15 @@ pub enum Priority {
 impl From<usize> for Priority {
     fn from(value: usize) -> Self {
         match value {
-            0 => Priority::P0,
-            1 => Priority::P1,
-            _ => Priority::LeastImportant,
+            0 => Self::P0,
+            1 => Self::P1,
+            _ => Self::LeastImportant,
         }
     }
 }
 
 impl From<Priority> for usize {
-    fn from(priority: Priority) -> usize {
+    fn from(priority: Priority) -> Self {
         match priority {
             Priority::P0 => 0,
             Priority::P1 => 1,

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -60,7 +60,7 @@ pub fn set_default_digest_size_health_check(size: usize) -> Result<(), Error> {
     })
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum UploadSizeInfo {
     /// When the data transfer amount is known to be exact size, this enum should be used.
     /// The receiver store can use this to better optimize the way the data is sent or stored.
@@ -190,7 +190,7 @@ impl<'a> StoreKey<'a> {
         clippy::missing_const_for_fn,
         reason = "False positive on stable, but not on nightly"
     )]
-    pub fn borrow(&'a self) -> StoreKey<'a> {
+    pub fn borrow(&'a self) -> Self {
         match self {
             StoreKey::Str(Cow::Owned(s)) => StoreKey::Str(Cow::Borrowed(s)),
             StoreKey::Str(Cow::Borrowed(s)) => StoreKey::Str(Cow::Borrowed(s)),

--- a/nativelink-util/src/write_counter.rs
+++ b/nativelink-util/src/write_counter.rs
@@ -31,7 +31,7 @@ pin_project! {
 
 impl<T: AsyncWrite> WriteCounter<T> {
     pub const fn new(inner: T) -> Self {
-        WriteCounter {
+        Self {
             inner,
             bytes_written: 0,
             failed: false,

--- a/nativelink-util/tests/channel_body_for_tests_test.rs
+++ b/nativelink-util/tests/channel_body_for_tests_test.rs
@@ -148,6 +148,8 @@ async fn test_channel_body_cancellation() {
         let mut body = body;
         for _ in 0..2 {
             match body.frame().await {
+                #[expect(clippy::print_stdout, reason = "improves debugging")]
+                #[expect(clippy::use_debug, reason = "improves debugging")]
                 Some(Ok(frame)) => {
                     println!("Received: {:?}", frame.into_data().unwrap());
                 }

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -26,7 +26,7 @@ use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::instant_wrapper::MockInstantWrapped;
 use pretty_assertions::assert_eq;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct BytesWrapper(Bytes);
 
 impl LenEntry for BytesWrapper {
@@ -43,8 +43,8 @@ impl LenEntry for BytesWrapper {
 
 impl From<Bytes> for BytesWrapper {
     #[inline]
-    fn from(bytes: Bytes) -> BytesWrapper {
-        BytesWrapper(bytes)
+    fn from(bytes: Bytes) -> Self {
+        Self(bytes)
     }
 }
 

--- a/nativelink-util/tests/fastcdc_test.rs
+++ b/nativelink-util/tests/fastcdc_test.rs
@@ -60,7 +60,7 @@ async fn test_all_zeros() -> Result<(), std::io::Error> {
 async fn test_sekien_16k_chunks() -> Result<(), Box<dyn core::error::Error>> {
     let contents = include_bytes!("data/SekienAkashita.jpg");
     let mut cursor = Cursor::new(&contents);
-    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(8192, 16384, 32768));
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(0x2000, 0x4000, 0x8000));
 
     let mut frames = vec![];
     let mut sum_frame_len = 0;
@@ -74,7 +74,7 @@ async fn test_sekien_16k_chunks() -> Result<(), Box<dyn core::error::Error>> {
     assert_eq!(frames[1].len(), 8282);
     assert_eq!(frames[2].len(), 16303);
     assert_eq!(frames[3].len(), 18696);
-    assert_eq!(frames[4].len(), 32768);
+    assert_eq!(frames[4].len(), 0x8000);
     assert_eq!(frames[5].len(), 11052);
     assert_eq!(sum_frame_len, contents.len());
     Ok(())
@@ -89,8 +89,9 @@ async fn test_random_20mb_16k_chunks() -> Result<(), std::io::Error> {
         data
     };
     let mut cursor = Cursor::new(&data);
-    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(1024, 2048, 4096));
+    let mut frame_reader = FramedRead::new(&mut cursor, FastCDC::new(0x1000, 0x2000, 0x4000));
 
+    #[expect(clippy::collection_is_never_read, reason = "avoid empty loop")]
     let mut lens = vec![];
     for frame in get_frames(&mut frame_reader).await? {
         lens.push(frame.len());
@@ -163,11 +164,10 @@ async fn insert_garbage_check_boundaries_recover_test() -> Result<(), std::io::E
         for key in left_keys {
             let maybe_right_frame = right_frames.get(key);
             if maybe_right_frame.is_none() {
-                println!("missing {key}");
                 assert_eq!(
                     expected_missing_hashes.contains(key),
                     true,
-                    "Expected to find: {}",
+                    "Expected to find key: {}",
                     key
                 );
                 expected_missing_hashes.remove(key);

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -254,6 +254,7 @@ fn is_executable(metadata: &std::fs::Metadata, _full_path: &impl AsRef<Path>) ->
     (metadata.mode() & 0o111) != 0
 }
 
+#[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
 async fn upload_file(
     cas_store: Pin<&impl StoreLike>,
     full_path: impl AsRef<Path> + Debug,
@@ -1431,10 +1432,8 @@ impl UploadActionResults {
         action_result: &ActionResult,
         treat_infra_error_as_failure: bool,
     ) -> bool {
-        let mut did_fail = action_result.exit_code != 0;
-        if treat_infra_error_as_failure && action_result.error.is_some() {
-            did_fail = true;
-        }
+        let did_fail = action_result.exit_code != 0
+            || (treat_infra_error_as_failure && action_result.error.is_some());
         match strategy {
             UploadCacheResultsStrategy::SuccessOnly => !did_fail,
             UploadCacheResultsStrategy::Never => false,

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -26,6 +26,7 @@ use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::
 use tokio::process;
 use tracing::info;
 
+#[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
 pub async fn make_connect_worker_request<S: BuildHasher>(
     worker_id_prefix: String,
     worker_properties: &HashMap<String, WorkerProperty, S>,

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -68,7 +68,7 @@ const INSTANCE_NAME: &str = "foo";
 fn make_temp_path(data: &str) -> String {
     format!(
         "{}/{}/{}",
-        env::var("TEST_TMPDIR").unwrap_or(env::temp_dir().to_str().unwrap().to_string()),
+        env::var("TEST_TMPDIR").unwrap_or_else(|_| env::temp_dir().to_str().unwrap().to_string()),
         rand::rng().random::<u64>(),
         data
     )

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -72,14 +72,14 @@ fn make_temp_path(data: &str) -> String {
     #[cfg(target_family = "unix")]
     return format!(
         "{}/{}/{}",
-        env::var("TEST_TMPDIR").unwrap_or(env::temp_dir().to_str().unwrap().to_string()),
+        env::var("TEST_TMPDIR").unwrap_or_else(|_| env::temp_dir().to_str().unwrap().to_string()),
         rand::rng().random::<u64>(),
         data
     );
     #[cfg(target_family = "windows")]
     return format!(
         "{}\\{}\\{}",
-        env::var("TEST_TMPDIR").unwrap_or(env::temp_dir().to_str().unwrap().to_string()),
+        env::var("TEST_TMPDIR").unwrap_or_else(|_| env::temp_dir().to_str().unwrap().to_string()),
         rand::rng().random::<u64>(),
         data
     );
@@ -3052,7 +3052,7 @@ async fn unix_executable_file_test() -> Result<(), Box<dyn core::error::Error>> 
             arguments: vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("touch {FILE_1_NAME} && chmod 700 {FILE_1_NAME}").to_string(),
+                format!("touch {FILE_1_NAME} && chmod 700 {FILE_1_NAME}"),
             ],
             output_paths: vec![FILE_1_NAME.to_string()],
             working_directory: ".".to_string(),

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -94,7 +94,7 @@ impl Default for MockWorkerApiClient {
 
 impl MockWorkerApiClient {
     pub(crate) async fn expect_connect_worker(
-        &mut self,
+        &self,
         result: Result<Response<Streaming<UpdateForWorker>>, Status>,
     ) -> ConnectWorkerRequest {
         let mut rx_call_lock = self.rx_call.lock().await;
@@ -115,7 +115,7 @@ impl MockWorkerApiClient {
     }
 
     pub(crate) async fn expect_execution_response(
-        &mut self,
+        &self,
         result: Result<Response<()>, Status>,
     ) -> ExecuteResult {
         let mut rx_call_lock = self.rx_call.lock().await;


### PR DESCRIPTION
**Note**: This builds on #1745. That PR should be merged first.

# Description

Largely warnings, which indicate possible errors, future incompatibility, stylistic issues (including idioms). Warnings can be allowed as necessary. `clippy::as_underscore` is denied to ensure the type is always explicitly specified.
    
A handful of lints are temporarily commented out or allow-by-default. These will be enabled in the future.

## How Has This Been Tested?

`cargo clippy --all-features --workspace --all-targets` and `bazel test //...` both pass.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1746)
<!-- Reviewable:end -->
