### PR TITLE
Add GCS bucket/path when we fail to load metadata

### DIFF
--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -67,14 +67,16 @@ impl MetricsComponent for Error {
 
 impl Error {
     #[must_use]
+    pub const fn new_with_messages(code: Code, messages: Vec<String>) -> Self {
+        Self { code, messages }
+    }
+
+    #[must_use]
     pub fn new(code: Code, msg: String) -> Self {
-        let mut msgs = Vec::with_capacity(1);
-        if !msg.is_empty() {
-            msgs.push(msg);
-        }
-        Self {
-            code,
-            messages: msgs,
+        if msg.is_empty() {
+            Self::new_with_messages(code, vec![])
+        } else {
+            Self::new_with_messages(code, vec![msg])
         }
     }
 

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -143,7 +143,12 @@ where
 
         self.retrier
             .retry(unfold(object_path, move |object_path| async move {
-                match client.read_object_metadata(&object_path).await {
+                match client.read_object_metadata(&object_path).await.err_tip(|| {
+                    format!(
+                        "Error while trying to read - bucket: {} path: {}",
+                        object_path.bucket, object_path.path
+                    )
+                }) {
                     Ok(Some(metadata)) => {
                         if consider_expired_after_s != 0 {
                             if let Some(update_time) = &metadata.update_time {


### PR DESCRIPTION
# Description

While trying to fix some GCS permission errors it wasn't always clear what path/bucket wasn't able to be accessed. This PR adds some extra context to make fixing those a little easier.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Regular `cargo test` stuff

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1849)
<!-- Reviewable:end -->
