### PR TITLE
Add JSON5 formatting to pre-commit

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json5
+++ b/deployment-examples/docker-compose/local-storage-cas.json5
@@ -4,87 +4,100 @@
 // so objects are compressed, deduplicated and uses some in-memory
 // optimizations for certain hot paths.
 {
-  "stores": [
+  stores: [
     {
-      "name": "CAS_MAIN_STORE",
-      "compression": {
-        "compression_algorithm": {
-          "lz4": {}
+      name: "CAS_MAIN_STORE",
+      compression: {
+        compression_algorithm: {
+          lz4: {},
         },
-        "backend": {
-          "filesystem": {
-            "content_path": "~/.cache/nativelink/content_path-cas",
-            "temp_path": "~/.cache/nativelink/tmp_path-cas",
-            "eviction_policy": {
+        backend: {
+          filesystem: {
+            content_path: "~/.cache/nativelink/content_path-cas",
+            temp_path: "~/.cache/nativelink/tmp_path-cas",
+            eviction_policy: {
               // 10gb.
-              "max_bytes": 10000000000
-            }
-          }
-        }
-      }
-    }, {
-      "name": "AC_MAIN_STORE",
-      "filesystem": {
-        "content_path": "~/.cache/nativelink/content_path-ac",
-        "temp_path": "~/.cache/nativelink/tmp_path-ac",
-        "eviction_policy": {
+              max_bytes: 10000000000,
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "~/.cache/nativelink/content_path-ac",
+        temp_path: "~/.cache/nativelink/tmp_path-ac",
+        eviction_policy: {
           // 500mb.
-          "max_bytes": 500000000
-        }
-      }
-    }
+          max_bytes: 500000000,
+        },
+      },
+    },
   ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
-    },
-    "services": {
-      "cas": [{
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "capabilities": [],
-      "bytestream": {
-        "cas_stores": {
-          "": "CAS_MAIN_STORE"
-        }
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
       },
-      "fetch": {},
-      "push": {},
-    }
-  }, {
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50071",
-        "tls": {
-          "cert_file": "/root/example-do-not-use-in-prod-rootca.crt",
-          "key_file": "/root/example-do-not-use-in-prod-key.pem"
-        }
-      }
-    },
-    // Each of the services below is keyed on an instance_name.
-    // By default, an empty string is used, but if a different
-    // instance_name is provided, the instance name must be
-    // specified by the invoking tool (e.g. using
-    // `--remote_instance_name=` for Bazel)
-    "services": {
-      "cas": [{
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "capabilities": [],
-      "bytestream": {
-        "cas_stores": {
-          "": "CAS_MAIN_STORE"
-        }
+      services: {
+        cas: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        capabilities: [],
+        bytestream: {
+          cas_stores: {
+            "": "CAS_MAIN_STORE",
+          },
+        },
+        fetch: {},
+        push: {},
       },
-      "health": {}
-    }
-  }]
+    },
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50071",
+          tls: {
+            cert_file: "/root/example-do-not-use-in-prod-rootca.crt",
+            key_file: "/root/example-do-not-use-in-prod-key.pem",
+          },
+        },
+      },
+
+      // Each of the services below is keyed on an instance_name.
+      // By default, an empty string is used, but if a different
+      // instance_name is provided, the instance name must be
+      // specified by the invoking tool (e.g. using
+      // `--remote_instance_name=` for Bazel)
+      services: {
+        cas: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        capabilities: [],
+        bytestream: {
+          cas_stores: {
+            "": "CAS_MAIN_STORE",
+          },
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/deployment-examples/docker-compose/scheduler.json5
+++ b/deployment-examples/docker-compose/scheduler.json5
@@ -1,81 +1,98 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "GRPC_LOCAL_STORE",
+      name: "GRPC_LOCAL_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "cas"
-      }
-    }, {
-      "name": "GRPC_LOCAL_AC_STORE",
+        store_type: "cas",
+      },
+    },
+    {
+      name: "GRPC_LOCAL_AC_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "ac"
-      }
-    }
+        store_type: "ac",
+      },
+    },
   ],
-  "schedulers": [
+  schedulers: [
     {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "OSFamily": "priority",
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          OSFamily: "priority",
           "container-image": "priority",
           "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
-  ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50052"
-      }
-    },
-    // Each of the services below is keyed on an instance_name.
-    // By default, an empty string is used, but if a different
-    // instance_name is provided, the instance name must be
-    // specified by the invoking tool (e.g. using
-    // `--remote_instance_name=` for Bazel)
-    "services": {
-      "ac": [{
-        "ac_store": "GRPC_LOCAL_AC_STORE"
-      }],
-      "execution": [{
-        "cas_store": "GRPC_LOCAL_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }]
-    }
-  }, {
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER"
+          ISA: "exact",
+        },
       },
-      "health": {}
-    }
-  }]
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50052",
+        },
+      },
+
+      // Each of the services below is keyed on an instance_name.
+      // By default, an empty string is used, but if a different
+      // instance_name is provided, the instance name must be
+      // specified by the invoking tool (e.g. using
+      // `--remote_instance_name=` for Bazel)
+      services: {
+        ac: [
+          {
+            ac_store: "GRPC_LOCAL_AC_STORE",
+          },
+        ],
+        execution: [
+          {
+            cas_store: "GRPC_LOCAL_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+      },
+    },
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/deployment-examples/docker-compose/worker.json5
+++ b/deployment-examples/docker-compose/worker.json5
@@ -1,74 +1,92 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "GRPC_LOCAL_STORE",
+      name: "GRPC_LOCAL_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "cas"
-      }
-    }, {
-      "name": "GRPC_LOCAL_AC_STORE",
+        store_type: "cas",
+      },
+    },
+    {
+      name: "GRPC_LOCAL_AC_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "ac"
-      }
-    }, {
-      "name": "WORKER_FAST_SLOW_STORE",
-      "fast_slow": {
-        "fast": {
-          "filesystem": {
-            "content_path": "/root/.cache/nativelink/data-worker-test/content_path-cas",
-            "temp_path": "/root/.cache/nativelink/data-worker-test/tmp_path-cas",
-            "eviction_policy": {
+        store_type: "ac",
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "/root/.cache/nativelink/data-worker-test/content_path-cas",
+            temp_path: "/root/.cache/nativelink/data-worker-test/tmp_path-cas",
+            eviction_policy: {
               // 10gb.
-              "max_bytes": 10000000000
-            }
-          }
+              max_bytes: 10000000000,
+            },
+          },
         },
-        "slow": {
-          "ref_store": {
-            "name": "GRPC_LOCAL_STORE"
-          }
-        }
-      }
-    }
+        slow: {
+          ref_store: {
+            name: "GRPC_LOCAL_STORE",
+          },
+        },
+      },
+    },
   ],
