### PR TITLE
Early scheduling

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -57,6 +57,10 @@ service WorkerApi {
 
     /// Informs the scheduler about the result of an execution request.
     rpc ExecutionResponse(ExecuteResult) returns (google.protobuf.Empty);
+
+    /// Notify the scheduler that an execution request is in the upload phase
+    /// and therefore a new execution may be scheduled.
+    rpc ExecutionComplete(ExecuteComplete) returns (google.protobuf.Empty);
 }
 
 /// Request object for keep alive requests.
@@ -121,6 +125,21 @@ message ExecuteResult {
     }
 
     reserved 9; // NextId.
+}
+
+/// A notification that an ExecutionRequest is in the upload phase.
+message ExecuteComplete {
+    /// ID of the worker making the request.
+    string worker_id = 1;
+
+    /// The `instance_name` this task was initially assigned to. This is set by the client
+    /// that initially sent the job as part of the BRE protocol.
+    string instance_name = 2;
+
+    /// The operation ID that was executed.
+    string operation_id = 3;
+
+    reserved 4; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -86,6 +86,20 @@ pub mod execute_result {
         InternalError(super::super::super::super::super::super::google::rpc::Status),
     }
 }
+/// / A notification that an ExecutionRequest is in the upload phase.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExecuteComplete {
+    /// / ID of the worker making the request.
+    #[prost(string, tag = "1")]
+    pub worker_id: ::prost::alloc::string::String,
+    /// / The `instance_name` this task was initially assigned to. This is set by the client
+    /// / that initially sent the job as part of the BRE protocol.
+    #[prost(string, tag = "2")]
+    pub instance_name: ::prost::alloc::string::String,
+    /// / The operation ID that was executed.
+    #[prost(string, tag = "3")]
+    pub operation_id: ::prost::alloc::string::String,
+}
 /// / Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionResult {
