### PR TITLE
Replace the Video In Website's Hero Section with a Less Blurry One

### DIFF
--- a/web/platform/src/components/qwik/sections/hero.tsx
+++ b/web/platform/src/components/qwik/sections/hero.tsx
@@ -4,8 +4,9 @@ import { BackgroundVideo } from "../components/video.tsx";
 
 const _MockUp =
   "https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_dashboard.webp";
+
 const videoMockUp =
-  "https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_introduction.mp4";
+  "https://nativelink-cdn.s3.us-east-1.amazonaws.com/NativeLink+Cloud+Walkthrough.mp4";
 
 export const Hero = component$(() => {
   const rotatingText = useSignal("Accelerating Advanced CI");
@@ -90,7 +91,7 @@ export const Hero = component$(() => {
           </a>
         </div>
         <div class="w-full flex justify-center items-center">
-          <div class="w-9/11 aspect-video relative">
+          <div class="w-9/11 relative">
             <video
               src={videoMockUp}
               class="w-full h-full object-contain self-center shadow-[0px_0px_50px_0px_rgba(96,80,230,0.3)]"


### PR DESCRIPTION
# Description

The current video in the website's landing page is very blurry. This PR replaces that with a newly recorded, clearer video.

Fixes #1784 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Once the video link was updated, the page was examined via rm -rd dist && bun preview and everything looked as expected. To check how the website would look on mobile, I clicked to inspect the page on Chrome; this opened the Developer's console and simulated the web page on a modern phone. Everything was rendered as expected. Chrome's dev tools also let me emulate 4K by setting custom resolution and the preview looked good.