-  "workers": [{
-    "local": {
-      "worker_api_endpoint": {
-        "uri": "grpc://${SCHEDULER_ENDPOINT:-127.0.0.1}:50061"
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://${SCHEDULER_ENDPOINT:-127.0.0.1}:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "GRPC_LOCAL_AC_STORE",
+        },
+        work_directory: "/root/.cache/nativelink/work",
+        platform_properties: {
+          cpu_count: {
+            query_cmd: "nproc",
+          },
+          OSFamily: {
+            values: [
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+          "lre-rs": {
+            values: [
+              "",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+        },
       },
-      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
-      "upload_action_result": {
-        "ac_store": "GRPC_LOCAL_AC_STORE"
-      },
-      "work_directory": "/root/.cache/nativelink/work",
-      "platform_properties": {
-        "cpu_count": {
-          "query_cmd": "nproc"
-        },
-        "OSFamily": {
-          "values": [""]
-        },
-        "container-image": {
-          "values": [""]
-        },
-        "lre-rs": {
-          "values": [""]
-        },
-        "ISA": {
-          values: ["x86-64"]
-        },
-      }
-    }
-  }],
-  "servers": []
+    },
+  ],
+  servers: [],
 }

--- a/integration_tests/buildstream/buildstream_cas.json5
+++ b/integration_tests/buildstream/buildstream_cas.json5
@@ -1,161 +1,195 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "AC_MAIN_STORE",
-      "filesystem": {
-        "content_path": "/tmp/nativelink/data-worker-test/content_path-ac",
-        "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-ac",
-        "eviction_policy": {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "/tmp/nativelink/data-worker-test/content_path-ac",
+        temp_path: "/tmp/nativelink/data-worker-test/tmp_path-ac",
+        eviction_policy: {
           // 1gb.
-          "max_bytes": 1000000000
-        }
-      }
-    }, {
-      "name": "WORKER_FAST_SLOW_STORE",
-      "fast_slow": {
+          max_bytes: 1000000000,
+        },
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
         // "fast" must be a "filesystem" store because the worker uses it to make
         // hardlinks on disk to a directory where the jobs are running.
-        "fast": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/data-worker-test/content_path-cas",
-            "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-cas",
-            "eviction_policy": {
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data-worker-test/content_path-cas",
+            temp_path: "/tmp/nativelink/data-worker-test/tmp_path-cas",
+            eviction_policy: {
               // 10gb.
-              "max_bytes": 10000000000
-            }
-          }
+              max_bytes: 10000000000,
+            },
+          },
         },
-        "slow": {
+        slow: {
           /// Discard data.
           /// This example usage has the CAS and the Worker live in the same place,
           /// so they share the same underlying CAS. Since workers require a fast_slow
           /// store, we use the fast store as our primary data store, and the slow store
           /// is just a noop, since there's no shared storage in this config.
-          "noop": {}
-        }
-      }
-    }
+          noop: {},
+        },
+      },
+    },
   ],
-  "schedulers": [
+  schedulers: [
     {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "disk_read_iops": "minimum",
-          "disk_read_bps": "minimum",
-          "disk_write_iops": "minimum",
-          "disk_write_bps": "minimum",
-          "shm_size": "minimum",
-          "gpu_count": "minimum",
-          "gpu_model": "exact",
-          "cpu_vendor": "exact",
-          "cpu_arch": "exact",
-          "cpu_model": "exact",
-          "kernel_version": "exact",
-          "OSFamily": "priority",
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          OSFamily: "priority",
           "container-image": "priority",
           "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
+          ISA: "exact",
+        },
+      },
+    },
   ],
-  "workers": [{
-    "local": {
-      "worker_api_endpoint": {
-        "uri": "grpc://127.0.0.1:50061"
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://127.0.0.1:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "AC_MAIN_STORE",
+        },
+        work_directory: "/tmp/nativelink/work",
+        platform_properties: {
+          cpu_count: {
+            values: [
+              "16",
+            ],
+          },
+          memory_kb: {
+            values: [
+              "500000",
+            ],
+          },
+          network_kbps: {
+            values: [
+              "100000",
+            ],
+          },
+          cpu_arch: {
+            values: [
+              "x86_64",
+            ],
+          },
+          OSFamily: {
+            values: [
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+          "lre-rs": {
+            values: [
+              "",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+        },
       },
-      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
-      "upload_action_result": {
-        "ac_store": "AC_MAIN_STORE"
-      },
-      "work_directory": "/tmp/nativelink/work",
-      "platform_properties": {
-        "cpu_count": {
-          "values": ["16"]
-        },
-        "memory_kb": {
-          "values": ["500000"]
-        },
-        "network_kbps": {
-          "values": ["100000"]
-        },
-        "cpu_arch": {
-          "values": ["x86_64"]
-        },
-        "OSFamily": {
-          "values": [""]
-        },
-        "container-image": {
-          "values": [""]
-        },
-        "lre-rs": {
-          "values": [""]
-        },
-        "ISA": {
-          "values": ["x86-64"]
-        },
-      }
-    }
-  }],
-  "servers": [{
-    "name": "public",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
     },
-    "services": {
-      "cas": [{
-        "cas_store": "WORKER_FAST_SLOW_STORE"
-      }],
-      "ac": [{
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-        "cas_store": "WORKER_FAST_SLOW_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "fetch": [{
-        "fetch_store": "WORKER_FAST_SLOW_STORE"
-      }],
-      "push": [{
-        "push_store": "WORKER_FAST_SLOW_STORE"
-      }],
-      "capabilities": [{
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "": "WORKER_FAST_SLOW_STORE"
-        }
-      }
-    }
-  }, {
-    "name": "private_workers_servers",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER"
+  ],
+  servers: [
+    {
+      name: "public",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
       },
-      "admin": {},
-      "health": {}
-    }
-  }],
-  "global": {
-    "max_open_files": 24576
-  }
+      services: {
+        cas: [
+          {
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            cas_store: "WORKER_FAST_SLOW_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        fetch: [
+          {
+            fetch_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        push: [
+          {
+            push_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            "": "WORKER_FAST_SLOW_STORE",
+          },
+        },
+      },
+    },
+    {
+      name: "private_workers_servers",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        admin: {},
+        health: {},
+      },
+    },
+  ],
+  global: {
+    max_open_files: 24576,
+  },
 }

--- a/kubernetes/components/worker/worker.json5
+++ b/kubernetes/components/worker/worker.json5
@@ -1,93 +1,113 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "GRPC_LOCAL_STORE",
+      name: "GRPC_LOCAL_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "cas"
-      }
-    }, {
-      "name": "GRPC_LOCAL_AC_STORE",
+        store_type: "cas",
+      },
+    },
+    {
+      name: "GRPC_LOCAL_AC_STORE",
+
       // Note: This file is used to test GRPC store.
-      "grpc": {
-        "instance_name": "",
-        "endpoints": [
-          {"address": "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50051"}
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50051",
+          },
         ],
-        "store_type": "ac"
-      }
-    }, {
-      "name": "WORKER_FAST_SLOW_STORE",
-      "fast_slow": {
-        "fast": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/content_path-cas",
-            "temp_path": "/tmp/nativelink/tmp_path-cas",
-            "eviction_policy": {
-              "max_bytes": "10Gb"
-            }
-          }
+        store_type: "ac",
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/content_path-cas",
+            temp_path: "/tmp/nativelink/tmp_path-cas",
+            eviction_policy: {
+              max_bytes: "10Gb",
+            },
+          },
         },
