### PR TITLE
Fake Redis test

### DIFF
--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::time::Duration;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
@@ -27,24 +28,42 @@ use fred::mocks::{MockCommand, Mocks};
 use fred::prelude::{Builder, Pool as RedisPool};
 use fred::types::Value as RedisValue;
 use fred::types::config::{Config as RedisConfig, PerformanceConfig};
+use futures::StreamExt;
 use mock_instant::global::SystemTime as MockSystemTime;
-use nativelink_error::Error;
+use nativelink_config::schedulers::SimpleSpec;
+use nativelink_error::{Error, ResultExt};
 use nativelink_macro::nativelink_test;
+use nativelink_proto::build::bazel::remote::execution::v2::{
+    ExecuteRequest, Platform, digest_function,
+};
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
+    ConnectionResult, StartExecute, UpdateForWorker, update_for_worker,
+};
 use nativelink_scheduler::awaited_action_db::{
     AwaitedAction, AwaitedActionDb, AwaitedActionSubscriber,
 };
+use nativelink_scheduler::simple_scheduler::SimpleScheduler;
 use nativelink_scheduler::store_awaited_action_db::StoreAwaitedActionDb;
+use nativelink_scheduler::worker::Worker;
+use nativelink_scheduler::worker_scheduler::WorkerScheduler;
 use nativelink_store::redis_store::{RedisStore, RedisSubscriptionManager};
 use nativelink_util::action_messages::{
-    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier, OperationId,
+    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier, OperationId, WorkerId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::instant_wrapper::MockInstantWrapped;
+use nativelink_util::operation_state_manager::{ClientStateManager, OperationFilter};
+use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::store_trait::{SchedulerStore, SchedulerSubscriptionManager};
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc};
+use utils::scheduler_utils::update_eq;
+
+mod utils {
+    pub(crate) mod scheduler_utils;
+}
 
 const INSTANCE_NAME: &str = "instance_name";
 const TEMP_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
@@ -151,6 +170,208 @@ impl Drop for MockRedisBackend {
     }
 }
 
