### PR TITLE
Override the reclient ToC with a working version

### DIFF
--- a/web/platform/src/routeData.ts
+++ b/web/platform/src/routeData.ts
@@ -1,0 +1,70 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const { headings } = context.locals.starlightRoute;
+  if (
+    context.locals.starlightRoute.toc !== undefined &&
+    headings.length > 0 &&
+    headings[0]?.text.indexOf("Reclient") !== -1
+  ) {
+    // TODO(palfrey): The tabs setup completely breaks the ToC generation
+    // so we override here entirely with a fixed version
+    context.locals.starlightRoute.toc.items = [
+      {
+        depth: 2,
+        slug: "_top",
+        text: "Overview",
+        children: [
+          {
+            depth: 3,
+            slug: "1-setup-reclient-chromium",
+            text: "1. Setup Reclient/Chromium",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "2-setup-your-nativelink-configuration-directory",
+            text: "2. Setup your NativeLink configuration directory",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "2-setup-your-nativelink-configuration-directory",
+            text: "2. Setup your NativeLink configuration directory",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "3-generating-your-mtls-key-files",
+            text: "3. Generating your mTLS key files",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "4-upload-the-public-key-to-nativelink",
+            text: "4. Upload the public key to NativeLink",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "5-setup-your-environment",
+            text: "5. Setup your environment",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "6-build-chromium",
+            text: "6. Build Chromium",
+            children: [],
+          },
+          {
+            depth: 3,
+            slug: "7-watch-the-execution",
+            text: "7. Watch the execution",
+            children: [],
+          },
+        ],
+      },
+    ];
+  }
+});

--- a/web/platform/starlight.conf.ts
+++ b/web/platform/starlight.conf.ts
@@ -37,6 +37,7 @@ export const starlightConfig = {
       },
     }),
   ],
+  routeMiddleware: "./src/routeData.ts",
   sidebar: [
     // The documentation structure follows the Diátaxis framework.
     // See https://diataxis.fr/ for details.


### PR DESCRIPTION
# Description

[The current reclient page](https://www.nativelink.com/docs/nativelink-cloud/reclient) has a duplicated ToC due to the tabs setup breaking the generation entirely. The ideal scenario would be doing the tabs on a per-step basis and syncing the OS choice somehow, but this at least mostly fixes the ToC for now.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

local testing with `bun run build && bun serve`

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1827)
<!-- Reviewable:end -->
