### PR TITLE
Revert ExecutionComplete early scheduling optimization

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -57,10 +57,6 @@ service WorkerApi {
 
     /// Informs the scheduler about the result of an execution request.
     rpc ExecutionResponse(ExecuteResult) returns (google.protobuf.Empty);
-
-    /// Notify the scheduler that an execution request is in the upload phase
-    /// and therefore a new execution may be scheduled.
-    rpc ExecutionComplete(ExecuteComplete) returns (google.protobuf.Empty);
 }
 
 /// Request object for keep alive requests.
@@ -125,21 +121,6 @@ message ExecuteResult {
     }
 
     reserved 9; // NextId.
-}
-
-/// A notification that an ExecutionRequest is in the upload phase.
-message ExecuteComplete {
-    /// ID of the worker making the request.
-    string worker_id = 1;
-
-    /// The `instance_name` this task was initially assigned to. This is set by the client
-    /// that initially sent the job as part of the BRE protocol.
-    string instance_name = 2;
-
-    /// The operation ID that was executed.
-    string operation_id = 3;
-
-    reserved 4; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -86,20 +86,6 @@ pub mod execute_result {
         InternalError(super::super::super::super::super::super::google::rpc::Status),
     }
 }
-/// / A notification that an ExecutionRequest is in the upload phase.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExecuteComplete {
-    /// / ID of the worker making the request.
-    #[prost(string, tag = "1")]
-    pub worker_id: ::prost::alloc::string::String,
-    /// / The `instance_name` this task was initially assigned to. This is set by the client
-    /// / that initially sent the job as part of the BRE protocol.
-    #[prost(string, tag = "2")]
-    pub instance_name: ::prost::alloc::string::String,
-    /// / The operation ID that was executed.
-    #[prost(string, tag = "3")]
-    pub operation_id: ::prost::alloc::string::String,
-}
 /// / Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionResult {
@@ -402,34 +388,6 @@ pub mod worker_api_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// / Notify the scheduler that an execution request is in the upload phase
-        /// / and therefore a new execution may be scheduled.
-        pub async fn execution_complete(
-            &mut self,
-            request: impl tonic::IntoRequest<super::ExecuteComplete>,
-        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "com.github.trace_machina.nativelink.remote_execution.WorkerApi",
-                        "ExecutionComplete",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
     }
 }
 /// Generated server implementations.
