### PR TITLE
Make K8s filesystem paths independent of `$HOME`

### DIFF
--- a/kubernetes/components/worker/worker.json5
+++ b/kubernetes/components/worker/worker.json5
@@ -25,8 +25,8 @@
       "fast_slow": {
         "fast": {
           "filesystem": {
-            "content_path": "~/.cache/nativelink/data-worker-test/content_path-cas",
-            "temp_path": "~/.cache/nativelink/data-worker-test/tmp_path-cas",
+            "content_path": "/tmp/nativelink/content_path-cas",
+            "temp_path": "/tmp/nativelink/tmp_path-cas",
             "eviction_policy": {
               "max_bytes": "10Gb"
             }
@@ -49,7 +49,7 @@
       "upload_action_result": {
         "ac_store": "GRPC_LOCAL_AC_STORE"
       },
-      "work_directory": "~/.cache/nativelink/work",
+      "work_directory": "/tmp/nativelink/work",
       "platform_properties": {
         "cpu_count": {
           "query_cmd": "nproc"

--- a/kubernetes/nativelink/nativelink-config.json5
+++ b/kubernetes/nativelink/nativelink-config.json5
@@ -13,8 +13,8 @@
             },
             "backend": {
               "filesystem": {
-                "content_path": "~/.cache/nativelink/content_path-cas",
-                "temp_path": "~/.cache/nativelink/tmp_path-cas",
+                "content_path": "/tmp/nativelink/data/content_path-cas",
+                "temp_path": "/tmp/nativelink/data/tmp_path-cas",
                 "eviction_policy": {
                   "max_bytes": "10Gb"
                 }
@@ -28,8 +28,8 @@
       "completeness_checking": {
         "backend": {
           "filesystem": {
-            "content_path": "~/.cache/nativelink/content_path-ac",
-            "temp_path": "~/.cache/nativelink/tmp_path-ac",
+            "content_path": "/tmp/nativelink/data/content_path-ac",
+            "temp_path": "/tmp/nativelink/data/tmp_path-ac",
             "eviction_policy": {
               "max_bytes": "500Mb"
             }


### PR DESCRIPTION
This syncs the directory locations to what we use in the Helm chart. Generally it seems more portable and efficient to skip the home directory lookup and use static `/tmp` paths instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1761)
<!-- Reviewable:end -->
