### PR TITLE
Drop 22.04 support entirely

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -168,10 +168,6 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Which OS versions we will test on.
-        os_version: [ 24.04 ]
     steps:
     - name: Checkout
       uses: >- # v4.2.2
@@ -189,7 +185,6 @@ jobs:
         file: ./deployment-examples/docker-compose/Dockerfile
         build-args: |
           OPT_LEVEL=fastbuild
-          OS_VERSION=${{ matrix.os_version }}
           ADDITIONAL_BAZEL_FLAGS=--extra_toolchains=@rust_toolchains//:all
         load: true # This brings the build into `docker images` from buildx.
         tags: trace_machina/nativelink:latest

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -76,7 +76,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
           - ubuntu-24.04
           - macos-14
           - macos-15

--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 The NativeLink Authors. All rights reserved.
+# Copyright 2022-2025 The NativeLink Authors. All rights reserved.
 #
 # Licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Override this if you want to run on a different version of ubuntu.
-ARG OS_VERSION=22.04
+# Current supported Ubuntu version, Noble Numbat aka 24.04 LTS
+# Locked down to a specific revision to avoid issues with package versions
+ARG OS_VERSION=noble-20250925
 # `--compilation_mode` to pass into bazel (eg: opt, dbg, fastbuild).
 ARG OPT_LEVEL=opt
 # Additional bazel flags.
@@ -25,28 +26,14 @@ ARG ADDITIONAL_SETUP_WORKER_CMD=
 FROM ubuntu:${OS_VERSION} AS dependencies
 ARG OS_VERSION
 RUN apt-get update \
-    && if [ "${OS_VERSION}" = "24.04" ]; then \
-        DEBIAN_FRONTEND=noninteractive \
-        apt-get install --no-install-recommends -y \
-            npm=9.2.0~ds1-2 \
-            git=1:2.43.0-1ubuntu7.3 \
-            gcc=4:13.2.0-7ubuntu1 \
-            g++=4:13.2.0-7ubuntu1 \
-            python3=3.12.3-0ubuntu2 \
-            ca-certificates=20240203; \
-    elif [ "${OS_VERSION}" = "22.04" ]; then \
-        DEBIAN_FRONTEND=noninteractive \
-        apt-get install --no-install-recommends -y \
-            npm=8.5.1~ds-1 \
-            git=1:2.34.1-1ubuntu1.15 \
-            gcc=4:11.2.0-1ubuntu1 \
-            g++=4:11.2.0-1ubuntu1 \
-            python3=3.10.6-1~22.04.1 \
-            ca-certificates=20240203~22.04.1; \
-    else \
-        echo "Unsupported OS version: ${OS_VERSION}" >&2; \
-        exit 1; \
-    fi \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends -y \
+        npm=9.2.0~ds1-2 \
+        git=1:2.43.0-1ubuntu7.3 \
+        gcc=4:13.2.0-7ubuntu1 \
+        g++=4:13.2.0-7ubuntu1 \
+        python3=3.12.3-0ubuntu2 \
+        ca-certificates=20240203 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @bazel/bazelisk@1.25.0
@@ -72,11 +59,7 @@ COPY --from=builder /root/nativelink-bin /usr/local/bin/nativelink
 ARG ADDITIONAL_SETUP_WORKER_CMD
 
 RUN apt-get update \
-    && if [ "${OS_VERSION}" = "24.04" ]; then \
-        apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.6; \
-    elif [ "${OS_VERSION}" = "22.04" ]; then \
-        apt-get install -y --no-install-recommends curl=7.81.0-1ubuntu1.21; \
-    fi \
+    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && bash -ueo pipefail -c "${ADDITIONAL_SETUP_WORKER_CMD}" \

