### PR TITLE
Introduce generic metrics for caches

### DIFF
--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -28,8 +28,10 @@ use nativelink_util::action_messages::{
 use nativelink_util::chunked_stream::ChunkedStream;
 use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::instant_wrapper::InstantWrapper;
+use nativelink_util::metrics::CACHE_TYPE;
 use nativelink_util::spawn;
 use nativelink_util::task::JoinHandleDropGuard;
+use opentelemetry::KeyValue;
 use tokio::sync::{Notify, mpsc, watch};
 use tracing::{debug, error};
 
@@ -838,7 +840,11 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync + 'static>
     ) -> Self {
         let (action_event_tx, mut action_event_rx) = mpsc::unbounded_channel();
         let inner = Arc::new(Mutex::new(AwaitedActionDbImpl {
-            client_operation_to_awaited_action: EvictingMap::new(eviction_config, (now_fn)()),
+            client_operation_to_awaited_action: EvictingMap::new(
+                eviction_config,
+                (now_fn)(),
+                &[KeyValue::new(CACHE_TYPE, "memory_awaited_action_db")],
+            ),
             operation_id_to_awaited_action: BTreeMap::new(),
             action_info_hash_key_to_awaited_action: HashMap::new(),
             sorted_action_info_hash_keys: SortedAwaitedActions::default(),

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -26,7 +26,9 @@ use nativelink_util::common::DigestInfo;
 use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::health_utils::{HealthStatus, HealthStatusIndicator};
 use nativelink_util::instant_wrapper::InstantWrapper;
+use nativelink_util::metrics::CACHE_TYPE;
 use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo};
+use opentelemetry::KeyValue;
 
 #[derive(Clone, Debug)]
 struct ExistenceItem(u64);
@@ -66,7 +68,11 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
         let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
             inner_store,
-            existence_cache: EvictingMap::new(eviction_policy, anchor_time),
+            existence_cache: EvictingMap::new(
+                eviction_policy,
+                anchor_time,
+                &[KeyValue::new(CACHE_TYPE, "existence_cache")],
+            ),
         })
     }
 

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -35,9 +35,11 @@ use nativelink_util::buf_channel::{
 use nativelink_util::common::{DigestInfo, fs};
 use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
+use nativelink_util::metrics::CACHE_TYPE;
 use nativelink_util::store_trait::{
     StoreDriver, StoreKey, StoreKeyBorrow, StoreOptimizations, UploadSizeInfo,
 };
+use opentelemetry::KeyValue;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, Take};
 use tokio_stream::wrappers::ReadDirStream;
 use tracing::{debug, error, warn};
@@ -639,7 +641,11 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
 
         let empty_policy = nativelink_config::stores::EvictionPolicy::default();
         let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
-        let evicting_map = Arc::new(EvictingMap::new(eviction_policy, now));
+        let evicting_map = Arc::new(EvictingMap::new(
+            eviction_policy,
+            now,
+            &[KeyValue::new(CACHE_TYPE, "filesystem")],
+        ));
 
         // Create temp and content directories and the s and d subdirectories.
 

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -29,7 +29,9 @@ use nativelink_util::evicting_map::{EvictingMap, LenEntry};
 use nativelink_util::health_utils::{
     HealthRegistryBuilder, HealthStatusIndicator, default_health_status_indicator,
 };
+use nativelink_util::metrics::CACHE_TYPE;
 use nativelink_util::store_trait::{StoreDriver, StoreKey, StoreKeyBorrow, UploadSizeInfo};
+use opentelemetry::KeyValue;
 
 use crate::cas_utils::is_zero_digest;
 
