### PR TITLE
Check example JSON5 files pass the parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ version = "0.6.0"
 dependencies = [
  "byte-unit",
  "humantime",
+ "nativelink-error",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -2286,6 +2287,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "serde_json5",
  "tokio",
  "tonic 0.13.0",
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
         src = pkgs.lib.cleanSourceWith {
           src = (craneLibFor pkgs).path ./.;
           filter = path: type:
-            (builtins.match "^.*(data/SekienAkashita\.jpg|nativelink-config/README\.md)" path != null)
+            (builtins.match "^.*(examples/.+\.json5|data/SekienAkashita\.jpg|nativelink-config/README\.md)" path != null)
             || ((craneLibFor pkgs).filterCargoSources path type);
         };
 

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -22,9 +22,11 @@ rust_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//nativelink-error",
         "@crates//:byte-unit",
         "@crates//:humantime",
         "@crates//:serde",
+        "@crates//:serde_json5",
         "@crates//:shellexpand",
     ],
 )
@@ -34,7 +36,11 @@ rust_test_suite(
     timeout = "short",
     srcs = [
         "tests/deserialization_test.rs",
+        "tests/json5_test.rs",
     ],
+    data = glob(
+        ["examples/*.json5"],
+    ),
     deps = [
         "//nativelink-config",
         "//nativelink-error",

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -6,6 +6,8 @@ name = "nativelink-config"
 version = "0.6.0"
 
 [dependencies]
+nativelink-error = { path = "../nativelink-error" }
+
 byte-unit = { version = "5.1.6", default-features = false, features = ["byte"] }
 humantime = "2.2.0"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
@@ -16,4 +18,6 @@ shellexpand = { version = "3.1.0", default-features = false, features = [
 
 [dev-dependencies]
 pretty_assertions = { version = "1.4.1", features = ["std"] }
-serde_json = { version = "1.0.140", default-features = false }
+serde_json = { version = "1.0.140", default-features = false, features = [
+  "std",
+] }

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use nativelink_error::{Error, ResultExt};
 use serde::Deserialize;
 
 use crate::schedulers::SchedulerSpec;
@@ -796,4 +797,12 @@ pub struct CasConfig {
 
     /// Any global configurations that apply to all modules live here.
     pub global: Option<GlobalConfig>,
+}
+
+impl CasConfig {
+    pub fn try_from_json5_file(config_file: &str) -> Result<Self, Error> {
+        let json_contents = std::fs::read_to_string(config_file)
+            .err_tip(|| format!("Could not open config file {config_file}"))?;
+        Ok(serde_json5::from_str(&json_contents)?)
+    }
 }

--- a/nativelink-config/tests/json5_test.rs
+++ b/nativelink-config/tests/json5_test.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::Path;
+
+use nativelink_config::cas_server::CasConfig;
+
+#[test]
+fn test_example_parsing() {
+    let mut examples_path = Path::new(".")
+        .canonicalize()
+        .expect("Can canonicalize current dir");
+
+    if examples_path.join("nativelink-config").exists() {
+        // inside bazel
+        examples_path = examples_path.join("nativelink-config");
+    }
+    examples_path = examples_path.join("examples");
+
+    let mut found_at_least_one_entry = false;
+
+    for entry in fs::read_dir(&examples_path)
+        .unwrap_or_else(|e| panic!("Failed to read from {:?}: {}", &examples_path, e))
+    {
+        let config_file = entry.unwrap().path().display().to_string();
+        if !config_file.contains(".json5") {
+            continue;
+        }
+        CasConfig::try_from_json5_file(&config_file)
+            .unwrap_or_else(|e| panic!("Error while reading {config_file}: {e}"));
+        found_at_least_one_entry = true;
+    }
+
+    assert!(found_at_least_one_entry);
+}

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -20,6 +20,7 @@ rust_library(
         "@crates//:prost",
         "@crates//:prost-types",
         "@crates//:serde",
+        "@crates//:serde_json5",
         "@crates//:tokio",
         "@crates//:tonic",
     ],

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -20,6 +20,7 @@ hex = { version = "0.4.3", default-features = false }
 prost = { version = "0.13.5", default-features = false }
 prost-types = { version = "0.13.5", default-features = false }
 serde = { version = "1.0.219", default-features = false }
+serde_json5 = { version = "0.2.1", default-features = false }
 tokio = { version = "1.44.1", features = [
   "fs",
   "io-util",

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -182,6 +182,12 @@ impl From<tokio::task::JoinError> for Error {
     }
 }
 
+impl From<serde_json5::Error> for Error {
+    fn from(err: serde_json5::Error) -> Self {
+        make_err!(Code::Internal, "{}", err.to_string())
+    }
+}
+
 impl From<core::num::ParseIntError> for Error {
     fn from(err: core::num::ParseIntError) -> Self {
         make_err!(Code::InvalidArgument, "{}", err.to_string())

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -820,13 +820,9 @@ async fn inner_main(
     Ok(())
 }
 
-fn get_config() -> Result<CasConfig, Box<dyn core::error::Error>> {
+fn get_config() -> Result<CasConfig, Error> {
     let args = Args::parse();
-    let json_contents = String::from_utf8(
-        std::fs::read(&args.config_file)
-            .err_tip(|| format!("Could not open config file {}", args.config_file))?,
-    )?;
-    Ok(serde_json5::from_str(&json_contents)?)
+    CasConfig::try_from_json5_file(&args.config_file)
 }
 
 fn main() -> Result<(), Box<dyn core::error::Error>> {


### PR DESCRIPTION
# Description

This confirms that all the example JSON5 configs actually pass the parser. It turned out to be fine, but I was worried we could make changes and accidentally break them.

It could be expanded to also pull in the other demo configs in the repo, but that's a bit tricky given fun of where Bazel has certain files and not being able to go up a directory in the config.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing test suites

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1818)
<!-- Reviewable:end -->
