### PR TITLE
Include Vale changes into web only workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all

--- a/.github/workflows/templates.yaml
+++ b/.github/workflows/templates.yaml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
   pull_request:
     branches: [main]
     paths-ignore:
+      - '.github/styles/**'
       - 'web/**'
 
 permissions: read-all


### PR DESCRIPTION
Extends #1750

Web content only changes often include adjustments to Vale allows. Note that changes to Vale don't affect the remaining code, so it's fine to exclude them from other workflows.