### PR TITLE
Add nix command to create local nativelink images

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -352,7 +352,8 @@
               nativelink-x86_64-linux
               ;
 
-            inherit (pkgs.nativelink-tools) local-image-test publish-ghcr native-cli;
+            # Used by the CI
+            inherit (pkgs.nativelink-tools) local-image-test;
 
             default = nativelink;
 
@@ -498,6 +499,7 @@
               pkgs.lre.lre-cc.lre-cc-configs-gen
               pkgs.nativelink-tools.local-image-test
               pkgs.nativelink-tools.native-cli
+              pkgs.nativelink-tools.create-local-image
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
               pkgs.darwin.apple_sdk.frameworks.CoreFoundation

--- a/tools/public/create-local-image.nix
+++ b/tools/public/create-local-image.nix
@@ -1,0 +1,7 @@
+{writeShellScriptBin}:
+writeShellScriptBin "create-local-image" ''
+  set -euo pipefail
+
+  nix run .#image.copyTo docker-daemon:local-nativelink:latest
+  echo "Created local-nativelink image"
+''

--- a/tools/public/default.nix
+++ b/tools/public/default.nix
@@ -6,6 +6,7 @@
     local-image-test = final.callPackage ./local-image-test.nix {};
     publish-ghcr = final.callPackage ./publish-ghcr.nix {};
     native-cli = final.callPackage ../../native-cli/default.nix {};
+    create-local-image = final.callPackage ./create-local-image.nix {};
 
     lib = {
       createWorker = self:

--- a/web/platform/src/content/docs/docs/contribute/nix.mdx
+++ b/web/platform/src/content/docs/docs/contribute/nix.mdx
@@ -41,14 +41,10 @@ and get tagged with nix derivation hashes.
 To build an image locally and make it available to your container runtime:
 
 ```sh
-nix run github:TraceMachina/nativelink#image.copyToDockerDaemon
+nix run create-local-image
 ```
 
-To view the tag of an image
-
-```sh
-nix eval github:TraceMachina/nativelink#image.imageTag --raw
-```
+which will be called `local-nativelink:latest`
 
 ## On NixOS
 


### PR DESCRIPTION
# Description

It's occasionally useful to make a local version of the Nativelink image that can be used interchangeably with the released ones.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local running of the command

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1871)
<!-- Reviewable:end -->
