### PR TITLE
Fix clippy lints after d106fe7

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -104,12 +104,35 @@ build --@rules_rust//:extra_rustc_flag=-Wvariant_size_differences
 # TODO(aaronmondal): Extend these flags until we can run with clippy::pedantic.
 
 # clippy lints with negative (low) priority
-build --@rules_rust//:clippy_flag=-Wall
-build --@rules_rust//:clippy_flag=-Wnursery
+build --@rules_rust//:clippy_flag=-Wclippy::all
+build --@rules_rust//:clippy_flag=-Wclippy::nursery
+build --@rules_rust//:clippy_flag=-Wclippy::pedantic
+
+# TODO(aaronmondal): Remove these to get to pedantic.
+build --@rules_rust//:clippy_flag=-Aclippy::cast_possible_truncation
+build --@rules_rust//:clippy_flag=-Aclippy::cast_possible_wrap
+build --@rules_rust//:clippy_flag=-Aclippy::cast_precision_loss
+build --@rules_rust//:clippy_flag=-Aclippy::cast_sign_loss
+build --@rules_rust//:clippy_flag=-Aclippy::doc_link_with_quotes
+build --@rules_rust//:clippy_flag=-Aclippy::from_iter_instead_of_collect
+build --@rules_rust//:clippy_flag=-Aclippy::if_not_else
+build --@rules_rust//:clippy_flag=-Aclippy::large_futures
+build --@rules_rust//:clippy_flag=-Aclippy::missing_errors_doc
+build --@rules_rust//:clippy_flag=-Aclippy::missing_fields_in_debug
+build --@rules_rust//:clippy_flag=-Aclippy::missing_panics_doc
+build --@rules_rust//:clippy_flag=-Aclippy::must_use_candidate
+build --@rules_rust//:clippy_flag=-Aclippy::option_option
+build --@rules_rust//:clippy_flag=-Aclippy::ref_option
+build --@rules_rust//:clippy_flag=-Aclippy::similar_names
+build --@rules_rust//:clippy_flag=-Aclippy::too_many_lines
+build --@rules_rust//:clippy_flag=-Aclippy::unnecessary_semicolon
+build --@rules_rust//:clippy_flag=-Aclippy::unused_async
+build --@rules_rust//:clippy_flag=-Aclippy::unused_self
+build --@rules_rust//:clippy_flag=-Aclippy::used_underscore_binding
 
 # clippy denies with default priority
 build --@rules_rust//:clippy_flag=-Dclippy::alloc_instead_of_core
-build --@rules_rust//:clippy_flag=-Das_underscore
+build --@rules_rust//:clippy_flag=-Dclippy::as_underscore
 build --@rules_rust//:clippy_flag=-Dclippy::cast_lossless
 build --@rules_rust//:clippy_flag=-Dclippy::default_trait_access
 build --@rules_rust//:clippy_flag=-Dclippy::doc_markdown
@@ -149,25 +172,25 @@ build --@rules_rust//:clippy_flag=-Dclippy::unreadable_literal
 build --@rules_rust//:clippy_flag=-Dclippy::wildcard_imports
 
 # clippy warnings with default priority
-build --@rules_rust//:clippy_flag=-Wdbg_macro
-build --@rules_rust//:clippy_flag=-Wdecimal_literal_representation
-build --@rules_rust//:clippy_flag=-Wexplicit_auto_deref
-build --@rules_rust//:clippy_flag=-Wmissing_enforced_import_renames
-build --@rules_rust//:clippy_flag=-Wobfuscated_if_else
-build --@rules_rust//:clippy_flag=-Wprint_stdout
-build --@rules_rust//:clippy_flag=-Wtodo
-build --@rules_rust//:clippy_flag=-Wunimplemented
-build --@rules_rust//:clippy_flag=-Wunnested_or_patterns
-build --@rules_rust//:clippy_flag=-Wuse_debug
+build --@rules_rust//:clippy_flag=-Wclippy::dbg_macro
+build --@rules_rust//:clippy_flag=-Wclippy::decimal_literal_representation
+build --@rules_rust//:clippy_flag=-Wclippy::explicit_auto_deref
+build --@rules_rust//:clippy_flag=-Wclippy::missing_enforced_import_renames
+build --@rules_rust//:clippy_flag=-Wclippy::obfuscated_if_else
+build --@rules_rust//:clippy_flag=-Wclippy::print_stdout
+build --@rules_rust//:clippy_flag=-Wclippy::todo
+build --@rules_rust//:clippy_flag=-Wclippy::unimplemented
+build --@rules_rust//:clippy_flag=-Wclippy::unnested_or_patterns
+build --@rules_rust//:clippy_flag=-Wclippy::use_debug
 
 # clippy lints with positive (high) priority
