### PR TITLE
Reduce Renovate noise by limiting to security and major fixes only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,26 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+  ],
+  packageRules: [
+    {
+      matchUpdateTypes: [
+        "patch",
+        "minor",
+      ],
+      enabled: false,
+    },
+    {
+      matchPackageNames: [
+        "*",
+      ],
+      automerge: true,
+    },
+  ],
+  prConcurrentLimit: 2,
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+  osvVulnerabilityAlerts: true,
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/tools/pre-commit-hooks.nix
+++ b/tools/pre-commit-hooks.nix
@@ -193,4 +193,13 @@ in {
     args = ["-r" "--indent" "2"];
     types = ["json5"];
   };
+
+  # Renovate config validator
+  renovate = {
+    description = "Validate renovate config";
+    enable = true;
+    entry = "${pkgs.renovate}/bin/renovate-config-validator";
+    args = ["--strict"];
+    files = "renovate.json5";
+  };
 }


### PR DESCRIPTION
# Description

Right now, we get a whole stack of Renovate PRs for things like "upgrades X by from 4.0.1 to 4.0.2" which are for the most part basically worthless. This PR strips the Renovate changes down to just major package upgrades and security fixes. None of this stops us doing the little upgrades by hand, but this at least reduces the amount of noise.

It also enables automerge, but we still currently require by-hand approvals.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

New pre-commit hook for renovate validation

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