+struct FakeRedisBackend {
+    /// Contains a list of all of the Redis keys -> fields.
+    table: Mutex<HashMap<String, HashMap<String, RedisValue>>>,
+    /// The subscription manager (maybe).
+    subscription_manager: Mutex<Option<Arc<RedisSubscriptionManager>>>,
+}
+
+impl fmt::Debug for FakeRedisBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FakeRedisBackend").finish()
+    }
+}
+
+impl FakeRedisBackend {
+    fn new() -> Self {
+        Self {
+            table: Mutex::new(HashMap::new()),
+            subscription_manager: Mutex::new(None),
+        }
+    }
+
+    fn set_subscription_manager(&self, subscription_manager: Arc<RedisSubscriptionManager>) {
+        *self.subscription_manager.lock() = Some(subscription_manager);
+    }
+}
+
+impl Mocks for FakeRedisBackend {
+    fn process_command(&self, actual: MockCommand) -> Result<RedisValue, RedisError> {
+        if actual.cmd == Str::from_static("SUBSCRIBE") {
+            // This does nothing at the moment, maybe we need to implement it later.
+            return Ok(RedisValue::Integer(0));
+        }
+
+        if actual.cmd == Str::from_static("PUBLISH") {
+            if let Some(subscription_manager) = self.subscription_manager.lock().as_ref() {
+                subscription_manager.notify_for_test(
+                    str::from_utf8(actual.args[1].as_bytes().expect("Notification not bytes"))
+                        .expect("Notification not UTF-8")
+                        .into(),
+                );
+            }
+            return Ok(RedisValue::Integer(0));
+        }
+
+        if actual.cmd == Str::from_static("FT.AGGREGATE") {
+            // The query is @field:value where value might be wrapped in braces.
+            let query = actual.args[1]
+                .clone()
+                .into_string()
+                .expect("Aggregate query should be a string");
+            assert_eq!(&query[..1], "@");
+            let mut parts = query[1..].split(':');
+            let field = parts.next().expect("No field name");
+            let value = parts.next().expect("No value");
+            let value = value
+                .strip_prefix("{ ")
+                .and_then(|s| s.strip_suffix(" }"))
+                .unwrap_or(value);
+            // Lazy implementation making assumptions.
+            assert_eq!(
+                actual.args[2..6],
+                vec!["LOAD".into(), 2.into(), "data".into(), "version".into()]
+            );
+            let mut results = vec![RedisValue::Integer(0)];
+            for fields in self.table.lock().values() {
+                if let Some(key_value) = fields.get(field) {
+                    if *key_value == RedisValue::Bytes(Bytes::from(value.to_owned())) {
+                        results.push(RedisValue::Array(vec![
+                            RedisValue::Bytes(Bytes::from("data")),
+                            fields.get("data").expect("No data field").clone(),
+                            RedisValue::Bytes(Bytes::from("version")),
+                            fields.get("version").expect("No version field").clone(),
+                        ]));
+                    }
+                }
+            }
+            results[0] = ((results.len() - 1) as u32).into();
+            return Ok(RedisValue::Array(vec![
+                RedisValue::Array(results),
+                RedisValue::Integer(0), // Means no more items in cursor.
+            ]));
+        }
+
+        if actual.cmd == Str::from_static("EVALSHA") {
+            assert_eq!(actual.args[0], VERSION_SCRIPT_HASH.into());
+            let mut value = HashMap::new();
+            value.insert("data".into(), actual.args[4].clone());
+            for pair in actual.args[5..].chunks(2) {
+                value.insert(
+                    str::from_utf8(pair[0].as_bytes().expect("Field name not bytes"))
+                        .expect("Unable to parse field name as string")
+                        .into(),
+                    pair[1].clone(),
+                );
+            }
+            let version = match self.table.lock().entry(
+                str::from_utf8(actual.args[2].as_bytes().expect("Key not bytes"))
+                    .expect("Key cannot be parsed as string")
+                    .into(),
+            ) {
+                Entry::Occupied(mut occupied_entry) => {
+                    let version = occupied_entry
+                        .get()
+                        .get("version")
+                        .expect("No version field");
+                    if *version != actual.args[3] {
+                        // Version mismatch.
+                        return Ok(0.into());
+                    }
+                    let version_int: u32 =
+                        str::from_utf8(version.as_bytes().expect("Version field not bytes"))
+                            .expect("Version field not valid string")
+                            .parse()
+                            .expect("Unable to parse version field");
+                    value.insert(
+                        "version".into(),
+                        RedisValue::Bytes(
+                            format!("{}", version_int + 1).as_bytes().to_owned().into(),
+                        ),
+                    );
+                    occupied_entry.insert(value);
+                    version_int + 1
+                }
+                Entry::Vacant(vacant_entry) => {
+                    value.insert("version".into(), RedisValue::Bytes("1".into()));
+                    vacant_entry.insert_entry(value);
+                    1
+                }
+            };
+            return Ok(version.into());
+        }
+
+        if actual.cmd == Str::from_static("HSET") {
+            assert_eq!(
+                RedisValue::Bytes(Bytes::from_static(b"data")),
+                actual.args[1]
+            );
+            let mut values = HashMap::new();
+            values.insert("data".into(), actual.args[2].clone());
+            self.table.lock().insert(
+                str::from_utf8(
+                    actual.args[0]
+                        .as_bytes()
+                        .expect("Key argument is not bytes"),
+                )
+                .expect("Unable to parse key as string")
+                .into(),
+                values,
+            );
+            return Ok(RedisValue::new_ok());
+        }
+
+        if actual.cmd == Str::from_static("HMGET") {
+            if let Some(fields) = self.table.lock().get(
+                str::from_utf8(
+                    actual.args[0]
+                        .as_bytes()
+                        .expect("Key argument is not bytes"),
+                )
+                .expect("Unable to parse key name"),
+            ) {
+                let mut result = vec![];
+                for key in &actual.args[1..] {
+                    if let Some(value) = fields.get(
+                        str::from_utf8(key.as_bytes().expect("Field argument is not bytes"))
+                            .expect("Unable to parse requested field"),
+                    ) {
+                        result.push(value.clone());
+                    } else {
+                        result.push(RedisValue::Null);
+                    }
+                }
+                return Ok(RedisValue::Array(result));
+            }
+            return Err(RedisError::new(RedisErrorKind::NotFound, String::new()));
+        }
+
+        panic!("Mock command not implemented! {actual:?}");
+    }
+
+    fn process_transaction(&self, commands: Vec<MockCommand>) -> Result<RedisValue, RedisError> {
+        static MULTI: MockCommand = MockCommand {
+            cmd: Str::from_static("MULTI"),
+            subcommand: None,
+            args: Vec::new(),
+        };
+        static EXEC: MockCommand = MockCommand {
+            cmd: Str::from_static("EXEC"),
+            subcommand: None,
+            args: Vec::new(),
+        };
+
+        let results = core::iter::once(MULTI.clone())
+            .chain(commands)
+            .chain([EXEC.clone()])
+            .map(|command| self.process_command(command))
+            .collect::<Result<Vec<_>, RedisError>>()?;
+
+        Ok(RedisValue::Array(results))
+    }
+}
+
 fn make_clients(mut builder: Builder) -> (RedisPool, SubscriberClient) {
     const CONNECTION_POOL_SIZE: usize = 1;
     let client_pool = builder
@@ -163,6 +384,40 @@ fn make_clients(mut builder: Builder) -> (RedisPool, SubscriberClient) {
 
     let subscriber_client = builder.build_subscriber_client().unwrap();
     (client_pool, subscriber_client)
+}
+
+async fn verify_initial_connection_message(
+    worker_id: WorkerId,
+    rx: &mut mpsc::UnboundedReceiver<UpdateForWorker>,
+) {
+    // Worker should have been sent an execute command.
+    let expected_msg_for_worker = UpdateForWorker {
+        update: Some(update_for_worker::Update::ConnectionResult(
+            ConnectionResult {
+                worker_id: worker_id.into(),
+            },
+        )),
+    };
+    let msg_for_worker = rx.recv().await.unwrap();
+    assert_eq!(msg_for_worker, expected_msg_for_worker);
+}
+
+const NOW_TIME: u64 = 10000;
+
+async fn setup_new_worker(
+    scheduler: &SimpleScheduler,
+    worker_id: WorkerId,
+    props: PlatformProperties,
+) -> Result<mpsc::UnboundedReceiver<UpdateForWorker>, Error> {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let worker = Worker::new(worker_id.clone(), props, tx, NOW_TIME);
+    scheduler
+        .add_worker(worker)
+        .await
+        .err_tip(|| "Failed to add worker")?;
+    tokio::task::yield_now().await; // Allow task<->worker matcher to run.
+    verify_initial_connection_message(worker_id, &mut rx).await;
+    Ok(rx)
 }
 
 #[nativelink_test]
@@ -534,7 +789,6 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
     const CLIENT_OPERATION_ID_1: &str = "client_operation_id_1";
     const CLIENT_OPERATION_ID_2: &str = "client_operation_id_2";
     const WORKER_OPERATION_ID: &str = "worker_operation_id";
-    static SUBSCRIPTION_MANAGER: Mutex<Option<Arc<RedisSubscriptionManager>>> = Mutex::new(None);
     const SUB_CHANNEL: &str = "sub_channel";
 
     let action_info = Arc::new(ActionInfo {
@@ -552,287 +806,7 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
         }),
     });
 
