### PR TITLE
Fix clippy::doc_link_with_quotes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -140,7 +140,6 @@ build --@rules_rust//:clippy_flag=-Aclippy::cast_possible_truncation
 build --@rules_rust//:clippy_flag=-Aclippy::cast_possible_wrap
 build --@rules_rust//:clippy_flag=-Aclippy::cast_precision_loss
 build --@rules_rust//:clippy_flag=-Aclippy::cast_sign_loss
-build --@rules_rust//:clippy_flag=-Aclippy::doc_link_with_quotes
 build --@rules_rust//:clippy_flag=-Aclippy::from_iter_instead_of_collect
 build --@rules_rust//:clippy_flag=-Aclippy::if_not_else
 build --@rules_rust//:clippy_flag=-Aclippy::large_futures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,6 @@ cast_possible_truncation = { level = "allow", priority = 1 }
 cast_possible_wrap = { level = "allow", priority = 1 }
 cast_precision_loss = { level = "allow", priority = 1 }
 cast_sign_loss = { level = "allow", priority = 1 }
-doc_link_with_quotes = { level = "allow", priority = 1 }
 from_iter_instead_of_collect = { level = "allow", priority = 1 }
 if_not_else = { level = "allow", priority = 1 }
 large_futures = { level = "allow", priority = 1 }

--- a/nativelink-proto/gen_lib_rs_tool.py
+++ b/nativelink-proto/gen_lib_rs_tool.py
@@ -43,6 +43,7 @@ _HEADER = """\
     clippy::default_trait_access,
     clippy::derive_partial_eq_without_eq,
     clippy::doc_lazy_continuation,
+    clippy::doc_link_with_quotes,
     clippy::doc_markdown,
     clippy::doc_overindented_list_items,
     clippy::large_enum_variant,

--- a/nativelink-proto/genproto/lib.rs
+++ b/nativelink-proto/genproto/lib.rs
@@ -23,6 +23,7 @@
     clippy::default_trait_access,
     clippy::derive_partial_eq_without_eq,
     clippy::doc_lazy_continuation,
+    clippy::doc_link_with_quotes,
     clippy::doc_markdown,
     clippy::doc_overindented_list_items,
     clippy::large_enum_variant,


### PR DESCRIPTION
Turns out this was already fine and just needed to be added as exclude to the generated proto files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1767)
<!-- Reviewable:end -->
