### PR TITLE
Redact data fields in tracing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -144,6 +144,10 @@ test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml
 test --output_groups=+rustfmt_checks
 test --output_groups=+clippy_checks
 
+# Get a bit more output from bazel tests
+# See https://github.com/bazelbuild/bazel/issues/12602
+test --experimental_ui_max_stdouterr_bytes=104857600
+
 # Optional nightly toolchain. Mostly useful for running sanitizers.
 build:nightly --@rules_rust//rust/toolchain/channel=nightly
 

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -198,7 +198,7 @@ jobs:
       - name: Debug Kustomizations
         run: >
           nix develop --impure --command
-          bash -c "kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A && kubectl describe kustomizations.kustomize.toolkit.fluxcd.io -A"
+          bash -c "kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A && kubectl events --all-namespaces && kubectl describe kustomizations.kustomize.toolkit.fluxcd.io -A"
         if: always()
 
       - name: Wait for Worker Kustomization
@@ -213,7 +213,7 @@ jobs:
       - name: Debug Kustomizations
         run: >
           nix develop --impure --command
-          bash -c "kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A && kubectl describe kustomizations.kustomize.toolkit.fluxcd.io -A"
+          bash -c "kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A && kubectl events --all-namespaces && kubectl describe kustomizations.kustomize.toolkit.fluxcd.io -A"
         if: always()
 
       - name: Wait for NativeLink

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-syn-parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2643,7 @@ dependencies = [
 name = "nativelink-proto"
 version = "0.6.0"
 dependencies = [
+ "derivative",
  "prost",
  "prost-build",
  "prost-types",

--- a/nativelink-macro/src/lib.rs
+++ b/nativelink-macro/src/lib.rs
@@ -39,7 +39,16 @@ pub fn nativelink_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             ::nativelink_util::__tracing::error_span!(stringify!(#fn_name))
                 .in_scope(|| async move {
                     ::nativelink_util::common::reseed_rng_for_test().unwrap();
-                    #fn_block
+                    let res = #fn_block;
+                    logs_assert(|lines: &[&str]| {
+                        for line in lines {
+                            if line.contains(" data: b") {
+                                return Err(format!("Non-redacted data in \"{line}\""));
+                            }
+                        }
+                        Ok(())
+                    });
+                    res
                 })
                 .await
         }

--- a/nativelink-proto/BUILD.bazel
+++ b/nativelink-proto/BUILD.bazel
@@ -148,6 +148,9 @@ genrule(
 rust_library(
     name = "nativelink-proto",
     srcs = glob(["genproto/*.rs"]),
+    proc_macro_deps = [
+        "@crates//:derivative",
+    ],
     tags = ["no-rustfmt"],
     visibility = ["//visibility:public"],
     deps = [

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -8,6 +8,7 @@ name = "nativelink_proto"
 path = "genproto/lib.rs"
 
 [dependencies]
+derivative = { version="2.2.0", default-features = false }
 prost = { version = "0.13.5", default-features = false }
 prost-types = { version = "0.13.5", default-features = false }
 tonic = { version = "0.13.0", features = ["codegen", "prost", "transport", "tls-ring"], default-features = false }

--- a/nativelink-proto/gen_protos_tool.rs
+++ b/nativelink-proto/gen_protos_tool.rs
@@ -28,6 +28,25 @@ fn main() -> std::io::Result<()> {
 
     let mut config = Config::new();
     config.bytes(["."]);
+
+    let structs_with_data_to_ignore = [
+        "BatchReadBlobsResponse.Response",
+        "BatchUpdateBlobsRequest.Request",
+        "ReadResponse",
+        "WriteRequest",
+    ];
+
+    for struct_name in structs_with_data_to_ignore {
+        config.type_attribute(struct_name, "#[derive(::derivative::Derivative)]");
+        config.type_attribute(struct_name, "#[derivative(Debug)]");
+        config.field_attribute(
+            format!("{struct_name}.data"),
+            "#[derivative(Debug=\"ignore\")]",
+        );
+    }
+
+    config.skip_debug(structs_with_data_to_ignore);
+
     tonic_build::configure()
         .out_dir(output_dir)
         .compile_protos_with_config(config, &paths, &["nativelink-proto"])?;

--- a/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
+++ b/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
@@ -1269,7 +1269,10 @@ pub struct BatchUpdateBlobsRequest {
 /// Nested message and enum types in `BatchUpdateBlobsRequest`.
 pub mod batch_update_blobs_request {
     /// A request corresponding to a single blob that the client wants to upload.
+    #[derive(::derivative::Derivative)]
+    #[derivative(Debug)]
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(skip_debug)]
     pub struct Request {
         /// The digest of the blob. This MUST be the digest of `data`. All
         /// digests MUST use the same digest function.
@@ -1277,6 +1280,7 @@ pub mod batch_update_blobs_request {
         pub digest: ::core::option::Option<super::Digest>,
         /// The raw binary data.
         #[prost(bytes = "bytes", tag = "2")]
+        #[derivative(Debug = "ignore")]
         pub data: ::prost::bytes::Bytes,
         /// The format of `data`. Must be `IDENTITY`/unspecified, or one of the
         /// compressors advertised by the
@@ -1349,13 +1353,17 @@ pub struct BatchReadBlobsResponse {
 /// Nested message and enum types in `BatchReadBlobsResponse`.
 pub mod batch_read_blobs_response {
     /// A response corresponding to a single blob that the client tried to download.
+    #[derive(::derivative::Derivative)]
+    #[derivative(Debug)]
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(skip_debug)]
     pub struct Response {
         /// The digest to which this response corresponds.
         #[prost(message, optional, tag = "1")]
         pub digest: ::core::option::Option<super::Digest>,
         /// The raw binary data.
         #[prost(bytes = "bytes", tag = "2")]
+        #[derivative(Debug = "ignore")]
         pub data: ::prost::bytes::Bytes,
         /// The format the data is encoded in. MUST be `IDENTITY`/unspecified,
         /// or one of the acceptable compressors specified in the `BatchReadBlobsRequest`.

--- a/nativelink-proto/genproto/google.bytestream.pb.rs
+++ b/nativelink-proto/genproto/google.bytestream.pb.rs
@@ -37,17 +37,24 @@ pub struct ReadRequest {
     pub read_limit: i64,
 }
 /// Response object for ByteStream.Read.
+#[derive(::derivative::Derivative)]
+#[derivative(Debug)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(skip_debug)]
 pub struct ReadResponse {
     /// A portion of the data for the resource. The service **may** leave `data`
     /// empty for any given `ReadResponse`. This enables the service to inform the
     /// client that the request is still live while it is running an operation to
     /// generate more data.
     #[prost(bytes = "bytes", tag = "10")]
+    #[derivative(Debug = "ignore")]
     pub data: ::prost::bytes::Bytes,
 }
 /// Request object for ByteStream.Write.
+#[derive(::derivative::Derivative)]
+#[derivative(Debug)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(skip_debug)]
 pub struct WriteRequest {
     /// The name of the resource to write. This **must** be set on the first
     /// `WriteRequest` of each `Write()` action. If it is set on subsequent calls,
@@ -78,6 +85,7 @@ pub struct WriteRequest {
     /// service that the request is still live while it is running an operation to
     /// generate more data.
     #[prost(bytes = "bytes", tag = "10")]
+    #[derivative(Debug = "ignore")]
     pub data: ::prost::bytes::Bytes,
 }
 /// Response object for ByteStream.Write.

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -399,14 +399,7 @@ impl ByteStreamServer {
     #[instrument(
         ret(level = Level::DEBUG),
         level = Level::ERROR,
-        skip(self, store, stream),
-        fields(
-              // we also skip stream.stream as it doesn't implement debug
-              stream.resource_info = ?stream.resource_info,
-              stream.bytes_received = stream.bytes_received,
-              stream.first_msg = "<redacted>",
-              stream.write_finished = stream.write_finished
-        )
+        skip(self, store),
     )]
     async fn inner_write(
         &self,

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -266,26 +266,6 @@ pub async fn chunked_stream_receives_all_data() -> Result<(), Box<dyn core::erro
         );
     }
 
-    logs_assert(|lines: &[&str]| {
-        // Filter out OpenTelemetry NoopMeterProvider warnings
-        let filtered_lines: Vec<&str> = lines
-            .iter()
-            .filter(|line| !line.contains("NoopMeterProvider"))
-            .copied()
-            .collect();
-
-        if filtered_lines.len() != 1 {
-            return Err(format!(
-                "Expected 1 log line (excluding OpenTelemetry warnings), got: {filtered_lines:?}"
-            ));
-        }
-        let line = filtered_lines[0];
-        if !line.contains("stream.first_msg=\"<redacted>\"") && line.contains("first_msg") {
-            return Err(format!("Non-redacted first_msg in \"{line}\""));
-        }
-        Ok(())
-    });
-
     Ok(())
 }
 


### PR DESCRIPTION
# Description

We log a lot of request data in tracing, and the `data` fields in particular tend to overwhelm everything else and make it hard to read e.g. here's an example from a test

`2025-07-30T10:49:46.659937Z TRACE chunked_stream_reads_10mb_of_data:read{request=ReadRequest { resource_name: "foo_instance_name/blobs/0123456789abcdef000000000000000000000000000000000123456789abcdef/10000000", read_offset: 0, read_limit: 10000000 }}:bytestream_read:read_stream: nativelink_service::bytestream_server: response=ReadResponse { data: b"))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))" }`

The data is rarely useful, and mostly it just makes it hard to dig through the rest of the logs - some of them are orders of magnitude longer than that example. This PR redacts the `data` fields from `Debug` implementations which is what we use to get the output in the traces.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`bazel test //...` and a lot of checking things with the `logs_assert` addition to make sure we don't accidentally hit this again in the future (or at least not for `data` fields)

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1884)
<!-- Reviewable:end -->