-    let worker_awaited_action = AwaitedAction::new(
-        WORKER_OPERATION_ID.into(),
-        action_info.clone(),
-        MockSystemTime::now().into(),
-    );
-
-    let worker_awaited_action_with_keepalive = {
-        let mut action_json: serde_json::Value =
-            serde_json::from_str(&serde_json::to_string(&worker_awaited_action).unwrap()).unwrap();
-        action_json["version"] = serde_json::json!(1);
-        action_json["last_client_keepalive_timestamp"] =
-            serde_json::json!({"secs_since_epoch": 0, "nanos_since_epoch": 0});
-        serde_json::to_string(&action_json).unwrap()
-    };
-
-    let ft_aggregate_args = vec![
-        format!("aa__unique_qualifier__{SCRIPT_VERSION}").into(),
-        format!("@unique_qualifier:{{ {INSTANCE_NAME}_SHA256_0000000000000000000000000000000000000000000000000000000000000000_0_c }}").into(),
-        "LOAD".into(),
-        2.into(),
-        "data".into(),
-        "version".into(),
-        "SORTBY".into(),
-        0.into(),
-        "WITHCURSOR".into(),
-        "COUNT".into(),
-        256.into(),
-        "MAXIDLE".into(),
-        2000.into(),
-    ];
-
-    let mocks = Arc::new(MockRedisBackend::new());
-    #[expect(
-        clippy::string_lit_as_bytes,
-        reason = r#"avoids `b"foo".as_slice()`, which is hardly better"#
-    )]
-    mocks
-        // First client tries to subscribe - action doesn't exist
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("FT.AGGREGATE"),
-                subcommand: None,
-                args: ft_aggregate_args.clone(),
-            },
-            Err(RedisError::new(
-                RedisErrorKind::NotFound,
-                String::new(),
-            )),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("SUBSCRIBE"),
-                subcommand: None,
-                args: vec![SUB_CHANNEL.as_bytes().into()],
-            },
-            Ok(RedisValue::Integer(0)),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("FT.CREATE"),
-                subcommand: None,
-                args: vec![
-                    format!("aa__unique_qualifier__{SCRIPT_VERSION}").into(),
-                    "ON".into(),
-                    "HASH".into(),
-                    "PREFIX".into(),
-                    1.into(),
-                    "aa_".into(),
-                    "TEMPORARY".into(),
-                    86400.into(),
-                    "NOOFFSETS".into(),
-                    "NOHL".into(),
-                    "NOFIELDS".into(),
-                    "NOFREQS".into(),
-                    "SCHEMA".into(),
-                    "unique_qualifier".into(),
-                    "TAG".into(),
-                ],
-            },
-            Ok(RedisValue::Bytes(Bytes::from("data"))),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("FT.AGGREGATE"),
-                subcommand: None,
-                args: ft_aggregate_args.clone(),
-            },
-            Ok(RedisValue::Array(vec![
-                RedisValue::Array(vec![
-                    RedisValue::Integer(0),
-                ]),
-                RedisValue::Integer(0), // Means no more items in cursor.
-            ])),
-            None,
-        )
-        // First client creates the action
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("EVALSHA"),
-                subcommand: None,
-                args: vec![
-                    VERSION_SCRIPT_HASH.into(),
-                    1.into(),
-                    format!("aa_{WORKER_OPERATION_ID}").as_bytes().into(),
-                    "0".as_bytes().into(),
-                    RedisValue::Bytes(Bytes::from(serde_json::to_string(&worker_awaited_action).unwrap())),
-                    "unique_qualifier".as_bytes().into(),
-                    format!("{INSTANCE_NAME}_SHA256_0000000000000000000000000000000000000000000000000000000000000000_0_c").as_bytes().into(),
-                    "state".as_bytes().into(),
-                    "queued".as_bytes().into(),
-                    "sort_key".as_bytes().into(),
-                    "80000000ffffffff".as_bytes().into(),
-                ],
-            },
-            Ok(1.into() /* New version */),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("PUBLISH"),
-                subcommand: None,
-                args: vec![
-                    SUB_CHANNEL.into(),
-                    format!("aa_{WORKER_OPERATION_ID}").into(),
-                ],
-            },
-            Ok(0.into() /* unused */),
-            Some(Box::new(|| SUBSCRIPTION_MANAGER.lock().as_ref().unwrap().notify_for_test(format!("aa_{WORKER_OPERATION_ID}")))),
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("HSET"),
-                subcommand: None,
-                args: vec![
-                    format!("cid_{CLIENT_OPERATION_ID_1}").as_bytes().into(),
-                    "data".as_bytes().into(),
-                    format!("{{\"String\":\"{WORKER_OPERATION_ID}\"}}").as_bytes().into(),
-                ],
-            },
-            Ok(RedisValue::new_ok()),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("PUBLISH"),
-                subcommand: None,
-                args: vec![
-                    SUB_CHANNEL.into(),
-                    format!("cid_{CLIENT_OPERATION_ID_1}").into(),
-                ],
-            },
-            Ok(0.into() /* unused */),
-            Some(Box::new(|| SUBSCRIPTION_MANAGER.lock().as_ref().unwrap().notify_for_test(format!("aa_{CLIENT_OPERATION_ID_1}")))),
-        )
-        // Second client tries to subscribe - action exists
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("FT.AGGREGATE"),
-                subcommand: None,
-                args: ft_aggregate_args.clone(),
-            },
-            Ok(RedisValue::Array(vec![
-                RedisValue::Array(vec![
-                    RedisValue::Integer(1),
-                    RedisValue::Array(vec![
-                        RedisValue::Bytes(Bytes::from("data")),
-                        RedisValue::Bytes(Bytes::from(serde_json::to_string(&worker_awaited_action).unwrap())),
-                        RedisValue::Bytes(Bytes::from("version")),
-                        RedisValue::Bytes(Bytes::from("1")),
-                    ]),
-                ]),
-                RedisValue::Integer(0), // Means no more items in cursor.
-            ])),
-            None,
-        )
-        // Update keep alive for the existing action
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("EVALSHA"),
-                subcommand: None,
-                args: vec![
-                    VERSION_SCRIPT_HASH.into(),
-                    1.into(),
-                    format!("aa_{WORKER_OPERATION_ID}").as_bytes().into(),
-                    "1".as_bytes().into(),
-                    RedisValue::Bytes(Bytes::from(worker_awaited_action_with_keepalive.clone())),
-                    "unique_qualifier".as_bytes().into(),
-                    format!("{INSTANCE_NAME}_SHA256_0000000000000000000000000000000000000000000000000000000000000000_0_c").as_bytes().into(),
-                    "state".as_bytes().into(),
-                    "queued".as_bytes().into(),
-                    "sort_key".as_bytes().into(),
-                    "80000000ffffffff".as_bytes().into(),
-                ],
-            },
-            Ok(2.into() /* New version */),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("PUBLISH"),
-                subcommand: None,
-                args: vec![
-                    SUB_CHANNEL.into(),
-                    format!("aa_{WORKER_OPERATION_ID}").into(),
-                ],
-            },
-            Ok(0.into() /* unused */),
-            Some(Box::new(|| SUBSCRIPTION_MANAGER.lock().as_ref().unwrap().notify_for_test(format!("aa_{WORKER_OPERATION_ID}")))),
-        )
-        // THE MISSING PIECE: Second client should create mapping from CLIENT_OPERATION_ID_2 to WORKER_OPERATION_ID
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("HSET"),
-                subcommand: None,
-                args: vec![
-                    format!("cid_{CLIENT_OPERATION_ID_2}").as_bytes().into(),
-                    "data".as_bytes().into(),
-                    format!("{{\"String\":\"{WORKER_OPERATION_ID}\"}}").as_bytes().into(),
-                ],
-            },
-            Ok(RedisValue::new_ok()),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("PUBLISH"),
-                subcommand: None,
-                args: vec![
-                    SUB_CHANNEL.into(),
-                    format!("cid_{CLIENT_OPERATION_ID_2}").into(),
-                ],
-            },
-            Ok(0.into() /* unused */),
-            Some(Box::new(|| SUBSCRIPTION_MANAGER.lock().as_ref().unwrap().notify_for_test(format!("aa_{CLIENT_OPERATION_ID_2}")))),
-        )
-        // Client 2 tries to get by its client_operation_id
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("HMGET"),
-                subcommand: None,
-                args: vec![
-                    format!("cid_{CLIENT_OPERATION_ID_2}").as_bytes().into(),
-                    "version".as_bytes().into(),
-                    "data".as_bytes().into(),
-                ],
-            },
-            Ok(RedisValue::Array(vec![
-                // Version.
-                RedisValue::Null,
-                // Data.
-                RedisValue::Bytes(Bytes::from(format!("{{\"String\":\"{WORKER_OPERATION_ID}\"}}"))),
-            ])),
-            None,
-        )
-        .expect(
-            MockCommand {
-                cmd: Str::from_static("HMGET"),
-                subcommand: None,
-                args: vec![
-                    format!("aa_{WORKER_OPERATION_ID}").as_bytes().into(),
-                    "version".as_bytes().into(),
-                    "data".as_bytes().into(),
-                ],
-            },
-            Ok(RedisValue::Array(vec![
-                // Version.
-                "2".into(),
-                // Data.
-                RedisValue::Bytes(Bytes::from({
-                    let mut action_json: serde_json::Value = serde_json::from_str(&serde_json::to_string(&worker_awaited_action).unwrap()).unwrap();
-                    action_json["version"] = serde_json::json!(2);
-                    action_json["last_client_keepalive_timestamp"] = serde_json::json!({"secs_since_epoch": 0, "nanos_since_epoch": 0});
-                    serde_json::to_string(&action_json).unwrap()
-                })),
-            ])),
-            None,
-        );
-
+    let mocks = Arc::new(FakeRedisBackend::new());
     let store = {
         let mut builder = Builder::default_centralized();
         let mocks = Arc::clone(&mocks);
@@ -855,9 +829,7 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
             .unwrap(),
         )
     };