@@ -65,7 +67,11 @@ impl MemoryStore {
         let empty_policy = nativelink_config::stores::EvictionPolicy::default();
         let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
-            evicting_map: EvictingMap::new(eviction_policy, SystemTime::now()),
+            evicting_map: EvictingMap::new(
+                eviction_policy,
+                SystemTime::now(),
+                &[KeyValue::new(CACHE_TYPE, "memory")],
+            ),
         })
     }
 

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -24,6 +24,7 @@ rust_library(
         "src/instant_wrapper.rs",
         "src/known_platform_property_provider.rs",
         "src/lib.rs",
+        "src/metrics.rs",
         "src/metrics_utils.rs",
         "src/operation_state_manager.rs",
         "src/origin_event.rs",

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -25,6 +25,7 @@ pub mod fs;
 pub mod health_utils;
 pub mod instant_wrapper;
 pub mod known_platform_property_provider;
+pub mod metrics;
 pub mod metrics_utils;
 pub mod operation_state_manager;
 pub mod origin_event;

--- a/nativelink-util/src/metrics.rs
+++ b/nativelink-util/src/metrics.rs
@@ -1,0 +1,263 @@
+// Copyright 2025 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::LazyLock;
+
+use opentelemetry::{InstrumentationScope, KeyValue, Value, global, metrics};
+
+// Metric attribute keys for cache operations.
+pub const CACHE_TYPE: &str = "cache.type";
+pub const CACHE_OPERATION: &str = "cache.operation.name";
+pub const CACHE_RESULT: &str = "cache.operation.result";
+
+/// Cache operation types for metrics classification.
+#[derive(Debug, Clone, Copy)]
+pub enum CacheOperationName {
+    /// Data retrieval operations (get, peek, contains, etc.)
+    Read,
+    /// Data storage operations (insert, update, replace, etc.)
+    Write,
+    /// Explicit data removal operations
+    Delete,
+    /// Automatic cache maintenance (evictions, TTL cleanup, etc.)
+    Evict,
+}
+
+impl From<CacheOperationName> for Value {
+    fn from(op: CacheOperationName) -> Self {
+        match op {
+            CacheOperationName::Read => Self::from("read"),
+            CacheOperationName::Write => Self::from("write"),
+            CacheOperationName::Delete => Self::from("delete"),
+            CacheOperationName::Evict => Self::from("evict"),
+        }
+    }
+}
+
+/// Results of cache operations.
+///
+/// Result semantics vary by operation type:
+/// - Read: Hit/Miss/Expired indicate data availability
+/// - Write/Delete/Evict: Success/Error indicate completion status
+#[derive(Debug, Clone, Copy)]
+pub enum CacheOperationResult {
+    /// Data found and valid (Read operations)
+    Hit,
+    /// Data not found (Read operations)
+    Miss,
+    /// Data found but invalid/expired (Read operations)
+    Expired,
+    /// Operation completed successfully (Write/Delete/Evict operations)
+    Success,
+    /// Operation failed (any operation type)
+    Error,
+}
+
+impl From<CacheOperationResult> for Value {
+    fn from(result: CacheOperationResult) -> Self {
+        match result {
+            CacheOperationResult::Hit => Self::from("hit"),
+            CacheOperationResult::Miss => Self::from("miss"),
+            CacheOperationResult::Expired => Self::from("expired"),
+            CacheOperationResult::Success => Self::from("success"),
+            CacheOperationResult::Error => Self::from("error"),
+        }
+    }
+}
+
+/// Pre-allocated attribute combinations for efficient cache metrics collection.
+///
+/// Avoids runtime allocation by pre-computing common attribute combinations
+/// for cache operations and results.
+#[derive(Debug)]
+pub struct CacheMetricAttrs {
+    // Read operation attributes
+    read_hit: Vec<KeyValue>,
+    read_miss: Vec<KeyValue>,
+    read_expired: Vec<KeyValue>,
+
+    // Write operation attributes
+    write_success: Vec<KeyValue>,
+    write_error: Vec<KeyValue>,
+
+    // Delete operation attributes
+    delete_success: Vec<KeyValue>,
+    delete_miss: Vec<KeyValue>,
+    delete_error: Vec<KeyValue>,
+
+    // Evict operation attributes
+    evict_success: Vec<KeyValue>,
+    evict_expired: Vec<KeyValue>,
+}
+
+impl CacheMetricAttrs {
+    /// Creates a new set of pre-computed attributes.
+    ///
+    /// The `base_attrs` are included in all attribute combinations (e.g., cache
+    /// type, instance ID).
+    #[must_use]
+    pub fn new(base_attrs: &[KeyValue]) -> Self {
+        let make_attrs = |op: CacheOperationName, result: CacheOperationResult| {
+            let mut attrs = base_attrs.to_vec();
+            attrs.push(KeyValue::new(CACHE_OPERATION, op));
+            attrs.push(KeyValue::new(CACHE_RESULT, result));
+            attrs
+        };
+
+        Self {
+            read_hit: make_attrs(CacheOperationName::Read, CacheOperationResult::Hit),
+            read_miss: make_attrs(CacheOperationName::Read, CacheOperationResult::Miss),
+            read_expired: make_attrs(CacheOperationName::Read, CacheOperationResult::Expired),
+
+            write_success: make_attrs(CacheOperationName::Write, CacheOperationResult::Success),
+            write_error: make_attrs(CacheOperationName::Write, CacheOperationResult::Error),
+
+            delete_success: make_attrs(CacheOperationName::Delete, CacheOperationResult::Success),
+            delete_miss: make_attrs(CacheOperationName::Delete, CacheOperationResult::Miss),
+            delete_error: make_attrs(CacheOperationName::Delete, CacheOperationResult::Error),
+
+            evict_success: make_attrs(CacheOperationName::Evict, CacheOperationResult::Success),
+            evict_expired: make_attrs(CacheOperationName::Evict, CacheOperationResult::Expired),
+        }
+    }
+
+    // Attribute accessors
+    #[must_use]
+    pub fn read_hit(&self) -> &[KeyValue] {
+        &self.read_hit
+    }
+    #[must_use]
+    pub fn read_miss(&self) -> &[KeyValue] {
+        &self.read_miss
+    }
+    #[must_use]
+    pub fn read_expired(&self) -> &[KeyValue] {
+        &self.read_expired
+    }
+    #[must_use]
+    pub fn write_success(&self) -> &[KeyValue] {
+        &self.write_success
+    }
+    #[must_use]
+    pub fn write_error(&self) -> &[KeyValue] {
+        &self.write_error
+    }
+    #[must_use]
+    pub fn delete_success(&self) -> &[KeyValue] {
+        &self.delete_success
+    }
+    #[must_use]
+    pub fn delete_miss(&self) -> &[KeyValue] {
+        &self.delete_miss
+    }
+    #[must_use]
+    pub fn delete_error(&self) -> &[KeyValue] {
+        &self.delete_error
+    }
+    #[must_use]
+    pub fn evict_success(&self) -> &[KeyValue] {
+        &self.evict_success
+    }
+    #[must_use]
+    pub fn evict_expired(&self) -> &[KeyValue] {
+        &self.evict_expired
+    }
+}
+
+/// Global cache metrics instruments.
+pub static CACHE_METRICS: LazyLock<CacheMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    CacheMetrics {
+        cache_operation_duration: meter
+            .f64_histogram("cache.operation.duration")
+            .with_description("Duration of cache operations in milliseconds")
+            .with_unit("ms")
+            // The range of these is quite large as a cache might be backed by
+            // memory, a filesystem, or network storage. The current values were
+            // determined empirically and might need adjustment.
+            .with_boundaries(vec![
+                // Microsecond range
+                0.001, // 1μs
+                0.005, // 5μs
+                0.01,  // 10μs
+                0.05,  // 50μs
+                0.1,   // 100μs
+                // Sub-millisecond range
+                0.2, // 200μs
+                0.5, // 500μs
+                1.0, // 1ms
+                // Low millisecond range
+                2.0,   // 2ms
+                5.0,   // 5ms
+                10.0,  // 10ms
+                20.0,  // 20ms
+                50.0,  // 50ms
+                100.0, // 100ms
+                // Higher latency range
+                200.0,  // 200ms
+                500.0,  // 500ms
+                1000.0, // 1 second
+                2000.0, // 2 seconds
+                5000.0, // 5 seconds
+            ])
+            .build(),
+
+        cache_operations: meter
+            .u64_counter("cache.operations")
+            .with_description("Total cache operations by type and result")
+            .build(),
+
+        cache_io: meter
+            .u64_counter("cache.io")
+            .with_description("Total bytes processed by cache operations")
+            .with_unit("By")
+            .build(),
+
+        cache_size: meter
+            .i64_up_down_counter("cache.size")
+            .with_description("Current total size of cached data")
+            .with_unit("By")
+            .build(),
+
+        cache_entries: meter
+            .i64_up_down_counter("cache.entries")
+            .with_description("Current number of cached entries")
+            .with_unit("{entry}")
+            .build(),
+
+        cache_entry_size: meter
+            .u64_histogram("cache.item.size")
+            .with_description("Size distribution of cached entries")
+            .with_unit("By")
+            .build(),
+    }
+});
+
+/// OpenTelemetry metrics instruments for cache monitoring.
+#[derive(Debug)]
+pub struct CacheMetrics {
+    /// Histogram of cache operation durations in milliseconds
+    pub cache_operation_duration: metrics::Histogram<f64>,
+    /// Counter of cache operations by type and result
+    pub cache_operations: metrics::Counter<u64>,
+    /// Counter of bytes read/written during cache operations
+    pub cache_io: metrics::Counter<u64>,
+    /// Current total size of all cached data in bytes
+    pub cache_size: metrics::UpDownCounter<i64>,
+    /// Current number of entries in cache
+    pub cache_entries: metrics::UpDownCounter<i64>,
+    /// Histogram of individual cache entry sizes in bytes
+    pub cache_entry_size: metrics::Histogram<u64>,
+}

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -63,6 +63,7 @@ async fn insert_purges_at_max_count() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
     evicting_map
         .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::new().into())
