### PR TITLE
Add more logging around active_drop_spawns

### DIFF
--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -367,6 +367,13 @@ async fn temp_files_get_deleted_on_replace_test() -> Result<(), Error> {
         tokio::task::yield_now().await;
     }
 
+    assert!(logs_contain(
+        "Spawned a filesystem_delete_file current_active_drop_spawns=1"
+    ));
+    assert!(logs_contain(
+        "Dropped a filesystem_delete_file current_active_drop_spawns=0"
+    ));
+
     check_temp_empty(&temp_path).await
 }
 


### PR DESCRIPTION
# Description

We've seen some scenarios where our temp storage exceeds the expected usage of said, despite deletes occurring. One possibility there is that we've got a _lot_ of extra delete spawns in flight and this PR adds logging around that.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1941)
<!-- Reviewable:end -->