-    SUBSCRIPTION_MANAGER
-        .lock()
-        .replace(store.subscription_manager().unwrap());
+    mocks.set_subscription_manager(store.subscription_manager().unwrap());
 
     let notifier = Arc::new(Notify::new());
     let awaited_action_db = StoreAwaitedActionDb::new(
@@ -868,31 +840,108 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
     )
     .unwrap();
 
+    let task_change_notify = Arc::new(Notify::new());
+    let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
+        &SimpleSpec::default(),
+        awaited_action_db,
+        || async move {},
+        task_change_notify,
+        MockInstantWrapped::default,
+        None,
+    );
+
     // First client adds the action
-    let _subscription1 = awaited_action_db
+    let mut subscription1 = scheduler
         .add_action(CLIENT_OPERATION_ID_1.into(), action_info.clone())
         .await
         .unwrap();
 
     // Second client tries to add the same action (should subscribe to existing one)
-    let _subscription2 = awaited_action_db
+    let _subscription2 = scheduler
         .add_action(CLIENT_OPERATION_ID_2.into(), action_info.clone())
         .await
         .unwrap();
 
     // Second client should be able to get the action by its client_operation_id
-    let get_subscription = awaited_action_db
-        .get_awaited_action_by_id(&OperationId::from(CLIENT_OPERATION_ID_2))
+    let get_subscription = scheduler
+        .filter_operations(OperationFilter {
+            client_operation_id: Some(OperationId::from(CLIENT_OPERATION_ID_2)),
+            ..Default::default()
+        })
         .await
