### PR TITLE
Retry on disconnect

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -240,6 +240,7 @@ impl ApiWorkerSchedulerImpl {
             UpdateOperationType::UpdateWithError(err) => {
                 (true, err.code == Code::ResourceExhausted)
             }
+            UpdateOperationType::UpdateWithDisconnect => (true, false),
         };
 
         // Update the operation in the worker state manager.
@@ -354,7 +355,7 @@ impl ApiWorkerSchedulerImpl {
                 .notify_update(WorkerUpdate::RunAction((operation_id, action_info.clone())))
                 .await;
 
-            if notify_worker_result.is_err() {
+            if let Err(notify_worker_result) = notify_worker_result {
                 warn!(
                     ?worker_id,
                     ?action_info,
@@ -362,13 +363,22 @@ impl ApiWorkerSchedulerImpl {
                     "Worker command failed, removing worker",
                 );
 
+                // A slightly nasty way of figuring out that the worker disconnected
+                // from send_msg_to_worker without introducing complexity to the
+                // code path from here to there.
+                let is_disconnect = notify_worker_result.code == Code::Internal
+                    && notify_worker_result.messages.len() == 1
+                    && notify_worker_result.messages[0] == "Worker Disconnected";
+
                 let err = make_err!(
                     Code::Internal,
                     "Worker command failed, removing worker {worker_id} -- {notify_worker_result:?}",
                 );
 
-                return Result::<(), _>::Err(err.clone())
-                    .merge(self.immediate_evict_worker(&worker_id, err).await);
+                return Result::<(), _>::Err(err.clone()).merge(
+                    self.immediate_evict_worker(&worker_id, err, is_disconnect)
+                        .await,
+                );
             }
         } else {
             warn!(
@@ -386,19 +396,21 @@ impl ApiWorkerSchedulerImpl {
         &mut self,
         worker_id: &WorkerId,
         err: Error,
+        is_disconnect: bool,
     ) -> Result<(), Error> {
         let mut result = Ok(());
         if let Some(mut worker) = self.remove_worker(worker_id) {
             // We don't care if we fail to send message to worker, this is only a best attempt.
             drop(worker.notify_update(WorkerUpdate::Disconnect).await);
+            let update = if is_disconnect {
+                UpdateOperationType::UpdateWithDisconnect
+            } else {
+                UpdateOperationType::UpdateWithError(err)
+            };
             for (operation_id, _) in worker.running_action_infos.drain() {
                 result = result.merge(
                     self.worker_state_manager
-                        .update_operation(
-                            &operation_id,
-                            worker_id,
-                            UpdateOperationType::UpdateWithError(err.clone()),
-                        )
+                        .update_operation(&operation_id, worker_id, update.clone())
                         .await,
                 );
             }
@@ -536,7 +548,7 @@ impl WorkerScheduler for ApiWorkerScheduler {
             .err_tip(|| "Error while adding worker, removing from pool");
         if let Err(err) = result {
             return Result::<(), _>::Err(err.clone())
-                .merge(inner.immediate_evict_worker(&worker_id, err).await);
+                .merge(inner.immediate_evict_worker(&worker_id, err, false).await);
         }
         Ok(())
     }
@@ -577,6 +589,7 @@ impl WorkerScheduler for ApiWorkerScheduler {
             .immediate_evict_worker(
                 worker_id,
                 make_err!(Code::Internal, "Received request to remove worker"),
+                false,
             )
             .await
     }
@@ -609,6 +622,7 @@ impl WorkerScheduler for ApiWorkerScheduler {
                             Code::Internal,
                             "Worker {worker_id} timed out, removing from pool"
                         ),
+                        false,
                     )
                     .await,
             );

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -33,7 +33,7 @@ use static_assertions::{assert_eq_size, const_assert, const_assert_eq};
 /// This number will always increment by one each time
 /// the action is updated.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
-struct AwaitedActionVersion(u64);
+struct AwaitedActionVersion(i64);
 
 impl MetricsComponent for AwaitedActionVersion {
     fn publish(
@@ -41,7 +41,9 @@ impl MetricsComponent for AwaitedActionVersion {
         _kind: MetricKind,
         _field_metadata: MetricFieldData,
     ) -> Result<MetricPublishKnownKindData, nativelink_metric::Error> {
-        Ok(MetricPublishKnownKindData::Counter(self.0))
+        Ok(MetricPublishKnownKindData::Counter(u64::from_ne_bytes(
+            self.0.to_ne_bytes(),
+        )))
     }
 }
 
@@ -136,11 +138,11 @@ impl AwaitedAction {
         }
     }
 
-    pub(crate) const fn version(&self) -> u64 {
+    pub(crate) const fn version(&self) -> i64 {
         self.version.0
     }
 
-    pub(crate) const fn set_version(&mut self, version: u64) {
+    pub(crate) const fn set_version(&mut self, version: i64) {
         self.version = AwaitedActionVersion(version);
     }
 

--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -186,5 +186,6 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + Unpin + 'static {
         &self,
         client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
+        no_event_action_timeout: Duration,
     ) -> impl Future<Output = Result<Self::Subscriber, Error>> + Send;
 }

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::ops::{Bound, RangeBounds};
+use core::time::Duration;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
@@ -976,6 +977,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync + 'static> Awaite
         &self,
         client_operation_id: OperationId,
         action_info: Arc<ActionInfo>,
+        _no_event_action_timeout: Duration,
     ) -> Result<Self::Subscriber, Error> {
         let subscriber = self
             .inner

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -29,6 +29,7 @@ use nativelink_util::operation_state_manager::{
     OperationFilter, OperationStageFlags, OrderDirection, UpdateOperationType,
 };
 use nativelink_util::origin_event::OriginMetadata;
+use nativelink_util::shutdown_guard::ShutdownGuard;
 use nativelink_util::spawn;
 use nativelink_util::task::JoinHandleDropGuard;
 use opentelemetry::KeyValue;
@@ -539,6 +540,10 @@ impl WorkerScheduler for SimpleScheduler {
 
     async fn remove_worker(&self, worker_id: &WorkerId) -> Result<(), Error> {
         self.worker_scheduler.remove_worker(worker_id).await
+    }
+
+    async fn shutdown(&self, shutdown_guard: ShutdownGuard) {
+        self.worker_scheduler.shutdown(shutdown_guard).await;
     }
 
     async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error> {

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -566,6 +566,7 @@ where
                         ActionStage::Queued
                     }
                 }
+                UpdateOperationType::UpdateWithDisconnect => ActionStage::Queued,
             };
             let now = (self.now_fn)().now();
             if matches!(stage, ActionStage::Queued) {
@@ -619,7 +620,11 @@ where
         action_info: Arc<ActionInfo>,
     ) -> Result<T::Subscriber, Error> {
         self.action_db
-            .add_action(new_client_operation_id, action_info)
+            .add_action(
+                new_client_operation_id,
+                action_info,
+                self.no_event_action_timeout,
+            )
             .await
             .err_tip(|| "In SimpleSchedulerStateManager::add_operation")
     }

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -16,7 +16,6 @@ use core::ops::Bound;
 use core::time::Duration;
 use std::string::ToString;
 use std::sync::{Arc, Weak};
-use std::time::SystemTime;
 
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -439,19 +438,16 @@ where
             return Ok(());
         }
 
-        let last_worker_updated = awaited_action
+        let worker_should_update_before = awaited_action
             .last_worker_updated_timestamp()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| {
+            .checked_add(self.no_event_action_timeout)
+            .ok_or_else(|| {
                 make_err!(
                     Code::Internal,
-                    "Failed to convert last_worker_updated to duration since epoch {e:?}"
+                    "Timestamp overflow for operation {operation_id} in SimpleSchedulerStateManager::timeout_operation_id"
                 )
             })?;
-        let worker_should_update_before = last_worker_updated
-            .checked_add(self.no_event_action_timeout)
-            .err_tip(|| "Timestamp too big in SimpleSchedulerStateManager::timeout_operation_id")?;
-        if worker_should_update_before < (self.now_fn)().elapsed() {
+        if worker_should_update_before >= (self.now_fn)().now() {
             // The action was updated recently, we should not timeout the action.
             // This is to prevent timing out actions that have recently been updated
             // (like multiple clients timeout the same action at the same time).

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -239,7 +239,7 @@ where
     }
 }
 
-fn awaited_action_decode(version: u64, data: &Bytes) -> Result<AwaitedAction, Error> {
+fn awaited_action_decode(version: i64, data: &Bytes) -> Result<AwaitedAction, Error> {
     let mut awaited_action: AwaitedAction = serde_json::from_slice(data)
         .map_err(|e| make_input_err!("In AwaitedAction::decode - {e:?}"))?;
     awaited_action.set_version(version);
@@ -267,7 +267,7 @@ impl SchedulerStoreKeyProvider for OperationIdToAwaitedAction<'_> {
 }
 impl SchedulerStoreDecodeTo for OperationIdToAwaitedAction<'_> {
     type DecodeOutput = AwaitedAction;
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         awaited_action_decode(version, &data)
     }
 }
@@ -284,7 +284,7 @@ impl SchedulerStoreKeyProvider for ClientIdToOperationId<'_> {
 }
 impl SchedulerStoreDecodeTo for ClientIdToOperationId<'_> {
     type DecodeOutput = OperationId;
-    fn decode(_version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(_version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         serde_json::from_slice(&data).map_err(|e| {
             make_input_err!(
                 "In ClientIdToOperationId::decode - {e:?} (data: {:02x?})",
@@ -307,7 +307,7 @@ impl SchedulerIndexProvider for SearchUniqueQualifierToAwaitedAction<'_> {
 }
 impl SchedulerStoreDecodeTo for SearchUniqueQualifierToAwaitedAction<'_> {
     type DecodeOutput = AwaitedAction;
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         awaited_action_decode(version, &data)
     }
 }
@@ -324,7 +324,7 @@ impl SchedulerIndexProvider for SearchStateToAwaitedAction {
 }
 impl SchedulerStoreDecodeTo for SearchStateToAwaitedAction {
     type DecodeOutput = AwaitedAction;
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         awaited_action_decode(version, &data)
     }
 }
@@ -340,7 +340,7 @@ const fn get_state_prefix(state: SortedAwaitedActionState) -> &'static str {
 
 struct UpdateOperationIdToAwaitedAction(AwaitedAction);
 impl SchedulerCurrentVersionProvider for UpdateOperationIdToAwaitedAction {
-    fn current_version(&self) -> u64 {
+    fn current_version(&self) -> i64 {
         self.0.version()
     }
 }

--- a/nativelink-scheduler/src/worker_scheduler.rs
+++ b/nativelink-scheduler/src/worker_scheduler.rs
@@ -17,6 +17,7 @@ use nativelink_error::Error;
 use nativelink_metric::RootMetricsComponent;
 use nativelink_util::action_messages::{OperationId, WorkerId};
 use nativelink_util::operation_state_manager::UpdateOperationType;
+use nativelink_util::shutdown_guard::ShutdownGuard;
 
 use crate::platform_property_manager::PlatformPropertyManager;
 use crate::worker::{Worker, WorkerTimestamp};
@@ -55,6 +56,9 @@ pub trait WorkerScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static 
 
     /// Removes worker from pool and reschedule any tasks that might be running on it.
     async fn remove_worker(&self, worker_id: &WorkerId) -> Result<(), Error>;
+
+    /// Evict all workers from the scheduler, setting their actions back to queued.
+    async fn shutdown(&self, shutdown_guard: ShutdownGuard);
 
     /// Removes timed out workers from the pool. This is called periodically by an
     /// external source.

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -975,6 +975,7 @@ impl AwaitedActionDb for RxMockAwaitedAction {
         &self,
         _client_operation_id: OperationId,
         _action_info: Arc<ActionInfo>,
+        _no_event_action_timeout: Duration,
     ) -> Result<Self::Subscriber, Error> {
         unreachable!();
     }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1055,7 +1055,7 @@ impl SchedulerStore for RedisStore {
         }
     }
 
-    async fn update_data<T>(&self, data: T) -> Result<Option<u64>, Error>
+    async fn update_data<T>(&self, data: T) -> Result<Option<i64>, Error>
     where
         T: SchedulerStoreDataProvider
             + SchedulerStoreKeyProvider
@@ -1080,7 +1080,7 @@ impl SchedulerStore for RedisStore {
                 argv.push(Bytes::from_static(name.as_bytes()));
                 argv.push(value);
             }
-            let (success, new_version): (bool, u64) = self
+            let (success, new_version): (bool, i64) = self
                 .update_if_version_matches_script
                 .evalsha_with_reload(client, vec![key.as_ref()], argv)
                 .await
@@ -1249,7 +1249,7 @@ impl SchedulerStore for RedisStore {
                 redis_map
                     .remove(&RedisKey::from_static_str(VERSION_FIELD_NAME))
                     .err_tip(|| "Missing version field in RedisStore::search_by_index_prefix")?
-                    .as_u64()
+                    .as_i64()
                     .err_tip(|| {
                         formatcp!("'{VERSION_FIELD_NAME}' is not u64 in RedisStore::search_by_index_prefix::as_u64")
                     })?
@@ -1272,7 +1272,7 @@ impl SchedulerStore for RedisStore {
         let key = self.encode_key(&key);
         let client = self.get_client().await?;
         let (maybe_version, maybe_data) = client
-            .hmget::<(Option<u64>, Option<Bytes>), _, _>(
+            .hmget::<(Option<i64>, Option<Bytes>), _, _>(
                 key.as_ref(),
                 vec![
                     RedisKey::from(VERSION_FIELD_NAME),

--- a/nativelink-store/tests/mongo_store_test.rs
+++ b/nativelink-store/tests/mongo_store_test.rs
@@ -735,7 +735,7 @@ async fn create_ten_cas_entries() -> Result<(), Error> {
 struct TestSchedulerData {
     key: String,
     content: String,
-    version: u64,
+    version: i64,
 }
 
 impl SchedulerStoreKeyProvider for TestSchedulerData {
@@ -764,7 +764,7 @@ impl SchedulerStoreDataProvider for TestSchedulerData {
 }
 
 impl SchedulerCurrentVersionProvider for TestSchedulerData {
-    fn current_version(&self) -> u64 {
+    fn current_version(&self) -> i64 {
         self.version
     }
 }
@@ -772,7 +772,7 @@ impl SchedulerCurrentVersionProvider for TestSchedulerData {
 impl SchedulerStoreDecodeTo for TestSchedulerData {
     type DecodeOutput = Self;
 
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         let content = String::from_utf8(data.to_vec())
             .map_err(|e| make_err!(Code::InvalidArgument, "Invalid UTF-8 data: {e}"))?;
         // We don't have the key in the data, so we'll use a placeholder
@@ -799,7 +799,7 @@ impl SchedulerStoreKeyProvider for TestSchedulerKey {
 impl SchedulerStoreDecodeTo for TestSchedulerKey {
     type DecodeOutput = TestSchedulerData;
 
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
         TestSchedulerData::decode(version, data)
     }
 }
@@ -955,7 +955,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         impl SchedulerStoreDecodeTo for SearchByContentPrefix {
             type DecodeOutput = TestSchedulerData;
 
-            fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+            fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
                 TestSchedulerKey::decode(version, data)
             }
         }
@@ -1024,7 +1024,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         impl SchedulerStoreDecodeTo for SearchByTestIndex {
             type DecodeOutput = TestSchedulerData;
 
-            fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
+            fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
                 TestSchedulerKey::decode(version, data)
             }
         }

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -123,7 +123,7 @@ pub trait ClientStateManager: Sync + Send + Unpin + MetricsComponent + 'static {
 }
 
 /// The type of update to perform on an operation.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(
     clippy::large_enum_variant,
     reason = "TODO Fix this. Breaks on stable, but not on nightly"
@@ -137,6 +137,9 @@ pub enum UpdateOperationType {
 
     /// Notification that the operation has been completed.
     UpdateWithError(Error),
+
+    /// Notification that the worker disconnected.
+    UpdateWithDisconnect,
 }
 
 #[async_trait]

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -831,7 +831,7 @@ pub trait StoreDriver:
 /// the underlying type.
 pub trait SchedulerStoreDecodeTo {
     type DecodeOutput;
-    fn decode(version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error>;
+    fn decode(version: i64, data: Bytes) -> Result<Self::DecodeOutput, Error>;
 }
 
 pub trait SchedulerSubscription: Send + Sync {
@@ -862,7 +862,7 @@ pub trait SchedulerStore: Send + Sync + 'static {
     /// the version in the passed in data.
     /// No guarantees are made about when `Version` is `FalseValue`.
     /// Indexes are guaranteed to be updated atomically with the data.
-    fn update_data<T>(&self, data: T) -> impl Future<Output = Result<Option<u64>, Error>> + Send
+    fn update_data<T>(&self, data: T) -> impl Future<Output = Result<Option<i64>, Error>> + Send
     where
         T: SchedulerStoreDataProvider
             + SchedulerStoreKeyProvider
@@ -934,7 +934,7 @@ pub trait SchedulerStoreDataProvider {
 /// Provides the current version of the data in the store.
 pub trait SchedulerCurrentVersionProvider {
     /// Returns the current version of the data in the store.
-    fn current_version(&self) -> u64;
+    fn current_version(&self) -> i64;
 }
 
 /// Default implementation for when we are not providing a version
@@ -943,7 +943,7 @@ impl<T> SchedulerCurrentVersionProvider for T
 where
     T: SchedulerStoreKeyProvider<Versioned = FalseValue>,
 {
-    fn current_version(&self) -> u64 {
+    fn current_version(&self) -> i64 {
         0
     }
 }

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -814,6 +814,17 @@ async fn inner_main(
         }
     }
 
+    // Set up a shutdown handler for the worker schedulers.
+    let mut shutdown_rx = shutdown_tx.subscribe();
+    root_futures.push(Box::pin(async move {
+        if let Ok(shutdown_guard) = shutdown_rx.recv().await {
+            for (_name, scheduler) in worker_schedulers {
+                scheduler.shutdown(shutdown_guard.clone()).await;
+            }
+        }
+        Ok(())
+    }));
+
     if let Err(e) = try_join_all(root_futures).await {
         panic!("{e:?}");
     }


### PR DESCRIPTION
# Description

This suite of changes hardens the Redis scheduler for scaling and ensures that operations are correctly queued.  The existing scheduler has issues during shutdown and re-queuing of failed operations.  Here we ensure that worker disconnects during action assignment do not count against attempts (worker scale down), scheduler shutdown correctly sets operations back to queued (scheduler scale down) and operation re-joining when an action has completed correctly schedules a new operation rather than leaving it permanently in the executing stage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on my build cluster which is now functioning without issues even when scaling.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1906)
<!-- Reviewable:end -->