-build --@rules_rust//:clippy_flag=-Wclippy::fallible_impl_from
-build --@rules_rust//:clippy_flag=-Wclippy::iter_with_drain
-build --@rules_rust//:clippy_flag=-Wclippy::option_if_let_else
-build --@rules_rust//:clippy_flag=-Wclippy::redundant_pub_crate
-build --@rules_rust//:clippy_flag=-Wclippy::significant_drop_tightening
-build --@rules_rust//:clippy_flag=-Wclippy::too_long_first_doc_paragraph
-build --@rules_rust//:clippy_flag=-Wclippy::uninhabited_references
+build --@rules_rust//:clippy_flag=-Aclippy::fallible_impl_from # TODO(jhpratt) Flip.
+build --@rules_rust//:clippy_flag=-Aclippy::iter_with_drain # TODO(jhpratt): Flip.
+build --@rules_rust//:clippy_flag=-Aclippy::option_if_let_else # rust-lang/rust-clippy#8829, overrides ![warn(clippy::nursery)]
+build --@rules_rust//:clippy_flag=-Aclippy::redundant_pub_crate # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
+build --@rules_rust//:clippy_flag=-Aclippy::significant_drop_tightening # TODO(jhcpratt): Flip.
+build --@rules_rust//:clippy_flag=-Aclippy::too_long_first_doc_paragraph # TODO(jhcprat): Flip.
+build --@rules_rust//:clippy_flag=-Aclippy::uninhabited_references # rust-lang/rust-clippy#11984
 
 build --@rules_rust//:clippy.toml=//:clippy.toml
 test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,13 @@ unused-qualifications = "warn"
 variant-size-differences = "warn"
 
 [workspace.lints.clippy]
+
+# Global configuration
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Denies with default priority
 alloc-instead-of-core = "deny"
 as-underscore = "deny"
 cast-lossless = "deny"
@@ -166,14 +173,13 @@ unnecessary-wraps = "deny"
 unreadable-literal = "deny"
 wildcard-imports = "deny"
 
-all = { level = "warn", priority = -1 }
+# Warnings with default priority
 dbg-macro = "warn"
 decimal-literal-representation = "warn"
 explicit-auto-deref = "warn"
 # get-unwrap = "warn" # TODO(jhpratt) uncomment this
 # missing-docs-in-private-items = "warn" # TODO(jhpratt) uncomment this
 missing-enforced-import-renames = "warn"
-nursery = { level = "warn", priority = -1 }
 obfuscated-if-else = "warn"
 print-stdout = "warn"
 todo = "warn"
@@ -183,10 +189,33 @@ unnested-or-patterns = "warn"
 # unwrap-used = "warn" # TODO(jhpratt) uncomment this
 use-debug = "warn"
 
+# Overrides
 fallible-impl-from = { level = "allow", priority = 1 }          # TODO(jhpratt) remove this
 iter-with-drain = { level = "allow", priority = 1 }             # TODO(jhpratt) remove this
-option-if-let-else = { level = "allow", priority = 1 }          # suggests terrible code, overrides #![warn(clippy::nursery)]
+option-if-let-else = { level = "allow", priority = 1 }          # rust-lang/rust-clippy#8829, overrides ![warn(clippy::nursery)]
 redundant-pub-crate = { level = "allow", priority = 1 }         # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
 significant-drop-tightening = { level = "allow", priority = 1 } # TODO(jhpratt) remove this
 too-long-first-doc-paragraph = { level = "allow" }              # TODO(jhpratt) remove this
 uninhabited-references = { level = "allow", priority = 1 }      # rust-lang/rust-clippy#11984
+
+# TODO(aaronmondal): Remove these to get to pedantic.
+cast_possible_truncation = { level = "allow", priority = 1 }
+cast_possible_wrap = { level = "allow", priority = 1 }
+cast_precision_loss = { level = "allow", priority = 1 }
+cast_sign_loss = { level = "allow", priority = 1 }
+doc_link_with_quotes = { level = "allow", priority = 1 }
+from_iter_instead_of_collect = { level = "allow", priority = 1 }
+if_not_else = { level = "allow", priority = 1 }
+large_futures = { level = "allow", priority = 1 }
+missing_errors_doc = { level = "allow", priority = 1 }
+missing_fields_in_debug = { level = "allow", priority = 1 }
+missing_panics_doc = { level = "allow", priority = 1 }
+must_use_candidate = { level = "allow", priority = 1 }
+option_option = { level = "allow", priority = 1 }
+ref_option = { level = "allow", priority = 1 }
+similar_names = { level = "allow", priority = 1 }
+too_many_lines = { level = "allow", priority = 1 }
+unnecessary_semicolon = { level = "allow", priority = 1 }
+unused_async = { level = "allow", priority = 1 }
+unused_self = { level = "allow", priority = 1 }
+used_underscore_binding = { level = "allow", priority = 1 }

