### PR TITLE
Make the error on a size field clearer

### DIFF
--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -237,6 +237,9 @@ where
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
             let expanded = shellexpand::env(v).map_err(de::Error::custom)?;
             let s = expanded.as_ref().trim();
+            if v.is_empty() {
+                return Err(de::Error::custom("Missing value in a size field"));
+            }
             let byte_size = Byte::parse_str(s, true).map_err(de::Error::custom)?;
             let bytes = byte_size.as_u128();
             T::try_from(bytes).map_err(de::Error::custom)

--- a/nativelink-config/tests/deserialization_test.rs
+++ b/nativelink-config/tests/deserialization_test.rs
@@ -202,13 +202,17 @@ mod data_size_tests {
                 r#"{"data_size": "999999999999999999999B"}"#,
                 "the value 999999999999999999999 exceeds the valid range",
             ),
+            (r#"{"data_size": ""}"#, "Missing value in a size field"),
         ];
 
         for (input, expected_error) in examples {
             let error = serde_json5::from_str::<DataSizeEntity>(input)
                 .unwrap_err()
                 .to_string();
-            assert!(error.contains(expected_error));
+            assert!(
+                error.contains(expected_error),
+                "Error: {error} Expected: {expected_error}"
+            );
         }
     }
 }


### PR DESCRIPTION
# Description

Previously, it said "no value can be found" which is a bit unclear

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1939)
<!-- Reviewable:end -->
