### PR TITLE
Fix execution_server instance name error

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -18,6 +18,7 @@ rust_library(
         "src/grpc_scheduler.rs",
         "src/lib.rs",
         "src/memory_awaited_action_db.rs",
+        "src/mock_scheduler.rs",
         "src/platform_property_manager.rs",
         "src/property_modifier_scheduler.rs",
         "src/simple_scheduler.rs",
@@ -67,7 +68,6 @@ rust_test_suite(
         "tests/simple_scheduler_test.rs",
     ],
     compile_data = [
-        "tests/utils/mock_scheduler.rs",
         "tests/utils/scheduler_utils.rs",
     ],
     proc_macro_deps = [

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -18,6 +18,7 @@ pub mod cache_lookup_scheduler;
 pub mod default_scheduler_factory;
 pub mod grpc_scheduler;
 pub mod memory_awaited_action_db;
+pub mod mock_scheduler;
 pub mod platform_property_manager;
 pub mod property_modifier_scheduler;
 pub mod simple_scheduler;

--- a/nativelink-scheduler/src/mock_scheduler.rs
+++ b/nativelink-scheduler/src/mock_scheduler.rs
@@ -42,8 +42,8 @@ enum ActionSchedulerReturns {
     FilterOperations(Result<ActionStateResultStream<'static>, Error>),
 }
 
-#[derive(MetricsComponent)]
-pub(crate) struct MockActionScheduler {
+#[derive(MetricsComponent, Debug)]
+pub struct MockActionScheduler {
     rx_call: Mutex<mpsc::UnboundedReceiver<ActionSchedulerCalls>>,
     tx_call: mpsc::UnboundedSender<ActionSchedulerCalls>,
 
@@ -58,7 +58,7 @@ impl Default for MockActionScheduler {
 }
 
 impl MockActionScheduler {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let (tx_call, rx_call) = mpsc::unbounded_channel();
         let (tx_resp, rx_resp) = mpsc::unbounded_channel();
         Self {
@@ -70,10 +70,7 @@ impl MockActionScheduler {
     }
 
     #[allow(dead_code, reason = "https://github.com/rust-lang/rust/issues/46379")]
-    pub(crate) async fn expect_get_known_properties(
-        &self,
-        result: Result<Vec<String>, Error>,
-    ) -> String {
+    pub async fn expect_get_known_properties(&self, result: Result<Vec<String>, Error>) -> String {
         let mut rx_call_lock = self.rx_call.lock().await;
         let ActionSchedulerCalls::GetGetKnownProperties(req) = rx_call_lock
             .recv()
@@ -89,7 +86,8 @@ impl MockActionScheduler {
         req
     }
 
-    pub(crate) async fn expect_add_action(
+    #[allow(dead_code, reason = "https://github.com/rust-lang/rust/issues/46379")]
+    pub async fn expect_add_action(
         &self,
         result: Result<Box<dyn ActionStateResult>, Error>,
     ) -> (OperationId, ActionInfo) {
@@ -108,7 +106,8 @@ impl MockActionScheduler {
         req
     }
 
-    pub(crate) async fn expect_filter_operations(
+    #[allow(dead_code, reason = "https://github.com/rust-lang/rust/issues/46379")]
+    pub async fn expect_filter_operations(
         &self,
         result: Result<ActionStateResultStream<'static>, Error>,
     ) -> OperationFilter {

--- a/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/nativelink-scheduler/tests/cache_lookup_scheduler_test.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 mod utils {
-    pub(crate) mod mock_scheduler;
     pub(crate) mod scheduler_utils;
 }
 
@@ -26,6 +25,7 @@ use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
 use nativelink_scheduler::cache_lookup_scheduler::CacheLookupScheduler;
+use nativelink_scheduler::mock_scheduler::MockActionScheduler;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_util::action_messages::{
     ActionResult, ActionStage, ActionState, ActionUniqueQualifier, OperationId,
@@ -38,7 +38,6 @@ use prost::Message;
 use tokio::sync::watch;
 use tokio::{self};
 use tokio_stream::StreamExt;
-use utils::mock_scheduler::MockActionScheduler;
 use utils::scheduler_utils::{TokioWatchActionStateResult, make_base_action_info};
 
 struct TestContext {

--- a/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
+++ b/nativelink-scheduler/tests/property_modifier_scheduler_test.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 mod utils {
-    pub(crate) mod mock_scheduler;
     pub(crate) mod scheduler_utils;
 }
 
@@ -27,6 +26,7 @@ use nativelink_config::schedulers::{
 };
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
+use nativelink_scheduler::mock_scheduler::MockActionScheduler;
 use nativelink_scheduler::property_modifier_scheduler::PropertyModifierScheduler;
 use nativelink_util::action_messages::{ActionStage, ActionState, OperationId};
 use nativelink_util::common::DigestInfo;
@@ -34,7 +34,6 @@ use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProv
 use nativelink_util::operation_state_manager::{ClientStateManager, OperationFilter};
 use pretty_assertions::assert_eq;
 use tokio::sync::watch;
-use utils::mock_scheduler::MockActionScheduler;
 use utils::scheduler_utils::{INSTANCE_NAME, TokioWatchActionStateResult, make_base_action_info};
 
 struct TestContext {

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -60,6 +60,7 @@ rust_test_suite(
         "tests/bep_server_test.rs",
         "tests/bytestream_server_test.rs",
         "tests/cas_server_test.rs",
+        "tests/execution_server_test.rs",
         "tests/fetch_server_test.rs",
         "tests/push_server_test.rs",
         "tests/worker_api_server_test.rs",

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -245,7 +245,7 @@ impl ExecutionServer {
         let instance_info = self
             .instance_infos
             .get(&instance_name)
-            .err_tip(|| "Instance name '{}' not configured")?;
+            .err_tip(|| format!("'instance_name' not configured for '{instance_name}'"))?;
 
         let digest = DigestInfo::try_from(
             request

--- a/nativelink-service/tests/execution_server_test.rs
+++ b/nativelink-service/tests/execution_server_test.rs
@@ -1,0 +1,92 @@
+// Copyright 2025 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use nativelink_config::cas_server::{ExecutionConfig, WithInstanceName};
+use nativelink_config::stores::{MemorySpec, StoreSpec};
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_proto::build::bazel::remote::execution::v2::execution_server::Execution;
+use nativelink_proto::build::bazel::remote::execution::v2::{ExecuteRequest, digest_function};
+use nativelink_scheduler::mock_scheduler::MockActionScheduler;
+use nativelink_service::execution_server::ExecutionServer;
+use nativelink_store::default_store_factory::store_factory;
+use nativelink_store::store_manager::StoreManager;
+use nativelink_util::operation_state_manager::ClientStateManager;
+use tonic::Request;
+
+const INSTANCE_NAME: &str = "instance_name";
+
+async fn make_store_manager() -> Result<Arc<StoreManager>, Error> {
+    let store_manager = Arc::new(StoreManager::new());
+    store_manager.add_store(
+        "main_cas",
+        store_factory(
+            &StoreSpec::Memory(MemorySpec::default()),
+            &store_manager,
+            None,
+        )
+        .await?,
+    );
+    Ok(store_manager)
+}
+
+fn make_execution_server(store_manager: &StoreManager) -> Result<ExecutionServer, Error> {
+    let mock_scheduler = Arc::new(MockActionScheduler::new());
+    let mut action_schedulers: HashMap<String, Arc<dyn ClientStateManager>> = HashMap::new();
+    action_schedulers.insert("main_scheduler".to_string(), mock_scheduler);
+    ExecutionServer::new(
+        &[WithInstanceName {
+            instance_name: INSTANCE_NAME.to_string(),
+            config: ExecutionConfig {
+                cas_store: "main_cas".to_string(),
+                scheduler: "main_scheduler".to_string(),
+            },
+        }],
+        &action_schedulers,
+        store_manager,
+    )
+}
+
+#[nativelink_test]
+async fn instance_name_fail() -> Result<(), Box<dyn core::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let execution_server = make_execution_server(&store_manager)?;
+
+    let raw_response = execution_server
+        .execute(Request::new(ExecuteRequest {
+            instance_name: "foo".to_string(),
+            digest_function: digest_function::Value::Sha256.into(),
+            skip_cache_lookup: false,
+            action_digest: None,
+            execution_policy: None,
+            results_cache_policy: None,
+        }))
+        .await;
+
+    match raw_response {
+        Err(response_err) => {
+            assert_eq!(
+                response_err.message(),
+                "'instance_name' not configured for 'foo' : Failed on execute() command"
+            );
+        }
+        Ok(_) => {
+            panic!("Not expecting ok!");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
# Description

Was getting `ERROR nativelink_service::execution_server: error: status: Internal, message: "Instance name '{}' not configured : Failed on execute() command", details: [], metadata: MetadataMap { headers: {} }` i.e. a non-formatted instance name error

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1858)
<!-- Reviewable:end -->
