### PR TITLE
Tested redaction for stream.first_msg in bytestream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "tokio-stream",
  "tonic 0.13.0",
  "tracing",
+ "tracing-test",
  "uuid",
 ]
 
@@ -2708,6 +2709,7 @@ dependencies = [
  "tonic 0.13.0",
  "tower 0.5.2",
  "tracing",
+ "tracing-test",
  "uuid",
 ]
 
@@ -2764,6 +2766,7 @@ dependencies = [
  "tonic 0.13.0",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -2815,6 +2818,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -2852,6 +2856,7 @@ dependencies = [
  "tokio-stream",
  "tonic 0.13.0",
  "tracing",
+ "tracing-test",
  "uuid",
 ]
 
@@ -4664,6 +4669,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/nativelink-macro/src/lib.rs
+++ b/nativelink-macro/src/lib.rs
@@ -34,9 +34,8 @@ pub fn nativelink_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             reason = "`tokio::test` uses `tokio::runtime::Runtime::block_on`"
         )]
         #[tokio::test(#attr)]
+        #[::tracing_test::traced_test]
         async fn #fn_name(#fn_inputs) #fn_output {
-            nativelink_util::telemetry::init_tracing_for_tests();
-
             ::nativelink_util::__tracing::error_span!(stringify!(#fn_name))
                 .in_scope(|| async move {
                     ::nativelink_util::common::reseed_rng_for_test().unwrap();

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -93,6 +93,8 @@ rust_test_suite(
         "@crates//:serde_json",
         "@crates//:tokio",
         "@crates//:tokio-stream",
+        "@crates//:tracing",
+        "@crates//:tracing-test",
         "@crates//:uuid",
     ],
 )

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -59,3 +59,6 @@ nativelink-macro = { path = "../nativelink-macro" }
 
 fred = { version = "10.1.0", default-features = false, features = ["mocks"] }
 pretty_assertions = { version = "1.4.1", features = ["std"] }
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
+] }

--- a/nativelink-service/BUILD.bazel
+++ b/nativelink-service/BUILD.bazel
@@ -94,6 +94,8 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tonic",
         "@crates//:tower",
+        "@crates//:tracing",
+        "@crates//:tracing-test",
     ],
 )
 

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -67,3 +67,6 @@ maplit = "1.0.2"
 pretty_assertions = { version = "1.4.1", features = ["std"] }
 prost-types = { version = "0.13.5", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
+] }

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -399,8 +399,14 @@ impl ByteStreamServer {
     #[instrument(
         ret(level = Level::DEBUG),
         level = Level::ERROR,
-        skip(self, store),
-        fields(stream.first_msg = "<redacted>")
+        skip(self, store, stream),
+        fields(
+              // we also skip stream.stream as it doesn't implement debug
+              stream.resource_info = ?stream.resource_info,
+              stream.bytes_received = stream.bytes_received,
+              stream.first_msg = "<redacted>",
+              stream.write_finished = stream.write_finished
+        )
     )]
     async fn inner_write(
         &self,

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -265,6 +265,18 @@ pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn core::erro
             "Expected store to have been updated to new value"
         );
     }
+
+    logs_assert(|lines: &[&str]| {
+        if lines.len() != 1 {
+            return Err(format!("Expected 1 log line, got: {lines:?}"));
+        }
+        let line = lines[0];
+        if !line.contains("stream.first_msg=\"<redacted>\"") && line.contains("first_msg") {
+            return Err(format!("Non-redacted first_msg in \"{line}\""));
+        }
+        Ok(())
+    });
+
     Ok(())
 }
 

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -148,6 +148,7 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
+        "@crates//:tracing-test",
         "@crates//:uuid",
     ],
 )

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -126,3 +126,6 @@ rand = { version = "0.9.0", default-features = false, features = [
 serde_json = "1.0.140"
 sha2 = { version = "0.10.8", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false }
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
+] }

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -130,6 +130,8 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tokio-util",
         "@crates//:tonic",
+        "@crates//:tracing",
+        "@crates//:tracing-test",
         "@crates//:uuid",
     ],
 )

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -92,3 +92,6 @@ rand = { version = "0.9.0", default-features = false, features = [
   "thread_rng",
 ] }
 serde_json = { version = "1.0.140", default-features = false }
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
+] }

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -32,7 +32,7 @@ pub struct WriteRequestStreamWrapper<T> {
     pub bytes_received: usize,
     stream: T,
     first_msg: Option<WriteRequest>,
-    write_finished: bool,
+    pub write_finished: bool,
 }
 
 impl<T> Debug for WriteRequestStreamWrapper<T> {

--- a/nativelink-util/src/telemetry.rs
+++ b/nativelink-util/src/telemetry.rs
@@ -97,18 +97,6 @@ fn tracing_stdout_layer() -> impl Layer<Registry> {
     }
 }
 
-/// Initialize a minimal tracing configuration for tests.
-///
-/// The OTLP logic in the main tracing loop causes issues with the tokio runtime
-/// in tests, so we use a more naive logger implementation here. This function
-/// is idempotent and can be called multiple times safely.
-pub fn init_tracing_for_tests() {
-    static INITIALIZED: OnceLock<()> = OnceLock::new();
-    INITIALIZED.get_or_init(|| {
-        registry().with(tracing_stdout_layer()).init();
-    });
-}
-
 /// Initialize tracing with OpenTelemetry support.
 ///
 /// # Errors

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -81,6 +81,8 @@ rust_test_suite(
         "@crates//:serial_test",
         "@crates//:tokio",
         "@crates//:tonic",
+        "@crates//:tracing",
+        "@crates//:tracing-test",
     ],
 )
 

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -63,3 +63,6 @@ rand = { version = "0.9.0", default-features = false, features = [
 serial_test = { version = "3.2.0", features = [
   "async",
 ], default-features = false }
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
+] }


### PR DESCRIPTION
# Description

Previously `stream.first_msg` was configured for redaction in `ByteStreamServer.inner_write` but it wasn't tested and was actually broken. This PR both fixes the redaction, and explicitly tests it, replacing the previous custom test tracing setup with [`tracing_test`](https://docs.rs/tracing-test/) instead.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1865)
<!-- Reviewable:end -->
