### PR TITLE
Add support for native root certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3716,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -3944,6 +3945,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "socket2",
  "tokio",
  "tokio-rustls",

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -858,16 +858,28 @@ pub enum StoreType {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ClientTlsConfig {
     /// Path to the certificate authority to use to validate the remote.
-    #[serde(deserialize_with = "convert_string_with_shellexpand")]
-    pub ca_file: String,
+    ///
+    /// Default: None
+    #[serde(default, deserialize_with = "convert_optional_string_with_shellexpand")]
+    pub ca_file: Option<String>,
 
     /// Path to the certificate file for client authentication.
-    #[serde(deserialize_with = "convert_optional_string_with_shellexpand")]
+    ///
+    /// Default: None
+    #[serde(default, deserialize_with = "convert_optional_string_with_shellexpand")]
     pub cert_file: Option<String>,
 
     /// Path to the private key file for client authentication.
-    #[serde(deserialize_with = "convert_optional_string_with_shellexpand")]
+    ///
+    /// Default: None
+    #[serde(default, deserialize_with = "convert_optional_string_with_shellexpand")]
     pub key_file: Option<String>,
+
+    /// If set the client will use the native roots for TLS connections.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub use_native_roots: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -100,6 +100,7 @@ rust_test_suite(
         "tests/proto_stream_utils_test.rs",
         "tests/resource_info_test.rs",
         "tests/retry_test.rs",
+        "tests/tls_utils_test.rs",
     ],
     compile_data = [
         "tests/data/SekienAkashita.jpg",
@@ -124,6 +125,7 @@ rust_test_suite(
         "@crates//:rand",
         "@crates//:serde_json",
         "@crates//:sha2",
+        "@crates//:tempfile",
         "@crates//:tokio",
         "@crates//:tokio-stream",
         "@crates//:tokio-util",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -51,6 +51,7 @@ rand = { version = "0.9.0", default-features = false, features = [
 rlimit = { version = "0.10.2", default-features = false }
 serde = { version = "1.0.219", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
+tempfile = { version = "3.20.0", default-features = false }
 tokio = { version = "1.44.1", features = [
   "fs",
   "io-util",
@@ -62,6 +63,7 @@ tokio-stream = { version = "0.1.17", features = [
 ], default-features = false }
 tokio-util = { version = "0.7.14" }
 tonic = { version = "0.13.0", features = [
+  "tls-native-roots",
   "tls-ring",
   "transport",
 ], default-features = false }

--- a/nativelink-util/src/tls_utils.rs
+++ b/nativelink-util/src/tls_utils.rs
@@ -15,6 +15,7 @@
 use nativelink_config::stores::{ClientTlsConfig, GrpcEndpoint};
 use nativelink_error::{Code, Error, make_err, make_input_err};
 use tonic::transport::Uri;
+use tracing::warn;
 
 pub fn load_client_config(
     config: &Option<ClientTlsConfig>,
@@ -23,8 +24,24 @@ pub fn load_client_config(
         return Ok(None);
     };
 
+    if config.use_native_roots == Some(true) {
+        if config.ca_file.is_some() {
+            warn!("Native root certificates are being used, all certificate files will be ignored");
+        }
+        return Ok(Some(
+            tonic::transport::ClientTlsConfig::new().with_native_roots(),
+        ));
+    }
+
+    let Some(ca_file) = &config.ca_file else {
+        return Err(make_err!(
+            Code::Internal,
+            "CA certificate must be provided if not using native root certificates"
+        ));
+    };
+
     let read_config = tonic::transport::ClientTlsConfig::new().ca_certificate(
-        tonic::transport::Certificate::from_pem(std::fs::read_to_string(&config.ca_file)?),
+        tonic::transport::Certificate::from_pem(std::fs::read_to_string(ca_file)?),
     );
     let config = if let Some(client_certificate) = &config.cert_file {
         let Some(client_key) = &config.key_file else {
@@ -93,6 +110,11 @@ pub fn endpoint_from(
             .tls_config(tls_config)
             .map_err(|e| make_input_err!("Setting mTLS configuration: {e:?}"))?
     } else {
+        if endpoint.scheme_str() == Some("https") {
+            return Err(make_input_err!(
+                "The scheme of {endpoint} is https or grpcs, but no TLS configuration was provided"
+            ));
+        }
         tonic::transport::Endpoint::from(endpoint)
     };
 

--- a/nativelink-util/tests/tls_utils_test.rs
+++ b/nativelink-util/tests/tls_utils_test.rs
@@ -1,0 +1,187 @@
+// Copyright 2025 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nativelink_config::stores::ClientTlsConfig;
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_util::tls_utils::{endpoint_from, load_client_config};
+use tempfile::NamedTempFile;
+
+#[nativelink_test]
+async fn test_load_client_config_none() -> Result<(), Error> {
+    let config = load_client_config(&None)?;
+    assert!(config.is_none());
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_load_client_config_native_roots() -> Result<(), Error> {
+    let config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: Some(true),
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }))?;
+    assert!(config.is_some());
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_load_client_config_missing_ca() -> Result<(), Error> {
+    let result = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: None,
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }));
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("CA certificate must be provided")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_load_client_config_cert_without_key() -> Result<(), Error> {
+    let temp_file = NamedTempFile::new()?;
+    let result = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: None,
+        ca_file: Some(temp_file.path().to_str().unwrap().to_string()),
+        cert_file: Some("tls.crt".to_string()),
+        key_file: None,
+    }));
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("Client certificate specified, but no key")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_load_client_config_key_without_cert() -> Result<(), Error> {
+    let temp_file = NamedTempFile::new()?;
+    let result = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: None,
+        ca_file: Some(temp_file.path().to_str().unwrap().to_string()),
+        cert_file: None,
+        key_file: Some("tls.key".to_string()),
+    }));
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("Client key specified, but no certificate")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_load_client_config_with_cert_files() -> Result<(), Error> {
+    let temp_file = NamedTempFile::new()?;
+    let config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: None,
+        ca_file: Some(temp_file.path().to_str().unwrap().to_string()),
+        cert_file: Some(temp_file.path().to_str().unwrap().to_string()),
+        key_file: Some(temp_file.path().to_str().unwrap().to_string()),
+    }))?;
+    assert!(config.is_some());
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_http() -> Result<(), Error> {
+    let endpoint = endpoint_from("http://localhost:50051", None)?;
+    assert_eq!(endpoint.uri().scheme_str(), Some("http"));
+    assert_eq!(endpoint.uri().host(), Some("localhost"));
+    assert_eq!(endpoint.uri().port_u16(), Some(50051));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_https_with_tls() -> Result<(), Error> {
+    let tls_config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: Some(true),
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }))?;
+    let endpoint = endpoint_from("https://example.com", tls_config)?;
+    assert_eq!(endpoint.uri().scheme_str(), Some("https"));
+    assert_eq!(endpoint.uri().host(), Some("example.com"));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_grpcs_with_tls() -> Result<(), Error> {
+    let tls_config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: Some(true),
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }))?;
+    let endpoint = endpoint_from("grpcs://example.com", tls_config)?;
+    assert_eq!(endpoint.uri().scheme_str(), Some("https"));
+    assert_eq!(endpoint.uri().host(), Some("example.com"));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_https_without_tls() -> Result<(), Error> {
+    let result = endpoint_from("https://example.com", None);
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("is https or grpcs, but no TLS configuration was provided")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_http_with_tls() -> Result<(), Error> {
+    let tls_config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: Some(true),
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }))?;
+    let result = endpoint_from("http://example.com:8080", tls_config);
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("but the scheme is not https or grpcs")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_invalid_uri() -> Result<(), Error> {
+    let result = endpoint_from("not a valid uri", None);
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("Unable to parse endpoint")
+    ));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn test_endpoint_from_missing_authority() -> Result<(), Error> {
+    let tls_config = load_client_config(&Some(ClientTlsConfig {
+        use_native_roots: Some(true),
+        ca_file: None,
+        cert_file: None,
+        key_file: None,
+    }))?;
+    let result = endpoint_from("/path/no/authority", tls_config);
+    assert!(matches!(
+        result,
+        Err(e) if e.to_string().contains("Unable to determine authority of endpoint")
+    ));
+    Ok(())
+}


### PR DESCRIPTION
# Description

There currently is no way to connect to a given gRPC endpoint using TLS without manually providing a CA certificate file, certificate file, and/or key file. This causes issues when using managed certificates where it is not possible to connect via TLS to a secured endpoint unless the relevant secrets are distributed across workers and manually accessed via the config. 

The proposed changes add an option for the `ClientTlsConfig` of `use_native_roots`. This will ensure that tonic will use the root native certs for it's tls config. If the field `use_native_roots` is present ca, cert, and key files will be ignored if provided but are not required. This adds the tonic `tls-native-roots` feature.

NOTE: The `ca_file` field in the `nativelink_config::stores::ClientTlsConfig` is no longer required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested connecting remote store and the scheduler using different configs for the `tls_config`.  Also added unit tests for `tls_utils.rs`
Cases:
1. tls_config is not specified -> no behaviour change
2. tls_config is specified but empty -> Raises error
3. tls_config specified with `use_native_roots` option true -> uses native roots and successfully creates connection
4. tls_config specified with `use_native_roots` option false -> Raises same error as 2
5. tls_config specified with combinations of ca_file, cert_file, key_file -> no behaviour change

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1782)
<!-- Reviewable:end -->
