### PR TITLE
Simplify clippy configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -101,12 +101,39 @@ build --@rules_rust//:extra_rustc_flag=-Wunused_lifetimes
 build --@rules_rust//:extra_rustc_flag=-Wunused_qualifications
 build --@rules_rust//:extra_rustc_flag=-Wvariant_size_differences
 
-# TODO(aaronmondal): Extend these flags until we can run with clippy::pedantic.
-
-# clippy lints with negative (low) priority
+# Globbal clippy configuration
 build --@rules_rust//:clippy_flag=-Wclippy::all
 build --@rules_rust//:clippy_flag=-Wclippy::nursery
 build --@rules_rust//:clippy_flag=-Wclippy::pedantic
+
+# Restriction denies with default priority
+build --@rules_rust//:clippy_flag=-Dclippy::alloc_instead_of_core
+build --@rules_rust//:clippy_flag=-Dclippy::as_underscore
+build --@rules_rust//:clippy_flag=-Dclippy::std_instead_of_core
+
+# Restriction warnings with default priority
+build --@rules_rust//:clippy_flag=-Wclippy::dbg_macro
+build --@rules_rust//:clippy_flag=-Wclippy::decimal_literal_representation
+build --@rules_rust//:clippy_flag=-Aclippy::get_unwrap # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Aclippy::missing_docs_in_private_items # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Wclippy::print_stdout
+build --@rules_rust//:clippy_flag=-Wclippy::todo
+build --@rules_rust//:clippy_flag=-Wclippy::unimplemented
+build --@rules_rust//:clippy_flag=-Aclippy::unwrap_in_result # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Aclippy::unwrap_used # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Wclippy::use_debug
+
+# Nursery denies we want once they get out of Nursery
+build --@rules_rust//:clippy_flag=-Dclippy::missing_const_for_fn
+
+# Nursery overrides that are either buggy or we want to fix
+build --@rules_rust//:clippy_flag=-Aclippy::fallible_impl_from # TODO(jhpratt) Flip
+build --@rules_rust//:clippy_flag=-Aclippy::iter_with_drain # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Aclippy::option_if_let_else # rust-lang/rust-clippy#8829
+build --@rules_rust//:clippy_flag=-Aclippy::redundant_pub_crate # rust-lang/rust-clippy#5369
+build --@rules_rust//:clippy_flag=-Aclippy::significant_drop_tightening # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Aclippy::too_long_first_doc_paragraph # TODO(jhpratt): Flip
+build --@rules_rust//:clippy_flag=-Aclippy::uninhabited_references # rust-lang/rust-clippy#11984
 
 # TODO(aaronmondal): Remove these to get to pedantic.
 build --@rules_rust//:clippy_flag=-Aclippy::cast_possible_truncation
@@ -129,68 +156,6 @@ build --@rules_rust//:clippy_flag=-Aclippy::unnecessary_semicolon
 build --@rules_rust//:clippy_flag=-Aclippy::unused_async
 build --@rules_rust//:clippy_flag=-Aclippy::unused_self
 build --@rules_rust//:clippy_flag=-Aclippy::used_underscore_binding
