### PR TITLE
Add worker_find_logging

### DIFF
--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -46,3 +46,7 @@ jobs:
 
       - name: Test on ${{ runner.os }}
         run: cargo test --all --profile=smol
+
+      # Not a default target, but need to make sure we don't actually break it
+      - name: Test worker_find_logging
+        run: cargo build --features worker_find_logging --all-targets

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,8 @@ rust_binary(
     srcs = [
         "src/bin/nativelink.rs",
     ],
+    # Enable this to get extra debug about workers that are not being used by the CAS
+    # crate_features = ["worker_find_logging"],
     deps = [
         "//nativelink-config",
         "//nativelink-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,14 @@ name = "nativelink"
 [features]
 nix = ["nativelink-worker/nix"]
 
+# Enable this to get extra debug about workers that are not being used by the CAS
+# for some reason. We don't enable this by default, as it's part of a hot path in
+# the scheduling system, and also that a worker not matching isn't necessarily bad.
+worker_find_logging = [
+  "nativelink-scheduler/worker_find_logging",
+  "nativelink-util/worker_find_logging",
+]
+
 [dependencies]
 nativelink-config = { path = "nativelink-config" }
 nativelink-error = { path = "nativelink-error" }

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,8 @@
           (craneLibFor p).buildPackage ((commonArgsFor p)
             // {
               cargoArtifacts = cargoArtifactsFor p;
+              # Enable this for debugging worker scheduler issues
+              # cargoExtraArgs = "--features worker_find_logging";
             });
 
         nativeTargetPkgs =

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 name = "nativelink-scheduler"
 version = "0.7.0"
 
+[features]
+worker_find_logging = ["nativelink-util/worker_find_logging"]
+
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 name = "nativelink-util"
 version = "0.7.0"
 
+[features]
+worker_find_logging = []
+
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -21,6 +21,8 @@ use nativelink_metric::{
 use nativelink_proto::build::bazel::remote::execution::v2::Platform as ProtoPlatform;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property as ProtoProperty;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "worker_find_logging")]
+use tracing::info;
 
 /// `PlatformProperties` helps manage the configuration of platform properties to
 /// keys and types. The scheduler uses these properties to decide what jobs
@@ -47,9 +49,19 @@ impl PlatformProperties {
         for (property, check_value) in &self.properties {
             if let Some(worker_value) = worker_properties.properties.get(property) {
                 if !check_value.is_satisfied_by(worker_value) {
+                    #[cfg(feature = "worker_find_logging")]
+                    {
+                        info!(
+                            "Property mismatch on worker property {property}. {worker_value:?} != {check_value:?}"
+                        );
+                    }
                     return false;
                 }
             } else {
+                #[cfg(feature = "worker_find_logging")]
+                {
+                    info!("Property missing on worker property {property}");
+                }
                 return false;
             }
         }

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -838,6 +838,10 @@ fn get_config() -> Result<CasConfig, Error> {
 }
 
 fn main() -> Result<(), Box<dyn core::error::Error>> {
+    if cfg!(feature = "worker_find_logging") {
+        info!("worker_find_logging enabled");
+    }
+
     let mut cfg = get_config()?;
 
     let global_cfg = if let Some(global_cfg) = &mut cfg.global {


### PR DESCRIPTION
# Description

Sometimes when you've got some workers who's config varies from the CAS config it'll reject them and it's unclear why. This PR adds a feature flag to add logging to this path. It's disabled by default as otherwise it'd slow down situations with many heterogenous workers.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually mostly, in a production scenario we were having difficulty determining issues with without this

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1925)
<!-- Reviewable:end -->