-        "slow": {
-          "ref_store": {
-            "name": "GRPC_LOCAL_STORE"
-          }
-        }
-      }
-    }
+        slow: {
+          ref_store: {
+            name: "GRPC_LOCAL_STORE",
+          },
+        },
+      },
+    },
   ],
-  "workers": [{
-    "local": {
-      "worker_api_endpoint": {
-        "uri": "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50061"
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://${NATIVELINK_ENDPOINT:-127.0.0.1}:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "GRPC_LOCAL_AC_STORE",
+        },
+        work_directory: "/tmp/nativelink/work",
+        platform_properties: {
+          cpu_count: {
+            query_cmd: "nproc",
+          },
+          memory_kb: {
+            values: [
+              "500000",
+            ],
+          },
+          network_kbps: {
+            values: [
+              "100000",
+            ],
+          },
+          cpu_arch: {
+            values: [
+              "x86_64",
+            ],
+          },
+          OSFamily: {
+            values: [
+              "Linux",
+            ],
+          },
+          "container-image": {
+            values: [
+              // WARNING: Treat the string below as nothing more than a raw string
+              // that is matched by the scheduler against the value specified in
+              // the `exec_properties` of the corresponding platform at
+              // `local-remote-execution/generated-cc/config/BUILD`.
+              "${NATIVELINK_WORKER_PLATFORM:-undefined_platform}",
+            ],
+          },
+          "lre-rs": {
+            values: [
+              "${NATIVELINK_WORKER_LRE_RS:-undefined}",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+        },
       },
-      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
-      "upload_action_result": {
-        "ac_store": "GRPC_LOCAL_AC_STORE"
-      },
-      "work_directory": "/tmp/nativelink/work",
-      "platform_properties": {
-        "cpu_count": {
-          "query_cmd": "nproc"
-        },
-        "memory_kb": {
-          "values": ["500000"]
-        },
-        "network_kbps": {
-          "values": ["100000"]
-        },
-        "cpu_arch": {
-          "values": ["x86_64"]
-        },
-        "OSFamily": {
-          "values": ["Linux"]
-        },
-        "container-image": {
-          "values": [
-            // WARNING: Treat the string below as nothing more than a raw string
-            // that is matched by the scheduler against the value specified in
-            // the `exec_properties` of the corresponding platform at
-            // `local-remote-execution/generated-cc/config/BUILD`.
-            "${NATIVELINK_WORKER_PLATFORM:-undefined_platform}"
-          ]
-        },
-        "lre-rs": {
-          "values": [
-            "${NATIVELINK_WORKER_LRE_RS:-undefined}"
-          ]
-        },
-        "ISA": {
-          values: ["x86-64"]
-        },
-      }
-    }
-  }],
-  "servers": [],
-  "global": {
-    "max_open_files": 524288
-  }
+    },
+  ],
+  servers: [],
+  global: {
+    max_open_files: 524288,
+  },
 }

