### PR TITLE
Fix GCS store implementation

### DIFF
--- a/nativelink-store/src/gcs_client/client.rs
+++ b/nativelink-store/src/gcs_client/client.rs
@@ -20,6 +20,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use futures::Stream;
 use google_cloud_auth::credentials::CredentialsFile;
 use google_cloud_storage::client::{Client, ClientConfig};
 use google_cloud_storage::http::Error as GcsError;
@@ -33,7 +35,7 @@ use nativelink_error::{Code, Error, make_err};
 use nativelink_util::buf_channel::DropCloserReadHalf;
 use rand::Rng;
 use tokio::fs;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::sleep;
 
 use crate::gcs_client::types::{
@@ -53,9 +55,9 @@ pub trait GcsOperations: Send + Sync + Debug {
     async fn read_object_content(
         &self,
         object_path: &ObjectPath,
-        start: i64,
-        end: Option<i64>,
-    ) -> Result<Vec<u8>, Error>;
+        start: u64,
+        end: Option<u64>,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, Error>> + Send + Unpin>, Error>;
 
     /// Write object with simple upload (for smaller objects)
     async fn write_object(&self, object_path: &ObjectPath, content: Vec<u8>) -> Result<(), Error>;
@@ -68,10 +70,10 @@ pub trait GcsOperations: Send + Sync + Debug {
         &self,
         upload_url: &str,
         object_path: &ObjectPath,
-        data: Vec<u8>,
-        offset: i64,
-        end_offset: i64,
-        is_final: bool,
+        data: Bytes,
+        offset: u64,
+        end_offset: u64,
+        total_size: Option<u64>,
     ) -> Result<(), Error>;
 
     /// Complete high-level operation to upload data from a reader
@@ -80,7 +82,7 @@ pub trait GcsOperations: Send + Sync + Debug {
         object_path: &ObjectPath,
         reader: &mut DropCloserReadHalf,
         upload_id: &str,
-        max_size: i64,
+        max_size: u64,
     ) -> Result<(), Error>;
 
     /// Check if an object exists
@@ -98,7 +100,7 @@ impl GcsClient {
     /// Create a new GCS client from the provided spec
     pub async fn new(spec: &ExperimentalGcsSpec) -> Result<Self, Error> {
         // Creating default config without authentication initially
-        let mut client_config = ClientConfig::default();
+        let mut client_config = ClientConfig::default().anonymous();
         let mut auth_success = false;
 
         // Trying authentication with credentials file path from environment variable.
@@ -240,7 +242,7 @@ impl GcsClient {
     }
 
     /// Handle error from GCS operations
-    fn handle_gcs_error(&self, err: &GcsError) -> Error {
+    fn handle_gcs_error(err: &GcsError) -> Error {
         let code = match &err {
             GcsError::Response(resp) => match resp.code {
                 404 => Code::NotFound,
@@ -260,15 +262,15 @@ impl GcsClient {
         &self,
         object_path: &ObjectPath,
         reader: &mut DropCloserReadHalf,
-        max_size: i64,
+        max_size: u64,
     ) -> Result<(), Error> {
         let initial_capacity = core::cmp::min(max_size as usize, 10 * 1024 * 1024);
         let mut data = Vec::with_capacity(initial_capacity);
-        let mut total_size: i64 = 0;
+        let max_size = max_size as usize;
+        let mut total_size = 0usize;
 
         while total_size < max_size {
-            let to_read =
-                core::cmp::min(self.resumable_chunk_size, (max_size - total_size) as usize);
+            let to_read = core::cmp::min(self.resumable_chunk_size, max_size - total_size);
             let chunk = reader.consume(Some(to_read)).await?;
 
             if chunk.is_empty() {
@@ -276,7 +278,7 @@ impl GcsClient {
             }
 
             data.extend_from_slice(&chunk);
-            total_size += chunk.len() as i64;
+            total_size += chunk.len();
         }
 
         self.write_object(object_path, data).await
@@ -287,7 +289,7 @@ impl GcsClient {
         &self,
         object_path: &ObjectPath,
         reader: &mut DropCloserReadHalf,
-        max_size: i64,
+        max_size: u64,
     ) -> Result<(), Error> {
         self.with_connection(|| async {
             let request = UploadObjectRequest {
@@ -311,17 +313,15 @@ impl GcsClient {
                 .client
                 .prepare_resumable_upload(&request, &upload_type)
                 .await
-                .map_err(|e| self.handle_gcs_error(&e))?;
+                .map_err(|e| Self::handle_gcs_error(&e))?;
 
             // Upload data in chunks
             let mut offset: u64 = 0;
-            let mut total_uploaded: i64 = 0;
+            let max_size = max_size as usize;
+            let mut total_uploaded = 0usize;
 
             while total_uploaded < max_size {
-                let to_read = core::cmp::min(
-                    self.resumable_chunk_size,
-                    (max_size - total_uploaded) as usize,
-                );
+                let to_read = core::cmp::min(self.resumable_chunk_size, max_size - total_uploaded);
                 let chunk = reader.consume(Some(to_read)).await?;
 
                 if chunk.is_empty() {
@@ -329,7 +329,7 @@ impl GcsClient {
                 }
 
                 let chunk_size = chunk.len() as u64;
-                total_uploaded += chunk.len() as i64;
+                total_uploaded += chunk.len();
 
                 let is_final = total_uploaded >= max_size || chunk.len() < to_read;
                 let total_size = if is_final {
@@ -344,7 +344,7 @@ impl GcsClient {
                 let status = uploader
                     .upload_multiple_chunk(chunk, &chunk_def)
                     .await
-                    .map_err(|e| self.handle_gcs_error(&e))?;
+                    .map_err(|e| Self::handle_gcs_error(&e))?;
 
                 // Update offset for next chunk
                 offset += chunk_size;
@@ -360,7 +360,7 @@ impl GcsClient {
                 uploader
                     .upload_multiple_chunk(Vec::new(), &chunk_def)
                     .await
-                    .map_err(|e| self.handle_gcs_error(&e))?;
+                    .map_err(|e| Self::handle_gcs_error(&e))?;
             }
 
             // Check if the object exists
@@ -406,7 +406,7 @@ impl GcsOperations for GcsClient {
                             return Ok(None);
                         }
                     }
-                    Err(self.handle_gcs_error(&err))
+                    Err(Self::handle_gcs_error(&err))
                 }
             }
         })
@@ -416,35 +416,67 @@ impl GcsOperations for GcsClient {
     async fn read_object_content(
         &self,
         object_path: &ObjectPath,
-        start: i64,
-        end: Option<i64>,
-    ) -> Result<Vec<u8>, Error> {
-        self.with_connection(|| async {
-            let request = GetObjectRequest {
-                bucket: object_path.bucket.clone(),
-                object: object_path.path.clone(),
-                ..Default::default()
-            };
+        start: u64,
+        end: Option<u64>,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, Error>> + Send + Unpin>, Error> {
+        type StreamItem = Result<Bytes, google_cloud_storage::http::Error>;
+        struct ReadStream<T: Stream<Item = StreamItem> + Send + Unpin> {
+            stream: T,
+            permit: Option<OwnedSemaphorePermit>,
+        }
 
-            let range = if start > 0 || end.is_some() {
-                Range(
-                    if start > 0 { Some(start as u64) } else { None },
-                    end.map(|e| e as u64),
-                )
-            } else {
-                Range(None, None)
-            };
+        impl<T: Stream<Item = StreamItem> + Send + Unpin> Stream for ReadStream<T> {
+            type Item = Result<Bytes, Error>;
 
-            // Download the object
-            let content = self
-                .client
-                .download_object(&request, &range)
-                .await
-                .map_err(|e| self.handle_gcs_error(&e))?;
+            fn poll_next(
+                mut self: core::pin::Pin<&mut Self>,
+                cx: &mut core::task::Context<'_>,
+            ) -> core::task::Poll<Option<Self::Item>> {
+                match std::pin::pin!(&mut self.stream).poll_next(cx) {
+                    core::task::Poll::Ready(Some(Ok(bytes))) => {
+                        core::task::Poll::Ready(Some(Ok(bytes)))
+                    }
+                    core::task::Poll::Ready(Some(Err(err))) => {
+                        self.permit.take();
+                        core::task::Poll::Ready(Some(Err(GcsClient::handle_gcs_error(&err))))
+                    }
+                    core::task::Poll::Ready(None) => {
+                        self.permit.take();
+                        core::task::Poll::Ready(None)
+                    }
+                    core::task::Poll::Pending => core::task::Poll::Pending,
+                }
+            }
 
-            Ok(content)
-        })
-        .await
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.stream.size_hint()
+            }
+        }
+
+        let permit =
+            self.semaphore.clone().acquire_owned().await.map_err(|e| {
+                make_err!(Code::Internal, "Failed to acquire connection permit: {}", e)
+            })?;
+        let request = GetObjectRequest {
+            bucket: object_path.bucket.clone(),
+            object: object_path.path.clone(),
+            ..Default::default()
+        };
+
+        let start = (start > 0).then_some(start);
+        let range = Range(start, end);
+
+        // Download the object
+        let stream = self
+            .client
+            .download_streamed_object(&request, &range)
+            .await
+            .map_err(|e| Self::handle_gcs_error(&e))?;
+
+        Ok(Box::new(ReadStream {
+            stream,
+            permit: Some(permit),
+        }))
     }
 
     async fn write_object(&self, object_path: &ObjectPath, content: Vec<u8>) -> Result<(), Error> {
@@ -460,7 +492,7 @@ impl GcsOperations for GcsClient {
             self.client
                 .upload_object(&request, content, &upload_type)
                 .await
-                .map_err(|e| self.handle_gcs_error(&e))?;
+                .map_err(|e| Self::handle_gcs_error(&e))?;
 
             Ok(())
         })
@@ -485,7 +517,7 @@ impl GcsOperations for GcsClient {
                 .client
                 .prepare_resumable_upload(&request, &upload_type)
                 .await
-                .map_err(|e| self.handle_gcs_error(&e))?;
+                .map_err(|e| Self::handle_gcs_error(&e))?;
 
             Ok(uploader.url().to_string())
         })
@@ -496,27 +528,22 @@ impl GcsOperations for GcsClient {
         &self,
         upload_url: &str,
         _object_path: &ObjectPath,
-        data: Vec<u8>,
-        offset: i64,
-        end_offset: i64,
-        is_final: bool,
+        data: Bytes,
+        offset: u64,
+        end_offset: u64,
+        total_size: Option<u64>,
     ) -> Result<(), Error> {
         self.with_connection(|| async {
             let uploader = self.client.get_resumable_upload(upload_url.to_string());
 
-            let total_size = if is_final {
-                Some(end_offset as u64)
-            } else {
-                None
-            };
-
-            let chunk_def = ChunkSize::new(offset as u64, end_offset as u64 - 1, total_size);
+            let last_byte = if end_offset == 0 { 0 } else { end_offset - 1 };
+            let chunk_def = ChunkSize::new(offset, last_byte, total_size);
 
             // Upload chunk
             uploader
                 .upload_multiple_chunk(data, &chunk_def)
                 .await
-                .map_err(|e| self.handle_gcs_error(&e))?;
+                .map_err(|e| Self::handle_gcs_error(&e))?;
 
             Ok(())
         })
@@ -528,7 +555,7 @@ impl GcsOperations for GcsClient {
         object_path: &ObjectPath,
         reader: &mut DropCloserReadHalf,
         _upload_id: &str,
-        max_size: i64,
+        max_size: u64,
     ) -> Result<(), Error> {
         let mut retry_count = 0;
         let mut retry_delay = INITIAL_UPLOAD_RETRY_DELAY_MS;

--- a/nativelink-store/src/gcs_client/mocks.rs
+++ b/nativelink-store/src/gcs_client/mocks.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use futures::Stream;
 use nativelink_error::{Code, Error, make_err};
 use nativelink_util::buf_channel::DropCloserReadHalf;
 use tokio::sync::RwLock;
@@ -82,8 +84,8 @@ pub enum MockRequest {
     },
     ReadContent {
         object_path: ObjectPath,
-        start: i64,
-        end: Option<i64>,
+        start: u64,
+        end: Option<u64>,
     },
     Write {
         object_path: ObjectPath,
@@ -96,14 +98,14 @@ pub enum MockRequest {
         upload_url: String,
         object_path: ObjectPath,
         data_len: usize,
-        offset: i64,
-        end_offset: i64,
-        is_final: bool,
+        offset: u64,
+        end_offset: u64,
+        total_size: Option<u64>,
     },
     UploadFromReader {
         object_path: ObjectPath,
         upload_id: String,
-        max_size: i64,
+        max_size: u64,
     },
     ObjectExists {
         object_path: ObjectPath,
@@ -295,9 +297,30 @@ impl GcsOperations for MockGcsOperations {
     async fn read_object_content(
         &self,
         object_path: &ObjectPath,
-        start: i64,
-        end: Option<i64>,
-    ) -> Result<Vec<u8>, Error> {
+        start: u64,
+        end: Option<u64>,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, Error>> + Send + Unpin>, Error> {
+        struct OnceStream {
+            content: Option<Bytes>,
+        }
+        impl Stream for OnceStream {
+            type Item = Result<Bytes, Error>;
+
+            fn poll_next(
+                mut self: core::pin::Pin<&mut Self>,
+                _cx: &mut core::task::Context<'_>,
+            ) -> core::task::Poll<Option<Self::Item>> {
+                core::task::Poll::Ready(self.content.take().map(Ok))
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                match &self.content {
+                    Some(bytes) => (bytes.len(), Some(bytes.len())),
+                    None => (0, Some(0)),
+                }
+            }
+        }
+
         self.call_counts.read_calls.fetch_add(1, Ordering::Relaxed);
         self.requests.write().await.push(MockRequest::ReadContent {
             object_path: object_path.clone(),
@@ -312,13 +335,6 @@ impl GcsOperations for MockGcsOperations {
 
         if let Some(obj) = objects.get(&object_key) {
             let content = &obj.content;
-            if start < 0 {
-                return Err(make_err!(
-                    Code::InvalidArgument,
-                    "Start index {} must be non-negative",
-                    start
-                ));
-            }
 
             let start_idx = start as usize;
             if start_idx > content.len() {
@@ -345,7 +361,9 @@ impl GcsOperations for MockGcsOperations {
                 content.len()
             };
 
-            Ok(content[start_idx..end_idx].to_vec())
+            Ok(Box::new(OnceStream {
+                content: Some(Bytes::copy_from_slice(&content[start_idx..end_idx])),
+            }))
         } else {
             Err(make_err!(Code::NotFound, "Object not found"))
         }
@@ -383,10 +401,10 @@ impl GcsOperations for MockGcsOperations {
         &self,
         upload_url: &str,
         object_path: &ObjectPath,
-        data: Vec<u8>,
-        offset: i64,
-        end_offset: i64,
-        is_final: bool,
+        data: Bytes,
+        offset: u64,
+        end_offset: u64,
+        total_size: Option<u64>,
     ) -> Result<(), Error> {
         self.call_counts
             .upload_chunk_calls
@@ -397,7 +415,7 @@ impl GcsOperations for MockGcsOperations {
             data_len: data.len(),
             offset,
             end_offset,
-            is_final,
+            total_size,
         });
 
         self.handle_failure().await?;
@@ -433,7 +451,7 @@ impl GcsOperations for MockGcsOperations {
         }
 
         // Update metadata if this is the final chunk
-        if is_final {
+        if total_size.map(|size| size == end_offset) == Some(true) {
             mock_object.metadata.size = mock_object.content.len() as i64;
             mock_object.metadata.update_time = Some(Timestamp {
                 seconds: self.get_current_timestamp(),
@@ -449,7 +467,7 @@ impl GcsOperations for MockGcsOperations {
         object_path: &ObjectPath,
         reader: &mut DropCloserReadHalf,
         upload_id: &str,
-        max_size: i64,
+        max_size: u64,
     ) -> Result<(), Error> {
         self.call_counts
             .upload_from_reader_calls
@@ -467,10 +485,11 @@ impl GcsOperations for MockGcsOperations {
 
         // Read all data from the reader
         let mut buffer = Vec::new();
-        let mut total_read = 0i64;
+        let max_size = max_size as usize;
+        let mut total_read = 0usize;
 
         while total_read < max_size {
-            let to_read = core::cmp::min((max_size - total_read) as usize, 8192); // 8KB chunks
+            let to_read = core::cmp::min(max_size - total_read, 8192); // 8KB chunks
             let chunk = reader.consume(Some(to_read)).await?;
 
             if chunk.is_empty() {
@@ -478,7 +497,7 @@ impl GcsOperations for MockGcsOperations {
             }
 
             buffer.extend_from_slice(&chunk);
-            total_read += chunk.len() as i64;
+            total_read += chunk.len();
         }
 
         self.write_object(object_path, buffer).await?;

--- a/nativelink-store/src/gcs_client/types.rs
+++ b/nativelink-store/src/gcs_client/types.rs
@@ -14,7 +14,7 @@
 
 // ----- File size thresholds -----
 /// Threshold for using simple upload vs. resumable upload (10MB)
-pub const SIMPLE_UPLOAD_THRESHOLD: i64 = 10 * 1024 * 1024;
+pub const SIMPLE_UPLOAD_THRESHOLD: u64 = 10 * 1024 * 1024;
 /// Minimum size for multipart upload (5MB)
 pub const MIN_MULTIPART_SIZE: u64 = 5 * 1024 * 1024;
 /// Default chunk size for uploads (~2MB)

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::TryStreamExt;
 use futures::stream::{FuturesUnordered, unfold};
+use futures::{StreamExt, TryStreamExt};
 use nativelink_config::stores::ExperimentalGcsSpec;
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_metric::MetricsComponent;
@@ -76,6 +76,9 @@ where
         client: Arc<dyn GcsOperations>,
         now_fn: NowFn,
     ) -> Result<Arc<Self>, Error> {
+        // Chunks must be a multiple of 256kb according to the documentation.
+        const CHUNK_MULTIPLE: usize = 256 * 1024;
+
         let max_connections = spec
             .common
             .multipart_max_concurrent_uploads
@@ -88,6 +91,27 @@ where
             }
             delay.mul_f32(jitter_amt.mul_add(rand::rng().random::<f32>() - 0.5, 1.))
         });
+
+        let max_chunk_size =
+            core::cmp::min(spec.resumable_chunk_size.unwrap_or(CHUNK_SIZE), CHUNK_SIZE);
+
+        let max_chunk_size = if max_chunk_size % CHUNK_MULTIPLE != 0 {
+            ((max_chunk_size + CHUNK_MULTIPLE / 2) / CHUNK_MULTIPLE) * CHUNK_MULTIPLE
+        } else {
+            max_chunk_size
+        };
+
+        let max_retry_buffer_size = spec
+            .common
+            .max_retry_buffer_per_request
+            .unwrap_or(DEFAULT_MAX_RETRY_BUFFER_PER_REQUEST);
+
+        // The retry buffer should be at least as big as the chunk size.
+        let max_retry_buffer_size = if max_retry_buffer_size < max_chunk_size {
+            max_chunk_size
+        } else {
+            max_retry_buffer_size
+        };
 
         Ok(Arc::new(Self {
             client,
@@ -105,14 +129,8 @@ where
                 spec.common.retry.clone(),
             ),
             consider_expired_after_s: i64::from(spec.common.consider_expired_after_s),
-            max_retry_buffer_size: spec
-                .common
-                .max_retry_buffer_per_request
-                .unwrap_or(DEFAULT_MAX_RETRY_BUFFER_PER_REQUEST),
-            max_chunk_size: core::cmp::min(
-                spec.resumable_chunk_size.unwrap_or(CHUNK_SIZE),
-                CHUNK_SIZE,
-            ),
+            max_retry_buffer_size,
+            max_chunk_size,
             max_concurrent_uploads: max_connections,
         }))
     }
@@ -200,9 +218,6 @@ where
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error> {
         let object_path = self.make_object_path(&digest);
-        let max_size = match upload_size {
-            UploadSizeInfo::ExactSize(sz) | UploadSizeInfo::MaxSize(sz) => sz,
-        };
 
         reader.set_max_recent_data_size(
             u64::try_from(self.max_retry_buffer_size)
@@ -210,149 +225,143 @@ where
         );
 
         // For small files with exact size, we'll use simple upload
-        if max_size < MIN_MULTIPART_SIZE && matches!(upload_size, UploadSizeInfo::ExactSize(_)) {
-            let content = reader.consume(Some(max_size as usize)).await?;
-            let client = &self.client;
-            let object_path_cloned = object_path.clone();
+        if let UploadSizeInfo::ExactSize(size) = upload_size {
+            if size < MIN_MULTIPART_SIZE {
+                let content = reader.consume(Some(size as usize)).await?;
+                let client = &self.client;
 
-            return self
-                .retrier
-                .retry(unfold(content, move |content| {
-                    let object_path_cloned = object_path_cloned.clone();
-                    async move {
-                        match client
-                            .write_object(&object_path_cloned, content.to_vec())
-                            .await
-                        {
+                return self
+                    .retrier
+                    .retry(unfold(content, |content| async {
+                        match client.write_object(&object_path, content.to_vec()).await {
                             Ok(()) => Some((RetryResult::Ok(()), content)),
                             Err(e) => Some((RetryResult::Retry(e), content)),
                         }
-                    }
-                }))
-                .await;
+                    }))
+                    .await;
+            }
         }
 
         // For larger files, we'll use resumable upload
-        // First, we'll initiate the upload session
-        let client = &self.client;
-        let object_path_for_start = object_path.clone();
-        let upload_id = self
-            .retrier
-            .retry(unfold((), move |()| {
-                let object_path = object_path_for_start.clone();
-                async move {
-                    match client.start_resumable_write(&object_path).await {
-                        Ok(id) => Some((RetryResult::Ok(id), ())),
-                        Err(e) => Some((
-                            RetryResult::Retry(make_err!(
-                                Code::Aborted,
-                                "Failed to start resumable upload: {:?}",
-                                e
-                            )),
-                            (),
-                        )),
-                    }
-                }
-            }))
-            .await?;
-
         // Stream and upload data in chunks
-        let chunk_size = core::cmp::min(self.max_chunk_size, max_size as usize);
         let mut offset = 0u64;
-        let mut total_uploaded = 0u64;
-
-        let upload_id = upload_id.clone();
-        let object_path_for_chunks = object_path.clone();
+        let mut total_size = if let UploadSizeInfo::ExactSize(size) = upload_size {
+            Some(size)
+        } else {
+            None
+        };
+        let mut upload_id: Option<String> = None;
+        let client = &self.client;
 
         loop {
-            let to_read = core::cmp::min(chunk_size, (max_size - total_uploaded) as usize);
-            if to_read == 0 {
-                break;
-            }
-
-            let chunk = reader.consume(Some(to_read)).await?;
+            let chunk = reader.consume(Some(self.max_chunk_size)).await?;
             if chunk.is_empty() {
                 break;
             }
+            // If a full chunk wasn't read, then this is the full length.
+            if chunk.len() < self.max_chunk_size {
+                total_size = Some(offset + chunk.len() as u64);
+            }
 
-            let chunk_size = chunk.len() as u64;
-            total_uploaded += chunk_size;
-            let is_final = total_uploaded >= max_size || chunk.len() < to_read;
+            let upload_id_ref = if let Some(upload_id_ref) = &upload_id {
+                upload_id_ref
+            } else {
+                // Initiate the upload session on the first non-empty chunk.
+                upload_id = Some(
+                    self.retrier
+                        .retry(unfold((), |()| async {
+                            match client.start_resumable_write(&object_path).await {
+                                Ok(id) => Some((RetryResult::Ok(id), ())),
+                                Err(e) => Some((
+                                    RetryResult::Retry(make_err!(
+                                        Code::Aborted,
+                                        "Failed to start resumable upload: {:?}",
+                                        e
+                                    )),
+                                    (),
+                                )),
+                            }
+                        }))
+                        .await?,
+                );
+                upload_id.as_deref().unwrap()
+            };
+
             let current_offset = offset;
-            let object_path = object_path_for_chunks.clone();
-            let upload_id_clone = upload_id.clone();
+            offset += chunk.len() as u64;
 
             // Uploading the chunk with a retry
+            let object_path_ref = &object_path;
             self.retrier
-                .retry(unfold(chunk, move |chunk| {
-                    let object_path = object_path.clone();
-                    let upload_id_clone = upload_id_clone.clone();
-                    async move {
-                        match client
-                            .upload_chunk(
-                                &upload_id_clone,
-                                &object_path,
-                                chunk.to_vec(),
-                                current_offset as i64,
-                                (current_offset + chunk.len() as u64) as i64,
-                                is_final,
-                            )
-                            .await
-                        {
-                            Ok(()) => Some((RetryResult::Ok(()), chunk)),
-                            Err(e) => Some((RetryResult::Retry(e), chunk)),
-                        }
+                .retry(unfold(chunk, |chunk| async move {
+                    match client
+                        .upload_chunk(
+                            upload_id_ref,
+                            object_path_ref,
+                            chunk.clone(),
+                            current_offset,
+                            offset,
+                            total_size,
+                        )
+                        .await
+                    {
+                        Ok(()) => Some((RetryResult::Ok(()), chunk)),
+                        Err(e) => Some((RetryResult::Retry(e), chunk)),
                     }
                 }))
                 .await?;
-
-            offset += chunk_size;
-
-            if is_final {
-                break;
-            }
         }
 
-        // Handle the edge case: empty file (nothing uploaded)
-        if offset == 0 {
-            let object_path = object_path.clone();
-            let upload_id_clone = upload_id.clone();
-
-            self.retrier
-                .retry(unfold((), move |()| {
-                    let object_path = object_path.clone();
-                    let upload_id_clone = upload_id_clone.clone();
-                    async move {
+        // Handle the case that the stream was of unknown length and
+        // happened to be an exact multiple of chunk size.
+        if let Some(upload_id_ref) = &upload_id {
+            if total_size.is_none() {
+                let object_path_ref = &object_path;
+                self.retrier
+                    .retry(unfold((), |()| async move {
                         match client
-                            .upload_chunk(&upload_id_clone, &object_path, Vec::new(), 0, 0, true)
+                            .upload_chunk(
+                                upload_id_ref,
+                                object_path_ref,
+                                Bytes::new(),
+                                offset,
+                                offset,
+                                Some(offset),
+                            )
                             .await
                         {
                             Ok(()) => Some((RetryResult::Ok(()), ())),
                             Err(e) => Some((RetryResult::Retry(e), ())),
                         }
+                    }))
+                    .await?;
+            }
+        } else {
+            // Handle streamed empty file.
+            return self
+                .retrier
+                .retry(unfold((), |()| async {
+                    match client.write_object(&object_path, Vec::new()).await {
+                        Ok(()) => Some((RetryResult::Ok(()), ())),
+                        Err(e) => Some((RetryResult::Retry(e), ())),
                     }
                 }))
-                .await?;
+                .await;
         }
 
         // Verifying if the upload was successful
-        let object_path = object_path.clone();
-
         self.retrier
-            .retry(unfold((), move |()| {
-                let object_path = object_path.clone();
-                async move {
-                    match client.object_exists(&object_path).await {
-                        Ok(true) => Some((RetryResult::Ok(()), ())),
-                        Ok(false) => Some((
-                            RetryResult::Retry(make_err!(
-                                Code::Internal,
-                                "Object not found after upload completion"
-                            )),
-                            (),
+            .retry(unfold((), |()| async {
+                match client.object_exists(&object_path).await {
+                    Ok(true) => Some((RetryResult::Ok(()), ())),
+                    Ok(false) => Some((
+                        RetryResult::Retry(make_err!(
+                            Code::Internal,
+                            "Object not found after upload completion"
                         )),
-                        Err(e) => Some((RetryResult::Retry(e), ())),
-                    }
+                        (),
+                    )),
+                    Err(e) => Some((RetryResult::Retry(e), ())),
                 }
             }))
             .await?;
@@ -376,48 +385,42 @@ where
         let end_offset = length.map(|len| offset + len);
         let client = &self.client;
 
-        let result = self
-            .retrier
+        let object_path_ref = &object_path;
+        self.retrier
             .retry(unfold(
-                (offset, end_offset, object_path.clone()),
-                move |(start_offset, end_offset, object_path)| async move {
-                    match client
-                        .read_object_content(
-                            &object_path,
-                            start_offset as i64,
-                            end_offset.map(|e| e as i64),
-                        )
+                (offset, writer),
+                |(mut offset, writer)| async move {
+                    let mut stream = match client
+                        .read_object_content(object_path_ref, offset, end_offset)
                         .await
                     {
-                        Ok(data) => Some((
-                            RetryResult::Ok(data),
-                            (start_offset, end_offset, object_path),
-                        )),
+                        Ok(stream) => stream,
                         Err(e) if e.code == Code::NotFound => {
-                            Some((RetryResult::Err(e), (start_offset, end_offset, object_path)))
+                            return Some((RetryResult::Err(e), (offset, writer)));
                         }
-                        Err(e) => Some((
-                            RetryResult::Retry(e),
-                            (start_offset, end_offset, object_path),
-                        )),
+                        Err(e) => return Some((RetryResult::Retry(e), (offset, writer))),
+                    };
+
+                    while let Some(next_chunk) = stream.next().await {
+                        match next_chunk {
+                            Ok(bytes) => {
+                                offset += bytes.len() as u64;
+                                if let Err(err) = writer.send(bytes).await {
+                                    return Some((RetryResult::Err(err), (offset, writer)));
+                                }
+                            }
+                            Err(err) => return Some((RetryResult::Retry(err), (offset, writer))),
+                        }
                     }
+
+                    if let Err(err) = writer.send_eof() {
+                        return Some((RetryResult::Err(err), (offset, writer)));
+                    }
+
+                    Some((RetryResult::Ok(()), (offset, writer)))
                 },
             ))
-            .await;
-
-        match result {
-            Ok(data) => {
-                if !data.is_empty() {
-                    writer.send(Bytes::from(data)).await?;
-                }
-                writer.send_eof()?;
-                Ok(())
-            }
-            Err(e) => {
-                drop(writer.send_eof());
-                Err(e)
-            }
-        }
+            .await
     }
 
     fn inner_store(&self, _digest: Option<StoreKey>) -> &'_ dyn StoreDriver {

--- a/nativelink-store/tests/gcs_client_test.rs
+++ b/nativelink-store/tests/gcs_client_test.rs
@@ -16,8 +16,8 @@ use core::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use bytes::{BufMut, Bytes, BytesMut};
-use futures::join;
-use nativelink_error::{Error, ResultExt};
+use futures::{StreamExt, join};
+use nativelink_error::{Code, Error, ResultExt};
 use nativelink_macro::nativelink_test;
 use nativelink_store::gcs_client::client::GcsOperations;
 use nativelink_store::gcs_client::mocks::MockGcsOperations;
@@ -86,14 +86,38 @@ async fn test_read_object_content() -> Result<(), Error> {
         .await;
 
     // Test reading the full content
-    let result = mock_ops.read_object_content(&object_path, 0, None).await?;
+    let result = mock_ops
+        .read_object_content(&object_path, 0, None)
+        .await?
+        .next()
+        .await
+        .map_or_else(
+            || {
+                Err(Error::new(
+                    Code::OutOfRange,
+                    "EOF reading result".to_string(),
+                ))
+            },
+            |result| result,
+        )?;
     assert_eq!(result, test_content);
 
     // Test reading a range of content
     let result = mock_ops
         .read_object_content(&object_path, 6, Some(11))
-        .await?;
-    assert_eq!(result, b"world");
+        .await?
+        .next()
+        .await
+        .map_or_else(
+            || {
+                Err(Error::new(
+                    Code::OutOfRange,
+                    "EOF reading result".to_string(),
+                ))
+            },
+            |result| result,
+        )?;
+    assert_eq!(result, Bytes::from_static(b"world"));
 
     // Verify call counts
     let call_counts = mock_ops.get_call_counts();
@@ -115,7 +139,20 @@ async fn test_write_object() -> Result<(), Error> {
         .await?;
 
     // Verify the object was stored
-    let result = mock_ops.read_object_content(&object_path, 0, None).await?;
+    let result = mock_ops
+        .read_object_content(&object_path, 0, None)
+        .await?
+        .next()
+        .await
+        .map_or_else(
+            || {
+                Err(Error::new(
+                    Code::OutOfRange,
+                    "EOF reading result".to_string(),
+                ))
+            },
+            |result| result,
+        )?;
     assert_eq!(result, test_content);
 
     // Verify call counts
@@ -137,8 +174,8 @@ async fn test_resumable_upload() -> Result<(), Error> {
     assert!(!upload_id.is_empty(), "Expected non-empty upload ID");
 
     // Upload chunks
-    let chunk1 = b"first chunk ".to_vec();
-    let chunk2 = b"second chunk".to_vec();
+    let chunk1 = Bytes::from_static(b"first chunk ");
+    let chunk2 = Bytes::from_static(b"second chunk");
 
     // Upload first chunk
     mock_ops
@@ -147,8 +184,8 @@ async fn test_resumable_upload() -> Result<(), Error> {
             &object_path,
             chunk1.clone(),
             0,
-            chunk1.len() as i64,
-            false,
+            chunk1.len() as u64,
+            None,
         )
         .await?;
 
@@ -158,14 +195,27 @@ async fn test_resumable_upload() -> Result<(), Error> {
             &upload_id,
             &object_path,
             chunk2.clone(),
-            chunk1.len() as i64,
-            (chunk1.len() + chunk2.len()) as i64,
-            true,
+            chunk1.len() as u64,
+            (chunk1.len() + chunk2.len()) as u64,
+            Some((chunk1.len() + chunk2.len()) as u64),
         )
         .await?;
 
     // Verify the content
-    let result = mock_ops.read_object_content(&object_path, 0, None).await?;
+    let result = mock_ops
+        .read_object_content(&object_path, 0, None)
+        .await?
+        .next()
+        .await
+        .map_or_else(
+            || {
+                Err(Error::new(
+                    Code::OutOfRange,
+                    "EOF reading result".to_string(),
+                ))
+            },
+            |result| result,
+        )?;
     assert_eq!(result, [&chunk1[..], &chunk2[..]].concat());
 
     // Verify call counts
@@ -200,7 +250,7 @@ async fn test_upload_from_reader() -> Result<(), Error> {
     let object_path_clone = object_path.clone();
     let upload_task = nativelink_util::spawn!("upload_test", async move {
         mock_ops_clone
-            .upload_from_reader(&object_path_clone, &mut reader, upload_id, data_size as i64)
+            .upload_from_reader(&object_path_clone, &mut reader, upload_id, data_size as u64)
             .await
     });
 
@@ -212,9 +262,13 @@ async fn test_upload_from_reader() -> Result<(), Error> {
     upload_task.await.unwrap()?;
 
     // Verify the content
-    let result = mock_ops.read_object_content(&object_path, 0, None).await?;
-    assert_eq!(result.len(), data_size);
-    assert_eq!(result, send_data);
+    let result = mock_ops
+        .read_object_content(&object_path, 0, None)
+        .await?
+        .next()
+        .await;
+    assert_eq!(send_data.len(), data_size);
+    assert_eq!(result, Some(Ok(send_data)));
 
     // Verify call counts
     let call_counts = mock_ops.get_call_counts();
@@ -300,19 +354,19 @@ async fn test_failure_modes() -> Result<(), Error> {
     let failure_modes = [
         (
             nativelink_store::gcs_client::mocks::FailureMode::NotFound,
-            nativelink_error::Code::NotFound,
+            Code::NotFound,
         ),
         (
             nativelink_store::gcs_client::mocks::FailureMode::NetworkError,
-            nativelink_error::Code::Unavailable,
+            Code::Unavailable,
         ),
         (
             nativelink_store::gcs_client::mocks::FailureMode::Unauthorized,
-            nativelink_error::Code::Unauthenticated,
+            Code::Unauthenticated,
         ),
         (
             nativelink_store::gcs_client::mocks::FailureMode::ServerError,
-            nativelink_error::Code::Internal,
+            Code::Internal,
         ),
     ];
 
@@ -368,7 +422,18 @@ async fn test_empty_data_handling() -> Result<(), Error> {
     // Verify the content was correctly stored
     let stored_content = mock_ops_for_verification
         .read_object_content(&object_path_for_verification, 0, None)
-        .await?;
+        .await?
+        .next()
+        .await
+        .map_or_else(
+            || {
+                Err(Error::new(
+                    Code::OutOfRange,
+                    "EOF reading result".to_string(),
+                ))
+            },
+            |result| result,
+        )?;
     assert_eq!(
         stored_content, expected_content,
         "Content wasn't stored correctly"


### PR DESCRIPTION
# Description

The GCS store implementation had numerous bugs to do with edge cases of upload sizes and did way more cloning that is necessary.  Update the implementation to remove the excessive clones, modify the get_part implementation to stream instead of buffer huge files in memory.  For upload the last chunk is not written if it sits on a chunk boundary, so change a flag to fix that.  Finally update all of the types to u64 rather than constantly switching back and forth between u64 and i64 unnecessarily.

Fixes #1845

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I implemented a test client to push a 100Mb file up to the CAS. Notably this failed before this change and passes afterward.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1846)
<!-- Reviewable:end -->
