### PR TITLE
Better logging for store_awaited_action update failures

### DIFF
--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -92,6 +92,7 @@ rust_test_suite(
         "@crates//:serde_json",
         "@crates//:tokio",
         "@crates//:tokio-stream",
+        "@crates//:tonic",
         "@crates//:tracing",
         "@crates//:tracing-test",
         "@crates//:uuid",


### PR DESCRIPTION
# Description

Previously we've seen errors like

`{"timestamp":"2025-09-25T16:48:41.449333Z","level":"INFO","fields":{"message":"Error updating Redis key aa_95c460d1-4443-445b-912c-7b80013bff8c expected version 67 but found 68"},"target":"nativelink_store::redis_store","span":{"name":"http_executor"},"spans":[{"remote_addr":"10.128.15.218:36894","socket_addr":"0.0.0.0:50051","name":"http_connection"},{"name":"http_executor"}]}`

and the existing code made it unclear whether this was a transient or permanent error. This PR makes that clearer by adding some new logging, and changing the levels on some others.

It also pulls the logging setup to the start of running the `nativelink` command so you get early logs as well.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1940)
<!-- Reviewable:end -->
