### PR TITLE
Remove python from NixOS path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -415,7 +415,6 @@
           "${binutils.bintools}/bin"
           "${pkgs.lre.clang}/bin"
           "${git}/bin"
-          "${python3}/bin"
 
           # In the lre-rs image these are copied to `/bin` by the create-worker
           # function,


### PR DESCRIPTION
This is no longer necessary as we use the `bootstrap_impl=script` flag to make `rules_python` independent of the host's Python distribution.