### PR TITLE
Graceful worker shutdown

### DIFF
--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -64,7 +64,6 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::{DigestInfo, fs};
 use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
 use nativelink_util::metrics_utils::{AsyncCounterWrapper, CounterWithTime};
-use nativelink_util::shutdown_guard::ShutdownGuard;
 use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
 use nativelink_util::{background_spawn, spawn, spawn_blocking};
 use parking_lot::Mutex;
@@ -1370,8 +1369,6 @@ pub trait RunningActionsManager: Sync + Send + Sized + Unpin + 'static {
         hasher: DigestHasherFunc,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 
-    fn complete_actions(&self, complete_msg: ShutdownGuard) -> impl Future<Output = ()> + Send;
-
     fn kill_all(&self) -> impl Future<Output = ()> + Send;
 
     fn kill_operation(
@@ -2031,18 +2028,6 @@ impl RunningActionsManager for RunningActionsManagerImpl {
         };
         Self::kill_operation(running_action).await;
         Ok(())
-    }
-
-    // Waits for all running actions to complete and signals completion.
-    // Use the ShutdownGuard to signal the completion of the actions
-    // Dropping the sender automatically notifies the process to terminate.
-    async fn complete_actions(&self, _complete_msg: ShutdownGuard) {
-        drop(
-            self.action_done_tx
-                .subscribe()
-                .wait_for(|()| self.running_actions.lock().is_empty())
-                .await,
-        );
     }
 
     // Note: When the future returns the process should be fully killed and cleaned up.

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::future;
 use std::sync::Arc;
 
 use async_lock::Mutex;
-use futures::Future;
 use nativelink_error::{Error, make_input_err};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_util::action_messages::{ActionResult, OperationId};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::shutdown_guard::ShutdownGuard;
 use nativelink_worker::running_actions_manager::{Metrics, RunningAction, RunningActionsManager};
 use tokio::sync::mpsc;
 
@@ -168,10 +165,6 @@ impl RunningActionsManager for MockRunningActionsManager {
             ))))
             .expect("Could not send request to mpsc");
         Ok(())
-    }
-
-    fn complete_actions(&self, _complete_msg: ShutdownGuard) -> impl Future<Output = ()> + Send {
-        future::ready(())
     }
 
     async fn kill_operation(&self, operation_id: &OperationId) -> Result<(), Error> {


### PR DESCRIPTION
# Description

In [PR#1394](https://github.com/TraceMachina/nativelink/pull/1394) the worker shutdown was made to happen gracefully and wait for scheduled actions to complete.  However it missed three separate race conditions which can cause this to misbehave and timeouts to occur at the scheduler.

Firstly, there is the condition where a shutdown request is handled while an action is in-flight (being downloaded, but not yet registered with the running actions manager).  If there are no other actions then this can result in the complete_actions returning immediately even though there are still actions in-flight which then get dropped and have to time out at the scheduler.

Secondly, there is the race of sending the GoingAwayRequest to the scheduler and it assigning new work.  This means that if the scheduler assigns work in this period it will go to the in-flight list while the complete_actions returns and once again the action is dropped with no notification to the scheduler.

Finally, the complete_actions triggers as soon as the start_action_fut returns which means that the result is not uploaded to the Action Cache and the scheduler isn't notified of the result.

To resolve this we remove the complete_actions solution and instead introduce a new counter similar to the actions_in_transit which only decrements when the entire action is completed including uploading to the AC and notifying the scheduler.  This is asynchronously notified through a new Notify to avoid a busy loop.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests are passing, but not fully soak tested yet, will do that soon.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1899)
<!-- Reviewable:end -->