-
-# clippy denies with default priority
-build --@rules_rust//:clippy_flag=-Dclippy::alloc_instead_of_core
-build --@rules_rust//:clippy_flag=-Dclippy::as_underscore
-build --@rules_rust//:clippy_flag=-Dclippy::cast_lossless
-build --@rules_rust//:clippy_flag=-Dclippy::default_trait_access
-build --@rules_rust//:clippy_flag=-Dclippy::doc_markdown
-build --@rules_rust//:clippy_flag=-Dclippy::explicit_deref_methods
-build --@rules_rust//:clippy_flag=-Dclippy::explicit_into_iter_loop
-build --@rules_rust//:clippy_flag=-Dclippy::explicit_iter_loop
-build --@rules_rust//:clippy_flag=-Dclippy::ignored_unit_patterns
-build --@rules_rust//:clippy_flag=-Dclippy::implicit_clone
-build --@rules_rust//:clippy_flag=-Dclippy::implicit_hasher
-build --@rules_rust//:clippy_flag=-Dclippy::inconsistent_struct_constructor
-build --@rules_rust//:clippy_flag=-Dclippy::inline_always
-build --@rules_rust//:clippy_flag=-Dclippy::items_after_statements
-build --@rules_rust//:clippy_flag=-Dclippy::manual_let_else
-build --@rules_rust//:clippy_flag=-Dclippy::manual_string_new
-build --@rules_rust//:clippy_flag=-Dclippy::map_unwrap_or
-build --@rules_rust//:clippy_flag=-Dclippy::match_same_arms
-build --@rules_rust//:clippy_flag=-Dclippy::match_wildcard_for_single_variants
-build --@rules_rust//:clippy_flag=-Dclippy::missing_const_for_fn
-build --@rules_rust//:clippy_flag=-Dclippy::needless_continue
-build --@rules_rust//:clippy_flag=-Dclippy::needless_pass_by_value
-build --@rules_rust//:clippy_flag=-Dclippy::needless_raw_string_hashes
-build --@rules_rust//:clippy_flag=-Dclippy::ptr_as_ptr
-build --@rules_rust//:clippy_flag=-Dclippy::range_plus_one
-build --@rules_rust//:clippy_flag=-Dclippy::redundant_closure_for_method_calls
-build --@rules_rust//:clippy_flag=-Dclippy::redundant_else
-build --@rules_rust//:clippy_flag=-Dclippy::ref_as_ptr
-build --@rules_rust//:clippy_flag=-Dclippy::return_self_not_must_use
-build --@rules_rust//:clippy_flag=-Dclippy::semicolon_if_nothing_returned
-build --@rules_rust//:clippy_flag=-Dclippy::single_match_else
-build --@rules_rust//:clippy_flag=-Dclippy::stable_sort_primitive
-build --@rules_rust//:clippy_flag=-Dclippy::std_instead_of_core
-build --@rules_rust//:clippy_flag=-Dclippy::struct_field_names
-build --@rules_rust//:clippy_flag=-Dclippy::trivially_copy_pass_by_ref
-build --@rules_rust//:clippy_flag=-Dclippy::uninlined_format_args
-build --@rules_rust//:clippy_flag=-Dclippy::unnecessary_wraps
-build --@rules_rust//:clippy_flag=-Dclippy::unreadable_literal
-build --@rules_rust//:clippy_flag=-Dclippy::wildcard_imports
-
-# clippy warnings with default priority
-build --@rules_rust//:clippy_flag=-Wclippy::dbg_macro
-build --@rules_rust//:clippy_flag=-Wclippy::decimal_literal_representation
-build --@rules_rust//:clippy_flag=-Wclippy::explicit_auto_deref
-build --@rules_rust//:clippy_flag=-Wclippy::missing_enforced_import_renames
-build --@rules_rust//:clippy_flag=-Wclippy::obfuscated_if_else
-build --@rules_rust//:clippy_flag=-Wclippy::print_stdout
-build --@rules_rust//:clippy_flag=-Wclippy::todo
-build --@rules_rust//:clippy_flag=-Wclippy::unimplemented
-build --@rules_rust//:clippy_flag=-Wclippy::unnested_or_patterns
-build --@rules_rust//:clippy_flag=-Wclippy::use_debug
-
-# clippy lints with positive (high) priority
-build --@rules_rust//:clippy_flag=-Aclippy::fallible_impl_from # TODO(jhpratt) Flip.
-build --@rules_rust//:clippy_flag=-Aclippy::iter_with_drain # TODO(jhpratt): Flip.
-build --@rules_rust//:clippy_flag=-Aclippy::option_if_let_else # rust-lang/rust-clippy#8829, overrides ![warn(clippy::nursery)]
-build --@rules_rust//:clippy_flag=-Aclippy::redundant_pub_crate # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
-build --@rules_rust//:clippy_flag=-Aclippy::significant_drop_tightening # TODO(jhcpratt): Flip.
-build --@rules_rust//:clippy_flag=-Aclippy::too_long_first_doc_paragraph # TODO(jhcprat): Flip.
-build --@rules_rust//:clippy_flag=-Aclippy::uninhabited_references # rust-lang/rust-clippy#11984
 
 build --@rules_rust//:clippy.toml=//:clippy.toml
 test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,70 +132,33 @@ all = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
-# Denies with default priority
+# Restriction Denies with default priority
 alloc-instead-of-core = "deny"
 as-underscore = "deny"