-        .unwrap()
+        .expect("Second client should be able to get action by its client_operation_id")
+        .next()
+        .await
         .expect("Second client should be able to get action by its client_operation_id");
 
-    let get_res = get_subscription.borrow().await?;
-    assert_eq!(get_res.state().stage, ActionStage::Queued);
-    assert_eq!(
-        get_res.operation_id(),
-        &OperationId::from(WORKER_OPERATION_ID)
-    );
+    let (state, _metadata) = get_subscription
+        .as_state()
+        .await
+        .expect("Unable to get state of operation");
+    assert_eq!(state.stage, ActionStage::Queued);
+
+    // Now create a worker and check that it is only allocated the job once.
+    let worker_id = WorkerId("worker_id".to_string());
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, worker_id.clone(), PlatformProperties::default()).await?;
+
+    // Try to ensure we schedule to the worker.
+    scheduler.do_try_match_for_test().await?;
+
+    {
+        // Worker should have been sent an execute command.
+        let expected_msg_for_worker = UpdateForWorker {
+            update: Some(update_for_worker::Update::StartAction(StartExecute {
+                execute_request: Some(ExecuteRequest {
+                    instance_name: INSTANCE_NAME.to_string(),
+                    action_digest: Some(DigestInfo::zero_digest().into()),
+                    digest_function: digest_function::Value::Sha256.into(),
+                    ..Default::default()
+                }),
+                operation_id: "Unknown Generated internally".to_string(),
+                queued_timestamp: Some(SystemTime::UNIX_EPOCH.into()),
+                platform: Some(Platform::default()),
+                worker_id: worker_id.clone().into(),
+            })),
+        };
+        let msg_for_worker = rx_from_worker.recv().await.unwrap();
+        // Operation ID is random so we ignore it.
+        assert!(update_eq(expected_msg_for_worker, msg_for_worker, true));
+    }
+
+    let (state, _metadata) = subscription1
+        .changed()
+        .await
+        .expect("No update to subscription");
+    assert_eq!(state.stage, ActionStage::Executing);
+    let (state, _metadata) = get_subscription
+        .as_state()
+        .await
+        .expect("Unable to get second operation");
+    assert_eq!(state.stage, ActionStage::Executing);
+
+    // Immediately try to schedule again to check we don't schedule the job
+    // again now that it's executing.
+    scheduler.do_try_match_for_test().await?;
+
+    // The worker shouldn't be allocated the job again.
+    tokio::select! {
+        () = tokio::time::sleep(Duration::from_secs(1)) => {}
+        _ = rx_from_worker.recv() => {
+            panic!("Worker was allocated another job");
+        }
+    }
+
+    // The worker goes away without completing the task, so the action goes back
+    // to queued.
+    drop(rx_from_worker);
+    scheduler.remove_worker(&worker_id).await?;
+
+    let (state, _metadata) = subscription1
+        .changed()
+        .await
+        .expect("No update to subscription");
+    assert_eq!(state.stage, ActionStage::Queued);
 
     Ok(())
 }