@@ -120,6 +121,7 @@ async fn insert_purges_at_max_bytes() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
     evicting_map
         .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
@@ -177,6 +179,7 @@ async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
             evict_bytes: 9,
         },
         MockInstantWrapped::default(),
+        &[],
     );
     evicting_map
         .insert(DigestInfo::try_new(HASH1, 0)?, Bytes::from(DATA).into())
@@ -235,6 +238,7 @@ async fn insert_purges_at_max_seconds() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     evicting_map
@@ -297,6 +301,7 @@ async fn get_refreshes_time() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     evicting_map
@@ -372,6 +377,7 @@ async fn unref_called_on_replace() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     let (entry1, entry2) = {
@@ -417,6 +423,7 @@ async fn contains_key_refreshes_time() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     evicting_map
@@ -470,6 +477,7 @@ async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     let value1 = BytesWrapper(Bytes::from_static(b"12345678"));
@@ -525,6 +533,7 @@ async fn get_evicts_on_time() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
@@ -558,6 +567,7 @@ async fn remove_evicts_on_time() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     let digest_info1: DigestInfo = DigestInfo::try_new(HASH1, 0)?;
@@ -614,6 +624,7 @@ async fn range_multiple_items_test() -> Result<(), Error> {
             evict_bytes: 0,
         },
         MockInstantWrapped::default(),
+        &[],
     );
 
     evicting_map


### PR DESCRIPTION
The naming scheme tries to follows the OpenTelemetry semantic conventions closely, but we might need to adjust it slightly in the future. Potentially expensive attribute allocation is zero-cost at runtime and despite the fairly heavy duration measurments there doesn't seem to be a relevant performance impact as all operations are in the nanosecond range when working with a memory-backed `EvictingMap`.

As an example we reinstrument the `EvictingMap` and slightly change its implementation to more clearly reflect the metrics we care about.