--- a/nativelink-proto/gen_lib_rs_tool.py
+++ b/nativelink-proto/gen_lib_rs_tool.py
@@ -41,6 +41,7 @@ _HEADER = """\
     unused_qualifications,
     clippy::alloc_instead_of_core,
     clippy::default_trait_access,
+    clippy::derive_partial_eq_without_eq,
     clippy::doc_lazy_continuation,
     clippy::doc_markdown,
     clippy::doc_overindented_list_items,

--- a/nativelink-proto/genproto/lib.rs
+++ b/nativelink-proto/genproto/lib.rs
@@ -21,6 +21,7 @@
     unused_qualifications,
     clippy::alloc_instead_of_core,
     clippy::default_trait_access,
+    clippy::derive_partial_eq_without_eq,
     clippy::doc_lazy_continuation,
     clippy::doc_markdown,
     clippy::doc_overindented_list_items,

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -604,14 +604,13 @@ where
             }
             return Ok(());
         }
-        match last_err {
-            Some(err) => Err(err),
-            None => Err(make_err!(
+        Err(last_err.unwrap_or_else(|| {
+            make_err!(
                 Code::Internal,
                 "Failed to update action after {} retries with no error set",
                 MAX_UPDATE_RETRIES,
-            )),
-        }
+            )
+        }))
     }
 
     async fn inner_add_operation(

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -287,11 +287,9 @@ impl CasServer {
         }
         // `next_page_token` will return the `{hash_str}:{size_bytes}` of the next request's first directory digest.
         // It will be an empty string when it reached the end of the directory tree.
-        let next_page_token: String = if let Some(value) = deque.front() {
-            format!("{value}")
-        } else {
-            String::new()
-        };
+        let next_page_token: String = deque
+            .front()
+            .map_or_else(String::new, |value| format!("{value}"));
 
         Ok(futures::stream::once(async {
             Ok(GetTreeResponse {

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -51,7 +51,6 @@ async fn insert_into_store<T: Message>(
     Ok(data_len.try_into().unwrap())
 }
 
-#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -50,7 +50,6 @@ use tonic::{Request, Streaming};
 const BEP_STORE_NAME: &str = "main_bep";
 
 /// Utility function to construct a [`StoreManager`]
-#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -56,7 +56,6 @@ use tower::service_fn;
 const INSTANCE_NAME: &str = "foo_instance_name";
 const HASH1: &str = "0123456789abcdef000000000000000000000000000000000123456789abcdef";
 
-#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -45,7 +45,6 @@ const HASH2: &str = "9993456789abcdef000000000000000000000000000000000123456789a
 const HASH3: &str = "7773456789abcdef000000000000000000000000000000000123456789abc777";
 const BAD_HASH: &str = "BAD_HASH";
 
-#[expect(clippy::future_not_send, reason = "not an issue for tests")]
 async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
     let store_manager = Arc::new(StoreManager::new());
     store_manager.add_store(

--- a/nativelink-store/src/default_store_factory.rs
+++ b/nativelink-store/src/default_store_factory.rs
@@ -41,7 +41,7 @@ use crate::size_partitioning_store::SizePartitioningStore;
 use crate::store_manager::StoreManager;
 use crate::verify_store::VerifyStore;
 
-type FutureMaybeStore<'a> = Box<dyn Future<Output = Result<Store, Error>> + 'a>;
+type FutureMaybeStore<'a> = Box<dyn Future<Output = Result<Store, Error>> + Send + 'a>;
 
 pub fn store_factory<'a>(
     backend: &'a StoreSpec,

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -344,14 +344,15 @@ impl StoreDriver for FastSlowStore {
                     .slow_store_downloaded_bytes
                     .fetch_add(output_buf_len, Ordering::Acquire);
 
-                let writer_fut = if let Some(range) = Self::calculate_range(
+                let writer_fut = Self::calculate_range(
                     &(bytes_received..bytes_received + output_buf_len),
                     &send_range,
-                )? {
-                    writer_pin.send(output_buf.slice(range)).right_future()
-                } else {
-                    futures::future::ready(Ok(())).left_future()
-                };
+                )?
+                .map_or_else(
+                    || futures::future::ready(Ok(())).left_future(),
+                    |range| writer_pin.send(output_buf.slice(range)).right_future(),
+                );
+
                 bytes_received += output_buf_len;
 
                 let (fast_tx_res, writer_res) = join!(fast_tx.send(output_buf), writer_fut);

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -442,11 +442,11 @@ async fn add_files_to_cache<Fe: FileEntry>(
         // folder regardless of the StoreKey type. This allows old versions of
         // nativelink file layout to be upgraded at startup time.
         // This logic can be removed once more time has passed.
-        let read_dir = if let Some(folder) = folder {
-            format!("{}/{folder}/", shared_context.content_path)
-        } else {
-            format!("{}/", shared_context.content_path)
-        };
+        let read_dir = folder.map_or_else(
+            || format!("{}/", shared_context.content_path),
+            |folder| format!("{}/{folder}/", shared_context.content_path),
+        );
+
         let (_permit, dir_handle) = fs::read_dir(read_dir)
             .await
             .err_tip(|| "Failed opening content directory for iterating in filesystem store")?

--- a/nativelink-store/src/gcs_client/mocks.rs
+++ b/nativelink-store/src/gcs_client/mocks.rs
@@ -406,10 +406,9 @@ impl GcsOperations for MockGcsOperations {
         let mut objects = self.objects.write().await;
 
         // Get or create the object
-        let mock_object = if let Some(obj) = objects.get_mut(&object_key) {
-            obj
-        } else {
-            let new_obj = MockObject {
+        let mock_object = objects
+            .entry(object_key.clone())
+            .or_insert_with(|| MockObject {
                 metadata: GcsObject {
                     name: object_path.path.clone(),
                     bucket: object_path.bucket.clone(),
@@ -421,10 +420,7 @@ impl GcsOperations for MockGcsOperations {
                     }),
                 },
                 content: Vec::new(),
-            };
-            objects.insert(object_key.clone(), new_obj);
-            objects.get_mut(&object_key).unwrap()
-        };
+            });
 
         // Handle the chunk data
         let offset_usize = offset as usize;

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -90,19 +90,13 @@ impl MetricsComponent for OperationId {
 
 impl From<&str> for OperationId {
     fn from(value: &str) -> Self {
-        match Uuid::parse_str(value) {
-            Ok(uuid) => Self::Uuid(uuid),
-            Err(_) => Self::String(value.to_string()),
-        }
+        Uuid::parse_str(value).map_or_else(|_| Self::String(value.to_string()), Self::Uuid)
     }
 }
 
 impl From<String> for OperationId {
     fn from(value: String) -> Self {
-        match Uuid::parse_str(&value) {
-            Ok(uuid) => Self::Uuid(uuid),
-            Err(_) => Self::String(value),
-        }
+        Uuid::parse_str(&value).map_or(Self::String(value), Self::Uuid)
     }
 }
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -939,16 +939,15 @@ impl RunningActionImpl {
                             maybe_all_stderr.err_tip(|| "Internal error reading from stderr of worker task")??
                         )
                     };
-                    let exit_code = if let Some(exit_code) = exit_status.code() {
+
+                    let exit_code = exit_status.code().map_or(EXIT_CODE_FOR_SIGNAL, |exit_code| {
                         if exit_code == 0 {
                             self.metrics().child_process_success_error_code.inc();
                         } else {
                             self.metrics().child_process_failure_error_code.inc();
                         }
                         exit_code
-                    } else {
-                        EXIT_CODE_FOR_SIGNAL
-                    };
+                    });
 
                     let maybe_error_override = if let Some(side_channel_file) = maybe_side_channel_file {
                         process_side_channel_file(side_channel_file.clone(), &args, requested_timeout).await

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -94,7 +94,7 @@ const DEFAULT_HEALTH_STATUS_CHECK_PATH: &str = "/status";
 
 // Note: This must be kept in sync with the documentation in
 // `OriginEventsConfig::max_event_queue_size`.
-const DEFAULT_MAX_QUEUE_EVENTS: usize = 65536;
+const DEFAULT_MAX_QUEUE_EVENTS: usize = 0x0001_0000;
 
 /// Broadcast Channel Capacity
 /// Note: The actual capacity may be greater than the provided capacity.
@@ -290,7 +290,7 @@ async fn inner_main(
                 counter: Counter::default(),
                 server_start_ts: server_start_timestamp,
             });
-            server_metrics.insert(name.clone(), connected_clients_mux.clone());
+            server_metrics.insert(name, connected_clients_mux.clone());
 
             (server_cfg, connected_clients_mux)
         })
@@ -758,7 +758,7 @@ async fn inner_main(
                 usize::try_from(value).err_tip(|| "Could not convert http2_max_send_buf_size")?,
             );
         }
-        if let Some(true) = http_config.experimental_http2_enable_connect_protocol {
+        if http_config.experimental_http2_enable_connect_protocol == Some(true) {
             http.http2().enable_connect_protocol();
         }
         if let Some(value) = http_config.experimental_http2_max_header_list_size {


### PR DESCRIPTION
The mentioned commit broke clippy for the bazel build, effectively
disabling clippy entirely. This fixes that and adjusts the lints to
prepare for clippy::pedantic.

Reenabling the lints pointed out various improperly fixed lints. This
change fixes those as well and while it keeps the `option_with_else`
lint disabled, refactors some potential occurances manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1758)
<!-- Reviewable:end -->