@@ -490,12 +448,6 @@ pub mod worker_api_server {
         async fn execution_response(
             &self,
             request: tonic::Request<super::ExecuteResult>,
-        ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
-        /// / Notify the scheduler that an execution request is in the upload phase
-        /// / and therefore a new execution may be scheduled.
-        async fn execution_complete(
-            &self,
-            request: tonic::Request<super::ExecuteComplete>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
     }
     /// / This API describes how schedulers communicate with Worker nodes.
@@ -745,51 +697,6 @@ pub mod worker_api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ExecutionResponseSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete" => {
-                    #[allow(non_camel_case_types)]
-                    struct ExecutionCompleteSvc<T: WorkerApi>(pub Arc<T>);
-                    impl<
-                        T: WorkerApi,
-                    > tonic::server::UnaryService<super::ExecuteComplete>
-                    for ExecutionCompleteSvc<T> {
-                        type Response = ();
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::ExecuteComplete>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as WorkerApi>::execution_complete(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = ExecutionCompleteSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -247,7 +247,7 @@ impl ApiWorkerSchedulerImpl {
                 "Operation {operation_id} should not be running on worker {worker_id} in SimpleScheduler::update_action"
             );
             return Result::<(), _>::Err(err.clone())
-                .merge(self.immediate_evict_worker(worker_id, err).await);
+                .merge(self.immediate_evict_worker(worker_id, err, false).await);
         }
 
         let (is_finished, due_to_backpressure) = match &update {

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use core::ops::{Deref, DerefMut};
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -81,10 +80,6 @@ struct ApiWorkerSchedulerImpl {
     /// A `LruCache` of workers available based on `allocation_strategy`.
     #[metric(group = "workers")]
     workers: Workers,
-
-    /// A set of operations that have notified completion, but are still
-    /// uploading results.
-    pending_results: HashMap<WorkerId, HashSet<OperationId>>,
 
     /// The worker state manager.
     #[metric(group = "worker_state_manager")]
@@ -173,7 +168,6 @@ impl ApiWorkerSchedulerImpl {
     /// running.
     fn remove_worker(&mut self, worker_id: &WorkerId) -> Option<Worker> {
         let result = self.workers.pop(worker_id);
-        self.pending_results.remove(worker_id);
         self.worker_change_notify.notify_one();
         result
     }
@@ -247,17 +241,13 @@ impl ApiWorkerSchedulerImpl {
         })?;
 
         // Ensure the worker is supposed to be running the operation.
-        let pending_completion = !worker.running_action_infos.contains_key(operation_id);
-        if pending_completion
-            && !self
-                .pending_results
-                .get(worker_id)
-                .is_some_and(|pending_operations| pending_operations.contains(operation_id))
-        {
-            return Err(make_err!(
+        if !worker.running_action_infos.contains_key(operation_id) {
+            let err = make_err!(
                 Code::Internal,
                 "Operation {operation_id} should not be running on worker {worker_id} in SimpleScheduler::update_action"
-            ));
+            );
+            return Result::<(), _>::Err(err.clone())
+                .merge(self.immediate_evict_worker(worker_id, err).await);
         }
 
         let (is_finished, due_to_backpressure) = match &update {
@@ -293,32 +283,6 @@ impl ApiWorkerSchedulerImpl {
             return Ok(());
         }
 
-        if pending_completion {
-            // This is absolutely always true, but pattern match anyway.
-            if let Some(pending_operations) = self.pending_results.get_mut(worker_id) {
-                pending_operations.remove(operation_id);
-                if pending_operations.is_empty() {
-                    self.pending_results.remove(worker_id);
-                }
-                return Ok(());
-            }
-        }
-
-        Self::complete_worker_action(
-            worker,
-            operation_id,
-            due_to_backpressure,
-            &self.worker_change_notify,
-        )
-        .await
-    }
-
-    async fn complete_worker_action(
-        worker: &mut Worker,
-        operation_id: &OperationId,
-        due_to_backpressure: bool,
-        notify: &Notify,
-    ) -> Result<(), Error> {
         // Clear this action from the current worker if finished.
         let complete_action_res = {
             let was_paused = !worker.can_accept_work();
@@ -333,41 +297,9 @@ impl ApiWorkerSchedulerImpl {
             complete_action_res
         };
 
-        notify.notify_one();
+        self.worker_change_notify.notify_one();
 
         complete_action_res
-    }
-
-    async fn notify_complete(
-        &mut self,
-        worker_id: &WorkerId,
-        operation_id: &OperationId,
-    ) -> Result<(), Error> {
-        let worker = self.workers.get_mut(worker_id).err_tip(|| {
-            format!("Worker {worker_id} does not exist in SimpleScheduler::notify_complete")
-        })?;
-
-        // Ensure the worker is supposed to be running the operation.
-        if !worker.running_action_infos.contains_key(operation_id) {
-            let err = make_err!(
-                Code::Internal,
-                "Operation {operation_id} should not be running on worker {worker_id} in SimpleScheduler::update_action"
-            );
-            return Err(err);
-        }
-
-        match self.pending_results.entry(worker_id.clone()) {
-            std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
-                occupied_entry.get_mut().insert(operation_id.clone());
-            }
-            std::collections::hash_map::Entry::Vacant(vacant_entry) => {
-                vacant_entry
-                    .insert(HashSet::new())
-                    .insert(operation_id.clone());
-            }
-        }
-
-        Self::complete_worker_action(worker, operation_id, false, &self.worker_change_notify).await
     }
 
     /// Notifies the specified worker to run the given action and handles errors by evicting
@@ -476,7 +408,6 @@ impl ApiWorkerScheduler {
         Arc::new(Self {
             inner: Mutex::new(ApiWorkerSchedulerImpl {
                 workers: Workers(LruCache::unbounded()),
-                pending_results: HashMap::new(),
                 worker_state_manager: worker_state_manager.clone(),
                 allocation_strategy,
                 worker_change_notify,
@@ -589,15 +520,6 @@ impl WorkerScheduler for ApiWorkerScheduler {
     ) -> Result<(), Error> {
         let mut inner = self.inner.lock().await;
         inner.update_action(worker_id, operation_id, update).await
-    }
-
-    async fn notify_complete(
-        &self,
-        worker_id: &WorkerId,
-        operation_id: &OperationId,
-    ) -> Result<(), Error> {
-        let mut inner = self.inner.lock().await;
-        inner.notify_complete(worker_id, operation_id).await
     }
 
     async fn worker_keep_alive_received(

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -518,16 +518,6 @@ impl WorkerScheduler for SimpleScheduler {
             .await
     }
 
-    async fn notify_complete(
-        &self,
-        worker_id: &WorkerId,
-        operation_id: &OperationId,
-    ) -> Result<(), Error> {
-        self.worker_scheduler
-            .notify_complete(worker_id, operation_id)
-            .await
-    }
-
     async fn worker_keep_alive_received(
         &self,
         worker_id: &WorkerId,

--- a/nativelink-scheduler/src/worker_scheduler.rs
+++ b/nativelink-scheduler/src/worker_scheduler.rs
@@ -40,13 +40,6 @@ pub trait WorkerScheduler: Sync + Send + Unpin + RootMetricsComponent + 'static 
         update: UpdateOperationType,
     ) -> Result<(), Error>;
 
-    /// Notify that the operation has completed execution, but not uploaded yet.
-    async fn notify_complete(
-        &self,
-        worker_id: &WorkerId,
-        operation_id: &OperationId,
-    ) -> Result<(), Error>;
-
     /// Event for when the keep alive message was received from the worker.
     async fn worker_keep_alive_received(
         &self,

--- a/nativelink-worker/src/worker_api_client_wrapper.rs
+++ b/nativelink-worker/src/worker_api_client_wrapper.rs
@@ -16,8 +16,7 @@ use core::future::Future;
 
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
-    UpdateForWorker,
+    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
 };
 use tonic::codec::Streaming;
 use tonic::transport::Channel;
@@ -44,11 +43,6 @@ pub trait WorkerApiClientTrait: Clone + Sync + Send + Sized + Unpin {
     fn execution_response(
         &mut self,
         request: ExecuteResult,
-    ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
-
-    fn execution_complete(
-        &mut self,
-        request: ExecuteComplete,
     ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
 }
 
@@ -81,12 +75,5 @@ impl WorkerApiClientTrait for WorkerApiClientWrapper {
 
     async fn execution_response(&mut self, request: ExecuteResult) -> Result<Response<()>, Status> {
         self.inner.execution_response(request).await
-    }
-
-    async fn execution_complete(
-        &mut self,
-        request: ExecuteComplete,
-    ) -> Result<Response<()>, Status> {
-        self.inner.execution_complete(request).await
     }
 }

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -273,14 +273,10 @@ async fn blake3_digest_function_registered_properly() -> Result<(), Error> {
         .expect_create_and_add_action(Ok(running_action.clone()))
         .await;
 
-    // Now the RunningAction needs to send a series of state updates.
-    running_action.simple_expect_prepare_and_execute().await?;
-    test_context
-        .client
-        .expect_execution_complete(Ok(Response::new(())))
-        .await;
+    // Now the RunningAction needs to send a series of state updates. This shortcuts them
+    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
     running_action
-        .simple_expect_upload_and_complete(Ok(ActionResult::default()))
+        .simple_expect_get_finished_result(Ok(ActionResult::default()))
         .await?;
 
     // Expect the action to be updated in the action cache.
@@ -391,14 +387,10 @@ async fn simple_worker_start_action_test() -> Result<(), Error> {
         .expect_create_and_add_action(Ok(running_action.clone()))
         .await;
 
-    // Now the RunningAction needs to send a series of state updates.
-    running_action.simple_expect_prepare_and_execute().await?;
-    test_context
-        .client
-        .expect_execution_complete(Ok(Response::new(())))
-        .await;
+    // Now the RunningAction needs to send a series of state updates. This shortcuts them
+    // into a single call (shortcut for prepare, execute, upload, collect_results, cleanup).
     running_action
-        .simple_expect_upload_and_complete(Ok(action_result.clone()))
+        .simple_expect_get_finished_result(Ok(action_result.clone()))
         .await?;
 
     // Expect the action to be updated in the action cache.

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -21,8 +21,7 @@ use hyper::body::Frame;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_error::Error;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
-    UpdateForWorker,
+    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
 };
 use nativelink_util::channel_body_for_tests::ChannelBody;
 use nativelink_util::shutdown_guard::ShutdownGuard;
@@ -54,7 +53,6 @@ const BROADCAST_CAPACITY: usize = 1;
 enum WorkerClientApiCalls {
     ConnectWorker(ConnectWorkerRequest),
     ExecutionResponse(ExecuteResult),
-    ExecutionComplete(ExecuteComplete),
 }
 
 #[derive(Debug)]
@@ -65,7 +63,6 @@ enum WorkerClientApiCalls {
 enum WorkerClientApiReturns {
     ConnectWorker(Result<Response<Streaming<UpdateForWorker>>, Status>),
     ExecutionResponse(Result<Response<()>, Status>),
-    ExecutionComplete(Result<Response<()>, Status>),
 }
 
 #[derive(Clone)]
@@ -107,7 +104,7 @@ impl MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiCalls::ConnectWorker(req) => req,
-            req => {
+            req @ WorkerClientApiCalls::ExecutionResponse(_) => {
                 panic!("expect_connect_worker expected ConnectWorker, got : {req:?}")
             }
         };
@@ -128,33 +125,12 @@ impl MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiCalls::ExecutionResponse(req) => req,
-            req => {
+            req @ WorkerClientApiCalls::ConnectWorker(_) => {
                 panic!("expect_execution_response expected ExecutionResponse, got : {req:?}")
             }
         };
         self.tx_resp
             .send(WorkerClientApiReturns::ExecutionResponse(result))
-            .expect("Could not send request to mpsc");
-        req
-    }
-
-    pub(crate) async fn expect_execution_complete(
-        &self,
-        result: Result<Response<()>, Status>,
-    ) -> ExecuteComplete {
-        let mut rx_call_lock = self.rx_call.lock().await;
-        let req = match rx_call_lock
-            .recv()
-            .await
-            .expect("Could not receive msg in mpsc")
-        {
-            WorkerClientApiCalls::ExecutionComplete(req) => req,
-            req => {
-                panic!("expect_execution_complete expected ExecutionComplete, got : {req:?}")
-            }
-        };
-        self.tx_resp
-            .send(WorkerClientApiReturns::ExecutionComplete(result))
             .expect("Could not send request to mpsc");
         req
     }
@@ -175,7 +151,7 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiReturns::ConnectWorker(result) => result,
-            resp => {
+            resp @ WorkerClientApiReturns::ExecutionResponse(_) => {
                 panic!("connect_worker expected ConnectWorker response, received {resp:?}")
             }
         }
@@ -200,27 +176,7 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
             .expect("Could not receive msg in mpsc")
         {
             WorkerClientApiReturns::ExecutionResponse(result) => result,
-            resp => {
-                panic!("execution_response expected ExecutionResponse response, received {resp:?}")
-            }
-        }
-    }
-
-    async fn execution_complete(
-        &mut self,
-        request: ExecuteComplete,
-    ) -> Result<Response<()>, Status> {
-        self.tx_call
-            .send(WorkerClientApiCalls::ExecutionComplete(request))
-            .expect("Could not send request to mpsc");
-        let mut rx_resp_lock = self.rx_resp.lock().await;
-        match rx_resp_lock
-            .recv()
-            .await
-            .expect("Could not receive msg in mpsc")
-        {
-            WorkerClientApiReturns::ExecutionComplete(result) => result,
-            resp => {
+            resp @ WorkerClientApiReturns::ConnectWorker(_) => {
                 panic!("execution_response expected ExecutionResponse response, received {resp:?}")
             }
         }

--- a/nativelink-worker/tests/utils/mock_running_actions_manager.rs
+++ b/nativelink-worker/tests/utils/mock_running_actions_manager.rs
@@ -230,15 +230,12 @@ impl MockRunningAction {
         }
     }
 
-    pub(crate) async fn simple_expect_prepare_and_execute(self: &Arc<Self>) -> Result<(), Error> {
-        self.expect_prepare_action(Ok(())).await?;
-        self.expect_execute(Ok(())).await
-    }
-
-    pub(crate) async fn simple_expect_upload_and_complete(
+    pub(crate) async fn simple_expect_get_finished_result(
         self: &Arc<Self>,
         result: Result<ActionResult, Error>,
     ) -> Result<(), Error> {
+        self.expect_prepare_action(Ok(())).await?;
+        self.expect_execute(Ok(())).await?;
         self.upload_results(Ok(())).await?;
         let result = self.get_finished_result(result).await;
         self.cleanup(Ok(())).await?;


### PR DESCRIPTION
# Description
This reverts commit `85c279a4467c5322159c5f55bca05be6b3bf92c4` for now, until we fix the underlying issue that is causing the worker panic.

We can reference the old commit in the branch: https://github.com/amankrx/nativelink/tree/early-scheduling

Panic logs: 
```

thread 'main' panicked at src/bin/nativelink.rs:829:9:
Error { code: Internal, messages: ["status: Internal, message: \"Action Uuid(b9eaa6f2-df15-45d7-a1a8-e33683fdb61c) is already completed with state Completed(ActionResult { output_files: [], output_folders: [], output_directory_symlinks: [], output_file_symlinks: [], exit_code: -178, stdout_digest: DigestInfo(\\\"0000000000000000000000000000000000000000000000000000000000000000-0\\\"), stderr_digest: DigestInfo(\\\"0000000000000000000000000000000000000000000000000000000000000000-0\\\"), execution_metadata: ExecutionMetadata { worker: \\\"gke-nativelink-large-rbe-default-pool-e9504922-wlxw_1f08f04c-7bb7-63e4-af23-fe5b2dfc32e9\\\", queued_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, worker_start_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, worker_completed_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, input_fetch_start_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, input_fetch_completed_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, execution_start_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, execution_completed_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, output_upload_start_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 }, output_upload_completed_timestamp: SystemTime { tv_sec: 0, tv_nsec: 0 } }, server_logs: {}, error: Some(Error { code: AlreadyExists, messages: [\\\"Action with operation_id b9eaa6f2-df15-45d7-a1a8-e33683fdb61c is already running\\\", \\\"---\\\", \\\"Job cancelled because it attempted to execute too many times 4 > 3 times for operation_id: b9eaa6f2-df15-45d7-a1a8-e33683fdb61c, maybe_worker_id: Some(gke-nativelink-large-rbe-default-pool-e9504922-wlxw_1f08f04c-7bb7-63e4-af23-fe5b2dfc32e9)\\\"] }), message: \\\"\\\" }) - maybe_worker_id: Some(gke-nativelink-large-rbe-default-pool-e9504922-wlxw_1f08f04c-7bb7-63e4-af23-fe5b2dfc32e9) : in update_operation on SimpleScheduler::update_action : Failed to operation Uuid(b9eaa6f2-df15-45d7-a1a8-e33683fdb61c)\", details: [], metadata: MetadataMap { headers: {\"content-type\": \"application/grpc\", \"date\": \"Thu, 11 Sep 2025 11:45:37 GMT\"} }", "Error calling execution_response with error", "Actions in transit did not reach zero before we disconnected from the scheduler"] }

```

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [X] `bazel test //...`  passes locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1929)
<!-- Reviewable:end -->