--- a/tools/toolchain-buck2/Dockerfile
+++ b/tools/toolchain-buck2/Dockerfile
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ubuntu:jammy-20240212
-# https://hub.docker.com/layers/library/ubuntu/jammy-20240212/images/sha256-9089166d0211acd54441bb6a532f69e0038287edf625d62fda94784df7f07474
-FROM ubuntu:22.04@sha256:3c61d3759c2639d4b836d32a2d3c83fa0214e36f195a3421018dbaaf79cbe37f AS dependencies
-# hadolint ignore=DL3009,DL3015
+# https://hub.docker.com/layers/library/ubuntu/noble-20250925/images/sha256-78281ac7684a7caf02348780a1b5de85844548a3cc0505df924de98380a0eeea
+FROM ubuntu:noble-20250925 AS dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y \
-        git=1:2.34.1-1ubuntu1.11 \
-        ca-certificates=20230311ubuntu0.22.04.1 \
-        curl=7.81.0-1ubuntu1.17 \
-        xz-utils=5.2.5-2ubuntu1 \
-        python3=3.10.6-1~22.04.1 \
-        unzip=6.0-26ubuntu3.2 && \
-        update-ca-certificates
+    apt-get install -y --no-install-recommends \
+        git=1:2.43.0-1ubuntu7.3 \
+        ca-certificates=20240203 \
+        curl=8.5.0-2ubuntu10.6 \
+        python3=3.12.3-0ubuntu2 \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+        && update-ca-certificates
 
 RUN curl -L https://go.dev/dl/go1.23.0.linux-amd64.tar.gz -o go1.23.0.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \

--- a/tools/toolchain-drake/Dockerfile
+++ b/tools/toolchain-drake/Dockerfile
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04@sha256:3c61d3759c2639d4b836d32a2d3c83fa0214e36f195a3421018dbaaf79cbe37f AS dependencies
-# hadolint ignore=DL3009
+FROM ubuntu:noble-20250925 AS dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends -y \
-        git=1:2.34.1-1ubuntu1.11 \
-        ca-certificates=20230311ubuntu0.22.04.1 && \
-        update-ca-certificates
+        git=1:2.43.0-1ubuntu7.3 \
+        ca-certificates=20240203 \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+        && update-ca-certificates
 
 FROM dependencies AS final
 
 # hadolint ignore=DL3003
-RUN git clone https://github.com/blakehatch/drake.git && \
+RUN git clone https://github.com/RobotLocomotion/drake.git && \
     cd drake && \
     DEBIAN_FRONTEND=noninteractive ./setup/ubuntu/install_prereqs.sh --with-bazel -y

--- a/tools/toolchain-nativelink/Dockerfile
+++ b/tools/toolchain-nativelink/Dockerfile
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04@sha256:3c61d3759c2639d4b836d32a2d3c83fa0214e36f195a3421018dbaaf79cbe37f
+# https://hub.docker.com/layers/library/ubuntu/noble-20250925/images/sha256-78281ac7684a7caf02348780a1b5de85844548a3cc0505df924de98380a0eeea
+FROM ubuntu:noble-20250925
 
 # Set shell to bash and enable pipefail
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Get Ubuntu packages
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-    gcc=4:11.2.0-1ubuntu1 \
-    g++=4:11.2.0-1ubuntu1 \
-    python3=3.10.6-1~22.04 \
-    python3-minimal=3.10.6-1~22.04 \
-    libpython3-stdlib=3.10.6-1~22.04 \
-    curl=7.81.0-1ubuntu1.20 \
-    ca-certificates=20240203~22.04.1 \
+    gcc=4:13.2.0-7ubuntu1 \
+    g++=4:13.2.0-7ubuntu1 \
+    python3=3.12.3-0ubuntu2 \
+    python3-minimal=3.12.3-0ubuntu2 \
+    libpython3-stdlib=3.12.3-0ubuntu2 \
+    curl=8.5.0-2ubuntu10.6 \
+    ca-certificates=20240203 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/web/platform/src/content/docs/docs/nativelink-cloud/api-key.mdx
+++ b/web/platform/src/content/docs/docs/nativelink-cloud/api-key.mdx
@@ -15,7 +15,7 @@ your `.github/workflows` folder with the following added to your `jobs` section:
 ```yaml
 jobs:
   build-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: production
     steps:
     - name: Checkout

--- a/web/platform/src/content/docs/docs/nativelink-cloud/rbe.mdx
+++ b/web/platform/src/content/docs/docs/nativelink-cloud/rbe.mdx
@@ -19,7 +19,7 @@ To enable RBE all you need to do is add the below flag to your Bazel builds:
 --remote_executor=grpcs://scheduler-YOUR_ACCOUNT_HERE.build-faster.nativelink.net:443
 ```
 