@@ -388,6 +402,34 @@ pub mod worker_api_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// / Notify the scheduler that an execution request is in the upload phase
+        /// / and therefore a new execution may be scheduled.
+        pub async fn execution_complete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ExecuteComplete>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "com.github.trace_machina.nativelink.remote_execution.WorkerApi",
+                        "ExecutionComplete",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -448,6 +490,12 @@ pub mod worker_api_server {
         async fn execution_response(
             &self,
             request: tonic::Request<super::ExecuteResult>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
+        /// / Notify the scheduler that an execution request is in the upload phase
+        /// / and therefore a new execution may be scheduled.
+        async fn execution_complete(
+            &self,
+            request: tonic::Request<super::ExecuteComplete>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
     }
     /// / This API describes how schedulers communicate with Worker nodes.
@@ -697,6 +745,51 @@ pub mod worker_api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ExecutionResponseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete" => {
+                    #[allow(non_camel_case_types)]
+                    struct ExecutionCompleteSvc<T: WorkerApi>(pub Arc<T>);
+                    impl<
+                        T: WorkerApi,
+                    > tonic::server::UnaryService<super::ExecuteComplete>
+                    for ExecutionCompleteSvc<T> {
+                        type Response = ();
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ExecuteComplete>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as WorkerApi>::execution_complete(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ExecutionCompleteSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::ops::{Deref, DerefMut};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -77,6 +78,10 @@ struct ApiWorkerSchedulerImpl {
     /// A `LruCache` of workers available based on `allocation_strategy`.
     #[metric(group = "workers")]
     workers: Workers,
+
+    /// A set of operations that have notified completion, but are still
+    /// uploading results.
+    pending_results: HashMap<WorkerId, HashSet<OperationId>>,
 
     /// The worker state manager.
     #[metric(group = "worker_state_manager")]
@@ -165,6 +170,7 @@ impl ApiWorkerSchedulerImpl {
     /// running.
     fn remove_worker(&mut self, worker_id: &WorkerId) -> Option<Worker> {
         let result = self.workers.pop(worker_id);
+        self.pending_results.remove(worker_id);
         self.worker_change_notify.notify_one();
         result
     }
@@ -213,13 +219,17 @@ impl ApiWorkerSchedulerImpl {
         })?;
 
         // Ensure the worker is supposed to be running the operation.
-        if !worker.running_action_infos.contains_key(operation_id) {
-            let err = make_err!(
+        let pending_completion = !worker.running_action_infos.contains_key(operation_id);
+        if pending_completion
+            && !self
+                .pending_results
+                .get(worker_id)
+                .is_some_and(|pending_operations| pending_operations.contains(operation_id))
+        {
+            return Err(make_err!(
                 Code::Internal,
                 "Operation {operation_id} should not be running on worker {worker_id} in SimpleScheduler::update_action"
-            );
-            return Result::<(), _>::Err(err.clone())
-                .merge(self.immediate_evict_worker(worker_id, err).await);
+            ));
         }
 
         let (is_finished, due_to_backpressure) = match &update {
@@ -254,6 +264,32 @@ impl ApiWorkerSchedulerImpl {
             return Ok(());
         }
 
+        if pending_completion {
+            // This is absolutely always true, but pattern match anyway.
+            if let Some(pending_operations) = self.pending_results.get_mut(worker_id) {
+                pending_operations.remove(operation_id);
+                if pending_operations.is_empty() {
+                    self.pending_results.remove(worker_id);
+                }
+                return Ok(());
+            }
+        }
+
+        Self::complete_worker_action(
+            worker,
+            operation_id,
+            due_to_backpressure,
+            &self.worker_change_notify,
+        )
+        .await
+    }
+
+    async fn complete_worker_action(
+        worker: &mut Worker,
+        operation_id: &OperationId,
+        due_to_backpressure: bool,
+        notify: &Notify,
+    ) -> Result<(), Error> {
         // Clear this action from the current worker if finished.
         let complete_action_res = {
             let was_paused = !worker.can_accept_work();
@@ -268,9 +304,41 @@ impl ApiWorkerSchedulerImpl {
             complete_action_res
         };
 
-        self.worker_change_notify.notify_one();
+        notify.notify_one();
 
         complete_action_res
+    }
+
+    async fn notify_complete(
+        &mut self,
+        worker_id: &WorkerId,
+        operation_id: &OperationId,
+    ) -> Result<(), Error> {
+        let worker = self.workers.get_mut(worker_id).err_tip(|| {
+            format!("Worker {worker_id} does not exist in SimpleScheduler::notify_complete")
+        })?;
+
+        // Ensure the worker is supposed to be running the operation.
+        if !worker.running_action_infos.contains_key(operation_id) {
+            let err = make_err!(
+                Code::Internal,
+                "Operation {operation_id} should not be running on worker {worker_id} in SimpleScheduler::update_action"
+            );
+            return Err(err);
+        }
+
+        match self.pending_results.entry(worker_id.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
+                occupied_entry.get_mut().insert(operation_id.clone());
+            }
+            std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                vacant_entry
+                    .insert(HashSet::new())
+                    .insert(operation_id.clone());
+            }
+        }
+
+        Self::complete_worker_action(worker, operation_id, false, &self.worker_change_notify).await
     }
 
     /// Notifies the specified worker to run the given action and handles errors by evicting
@@ -368,6 +436,7 @@ impl ApiWorkerScheduler {
         Arc::new(Self {
             inner: Mutex::new(ApiWorkerSchedulerImpl {
                 workers: Workers(LruCache::unbounded()),
+                pending_results: HashMap::new(),
                 worker_state_manager: worker_state_manager.clone(),
                 allocation_strategy,
                 worker_change_notify,
@@ -480,6 +549,15 @@ impl WorkerScheduler for ApiWorkerScheduler {
     ) -> Result<(), Error> {
         let mut inner = self.inner.lock().await;
         inner.update_action(worker_id, operation_id, update).await
+    }
+
+    async fn notify_complete(
+        &self,
+        worker_id: &WorkerId,
+        operation_id: &OperationId,
+    ) -> Result<(), Error> {
+        let mut inner = self.inner.lock().await;
+        inner.notify_complete(worker_id, operation_id).await
     }
 
     async fn worker_keep_alive_received(

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -503,6 +503,16 @@ impl WorkerScheduler for SimpleScheduler {
             .await
     }
 
+    async fn notify_complete(
+        &self,
+        worker_id: &WorkerId,
+        operation_id: &OperationId,
+    ) -> Result<(), Error> {
+        self.worker_scheduler
+            .notify_complete(worker_id, operation_id)
+            .await
+    }
+
     async fn worker_keep_alive_received(
         &self,
         worker_id: &WorkerId,

--- a/nativelink-scheduler/src/worker_scheduler.rs
+++ b/nativelink-scheduler/src/worker_scheduler.rs
@@ -39,6 +39,13 @@ pub trait WorkerScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static 
         update: UpdateOperationType,
     ) -> Result<(), Error>;
 
+    /// Notify that the operation has completed execution, but not uploaded yet.
+    async fn notify_complete(
+        &self,
+        worker_id: &WorkerId,
+        operation_id: &OperationId,
+    ) -> Result<(), Error>;
+
     /// Event for when the keep alive message was received from the worker.
     async fn worker_keep_alive_received(
         &self,

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -27,7 +27,7 @@ use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::
     WorkerApi, WorkerApiServer as Server,
 };
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    execute_result, ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker
+    execute_result, ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker
 };
 use nativelink_scheduler::worker::Worker;
 use nativelink_scheduler::worker_scheduler::WorkerScheduler;
@@ -258,6 +258,19 @@ impl WorkerApiServer {
         }
         Ok(Response::new(()))
     }
+
+    async fn inner_execution_complete(
+        &self,
+        execute_complete: ExecuteComplete,
+    ) -> Result<Response<()>, Error> {
+        let worker_id: WorkerId = execute_complete.worker_id.into();
+        let operation_id = OperationId::from(execute_complete.operation_id);
+        self.scheduler
+            .notify_complete(&worker_id, &operation_id)
+            .await
+            .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
+        Ok(Response::new(()))
+    }
 }
 
 #[tonic::async_trait]
@@ -328,6 +341,22 @@ impl WorkerApi for WorkerApiServer {
         grpc_request: Request<ExecuteResult>,
     ) -> Result<Response<()>, Status> {
         self.inner_execution_response(grpc_request.into_inner())
+            .await
+            .map_err(Into::into)
+    }
+
+    #[instrument(
+        err,
+        ret(level = Level::DEBUG),
+        level = Level::ERROR,
+        skip_all,
+        fields(request = ?grpc_request.get_ref())
+    )]
+    async fn execution_complete(
+        &self,
+        grpc_request: Request<ExecuteComplete>,
+    ) -> Result<Response<()>, Status> {
+        self.inner_execution_complete(grpc_request.into_inner())
             .await
             .map_err(Into::into)
     }

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -28,7 +28,8 @@ use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker, execute_result,
+    ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    execute_result,
 };
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_util::action_messages::{ActionResult, ActionStage, OperationId};
@@ -69,7 +70,7 @@ const DEFAULT_ENDPOINT_TIMEOUT_S: f32 = 5.;
 /// If this value gets modified the documentation in `cas_server.rs` must also be updated.
 const DEFAULT_MAX_ACTION_TIMEOUT: Duration = Duration::from_secs(1200); // 20 mins.
 
-struct LocalWorkerImpl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> {
+struct LocalWorkerImpl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> {
     config: &'a LocalWorkerConfig,
     // According to the tonic documentation it is a cheap operation to clone this.
     grpc_client: T,
@@ -261,6 +262,12 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                                 let actions_in_transit = self.actions_in_transit.clone();
                                 let worker_id = self.worker_id.clone();
                                 let running_actions_manager = self.running_actions_manager.clone();
+                                let execute_complete = maybe_instance_name.as_ref().map(|instance_name| ExecuteComplete{
+                                    worker_id: worker_id.clone(),
+                                    instance_name: instance_name.clone(),
+                                    operation_id: operation_id.clone(),
+                                });
+                                let mut grpc_client = self.grpc_client.clone();
                                 self.metrics.clone().wrap(move |metrics| async move {
                                     metrics.preconditions.wrap(preconditions_met(precondition_script_cfg))
                                     .and_then(|()| running_actions_manager.create_and_add_action(worker_id, start_execute))
@@ -270,7 +277,7 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                                         actions_in_transit.fetch_sub(1, Ordering::Release);
                                         r
                                     })
-                                    .and_then(|action| {
+                                    .and_then(move |action| {
                                         debug!(
                                             operation_id = ?action.get_operation_id(),
                                             "Received request to run action"
@@ -279,10 +286,19 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                                             .clone()
                                             .prepare_action()
                                             .and_then(RunningAction::execute)
+                                            .and_then(move |result| async move {
+                                                // Notify that we're completed with execution and simply uploading results.
+                                                // We only do this on success as otherwise the action may be retried and
+                                                // cause a conflict with our existing operation ID.
+                                                if let Some(execute_complete) = execute_complete {
+                                                    drop(grpc_client.execution_complete(execute_complete).await);
+                                                }
+                                                Ok(result)
+                                            })
                                             .and_then(RunningAction::upload_results)
                                             .and_then(RunningAction::get_finished_result)
                                             // Note: We need ensure we run cleanup even if one of the other steps fail.
-                                            .then(|result| async move {
+                                            .then(move |result| async move {
                                                 if let Err(e) = action.cleanup().await {
                                                     return Result::<ActionResult, Error>::Err(e).merge(result);
                                                 }
@@ -419,7 +435,7 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
 
 type ConnectionFactory<T> = Box<dyn Fn() -> BoxFuture<'static, Result<T, Error>> + Send + Sync>;
 
-pub struct LocalWorker<T: WorkerApiClientTrait, U: RunningActionsManager> {
+pub struct LocalWorker<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> {
     config: Arc<LocalWorkerConfig>,
     running_actions_manager: Arc<U>,
     connection_factory: ConnectionFactory<T>,

--- a/nativelink-worker/src/worker_api_client_wrapper.rs
+++ b/nativelink-worker/src/worker_api_client_wrapper.rs
@@ -16,7 +16,8 @@ use core::future::Future;
 
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
+    UpdateForWorker,
 };
 use tonic::codec::Streaming;
 use tonic::transport::Channel;
@@ -43,6 +44,11 @@ pub trait WorkerApiClientTrait: Clone + Sync + Send + Sized + Unpin {
     fn execution_response(
         &mut self,
         request: ExecuteResult,
+    ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
+
+    fn execution_complete(
+        &mut self,
+        request: ExecuteComplete,
     ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
 }
 
@@ -75,5 +81,12 @@ impl WorkerApiClientTrait for WorkerApiClientWrapper {
 
     async fn execution_response(&mut self, request: ExecuteResult) -> Result<Response<()>, Status> {
         self.inner.execution_response(request).await
+    }
+
+    async fn execution_complete(
+        &mut self,
+        request: ExecuteComplete,
+    ) -> Result<Response<()>, Status> {
+        self.inner.execution_complete(request).await
     }
 }

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -273,10 +273,14 @@ async fn blake3_digest_function_registered_properly() -> Result<(), Error> {
         .expect_create_and_add_action(Ok(running_action.clone()))
         .await;
 
-    // Now the RunningAction needs to send a series of state updates. This shortcuts them
-    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
+    // Now the RunningAction needs to send a series of state updates.
+    running_action.simple_expect_prepare_and_execute().await?;
+    test_context
+        .client
+        .expect_execution_complete(Ok(Response::new(())))
+        .await;
     running_action
-        .simple_expect_get_finished_result(Ok(ActionResult::default()))
+        .simple_expect_upload_and_complete(Ok(ActionResult::default()))
         .await?;
 
     // Expect the action to be updated in the action cache.
@@ -387,10 +391,14 @@ async fn simple_worker_start_action_test() -> Result<(), Error> {
         .expect_create_and_add_action(Ok(running_action.clone()))
         .await;
 
-    // Now the RunningAction needs to send a series of state updates. This shortcuts them
-    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
+    // Now the RunningAction needs to send a series of state updates.
+    running_action.simple_expect_prepare_and_execute().await?;
+    test_context
+        .client
+        .expect_execution_complete(Ok(Response::new(())))
+        .await;
     running_action
-        .simple_expect_get_finished_result(Ok(action_result.clone()))
+        .simple_expect_upload_and_complete(Ok(action_result.clone()))
         .await?;
 
     // Expect the action to be updated in the action cache.

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -21,7 +21,8 @@ use hyper::body::Frame;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_error::Error;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
+    UpdateForWorker,
 };
 use nativelink_util::channel_body_for_tests::ChannelBody;
 use nativelink_util::shutdown_guard::ShutdownGuard;
@@ -53,6 +54,7 @@ const BROADCAST_CAPACITY: usize = 1;
 enum WorkerClientApiCalls {
     ConnectWorker(ConnectWorkerRequest),
     ExecutionResponse(ExecuteResult),
+    ExecutionComplete(ExecuteComplete),
 }
 
 #[derive(Debug)]
@@ -63,6 +65,7 @@ enum WorkerClientApiCalls {
 enum WorkerClientApiReturns {
     ConnectWorker(Result<Response<Streaming<UpdateForWorker>>, Status>),
     ExecutionResponse(Result<Response<()>, Status>),
+    ExecutionComplete(Result<Response<()>, Status>),
 }
 
 #[derive(Clone)]
@@ -104,7 +107,7 @@ impl MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiCalls::ConnectWorker(req) => req,
-            req @ WorkerClientApiCalls::ExecutionResponse(_) => {
+            req => {
                 panic!("expect_connect_worker expected ConnectWorker, got : {req:?}")
             }
         };
@@ -125,12 +128,33 @@ impl MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiCalls::ExecutionResponse(req) => req,
-            req @ WorkerClientApiCalls::ConnectWorker(_) => {
+            req => {
                 panic!("expect_execution_response expected ExecutionResponse, got : {req:?}")
             }
         };
         self.tx_resp
             .send(WorkerClientApiReturns::ExecutionResponse(result))
+            .expect("Could not send request to mpsc");
+        req
+    }
+
+    pub(crate) async fn expect_execution_complete(
+        &self,
+        result: Result<Response<()>, Status>,
+    ) -> ExecuteComplete {
+        let mut rx_call_lock = self.rx_call.lock().await;
+        let req = match rx_call_lock
+            .recv()
+            .await
+            .expect("Could not receive msg in mpsc")
+        {
+            WorkerClientApiCalls::ExecutionComplete(req) => req,
+            req => {
+                panic!("expect_execution_complete expected ExecutionComplete, got : {req:?}")
+            }
+        };
+        self.tx_resp
+            .send(WorkerClientApiReturns::ExecutionComplete(result))
             .expect("Could not send request to mpsc");
         req
     }
@@ -151,7 +175,7 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiReturns::ConnectWorker(result) => result,
-            resp @ WorkerClientApiReturns::ExecutionResponse(_) => {
+            resp => {
                 panic!("connect_worker expected ConnectWorker response, received {resp:?}")
             }
         }
@@ -176,7 +200,27 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiReturns::ExecutionResponse(result) => result,
-            resp @ WorkerClientApiReturns::ConnectWorker(_) => {
+            resp => {
+                panic!("execution_response expected ExecutionResponse response, received {resp:?}")
+            }
+        }
+    }
+
+    async fn execution_complete(
+        &mut self,
+        request: ExecuteComplete,
+    ) -> Result<Response<()>, Status> {
+        self.tx_call
+            .send(WorkerClientApiCalls::ExecutionComplete(request))
+            .expect("Could not send request to mpsc");
+        let mut rx_resp_lock = self.rx_resp.lock().await;
+        match rx_resp_lock
+            .recv()
+            .await
+            .expect("Could not receive msg in mpsc")
+        {
+            WorkerClientApiReturns::ExecutionComplete(result) => result,
+            resp => {
                 panic!("execution_response expected ExecutionResponse response, received {resp:?}")
             }
         }

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -230,12 +230,15 @@ impl MockRunningAction {
         }
     }
 
-    pub(crate) async fn simple_expect_get_finished_result(
+    pub(crate) async fn simple_expect_prepare_and_execute(self: &Arc<Self>) -> Result<(), Error> {
+        self.expect_prepare_action(Ok(())).await?;
+        self.expect_execute(Ok(())).await
+    }
+
+    pub(crate) async fn simple_expect_upload_and_complete(
         self: &Arc<Self>,
         result: Result<ActionResult, Error>,
     ) -> Result<(), Error> {
-        self.expect_prepare_action(Ok(())).await?;
-        self.expect_execute(Ok(())).await?;
         self.upload_results(Ok(())).await?;
         let result = self.get_finished_result(result).await;
         self.cleanup(Ok(())).await?;


### PR DESCRIPTION
# Description

Currently the scheduler waits for an action to complete before freeing the worker to be scheduled again.  This is an inefficient use of CPU since uploading the result is IO bound.

Add a new message to the worker API to notify the scheduler that the execution has completed and is now doing upload and cleanup.  When this is received, the scheduler frees the resources from the worker.

Fixes #1903

## Type of change

Please delete options that aren't relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Updates to tests.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
