### PR TITLE
Remove background video on mobile

### DIFF
--- a/web/platform/src/components/qwik/components/footer.tsx
+++ b/web/platform/src/components/qwik/components/footer.tsx
@@ -1,7 +1,5 @@
 import { $, component$, useSignal } from "@builder.io/qwik";
-
-const videoLink =
-  "https://nativelink-cdn.s3.us-east-1.amazonaws.com/background_file.mp4";
+import { BackgroundVideo } from "./video.tsx";
 
 const Logo =
   "https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_logo.webp";
@@ -45,8 +43,6 @@ const law = [
 ];
 
 export const Footer = component$(() => {
-  const videoElementSignal = useSignal<HTMLAudioElement | undefined>();
-
   const email = useSignal("");
   const message = useSignal("");
 
@@ -81,19 +77,7 @@ export const Footer = component$(() => {
     <footer class="relative w-full text-white bg-black py-4 overflow-hidden">
       <div class="absolute bottom-0 mx-0 left-0 right-0 w-full h-full ">
         {/* Background Video */}
-        <video
-          class="absolute bottom-[0] md:bottom-[-20vh] left-0 z-0 h-full md:h-auto object-cover md:w-screen"
-          autoplay={true}
-          loop={true}
-          muted={true}
-          ref={videoElementSignal}
-          controls={false}
-          src={videoLink}
-          playsInline={true}
-        >
-          <source type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
+        <BackgroundVideo class="absolute bottom-[0] md:bottom-[-20vh] left-0 z-0 h-full md:h-auto object-cover md:w-screen" />
         {/* <div class="absolute w-[150vw] bottom-0 left-1/2 transform -translate-x-1/2 translate-y-5/12">
             <Background class="rotate-180 w-full" />
         </div> */}

--- a/web/platform/src/components/qwik/components/video.tsx
+++ b/web/platform/src/components/qwik/components/video.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal } from "@builder.io/qwik";
+import { component$, useSignal, useVisibleTask$ } from "@builder.io/qwik";
 
 const videoLink =
   "https://nativelink-cdn.s3.us-east-1.amazonaws.com/background_file.mp4";
@@ -11,6 +11,16 @@ export const BackgroundVideo = component$<BackgroundVideoProps>(
   ({ class: customClass = "" }) => {
     const videoElementSignal = useSignal<HTMLAudioElement | undefined>();
 
+    useVisibleTask$(() => {
+      const isMobile = window.innerWidth < 768;
+      if (!isMobile && videoElementSignal.value) {
+        videoElementSignal.value.src = videoLink;
+        videoElementSignal.value.load();
+        videoElementSignal.value.play().catch((error) => {
+          console.error("Video autoplay failed:", error);
+        });
+      }
+    });
     return (
       <video
         class={`${customClass}`}
@@ -19,7 +29,6 @@ export const BackgroundVideo = component$<BackgroundVideoProps>(
         muted={true}
         ref={videoElementSignal}
         controls={false}
-        src={videoLink}
         playsInline={true}
       >
         <source type="video/mp4" />


### PR DESCRIPTION
# Description

I removed the background video on the main page for **mobile devices only**, to improve performance and reduce LCP (Largest Contentful Paint).

The logic is simple: I avoided hardcoding the video `source` URL directly in the `<video>` tag. Instead, I first detect whether the user is on a mobile or desktop device, and then assign the `source` URL accordingly.

I’ve removed both background videos — one from the header and one from the footer.

Fixes #1799 

## Type of change

Please delete options that aren't relevant.

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update



Please also list any relevant details for your test configuration

before the change the some background video downloaded twice for Hader and Footer

![Screenshot 2025-05-29 145123](https://github.com/user-attachments/assets/2aa93a0d-7c61-4b9c-9f4e-a9bd8fdc8a64)
 
![Screenshot 2025-05-29 200645](https://github.com/user-attachments/assets/fb557d55-05fb-49dc-ad92-5dbba52560af)


![Screenshot 2025-05-29 200654](https://github.com/user-attachments/assets/550e41cc-da6e-4240-a81f-f9081ac8708c)


with caching 
![Screenshot 2025-05-29 215936](https://github.com/user-attachments/assets/f526eea9-2a20-4d7d-a9e3-159754229ca0)



## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1812)
<!-- Reviewable:end -->