-This will run your builds on a Ubuntu 22.04 image *without any* dependencies installed.
+This will run your builds on a Ubuntu 24.04 image *without any* dependencies installed.
 For most users we don't expect this to work out of the box as your project most
 likely depends on installations like GCC/Java/etc. To remedy that, continue with the
 instructions below to pass in your own images.
@@ -29,7 +29,7 @@ To support most RBE builds you will most likely need to pass in your own image w
 correct toolchains installed to support your build. To use your own __*public*__ image you can pass
 it using this configuration:
 ```bash
---remote_default_exec_properties="container-image=docker://public.ecr.aws/ubuntu/ubuntu:22.04_stable"
+--remote_default_exec_properties="container-image=docker://public.ecr.aws/ubuntu/ubuntu:24.04_stable"
 ```
 Or a public image on Docker Hub is accessible via:
 ```bash
@@ -71,7 +71,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Hermetic Bazel Builds
 An alternative option to passing in your own custom image is using a fully hermetic
-Bazel build. This will allow you to use our default Ubuntu 22.04 image and your Bazel
+Bazel build. This will allow you to use our default Ubuntu 24.04 image and your Bazel
 commands will install all needed dependencies.
 
 You can see a sample of that in the WORKSPACE file of our **Hermetic CC** example

--- a/web/platform/src/content/posts/Finetune_LLM_On_CPU.mdx
+++ b/web/platform/src/content/posts/Finetune_LLM_On_CPU.mdx
@@ -68,7 +68,7 @@ Logging and print statements that track progress (like "Starting to fine tune mo
 
 Most cloud infrastructure (including NativeLink) runs on x86_64 processors, while Apple Silicon Macs use ARM64. Dependencies such as PyTorch are built for specified architectures and setting up Bazel to handle platform-specific dependencies is complex.
 
-If you want to run this code and you only have a Mac, the simplest way would be to run this code via a cloud-based Linux VM (GCP/AWS). If you don't want to use a cloud server, you could create a minimal docker container for x86_64 (`FROM --platform=linux/amd64 ubuntu:22.04` with just `curl` and `Bazelisk` installed) with **Rosetta enabled** and run from your Mac's terminal using this container. However, we highly recommend against this approach; the correct approach here would be to use toolchain transitions from a local mac platform to the remote Linux runner, but that's outside of the scope of this article.
+If you want to run this code and you only have a Mac, the simplest way would be to run this code via a cloud-based Linux VM (GCP/AWS). If you don't want to use a cloud server, you could create a minimal docker container for x86_64 (`FROM --platform=linux/amd64 ubuntu:24.04` with just `curl` and `Bazelisk` installed) with **Rosetta enabled** and run from your Mac's terminal using this container. However, we highly recommend against this approach; the correct approach here would be to use toolchain transitions from a local mac platform to the remote Linux runner, but that's outside of the scope of this article.
 
 
 ## The NativeLink Difference


### PR DESCRIPTION
# Description

As noted in https://github.com/TraceMachina/nativelink/pull/1882, we don't test 22.04 and we have specific package versions locked down. This will break when a new patch version of Ubuntu or the packages comes out and we don't test it. This PR drops 22.04 support entirely (although we probably still build just fine on it, we're just not checking it) and locks down 24.04 to a very specific revision

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've built all of the Dockerfile's I've changed by hand and made sure they still work and have corrected package versions.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1883)
<!-- Reviewable:end -->
