### PR TITLE
Fix inconsistency in read/write format of OperationId in Redis Scheduler Store

### DIFF
--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -284,7 +284,8 @@ impl SchedulerStoreKeyProvider for ClientIdToOperationId<'_> {
 impl SchedulerStoreDecodeTo for ClientIdToOperationId<'_> {
     type DecodeOutput = OperationId;
     fn decode(_version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
-        OperationId::try_from(data).err_tip(|| "In ClientIdToOperationId::decode")
+        serde_json::from_slice(&data)
+            .map_err(|e| make_input_err!("In ClientIdToOperationId::decode - {e:?}"))
     }
 }
 


### PR DESCRIPTION
# Description

Redis Scheduler Store serialised OperationId as a JSON, but deserialised it as String, which resulted in (Error 34 Not Found) when running Bazel build with RBE.

Fixes #1855

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've observed the issue when running nativelink 0.6.0 (and snapshot versions) deployed in Kubernetes cluster by subscribing to the key misses on Redis instance used as a scheduler store.
```
redis-cli -c -u redis://localhost:6379 config set notify-keyspace-events KEm
redis-cli --csv psubscribe '__key*__:aa*'
"psubscribe","__key*__:aa*",1
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"9ad3639a-879f-4cc0-89c7-69186c13e6a0\"}","keymiss"
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"738f1da4-f311-4273-a3f7-60c294249df9\"}","keymiss"
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"147a9c57-c0a2-46c9-ab7d-bd0a96d45c65\"}","keymiss"
```
And I've reproduced the issue by adding `get_awaited_action_by_id` call in `add_action_smoke_test`.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