--- a/kubernetes/nativelink/nativelink-config.json5
+++ b/kubernetes/nativelink/nativelink-config.json5
@@ -2,199 +2,219 @@
 // `~/.cache/nativelink`. When this location is mounted as a PersistentVolume
 // it persists the cache across restarts.
 {
-  "stores": [
+  stores: [
     {
-      "name": "CAS_MAIN_STORE",
-      "existence_cache": {
-        "backend": {
-          "verify": {
-            "verify_size": true,
-            "verify_hash": true,
-            "backend": {
-              "fast_slow": {
-                "fast": {
-                  "size_partitioning":{
-                    "size": "64kb",
-                    "lower_store": {
-                      "memory": {
-                        "eviction_policy": {
-                          "max_bytes": "1gb",
-                          "max_count": 100000
-                        }
-                      }
+      name: "CAS_MAIN_STORE",
+      existence_cache: {
+        backend: {
+          verify: {
+            verify_size: true,
+            verify_hash: true,
+            backend: {
+              fast_slow: {
+                fast: {
+                  size_partitioning: {
+                    size: "64kb",
+                    lower_store: {
+                      memory: {
+                        eviction_policy: {
+                          max_bytes: "1gb",
+                          max_count: 100000,
+                        },
+                      },
                     },
-                    "upper_store": {
-                      "noop": {} // Entries larger than 64kb in slow store.
+                    upper_store: {
+                      noop: {}, // Entries larger than 64kb in slow store.
                     },
-                  }
+                  },
                 },
-                "slow": {
-                  "compression": {
-                    "compression_algorithm": {
-                      "lz4": {}
+                slow: {
+                  compression: {
+                    compression_algorithm: {
+                      lz4: {},
                     },
-                    "backend": {
-                      "filesystem": {
-                        "content_path": "/tmp/nativelink/data/content_path-cas",
-                        "temp_path": "/tmp/nativelink/data/tmp_path-cas",
-                        "eviction_policy": {
-                          "max_bytes": "10Gb"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }, {
-      "name": "AC_MAIN_STORE",
-      "completeness_checking": {
-        "backend": {
-          "fast_slow": {
-            "fast": {
-              "size_partitioning":{
-                "size": "1kb",
-                "lower_store": {
-                  "memory": {
-                    "eviction_policy": {
-                      "max_bytes": "100mb",
-                      "max_count": 150000
-                    }
-                  }
+                    backend: {
+                      filesystem: {
+                        content_path: "/tmp/nativelink/data/content_path-cas",
+                        temp_path: "/tmp/nativelink/data/tmp_path-cas",
+                        eviction_policy: {
+                          max_bytes: "10Gb",
+                        },
+                      },
+                    },
+                  },
                 },
-                "upper_store": {
-                  "noop": {} // Entries larger than 1kb in slow store.
-                }
-              }
+              },
             },
-            "slow": {
-              "filesystem": {
-                "content_path": "/tmp/nativelink/data/content_path-ac",
-                "temp_path": "/tmp/nativelink/data/tmp_path-ac",
-                "eviction_policy": {
-                  "max_bytes": "1gb"
-                }
-              }
-            }
-          }
+          },
         },
-        "cas_store": {
-          "ref_store": {
-            "name": "CAS_MAIN_STORE"
-          }
-        }
-      }
-    }
-  ],
-  "schedulers": [
+      },
+    },
     {
-      "name": "MAIN_SCHEDULER",
+      name: "AC_MAIN_STORE",
+      completeness_checking: {
+        backend: {
+          fast_slow: {
+            fast: {
+              size_partitioning: {
+                size: "1kb",
+                lower_store: {
+                  memory: {
+                    eviction_policy: {
+                      max_bytes: "100mb",
+                      max_count: 150000,
+                    },
+                  },
+                },
+                upper_store: {
+                  noop: {}, // Entries larger than 1kb in slow store.
+                },
+              },
+            },
+            slow: {
+              filesystem: {
+                content_path: "/tmp/nativelink/data/content_path-ac",
+                temp_path: "/tmp/nativelink/data/tmp_path-ac",
+                eviction_policy: {
+                  max_bytes: "1gb",
+                },
+              },
+            },
+          },
+        },
+        cas_store: {
+          ref_store: {
+            name: "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+
       // TODO(aaronmondal): use the right scheduler because reclient doesn't use the cached results?
       // TODO(aaronmondal): max_bytes_per_stream
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "priority",
-          "memory_kb": "priority",
-          "network_kbps": "priority",
-          "disk_read_iops": "priority",
-          "disk_read_bps": "priority",
-          "disk_write_iops": "priority",
-          "disk_write_bps": "priority",
-          "shm_size": "priority",
-          "gpu_count": "priority",
-          "gpu_model": "priority",
-          "cpu_vendor": "priority",
-          "cpu_arch": "priority",
-          "cpu_model": "priority",
-          "kernel_version": "priority",
-          "OSFamily": "priority",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "priority",
+          memory_kb: "priority",
+          network_kbps: "priority",
+          disk_read_iops: "priority",
+          disk_read_bps: "priority",
+          disk_write_iops: "priority",
+          disk_write_bps: "priority",
+          shm_size: "priority",
+          gpu_count: "priority",
+          gpu_model: "priority",
+          cpu_vendor: "priority",
+          cpu_arch: "priority",
+          cpu_model: "priority",
+          kernel_version: "priority",
+          OSFamily: "priority",
           "container-image": "priority",
           "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
-  ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
-    },
-    "services": {
-      "cas": [{
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "capabilities": [{
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "execution": [{
-        "cas_store": "CAS_MAIN_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "": "CAS_MAIN_STORE"
-        }
-      }
-    }
-  },
-  {
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50052",
-        "tls": {
-          "cert_file": "/root/example-do-not-use-in-prod-rootca.crt",
-          "key_file": "/root/example-do-not-use-in-prod-key.pem"
-        }
-      }
-    },
-    "services": {
-      "cas": [{
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "capabilities": [{
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "execution": [{
-        "cas_store": "CAS_MAIN_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "": "CAS_MAIN_STORE"
-        }
-      }
-    }
-  },
-  {
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER"
+          ISA: "exact",
+        },
       },
-      "health": {}
-    }
-  }]
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
+      },
+      services: {
+        cas: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        execution: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            "": "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50052",
+          tls: {
+            cert_file: "/root/example-do-not-use-in-prod-rootca.crt",
+            key_file: "/root/example-do-not-use-in-prod-key.pem",
+          },
+        },
+      },
+      services: {
+        cas: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        execution: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            "": "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/nativelink-config/examples/basic_cas.json5
+++ b/nativelink-config/examples/basic_cas.json5
@@ -1,159 +1,189 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "AC_MAIN_STORE",
-      "filesystem": {
-        "content_path": "/tmp/nativelink/data-worker-test/content_path-ac",
-        "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-ac",
-        "eviction_policy": {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "/tmp/nativelink/data-worker-test/content_path-ac",
+        temp_path: "/tmp/nativelink/data-worker-test/tmp_path-ac",
+        eviction_policy: {
           // 1gb.
-          "max_bytes": 1000000000
-        }
-      }
-    }, {
-      "name": "WORKER_FAST_SLOW_STORE",
-      "fast_slow": {
+          max_bytes: 1000000000,
+        },
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
         // "fast" must be a "filesystem" store because the worker uses it to make
         // hardlinks on disk to a directory where the jobs are running.
-        "fast": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/data-worker-test/content_path-cas",
-            "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-cas",
-            "eviction_policy": {
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data-worker-test/content_path-cas",
+            temp_path: "/tmp/nativelink/data-worker-test/tmp_path-cas",
+            eviction_policy: {
               // 10gb.
-              "max_bytes": 10000000000
-            }
-          }
+              max_bytes: 10000000000,
+            },
+          },
         },
-        "slow": {
+        slow: {
           /// Discard data.
           /// This example usage has the CAS and the Worker live in the same place,
           /// so they share the same underlying CAS. Since workers require a fast_slow
           /// store, we use the fast store as our primary data store, and the slow store
           /// is just a noop, since there's no shared storage in this config.
-          "noop": {}
-        }
-      }
-    }
+          noop: {},
+        },
+      },
+    },
   ],
-  "schedulers": [
+  schedulers: [
     {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "disk_read_iops": "minimum",
-          "disk_read_bps": "minimum",
-          "disk_write_iops": "minimum",
-          "disk_write_bps": "minimum",
-          "shm_size": "minimum",
-          "gpu_count": "minimum",
-          "gpu_model": "exact",
-          "cpu_vendor": "exact",
-          "cpu_arch": "exact",
-          "cpu_model": "exact",
-          "kernel_version": "exact",
-          "OSFamily": "priority",
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          OSFamily: "priority",
           "container-image": "priority",
           "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
+          ISA: "exact",
+        },
+      },
+    },
   ],
-  "workers": [{
-    "local": {
-      "worker_api_endpoint": {
-        "uri": "grpc://127.0.0.1:50061"
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://127.0.0.1:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "AC_MAIN_STORE",
+        },
+        work_directory: "/tmp/nativelink/work",
+        platform_properties: {
+          cpu_count: {
+            values: [
+              "16",
+            ],
+          },
+          memory_kb: {
+            values: [
+              "500000",
+            ],
+          },
+          network_kbps: {
+            values: [
+              "100000",
+            ],
+          },
+          cpu_arch: {
+            values: [
+              "x86_64",
+            ],
+          },
+          OSFamily: {
+            values: [
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+          "lre-rs": {
+            values: [
+              "",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+        },
       },
-      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
-      "upload_action_result": {
-        "ac_store": "AC_MAIN_STORE"
-      },
-      "work_directory": "/tmp/nativelink/work",
-      "platform_properties": {
-        "cpu_count": {
-          "values": ["16"]
-        },
-        "memory_kb": {
-          "values": ["500000"]
-        },
-        "network_kbps": {
-          "values": ["100000"]
-        },
-        "cpu_arch": {
-          "values": ["x86_64"]
-        },
-        "OSFamily": {
-          "values": [""]
-        },
-        "container-image": {
-          "values": [""]
-        },
-        "lre-rs": {
-          "values": [""]
-        },
-        "ISA": {
-          "values": ["x86-64"]
-        },
-      }
-    }
-  }],
-  "servers": [{
-    "name": "public",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
     },
-    "services": {
-      "cas": [{
-        "instance_name": "main",
-        "cas_store": "WORKER_FAST_SLOW_STORE"
-      }],
-      "ac": [{
-        "instance_name": "main",
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-        "instance_name": "main",
-        "cas_store": "WORKER_FAST_SLOW_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-        "instance_name": "main",
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "main": "WORKER_FAST_SLOW_STORE"
-        }
-      }
-    }
-  }, {
-    "name": "private_workers_servers",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER"
+  ],
+  servers: [
+    {
+      name: "public",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
       },
-      "admin": {},
-      "health": {}
-    }
-  }],
-  "global": {
-    "max_open_files": 24576
-  }
+      services: {
+        cas: [
+          {
+            instance_name: "main",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            instance_name: "main",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            instance_name: "main",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            main: "WORKER_FAST_SLOW_STORE",
+          },
+        },
+      },
+    },
+    {
+      name: "private_workers_servers",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        admin: {},
+        health: {},
+      },
+    },
+  ],
+  global: {
+    max_open_files: 24576,
+  },
 }

--- a/nativelink-config/examples/filesystem_cas.json5
+++ b/nativelink-config/examples/filesystem_cas.json5
@@ -4,166 +4,179 @@
 // so objects are compressed, deduplicated and uses some in-memory
 // optimizations for certain hot paths.
 {
-  "stores": [
+  stores: [
     {
-      "name": "FS_CONTENT_STORE",
-      "compression": {
-        "compression_algorithm": {
-          "lz4": {}
+      name: "FS_CONTENT_STORE",
+      compression: {
+        compression_algorithm: {
+          lz4: {},
         },
-        "backend": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/data/content_path-cas",
-            "temp_path": "/tmp/nativelink/data/tmp_path-cas",
-            "eviction_policy": {
+        backend: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data/content_path-cas",
+            temp_path: "/tmp/nativelink/data/tmp_path-cas",
+            eviction_policy: {
               // 2gb.
-              "max_bytes": 2000000000
-            }
-          }
-        }
-      }
-    }, {
-      "name": "CAS_MAIN_STORE",
-      "verify": {
-        "backend": {
+              max_bytes: 2000000000,
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "CAS_MAIN_STORE",
+      verify: {
+        backend: {
           // Because we are using a dedup store, we can bypass small objects
           // and put those objects directly into the content store without
           // having to be indexed. This greatly improves performance of serving
           // general build content, since many objects are quite small and by
           // putting this size distinguish store in place will prevent 1+ index
           // read/write per small object request.
-          "size_partitioning": {
-            "size": 262144, // 256k.
-            "lower_store": {
-              "ref_store": {
-                "name": "FS_CONTENT_STORE"
-              }
+          size_partitioning: {
+            size: 262144, // 256k.
+            lower_store: {
+              ref_store: {
+                name: "FS_CONTENT_STORE",
+              },
             },
-            "upper_store": {
-              "dedup": {
-                "index_store": {
+            upper_store: {
+              dedup: {
+                index_store: {
                   // Since our index store is queried so much, we use a fast_slow
                   // store so it will keep in memory objects that are accessed
                   // frequently before going to disk.
                   // Note: indexes are generally quite small, but accessed frequently.
-                  "fast_slow": {
-                    "fast": {
-                      "memory": {
-                        "eviction_policy": {
+                  fast_slow: {
+                    fast: {
+                      memory: {
+                        eviction_policy: {
                           // 10mb.
-                          "max_bytes": 10000000
-                        }
-                      }
+                          max_bytes: 10000000,
+                        },
+                      },
                     },
-                    "slow": {
-                      "filesystem": {
-                        "content_path": "/tmp/nativelink/data/content_path-index",
-                        "temp_path": "/tmp/nativelink/data/tmp_path-index",
-                        "eviction_policy": {
+                    slow: {
+                      filesystem: {
+                        content_path: "/tmp/nativelink/data/content_path-index",
+                        temp_path: "/tmp/nativelink/data/tmp_path-index",
+                        eviction_policy: {
                           // 500mb.
-                          "max_bytes": 500000000
-                        }
-                      }
-                    }
-                  }
+                          max_bytes: 500000000,
+                        },
+                      },
+                    },
+                  },
                 },
-                "content_store": {
-                  "ref_store": {
-                    "name": "FS_CONTENT_STORE"
-                  }
-                }
-              }
-            }
-          }
+                content_store: {
+                  ref_store: {
+                    name: "FS_CONTENT_STORE",
+                  },
+                },
+              },
+            },
+          },
         },
-        "verify_size": true,
-        "verify_hash": true
-      }
-    }, {
-      "name": "AC_MAIN_STORE",
-      "filesystem": {
-        "content_path": "/tmp/nativelink/data/content_path-ac",
-        "temp_path": "/tmp/nativelink/data/tmp_path-ac",
-        "eviction_policy": {
-          // 500mb.
-          "max_bytes": 500000000
-        }
-      }
-    }
-  ],
-  "schedulers": [
-    {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "disk_read_iops": "minimum",
-          "disk_read_bps": "minimum",
-          "disk_write_iops": "minimum",
-          "disk_write_bps": "minimum",
-          "shm_size": "minimum",
-          "gpu_count": "minimum",
-          "gpu_model": "exact",
-          "cpu_vendor": "exact",
-          "cpu_arch": "exact",
-          "cpu_model": "exact",
-          "kernel_version": "exact",
-          "docker_image": "priority",
-          "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
-  ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
-    },
-    "services": {
-      "cas": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "instance_name": "main",
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-        "instance_name": "main",
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "main": "CAS_MAIN_STORE"
-        }
-      }
-    }
-  }, {
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER"
+        verify_size: true,
+        verify_hash: true,
       },
-      "health": {}
-    }
-  }]
+    },
+    {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "/tmp/nativelink/data/content_path-ac",
+        temp_path: "/tmp/nativelink/data/tmp_path-ac",
+        eviction_policy: {
+          // 500mb.
+          max_bytes: 500000000,
+        },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          docker_image: "priority",
+          "lre-rs": "priority",
+          ISA: "exact",
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
+      },
+      services: {
+        cas: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            instance_name: "main",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            main: "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/nativelink-config/examples/gcs_backend.json5
+++ b/nativelink-config/examples/gcs_backend.json5
@@ -1,159 +1,169 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "CAS_MAIN_STORE",
-      "verify": {
-        "backend": {
-          "dedup": {
-            "index_store": {
-              "fast_slow": {
-                "fast": {
-                  "filesystem": {
-                    "content_path": "/tmp/nativelink/data/content_path-index",
-                    "temp_path": "/tmp/nativelink/data/tmp_path-index",
-                    "eviction_policy": {
-                      "max_bytes": 500000000  // 500mb
-                    }
-                  }
-                },
-                "slow": {
-                  "experimental_cloud_object_store": {
-                    "provider": "gcs",
-                    "bucket": "nativelink-test-aman",
-                    "key_prefix": "test-prefix-index/",
-                    "retry": {
-                      "max_retries": 6,
-                      "delay": 0.3,
-                      "jitter": 0.5
+      name: "CAS_MAIN_STORE",
+      verify: {
+        backend: {
+          dedup: {
+            index_store: {
+              fast_slow: {
+                fast: {
+                  filesystem: {
+                    content_path: "/tmp/nativelink/data/content_path-index",
+                    temp_path: "/tmp/nativelink/data/tmp_path-index",
+                    eviction_policy: {
+                      max_bytes: 500000000, // 500mb
                     },
-                    "multipart_max_concurrent_uploads": 10
-                  }
-                }
-              }
+                  },
+                },
+                slow: {
+                  experimental_cloud_object_store: {
+                    provider: "gcs",
+                    bucket: "nativelink-test-aman",
+                    key_prefix: "test-prefix-index/",
+                    retry: {
+                      max_retries: 6,
+                      delay: 0.3,
+                      jitter: 0.5,
+                    },
+                    multipart_max_concurrent_uploads: 10,
+                  },
+                },
+              },
             },
-            "content_store": {
-              "compression": {
-                "compression_algorithm": {
-                  "lz4": {}
+            content_store: {
+              compression: {
+                compression_algorithm: {
+                  lz4: {},
                 },
-                "backend": {
-                  "fast_slow": {
-                    "fast": {
-                      "filesystem": {
-                        "content_path": "/tmp/nativelink/data/content_path-content",
-                        "temp_path": "/tmp/nativelink/data/tmp_path-content",
-                        "eviction_policy": {
-                          "max_bytes": 2000000000  // 2gb
-                        }
-                      }
-                    },
-                    "slow": {
-                      "experimental_cloud_object_store": {
-                        "provider": "gcs",
-                        "bucket": "nativelink-test-aman",
-                        "key_prefix": "test-prefix-dedup-cas/",
-                        "retry": {
-                          "max_retries": 6,
-                          "delay": 0.3,
-                          "jitter": 0.5
+                backend: {
+                  fast_slow: {
+                    fast: {
+                      filesystem: {
+                        content_path: "/tmp/nativelink/data/content_path-content",
+                        temp_path: "/tmp/nativelink/data/tmp_path-content",
+                        eviction_policy: {
+                          max_bytes: 2000000000, // 2gb
                         },
-                        "multipart_max_concurrent_uploads": 10
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "verify_size": true
-      }
-    },
-    {
-      "name": "AC_MAIN_STORE",
-      "fast_slow": {
-        "fast": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/data/content_path-ac",
-            "temp_path": "/tmp/nativelink/data/tmp_path-ac",
-            "eviction_policy": {
-              "max_bytes": 500000000  // 500mb
-            }
-          }
-        },
-        "slow": {
-          "experimental_cloud_object_store": {
-            "provider": "gcs",
-            "bucket": "nativelink-test-aman",
-            "key_prefix": "test-prefix-ac/",
-            "retry": {
-              "max_retries": 6,
-              "delay": 0.3,
-              "jitter": 0.5
+                      },
+                    },
+                    slow: {
+                      experimental_cloud_object_store: {
+                        provider: "gcs",
+                        bucket: "nativelink-test-aman",
+                        key_prefix: "test-prefix-dedup-cas/",
+                        retry: {
+                          max_retries: 6,
+                          delay: 0.3,
+                          jitter: 0.5,
+                        },
+                        multipart_max_concurrent_uploads: 10,
+                      },
+                    },
+                  },
+                },
+              },
             },
-            "multipart_max_concurrent_uploads": 10
-          }
-        }
-      }
-    }
-  ],
-  "schedulers": [
-    {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "disk_read_iops": "minimum",
-          "disk_read_bps": "minimum",
-          "disk_write_iops": "minimum",
-          "disk_write_bps": "minimum",
-          "shm_size": "minimum",
-          "gpu_count": "minimum",
-          "gpu_model": "exact",
-          "cpu_vendor": "exact",
-          "cpu_arch": "exact",
-          "cpu_model": "exact",
-          "kernel_version": "exact",
-          "docker_image": "priority",
-          "lre-rs": "priority"
-        }
-      }
-    }
-  ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
-    },
-    "services": {
-      "cas": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "instance_name": "main",
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-        "instance_name": "main",
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "main": "CAS_MAIN_STORE"
-        }
+          },
+        },
+        verify_size: true,
       },
-      "health": {}
-    }
-  }]
+    },
+    {
+      name: "AC_MAIN_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data/content_path-ac",
+            temp_path: "/tmp/nativelink/data/tmp_path-ac",
+            eviction_policy: {
+              max_bytes: 500000000, // 500mb
+            },
+          },
+        },
+        slow: {
+          experimental_cloud_object_store: {
+            provider: "gcs",
+            bucket: "nativelink-test-aman",
+            key_prefix: "test-prefix-ac/",
+            retry: {
+              max_retries: 6,
+              delay: 0.3,
+              jitter: 0.5,
+            },
+            multipart_max_concurrent_uploads: 10,
+          },
+        },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          docker_image: "priority",
+          "lre-rs": "priority",
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
+      },
+      services: {
+        cas: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            instance_name: "main",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            main: "CAS_MAIN_STORE",
+          },
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/nativelink-config/examples/redis.json5
+++ b/nativelink-config/examples/redis.json5
@@ -1,72 +1,83 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "CAS_FAST_SLOW_STORE",
-      "redis_store": {
-        "addresses": ["redis://127.0.0.1:6379/"],
-        "mode": "cluster"
-      }
-    }, {
-      "name": "AC_FAST_SLOW_STORE",
-      "redis_store": {
-        "addresses": ["redis://127.0.0.1:6379/"],
-        "mode": "cluster"
-      }
-    }, {
-      "name": "AC_MAIN_STORE",
-      "completeness_checking": {
-        "backend": {
-          "ref_store": {
-            "name": "AC_FAST_SLOW_STORE"
-          }
-        },
-        "cas_store": {
-          "ref_store": {
-            "name": "CAS_MAIN_STORE"
-          }
-        }
-      }
-    }, {
-      "name": "CAS_MAIN_STORE",
-      "existence_cache": {
-        "backend": {
-          "compression": {
-            "compression_algorithm": {
-              "lz4": {}
-            },
-            "backend": {
-              "ref_store": {
-                "name": "CAS_FAST_SLOW_STORE"
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
-  "servers": [
-    {
-      "listener": {
-        "http": {
-          "socket_address": "0.0.0.0:50051"
-        }
+      name: "CAS_FAST_SLOW_STORE",
+      redis_store: {
+        addresses: [
+          "redis://127.0.0.1:6379/",
+        ],
+        mode: "cluster",
       },
-      "services": {
-        "cas": [{
-          "instance_name": "main",
-          "cas_store": "CAS_MAIN_STORE"
-        }],
-        "ac": [{
-          "instance_name": "main",
-          "ac_store": "AC_MAIN_STORE"
-        }],
-        "capabilities": [],
-        "bytestream": {
-          "cas_stores": {
-            "main": "CAS_MAIN_STORE"
-          }
-        }
-      }
-    }
-  ]
+    },
+    {
+      name: "AC_FAST_SLOW_STORE",
+      redis_store: {
+        addresses: [
+          "redis://127.0.0.1:6379/",
+        ],
+        mode: "cluster",
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      completeness_checking: {
+        backend: {
+          ref_store: {
+            name: "AC_FAST_SLOW_STORE",
+          },
+        },
+        cas_store: {
+          ref_store: {
+            name: "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+    {
+      name: "CAS_MAIN_STORE",
+      existence_cache: {
+        backend: {
+          compression: {
+            compression_algorithm: {
+              lz4: {},
+            },
+            backend: {
+              ref_store: {
+                name: "CAS_FAST_SLOW_STORE",
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
+      },
+      services: {
+        cas: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        capabilities: [],
+        bytestream: {
+          cas_stores: {
+            main: "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+  ],
 }

--- a/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
+++ b/nativelink-config/examples/s3_backend_with_local_fast_cas.json5
@@ -1,19 +1,20 @@
 {
-  "stores": [
+  stores: [
     {
-      "name": "CAS_MAIN_STORE",
-      "verify": {
-        "verify_size": true,
-        "backend": {
-          "dedup": {
-            "index_store": {
-              "fast_slow": {
-                "fast": {
-                  "memory": {
-                    "eviction_policy": {
-                      "max_bytes": "100mb"
-                    }
-                  }
+      name: "CAS_MAIN_STORE",
+      verify: {
+        verify_size: true,
+        backend: {
+          dedup: {
+            index_store: {
+              fast_slow: {
+                fast: {
+                  memory: {
+                    eviction_policy: {
+                      max_bytes: "100mb",
+                    },
+                  },
+
                   // "filesystem": {
                   //   "content_path": "/tmp/nativelink/data/content_path-index",
                   //   "temp_path": "/tmp/nativelink/data/tmp_path-index",
@@ -22,34 +23,35 @@
                   //   }
                   // }
                 },
-                "slow": {
-                  "experimental_cloud_object_store": {
-                    "provider": "aws",
-                    "region": "eu-central-1",
-                    "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
-                    "key_prefix": "test-prefix-index/",
-                    "retry": {
-                      "max_retries": 6,
-                      "delay": 0.3,
-                      "jitter": 0.5
-                    }
-                  }
-                }
-              }
-            },
-            "content_store": {
-              "compression": {
-                "compression_algorithm": {
-                  "lz4": {}
+                slow: {
+                  experimental_cloud_object_store: {
+                    provider: "aws",
+                    region: "eu-central-1",
+                    bucket: "mybucket-1b19581ba67b64d50b4325d1727205756",
+                    key_prefix: "test-prefix-index/",
+                    retry: {
+                      max_retries: 6,
+                      delay: 0.3,
+                      jitter: 0.5,
+                    },
+                  },
                 },
-                "backend": {
-                  "fast_slow": {
-                    "fast": {
-                      "memory": {
-                        "eviction_policy": {
-                          "max_bytes": "100mb"
-                        }
-                      }
+              },
+            },
+            content_store: {
+              compression: {
+                compression_algorithm: {
+                  lz4: {},
+                },
+                backend: {
+                  fast_slow: {
+                    fast: {
+                      memory: {
+                        eviction_policy: {
+                          max_bytes: "100mb",
+                        },
+                      },
+
                       // "filesystem": {
                       //   "content_path": "/tmp/nativelink/data/content_path-content",
                       //   "temp_path": "/tmp/nativelink/data/tmp_path-content",
@@ -58,36 +60,37 @@
                       //   }
                       // }
                     },
-                    "slow": {
-                      "experimental_cloud_object_store": {
-                        "provider": "aws",
-                        "region": "eu-central-1",
-                        "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
-                        "key_prefix": "test-prefix-dedup-cas/",
-                        "retry": {
-                          "max_retries": 6,
-                          "delay": 0.3,
-                          "jitter": 0.5
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    slow: {
+                      experimental_cloud_object_store: {
+                        provider: "aws",
+                        region: "eu-central-1",
+                        bucket: "mybucket-1b19581ba67b64d50b4325d1727205756",
+                        key_prefix: "test-prefix-dedup-cas/",
+                        retry: {
+                          max_retries: 6,
+                          delay: 0.3,
+                          jitter: 0.5,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
     {
-      "name": "AC_MAIN_STORE",
-      "fast_slow": {
-        "fast": {
-          "memory": {
-            "eviction_policy": {
-              "max_bytes": "100mb"
-            }
+      name: "AC_MAIN_STORE",
+      fast_slow: {
+        fast: {
+          memory: {
+            eviction_policy: {
+              max_bytes: "100mb",
+            },
           },
+
           // "filesystem": {
           //   "content_path": "/tmp/nativelink/data/content_path-ac",
           //   "temp_path": "/tmp/nativelink/data/tmp_path-ac",
@@ -96,81 +99,92 @@
           //   }
           // }
         },
-        "slow": {
-          "experimental_cloud_object_store": {
-            "provider": "aws",
-            "region": "eu-central-1",
-            "bucket": "mybucket-1b19581ba67b64d50b4325d1727205756",
-            "key_prefix": "test-prefix-ac/",
-            "retry": {
-              "max_retries": 6,
-              "delay": 0.3,
-              "jitter": 0.5,
-            }
+        slow: {
+          experimental_cloud_object_store: {
+            provider: "aws",
+            region: "eu-central-1",
+            bucket: "mybucket-1b19581ba67b64d50b4325d1727205756",
+            key_prefix: "test-prefix-ac/",
+            retry: {
+              max_retries: 6,
+              delay: 0.3,
+              jitter: 0.5,
+            },
+
             // "additional_max_concurrent_requests": 10,
-          }
-        }
-      }
-    }
-  ],
-  "schedulers": [
-    {
-      "name": "MAIN_SCHEDULER",
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "disk_read_iops": "minimum",
-          "disk_read_bps": "minimum",
-          "disk_write_iops": "minimum",
-          "disk_write_bps": "minimum",
-          "shm_size": "minimum",
-          "gpu_count": "minimum",
-          "gpu_model": "exact",
-          "cpu_vendor": "exact",
-          "cpu_arch": "exact",
-          "cpu_model": "exact",
-          "kernel_version": "exact",
-          "docker_image": "priority",
-          "lre-rs": "priority",
-          "ISA": "exact",
-        }
-      }
-    }
-  ],
-  "servers": [{
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
-    },
-    "services": {
-      "cas": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE"
-      }],
-      "ac": [{
-        "instance_name": "main",
-        "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-        "instance_name": "main",
-        "cas_store": "CAS_MAIN_STORE",
-        "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-        "instance_name": "main",
-        "remote_execution": {
-          "scheduler": "MAIN_SCHEDULER"
-        }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "main": "CAS_MAIN_STORE"
-        }
+          },
+        },
       },
-      "health": {}
-    }
-  }]
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          docker_image: "priority",
+          "lre-rs": "priority",
+          ISA: "exact",
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
+      },
+      services: {
+        cas: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            instance_name: "main",
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            instance_name: "main",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            main: "CAS_MAIN_STORE",
+          },
+        },
+        health: {},
+      },
+    },
+  ],
 }

--- a/toolchain-examples/nativelink-config.json5
+++ b/toolchain-examples/nativelink-config.json5
@@ -1,136 +1,161 @@
 {
-  "stores": {
-    "AC_MAIN_STORE": {
-      "filesystem": {
-        "content_path": "/tmp/nativelink/data-worker-test/content_path-ac",
-        "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-ac",
-        "eviction_policy": {
+  stores: {
+    AC_MAIN_STORE: {
+      filesystem: {
+        content_path: "/tmp/nativelink/data-worker-test/content_path-ac",
+        temp_path: "/tmp/nativelink/data-worker-test/tmp_path-ac",
+        eviction_policy: {
           // 1gb.
-          "max_bytes": 1000000000,
-        }
-      }
+          max_bytes: 1000000000,
+        },
+      },
     },
-    "WORKER_FAST_SLOW_STORE": {
-      "fast_slow": {
+    WORKER_FAST_SLOW_STORE: {
+      fast_slow: {
         // "fast" must be a "filesystem" store because the worker uses it to make
         // hardlinks on disk to a directory where the jobs are running.
-        "fast": {
-          "filesystem": {
-            "content_path": "/tmp/nativelink/data-worker-test/content_path-cas",
-            "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-cas",
-            "eviction_policy": {
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data-worker-test/content_path-cas",
+            temp_path: "/tmp/nativelink/data-worker-test/tmp_path-cas",
+            eviction_policy: {
               // 10gb.
-              "max_bytes": 10000000000,
-            }
-          }
+              max_bytes: 10000000000,
+            },
+          },
         },
-        "slow": {
+        slow: {
           /// Discard data.
           /// This example usage has the CAS and the Worker live in the same place,
           /// so they share the same underlying CAS. Since workers require a fast_slow
           /// store, we use the fast store as our primary data store, and the slow store
           /// is just a noop, since there's no shared storage in this config.
-          "noop": {}
-        }
-      }
-    }
+          noop: {},
+        },
+      },
+    },
   },
-  "schedulers": {
-    "MAIN_SCHEDULER": {
-      "simple": {
-        "supported_platform_properties": {
-          "cpu_count": "minimum",
-          "memory_kb": "minimum",
-          "network_kbps": "minimum",
-          "cpu_arch": "exact",
-          "OSFamily": "priority",
+  schedulers: {
+    MAIN_SCHEDULER: {
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          cpu_arch: "exact",
+          OSFamily: "priority",
           "container-image": "priority",
-        }
-      }
-    }
+        },
+      },
+    },
   },
-  "workers": [{
-    "local": {
-      "worker_api_endpoint": {
-        "uri": "grpc://127.0.0.1:50061",
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://127.0.0.1:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "AC_MAIN_STORE",
+        },
+        work_directory: "/tmp/nativelink/work",
+        platform_properties: {
+          cpu_count: {
+            values: [
+              "16",
+            ],
+          },
+          memory_kb: {
+            values: [
+              "500000",
+            ],
+          },
+          network_kbps: {
+            values: [
+              "100000",
+            ],
+          },
+          cpu_arch: {
+            values: [
+              "x86_64",
+            ],
+          },
+          OSFamily: {
+            values: [
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+        },
       },
-      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
-      "upload_action_result": {
-        "ac_store": "AC_MAIN_STORE",
-      },
-      "work_directory": "/tmp/nativelink/work",
-      "platform_properties": {
-        "cpu_count": {
-          "values": ["16"],
-        },
-        "memory_kb": {
-          "values": ["500000"],
-        },
-        "network_kbps": {
-          "values": ["100000"],
-        },
-        "cpu_arch": {
-          "values": ["x86_64"],
-        },
-        "OSFamily": {
-          "values": [""]
-        },
-        "container-image": {
-          "values": [""]
-        },
-      }
-    }
-  }],
-  "servers": [{
-    "name": "public",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50051"
-      }
     },
-    "services": {
-     "cas": [{
-          "cas_store": "WORKER_FAST_SLOW_STORE"
-      }],
-      "ac": [{
-          "ac_store": "AC_MAIN_STORE"
-      }],
-      "execution": [{
-          "cas_store": "WORKER_FAST_SLOW_STORE",
-          "scheduler": "MAIN_SCHEDULER"
-      }],
-      "capabilities": [{
-          "remote_execution": {
-            "scheduler": "MAIN_SCHEDULER"
-          }
-      }],
-      "bytestream": {
-        "cas_stores": {
-          "": "WORKER_FAST_SLOW_STORE",
-        }
-      }
-    }
-  }, {
-    "name": "private_workers_servers",
-    "listener": {
-      "http": {
-        "socket_address": "0.0.0.0:50061"
-      }
-    },
-    "services": {
-      // Note: This should be served on a different port, because it has
-      // a different permission set than the other services.
-      // In other words, this service is a backend api. The ones above
-      // are a frontend api.
-      "worker_api": {
-        "scheduler": "MAIN_SCHEDULER",
+  ],
+  servers: [
+    {
+      name: "public",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+        },
       },
-      "admin": {},
-      "health": {},
-    }
-  }],
-  "global": {
+      services: {
+        cas: [
+          {
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            cas_store: "WORKER_FAST_SLOW_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: {
+          cas_stores: {
+            "": "WORKER_FAST_SLOW_STORE",
+          },
+        },
+      },
+    },
+    {
+      name: "private_workers_servers",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        admin: {},
+        health: {},
+      },
+    },
+  ],
+  global: {
     // Defaults to 24576 = 24 * 1024.
-    "max_open_files": 24576
-  }
+    max_open_files: 24576,
+  },
 }

--- a/tools/pre-commit-hooks.nix
+++ b/tools/pre-commit-hooks.nix
@@ -184,4 +184,13 @@ in {
     files = "Cargo.toml|.bazelrc";
     pass_filenames = false;
   };
+
+  # json5
+  formatjson5 = {
+    description = "Format json5 files";
+    enable = true;
+    entry = "${pkgs.formatjson5}/bin/formatjson5";
+    args = ["-r" "--indent" "2"];
+    types = ["json5"];
+  };
 }


### PR DESCRIPTION
# Description

This adds formatting for JSON5 files to the pre-commit, and applies it to all the current files. Their formatting was previously mostly good, but somewhat inconsistent. Note this removes the quote formatting around properties which makes the diff notably larger, but the tool I've been using doesn't support that as an option. I like it personally, but that's an open question if it's a preferred style or not.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing test suites.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1817)
<!-- Reviewable:end -->
