### PR TITLE
extend scheduler factory to support Mongo store

### DIFF
--- a/nativelink-config/examples/mongo.json5
+++ b/nativelink-config/examples/mongo.json5
@@ -93,6 +93,23 @@
         worker_timeout_s: 300,
       },
     },
+    {
+      // Example of a scheduler using MongoDB backend for state management
+      name: "MONGO_BACKED_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_arch: "minimum",
+          OS: "exact",
+        },
+        max_job_retries: 3,
+        worker_timeout_s: 300,
+        experimental_backend: {
+          mongo: {
+            mongo_store: "MONGO_SCHEDULER",
+          },
+        },
+      },
+    },
   ],
   servers: [
     {

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -138,6 +138,8 @@ pub enum ExperimentalSimpleSchedulerBackend {
     Memory,
     /// Use a redis store for the scheduler.
     Redis(ExperimentalRedisSchedulerBackend),
+    /// Use a mongodb store for the scheduler.
+    Mongo(ExperimentalMongoSchedulerBackend),
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -146,6 +148,14 @@ pub struct ExperimentalRedisSchedulerBackend {
     /// A reference to the redis store to use for the scheduler.
     /// Note: This MUST resolve to a `RedisSpec`.
     pub redis_store: StoreRefName,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ExperimentalMongoSchedulerBackend {
+    /// A reference to the mongo store to use for the scheduler.
+    /// Note: This MUST resolve to a `ExperimentalMongoSpec`.
+    pub mongo_store: StoreRefName,
 }
 
 /// A scheduler that simply forwards requests to an upstream scheduler.  This


### PR DESCRIPTION
# Description

Modifying the scheduler factory to ensure that MongoDB could be an alternative to Redis.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1843)
<!-- Reviewable:end -->