-cast-lossless = "deny"
-default-trait-access = "deny"
-doc-markdown = "deny"
-explicit-deref-methods = "deny"
-explicit-into-iter-loop = "deny"
-explicit-iter-loop = "deny"
-ignored-unit-patterns = "deny"
-implicit-clone = "deny"
-implicit-hasher = "deny"
-inconsistent-struct-constructor = "deny"
-inline-always = "deny"
-items-after-statements = "deny"
-manual-let-else = "deny"
-manual-string-new = "deny"
-map-unwrap-or = "deny"
-match-same-arms = "deny"
-match-wildcard-for-single-variants = "deny"
-missing-const-for-fn = "deny"
-needless-continue = "deny"
-needless-pass-by-value = "deny"
-needless-raw-string-hashes = "deny"
-ptr-as-ptr = "deny"
-range-plus-one = "deny"
-redundant-closure-for-method-calls = "deny"
-redundant-else = "deny"
-ref-as-ptr = "deny"
-return-self-not-must-use = "deny"
-semicolon-if-nothing-returned = "deny"
-single-match-else = "deny"
-stable-sort-primitive = "deny"
 std-instead-of-core = "deny"
-struct-field-names = "deny"
-trivially-copy-pass-by-ref = "deny"
-uninlined-format-args = "deny"
-unnecessary-wraps = "deny"
-unreadable-literal = "deny"
-wildcard-imports = "deny"
 
-# Warnings with default priority
+# Restriction Warnings with default priority
 dbg-macro = "warn"
 decimal-literal-representation = "warn"
-explicit-auto-deref = "warn"
-# get-unwrap = "warn" # TODO(jhpratt) uncomment this
-# missing-docs-in-private-items = "warn" # TODO(jhpratt) uncomment this
-missing-enforced-import-renames = "warn"
-obfuscated-if-else = "warn"
+get-unwrap = "allow"                    # TODO(jhpratt) Flip
+missing-docs-in-private-items = "allow" # TODO(jhpratt) Flip
 print-stdout = "warn"
 todo = "warn"
 unimplemented = "warn"
-unnested-or-patterns = "warn"
-# unwrap-in-result = "warn" # TODO(jhpratt) uncomment this
-# unwrap-used = "warn" # TODO(jhpratt) uncomment this
+unwrap-in-result = "allow"              # TODO(jhpratt) Flip
+unwrap-used = "allow"                   # TODO(jhpratt) Flip
 use-debug = "warn"
 
-# Overrides
-fallible-impl-from = { level = "allow", priority = 1 }          # TODO(jhpratt) remove this
-iter-with-drain = { level = "allow", priority = 1 }             # TODO(jhpratt) remove this
-option-if-let-else = { level = "allow", priority = 1 }          # rust-lang/rust-clippy#8829, overrides ![warn(clippy::nursery)]
-redundant-pub-crate = { level = "allow", priority = 1 }         # rust-lang/rust-clippy#5369, overrides #![warn(clippy::nursery)]
-significant-drop-tightening = { level = "allow", priority = 1 } # TODO(jhpratt) remove this
-too-long-first-doc-paragraph = { level = "allow" }              # TODO(jhpratt) remove this
+# Nursery denies we want once they get out of Nursery
+missing-const-for-fn = "deny"
+
+# Nursery overrides that are either buggy or we want to fix
+fallible-impl-from = { level = "allow", priority = 1 }          # TODO(jhpratt) Flip
+iter-with-drain = { level = "allow", priority = 1 }             # TODO(jhpratt) Flip
+option-if-let-else = { level = "allow", priority = 1 }          # rust-lang/rust-clippy#8829
+redundant-pub-crate = { level = "allow", priority = 1 }         # rust-lang/rust-clippy#5369
+significant-drop-tightening = { level = "allow", priority = 1 } # TODO(jhpratt) Flip
+too-long-first-doc-paragraph = { level = "allow" }              # TODO(jhpratt) Flip
 uninhabited-references = { level = "allow", priority = 1 }      # rust-lang/rust-clippy#11984
 
 # TODO(aaronmondal): Remove these to get to pedantic.


### PR DESCRIPTION
We had a bunch of unnecessarily enabled lints that were already in the style or pedantic sets. This change removes all of them and makes it easier to see which lints are intentionally pulled from the restriction set and which ones from the nursery set we handle specially.

In terms of strictness this change is a no-op, but aside from the readibility improvements this is actually a network I/O improvement when using remote execution due to the shortened command lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1764)
<!-- Reviewable:end -->
