### PR TITLE
Support pre-0.7.0 cacheable spelling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
         src = pkgs.lib.cleanSourceWith {
           src = (craneLibFor pkgs).path ./.;
           filter = path: type:
-            (builtins.match "^.*(examples/.+\.json5|data/SekienAkashita\.jpg|nativelink-config/README\.md)" path != null)
+            (builtins.match "^.*(examples/.+\.json5|data/.+|nativelink-config/README\.md)" path != null)
             || ((craneLibFor pkgs).filterCargoSources path type);
         };
 

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -89,6 +89,7 @@ rust_test_suite(
     name = "integration",
     timeout = "short",
     srcs = [
+        "tests/action_messages_test.rs",
         "tests/buf_channel_test.rs",
         "tests/channel_body_for_tests_test.rs",
         "tests/common_test.rs",
@@ -104,6 +105,8 @@ rust_test_suite(
     ],
     compile_data = [
         "tests/data/SekienAkashita.jpg",
+        "tests/data/action_message_cachable_060.json",
+        "tests/data/action_message_uncachable_060.json",
     ],
     proc_macro_deps = [
         "//nativelink-macro",

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -173,8 +173,10 @@ impl From<String> for WorkerId {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActionUniqueQualifier {
     /// The action is cacheable.
+    #[serde(alias = "Cachable")] // Pre 0.7.0 spelling
     Cacheable(ActionUniqueKey),
     /// The action is uncacheable.
+    #[serde(alias = "Uncachable")] // Pre 0.7.0 spelling
     Uncacheable(ActionUniqueKey),
 }
 

--- a/nativelink-util/tests/action_messages_test.rs
+++ b/nativelink-util/tests/action_messages_test.rs
@@ -1,0 +1,39 @@
+use hex::FromHex;
+use nativelink_macro::nativelink_test;
+use nativelink_util::action_messages::{ActionInfo, ActionUniqueKey, ActionUniqueQualifier};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
+
+fn make_key() -> ActionUniqueKey {
+    ActionUniqueKey {
+        instance_name: String::from("main"),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::new(
+            <[u8; 32]>::from_hex(
+                "38fc5a8a97c1217160b0b658751979b9a1171286381489c8b98c993ec40b1546",
+            )
+            .unwrap(),
+            210,
+        ),
+    }
+}
+
+#[nativelink_test]
+fn old_unique_qualifier_cachable_works() {
+    let contents = include_str!("data/action_message_cachable_060.json");
+    let action_info: ActionInfo = serde_json::from_str(contents).unwrap();
+    assert_eq!(
+        action_info.unique_qualifier,
+        ActionUniqueQualifier::Cacheable(make_key())
+    );
+}
+
+#[nativelink_test]
+fn old_unique_qualifier_uncachable_works() {
+    let contents = include_str!("data/action_message_uncachable_060.json");
+    let action_info: ActionInfo = serde_json::from_str(contents).unwrap();
+    assert_eq!(
+        action_info.unique_qualifier,
+        ActionUniqueQualifier::Uncacheable(make_key())
+    );
+}

--- a/nativelink-util/tests/data/action_message_cachable_060.json
+++ b/nativelink-util/tests/data/action_message_cachable_060.json
@@ -1,0 +1,28 @@
+{
+  "command_digest": "1bdda06f381981eab0548babc2ffd90e084803159e6fe7d287b490dd1375f1fc-525",
+  "input_root_digest": "b9002e1da634b904c8bde2677cfba9a64f6a6e64a3c2d1e6f1f4915b84cecb79-82",
+  "insert_timestamp": {
+    "nanos_since_epoch": 803642506,
+    "secs_since_epoch": 1727466558
+  },
+  "load_timestamp": {
+    "nanos_since_epoch": 0,
+    "secs_since_epoch": 0
+  },
+  "platform_properties": {
+    "container-image": "docker://nativelink-toolchain-drake:latest",
+    "cpu_count": "50"
+  },
+  "priority": 0,
+  "timeout": {
+    "nanos": 999999999,
+    "secs": 18446744073709551615
+  },
+  "unique_qualifier": {
+    "Cachable": {
+      "digest": "38fc5a8a97c1217160b0b658751979b9a1171286381489c8b98c993ec40b1546-210",
+      "digest_function": "Sha256",
+      "instance_name": "main"
+    }
+  }
+}

--- a/nativelink-util/tests/data/action_message_uncachable_060.json
+++ b/nativelink-util/tests/data/action_message_uncachable_060.json
@@ -1,0 +1,28 @@
+{
+  "command_digest": "1bdda06f381981eab0548babc2ffd90e084803159e6fe7d287b490dd1375f1fc-525",
+  "input_root_digest": "b9002e1da634b904c8bde2677cfba9a64f6a6e64a3c2d1e6f1f4915b84cecb79-82",
+  "insert_timestamp": {
+    "nanos_since_epoch": 803642506,
+    "secs_since_epoch": 1727466558
+  },
+  "load_timestamp": {
+    "nanos_since_epoch": 0,
+    "secs_since_epoch": 0
+  },
+  "platform_properties": {
+    "container-image": "docker://nativelink-toolchain-drake:latest",
+    "cpu_count": "50"
+  },
+  "priority": 0,
+  "timeout": {
+    "nanos": 999999999,
+    "secs": 18446744073709551615
+  },
+  "unique_qualifier": {
+    "Uncachable": {
+      "digest": "38fc5a8a97c1217160b0b658751979b9a1171286381489c8b98c993ec40b1546-210",
+      "digest_function": "Sha256",
+      "instance_name": "main"
+    }
+  }
+}

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,13 @@
 # `conly_flags` in lre-cc
 conly = "conly"
 
+[default]
+# Old wrong spelling support
+extend-ignore-re = [
+  "alias = \"Cachable\"",
+  "old_unique_qualifier_cachable_works",
+]
+
 [files]
 extend-exclude = [
   # Covered by Vale
@@ -11,5 +18,7 @@ extend-exclude = [
   "kubernetes/vendor/olm/*",
   "nativelink-proto/*",
   "web/*",
+  # Contains old wrongly spelt data
+  "nativelink-util/tests/data/*.json",
 ]
 ignore-hidden = false


### PR DESCRIPTION
# Description

https://github.com/TraceMachina/nativelink/pull/1780 did some renaming, but at the cost of breaking things stored with the old names (e.g. Redis CAS). This PR adds the old names as aliases to enable easier upgrading.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Local testing with docker-compose, running first 0.6.0 to get the bad spelling, then 0.7.0 to demo failure, then this branch to show it working fine.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1926)
<!-- Reviewable:end -->
