### PR TITLE
Fix integer overflow in compression_store.rs data retrieval logic

### DIFF
--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -521,8 +521,9 @@ impl StoreDriver for CompressionStore {
                         uncompressed_data_sz + uncompressed_chunk_sz as u64;
                     if new_uncompressed_data_sz >= offset && remaining_bytes_to_send > 0 {
                         let start_pos = offset.saturating_sub(uncompressed_data_sz) as usize;
+                        // Use saturating_add to prevent overflow when remaining_bytes_to_send is very large
                         let end_pos = cmp::min(
-                            start_pos + remaining_bytes_to_send as usize,
+                            start_pos.saturating_add(remaining_bytes_to_send as usize),
                             uncompressed_chunk_sz,
                         );
                         if end_pos != start_pos {


### PR DESCRIPTION
## Issue
`nativelink-store/src/compression_store.rs` had an integer overflow issue during data retrieval. On line 526, the code was calculating an end position by adding `start_pos + remaining_bytes_to_send as usize`, which could overflow when `remaining_bytes_to_send` was very large. When this overflow occurred, it would cause `end_pos` to wrap around to a smaller value, potentially making it smaller than `start_pos` in the slice operation, triggering an "attempt to add with overflow" panic.

## Fix
Changed the standard addition operation to use Rust's saturating addition:
```rust
// Before
let end_pos = start_pos + remaining_bytes_to_send as usize;

// After
let end_pos = start_pos.saturating_add(remaining_bytes_to_send as usize);
```

This prevents integer overflow by capping the result at the maximum possible value for the type instead of wrapping around.

## Testing
All tests now pass, including the previously failing regression test that demonstrated this issue.

## Related Issues
Fixes #1566
