### PR TITLE
Re-add Nix magic cache

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -48,5 +48,9 @@ runs:
         fi
 
     - name: Install Nix
-      uses: >- # v17
+      uses: >- # https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v17
         DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3
+
+    - name: Add Nix magic cache
+      uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v11
+        DeterminateSystems/magic-nix-cache-action@def9f5a5c6a6b8751c0534e8813a5d0ad2635660


### PR DESCRIPTION
# Description

[It was removed](https://github.com/TraceMachina/nativelink/pull/1813), but now appears to be unbroken again (see for example https://github.com/DeterminateSystems/magic-nix-cache-action/pull/132). It's not entirely clear, but as far as I can tell the problems are apparently resolved?

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Github :)

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1851)
<!-- Reviewable:end -->