--- a/nativelink-scheduler/tests/utils/scheduler_utils.rs
+++ b/nativelink-scheduler/tests/utils/scheduler_utils.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// The utils is used by multiple tests and some the code is dead on.
+#![allow(dead_code)]
+
 use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,6 +22,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use nativelink_error::{Code, Error, make_err};
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
+    UpdateForWorker, update_for_worker,
+};
 use nativelink_util::action_messages::{
     ActionInfo, ActionState, ActionUniqueKey, ActionUniqueQualifier, OperationId,
 };
@@ -93,5 +99,49 @@ impl ActionStateResult for TokioWatchActionStateResult {
 
     async fn as_action_info(&self) -> Result<(Arc<ActionInfo>, Option<OriginMetadata>), Error> {
         Ok((self.action_info.clone(), None))
+    }
+}
+
+pub(crate) fn update_eq(
+    expected: UpdateForWorker,
+    actual: UpdateForWorker,
+    ignore_id: bool,
+) -> bool {
+    let Some(expected_update) = expected.update else {
+        return actual.update.is_none();
+    };
+    let Some(actual_update) = actual.update else {
+        return false;
+    };
+    match actual_update {
+        update_for_worker::Update::Disconnect(()) => {
+            matches!(expected_update, update_for_worker::Update::Disconnect(()))
+        }
+        update_for_worker::Update::KeepAlive(()) => {
+            matches!(expected_update, update_for_worker::Update::KeepAlive(()))
+        }
+        update_for_worker::Update::StartAction(actual_update) => match expected_update {
+            update_for_worker::Update::StartAction(mut expected_update) => {
+                if ignore_id {
+                    expected_update
+                        .operation_id
+                        .clone_from(&actual_update.operation_id);
+                }
+                expected_update == actual_update
+            }
+            _ => false,
+        },
+        update_for_worker::Update::KillOperationRequest(actual_update) => match expected_update {
+            update_for_worker::Update::KillOperationRequest(expected_update) => {
+                expected_update == actual_update
+            }
+            _ => false,
+        },
+        update_for_worker::Update::ConnectionResult(actual_update) => match expected_update {
+            update_for_worker::Update::ConnectionResult(expected_update) => {
+                expected_update == actual_update
+            }
+            _ => false,
+        },
     }
 }


### PR DESCRIPTION
# Description

Currently the tests have a mock Redis implementation that means complex scheduler tests require a lot of mock values to be populated by the developer.

Instead, implement a fake Redis implementation that provides the bare minimum Redis interface to allow for a scheduler to work.
Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

## Type of change

Please delete options that aren't relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This is a test only change, it's only tests :)

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1895)
<!-- Reviewable:end -->
