### PR TITLE
 Update nix setup for GHA workflows

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -48,9 +48,5 @@ runs:
         fi
 
     - name: Install Nix
-      uses: >- # v16
-        DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d
-
-    - name: Cache Nix derivations
-      uses: >- # v9
-        DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4
+      uses: >- # v17
+        DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3


### PR DESCRIPTION
Bump the nix installer action and remove the no longer functional cache
action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1813)
<!-- Reviewable:end -->
