### PR TITLE
Backwards compatibility now says what to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,6 +2580,8 @@ dependencies = [
  "serde_json",
  "serde_json5",
  "shellexpand",
+ "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/nativelink-config/BUILD.bazel
+++ b/nativelink-config/BUILD.bazel
@@ -26,8 +26,10 @@ rust_library(
         "@crates//:byte-unit",
         "@crates//:humantime",
         "@crates//:serde",
+        "@crates//:serde_json",
         "@crates//:serde_json5",
         "@crates//:shellexpand",
+        "@crates//:tracing",
     ],
 )
 
@@ -60,6 +62,7 @@ rust_test(
     deps = [
         "@crates//:pretty_assertions",
         "@crates//:serde_json",
+        "@crates//:tracing-test",
     ],
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -11,13 +11,17 @@ nativelink-error = { path = "../nativelink-error" }
 byte-unit = { version = "5.1.6", default-features = false, features = ["byte"] }
 humantime = "2.2.0"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.140", default-features = false, features = [
+  "std",
+] }
 serde_json5 = "0.2.1"
 shellexpand = { version = "3.1.0", default-features = false, features = [
   "base-0",
 ] }
+tracing = { version = "0.1.41", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = { version = "1.4.1", features = ["std"] }
-serde_json = { version = "1.0.140", default-features = false, features = [
-  "std",
+tracing-test = { version = "0.2.5", default-features = false, features = [
+  "no-env-filter",
 ] }

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use nativelink_error::{Error, ResultExt};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::schedulers::SchedulerSpec;
 use crate::serde_utils::{
@@ -33,7 +33,7 @@ pub type SchedulerRefName = String;
 /// Used when the config references `instance_name` in the protocol.
 pub type InstanceName = String;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct WithInstanceName<T> {
     #[serde(default)]
     pub instance_name: InstanceName,
@@ -49,14 +49,14 @@ impl<T> core::ops::Deref for WithInstanceName<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NamedConfig<Spec> {
     pub name: String,
     #[serde(flatten)]
     pub spec: Spec,
 }
 
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum HttpCompressionAlgorithm {
     /// No compression.
@@ -76,7 +76,7 @@ pub enum HttpCompressionAlgorithm {
 /// services with different compression settings that are served on
 /// different ports. Then configure the non-cloud clients to use one port
 /// and cloud-clients to use another.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct HttpCompressionConfig {
     /// The compression algorithm that the server will use when sending
@@ -99,7 +99,7 @@ pub struct HttpCompressionConfig {
     pub accepted_compression_algorithms: Vec<HttpCompressionAlgorithm>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct AcStoreConfig {
     /// The store name referenced in the `stores` map in the main config.
@@ -113,7 +113,7 @@ pub struct AcStoreConfig {
     pub read_only: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CasStoreConfig {
     /// The store name referenced in the `stores` map in the main config.
@@ -122,7 +122,7 @@ pub struct CasStoreConfig {
     pub cas_store: StoreRefName,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CapabilitiesRemoteExecutionConfig {
     /// Scheduler used to configure the capabilities of remote execution.
@@ -130,7 +130,7 @@ pub struct CapabilitiesRemoteExecutionConfig {
     pub scheduler: SchedulerRefName,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CapabilitiesConfig {
     /// Configuration for remote execution capabilities.
@@ -139,7 +139,7 @@ pub struct CapabilitiesConfig {
     pub remote_execution: Option<CapabilitiesRemoteExecutionConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionConfig {
     /// The store name referenced in the `stores` map in the main config.
@@ -153,7 +153,7 @@ pub struct ExecutionConfig {
     pub scheduler: SchedulerRefName,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FetchConfig {
     /// The store name referenced in the `stores` map in the main config.
@@ -162,7 +162,7 @@ pub struct FetchConfig {
     pub fetch_store: StoreRefName,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PushConfig {
     /// The store name referenced in the `stores` map in the main config.
@@ -176,7 +176,7 @@ pub struct PushConfig {
     pub read_only: bool,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ByteStreamConfig {
     /// Name of the store in the "stores" configuration.
@@ -206,7 +206,7 @@ pub struct ByteStreamConfig {
     pub persist_stream_on_disconnect_timeout: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct WorkerApiConfig {
     /// The scheduler name referenced in the `schedulers` map in the main config.
@@ -214,7 +214,7 @@ pub struct WorkerApiConfig {
     pub scheduler: SchedulerRefName,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AdminConfig {
     /// Path to register the admin API. If path is "/admin", and your
@@ -226,7 +226,7 @@ pub struct AdminConfig {
     pub path: String,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct HealthConfig {
     /// Path to register the health status check. If path is "/status", and your
@@ -238,7 +238,7 @@ pub struct HealthConfig {
     pub path: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct BepConfig {
     /// The store to publish build events to.
     /// The store name referenced in the `stores` map in the main config.
@@ -246,7 +246,7 @@ pub struct BepConfig {
     pub store: StoreRefName,
 }
 
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct IdentityHeaderSpec {
     /// The name of the header to look for the identity in.
     /// Default: "x-identity"
@@ -258,7 +258,7 @@ pub struct IdentityHeaderSpec {
     pub required: bool,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct OriginEventsPublisherSpec {
     /// The store to publish nativelink events to.
     /// The store name referenced in the `stores` map in the main config.
@@ -266,7 +266,7 @@ pub struct OriginEventsPublisherSpec {
     pub store: StoreRefName,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct OriginEventsSpec {
     /// The publisher configuration for origin events.
     pub publisher: OriginEventsPublisherSpec,
@@ -280,7 +280,7 @@ pub struct OriginEventsSpec {
     pub max_event_queue_size: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ServicesConfig {
     /// The Content Addressable Storage (CAS) backend config.
@@ -360,7 +360,7 @@ pub struct ServicesConfig {
     pub health: Option<HealthConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct TlsConfig {
     /// Path to the certificate file.
@@ -388,7 +388,7 @@ pub struct TlsConfig {
 ///
 /// Note: All of these default to hyper's default values unless otherwise
 /// specified.
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 pub struct HttpServerConfig {
     /// Interval to send keep-alive pings via HTTP2.
@@ -455,14 +455,14 @@ pub struct HttpServerConfig {
     pub experimental_http2_max_header_list_size: Option<u32>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ListenerConfig {
     /// Listener for HTTP/HTTPS/HTTP2 sockets.
     Http(HttpListener),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct HttpListener {
     /// Address to listen on. Example: `127.0.0.1:8080` or `:8080` to listen
@@ -486,7 +486,7 @@ pub struct HttpListener {
     pub tls: Option<TlsConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     /// Name of the server. This is used to help identify the service
@@ -508,7 +508,7 @@ pub struct ServerConfig {
     pub experimental_identity_header: IdentityHeaderSpec,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkerProperty {
     /// List of static values.
@@ -523,7 +523,7 @@ pub enum WorkerProperty {
 }
 
 /// Generic config for an endpoint and associated configs.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct EndpointConfig {
     /// URI of the endpoint.
@@ -538,7 +538,7 @@ pub struct EndpointConfig {
     pub tls_config: Option<ClientTlsConfig>,
 }
 
-#[derive(Copy, Clone, Deserialize, Debug, Default)]
+#[derive(Copy, Clone, Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum UploadCacheResultsStrategy {
     /// Only upload action results with an exit code of 0.
@@ -555,7 +555,7 @@ pub enum UploadCacheResultsStrategy {
     FailuresOnly,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum EnvironmentSource {
     /// The name of the platform property in the action to get the value from.
@@ -602,7 +602,7 @@ pub enum EnvironmentSource {
     ActionDirectory,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct UploadActionResultConfig {
     /// Underlying AC store that the worker will use to publish execution results
@@ -662,7 +662,7 @@ pub struct UploadActionResultConfig {
     pub failure_message_template: String,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LocalWorkerConfig {
     /// Name of the worker. This is give a more friendly name to a worker for logging
@@ -754,14 +754,14 @@ pub struct LocalWorkerConfig {
     pub additional_environment: Option<HashMap<String, EnvironmentSource>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkerConfig {
     /// A worker type that executes jobs locally on this machine.
     Local(LocalWorkerConfig),
 }
 
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalConfig {
     /// Maximum number of open files that can be opened at one time.
@@ -796,7 +796,7 @@ pub struct GlobalConfig {
 pub type StoreConfig = NamedConfig<StoreSpec>;
 pub type SchedulerConfig = NamedConfig<SchedulerSpec>;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CasConfig {
     /// List of stores available to use in this config.

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -14,12 +14,12 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::serde_utils::{convert_duration_with_shellexpand, convert_numeric_with_shellexpand};
 use crate::stores::{GrpcEndpoint, Retry, StoreRefName};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SchedulerSpec {
     Simple(SimpleSpec),
@@ -30,7 +30,7 @@ pub enum SchedulerSpec {
 
 /// When the scheduler matches tasks to workers that are capable of running
 /// the task, this value will be used to determine how the property is treated.
-#[derive(Deserialize, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyType {
     /// Requires the platform property to be a u64 and when the scheduler looks
@@ -55,7 +55,7 @@ pub enum PropertyType {
 /// When a worker is being searched for to run a job, this will be used
 /// on how to choose which worker should run the job when multiple
 /// workers are able to run the task.
-#[derive(Copy, Clone, Deserialize, Debug, Default)]
+#[derive(Copy, Clone, Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkerAllocationStrategy {
     /// Prefer workers that have been least recently used to run a job.
@@ -65,7 +65,7 @@ pub enum WorkerAllocationStrategy {
     MostRecentlyUsed,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SimpleSpec {
     /// A list of supported platform properties mapped to how these properties
@@ -131,7 +131,7 @@ pub struct SimpleSpec {
     pub experimental_backend: Option<ExperimentalSimpleSchedulerBackend>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ExperimentalSimpleSchedulerBackend {
     /// Use an in-memory store for the scheduler.
@@ -140,7 +140,7 @@ pub enum ExperimentalSimpleSchedulerBackend {
     Redis(ExperimentalRedisSchedulerBackend),
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ExperimentalRedisSchedulerBackend {
     /// A reference to the redis store to use for the scheduler.
@@ -152,7 +152,7 @@ pub struct ExperimentalRedisSchedulerBackend {
 /// is useful to use when doing some kind of local action cache or CAS away from
 /// the main cluster of workers.  In general, it's more efficient to point the
 /// build at the main scheduler directly though.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GrpcSpec {
     /// The upstream scheduler to forward requests to.
@@ -174,7 +174,7 @@ pub struct GrpcSpec {
     pub connections_per_endpoint: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CacheLookupSpec {
     /// The reference to the action cache store used to return cached
@@ -186,7 +186,7 @@ pub struct CacheLookupSpec {
     pub scheduler: Box<SchedulerSpec>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PlatformPropertyAddition {
     /// The name of the property to add.
@@ -195,7 +195,7 @@ pub struct PlatformPropertyAddition {
     pub value: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyModification {
     /// Add a property to the action properties.
@@ -204,7 +204,7 @@ pub enum PropertyModification {
     Remove(String),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PropertyModifierSpec {
     /// A list of modifications to perform to incoming actions for the nested


### PR DESCRIPTION
# Description

Previously, the backwards compatibility helper gave an example of how to fix things, but wasn't clear regarding a) it was only an example and b) which one it was complaining about.

This PR now outputs the exact config that was wrong and a better config.

Example:
```
2025-07-21T19:31:54.138311Z  WARN test_configs_deserialization: nativelink_config::backcompat: WARNING: Using deprecated map format for services. Please migrate to the new array format:
// Old:
{
  "bar": {
    "store": "bar_store"
  },
  "foo": {
    "store": "foo_store"
  }
}
// New:
[
  {
    "instance_name": "bar",
    "store": "bar_store"
  },
  {
    "instance_name": "foo",
    "store": "foo_store"
  }
]
```

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1870)
<!-- Reviewable:end -->
