### PR TITLE
Existence cache remove callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,6 @@ dependencies = [
 name = "nativelink-util"
 version = "0.7.1"
 dependencies = [
- "async-lock",
  "async-trait",
  "base64 0.22.1",
  "bitflags 2.9.4",

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -303,7 +303,8 @@ impl SortedAwaitedActions {
 pub struct AwaitedActionDbImpl<I: InstantWrapper, NowFn: Fn() -> I> {
     /// A lookup table to lookup the state of an action by its client operation id.
     #[metric(group = "client_operation_ids")]
-    client_operation_to_awaited_action: EvictingMap<OperationId, Arc<ClientAwaitedAction>, I>,
+    client_operation_to_awaited_action:
+        EvictingMap<OperationId, OperationId, Arc<ClientAwaitedAction>, I>,
 
     /// A lookup table to lookup the state of an action by its worker operation id.
     #[metric(group = "operation_ids")]

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::DerefMut;
 use core::pin::Pin;
 use std::borrow::Cow;
-use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -58,7 +58,7 @@ pub struct ExistenceCacheStore<I: InstantWrapper> {
     // as if it immediately expires them, we should only apply the remove callbacks
     // afterwards. If this is None, we're not pausing; if it's Some it's the location to
     // store them in temporarily
-    pause_remove_callbacks: Arc<Mutex<Option<Vec<StoreKey<'static>>>>>
+    pause_remove_callbacks: Arc<Mutex<Option<Vec<StoreKey<'static>>>>>,
 }
 
 impl ExistenceCacheStore<SystemTime> {
@@ -106,7 +106,7 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
         let existence_cache_store = Arc::new(Self {
             inner_store,
             existence_cache: EvictingMap::new(eviction_policy, anchor_time),
-            pause_remove_callbacks: Arc::new(Mutex::new(None))
+            pause_remove_callbacks: Arc::new(Mutex::new(None)),
         });
         let other_ref = existence_cache_store.clone();
         existence_cache_store

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -32,8 +32,8 @@ use nativelink_util::buf_channel::{
 use nativelink_util::fs;
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
 use nativelink_util::store_trait::{
-    Store, StoreDriver, StoreKey, StoreLike, StoreOptimizations, UploadSizeInfo,
-    slow_update_store_with_file,
+    RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, StoreOptimizations,
+    UploadSizeInfo, slow_update_store_with_file,
 };
 use parking_lot::Mutex;
 use tokio::sync::OnceCell;
@@ -87,10 +87,10 @@ impl FastSlowStore {
     /// cost function. Since the data itself is shared and not copied it should be fairly
     /// low cost to just discard the data, but does cost a few mutex locks while
     /// streaming.
-    pub async fn populate_fast_store(&self, key: StoreKey<'_>) -> Result<(), Error> {
+    pub async fn populate_fast_store(&self, key: StoreKey<'static>) -> Result<(), Error> {
         let maybe_size_info = self
             .fast_store
-            .has(key.borrow())
+            .has(key.clone())
             .await
             .err_tip(|| "While querying in populate_fast_store")?;
         if maybe_size_info.is_some() {
@@ -163,7 +163,7 @@ impl FastSlowStore {
 impl StoreDriver for FastSlowStore {
     async fn has_with_results(
         self: Pin<&Self>,
-        key: &[StoreKey<'_>],
+        key: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         // If our slow store is a noop store, it'll always return a 404,
@@ -314,19 +314,19 @@ impl StoreDriver for FastSlowStore {
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
     ) -> Result<(), Error> {
         // TODO(palfrey) Investigate if we should maybe ignore errors here instead of
         // forwarding the up.
-        if self.fast_store.has(key.borrow()).await?.is_some() {
+        if self.fast_store.has(key.clone()).await?.is_some() {
             self.metrics
                 .fast_store_hit_count
                 .fetch_add(1, Ordering::Acquire);
             self.fast_store
-                .get_part(key, writer.borrow_mut(), offset, length)
+                .get_part(key.clone(), writer.borrow_mut(), offset, length)
                 .await?;
             self.metrics
                 .fast_store_downloaded_bytes
@@ -334,9 +334,10 @@ impl StoreDriver for FastSlowStore {
             return Ok(());
         }
 
+        let err_key = key.clone();
         let sz = self
             .slow_store
-            .has(key.borrow())
+            .has(key.clone())
             .await
             .err_tip(|| "Failed to run has() on slow store")?
             .ok_or_else(|| {
@@ -344,7 +345,7 @@ impl StoreDriver for FastSlowStore {
                     Code::NotFound,
                     "Object {} not found in either fast or slow store. \
                     If using multiple workers, ensure all workers share the same CAS storage path.",
-                    key.as_str()
+                    err_key.as_str()
                 )
             })?;
         self.metrics
@@ -393,10 +394,10 @@ impl StoreDriver for FastSlowStore {
             }
         };
 
-        let slow_store_fut = self.slow_store.get(key.borrow(), slow_tx);
+        let slow_store_fut = self.slow_store.get(key.clone(), slow_tx);
         let fast_store_fut =
             self.fast_store
-                .update(key.borrow(), fast_rx, UploadSizeInfo::ExactSize(sz));
+                .update(key, fast_rx, UploadSizeInfo::ExactSize(sz));
 
         let (data_stream_res, slow_res, fast_res) =
             join!(data_stream_fut, slow_store_fut, fast_store_fut);
@@ -424,6 +425,11 @@ impl StoreDriver for FastSlowStore {
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
+    }
+
+    fn register_remove_callback(self: Arc<Self>, callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        self.fast_store.register_remove_callback(callback);
+        self.slow_store.register_remove_callback(callback);
     }
 }
 

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -395,9 +395,9 @@ impl StoreDriver for FastSlowStore {
         };
 
         let slow_store_fut = self.slow_store.get(key.clone(), slow_tx);
-        let fast_store_fut =
-            self.fast_store
-                .update(key, fast_rx, UploadSizeInfo::ExactSize(sz));
+        let fast_store_fut = self
+            .fast_store
+            .update(key, fast_rx, UploadSizeInfo::ExactSize(sz));
 
         let (data_stream_res, slow_res, fast_res) =
             join!(data_stream_fut, slow_store_fut, fast_store_fut);

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -827,11 +827,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.evicting_map
-            .sizes_for_keys(
-                keys.iter(),
-                results,
-                false, /* peek */
-            )
+            .sizes_for_keys(keys.iter(), results, false /* peek */)
             .await;
         // We need to do a special pass to ensure our zero files exist.
         // If our results failed and the result was a zero file, we need to

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -415,7 +415,7 @@ pub fn key_from_file(file_name: &str, file_type: FileType) -> Result<StoreKey<'_
 /// `add_files_to_cache`.
 const SIMULTANEOUS_METADATA_READS: usize = 200;
 
-type FsEvictingMap<Fe:FileEntry> = EvictingMap<StoreKeyBorrow, StoreKey<'static>, Arc<Fe>, SystemTime>;
+type FsEvictingMap<Fe> = EvictingMap<StoreKeyBorrow, StoreKey<'static>, Arc<Fe>, SystemTime>;
 
 async fn add_files_to_cache<Fe: FileEntry>(
     evicting_map: &FsEvictingMap<Fe>,

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -28,7 +28,7 @@ use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::store_trait::{StoreDriver, StoreKey, UploadSizeInfo};
+use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
 use rand::Rng;
 use tokio::time::sleep;
 
@@ -198,7 +198,7 @@ where
 {
     async fn has_with_results(
         self: Pin<&Self>,
-        keys: &[StoreKey<'_>],
+        keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         keys.iter()
@@ -376,7 +376,7 @@ where
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
@@ -442,6 +442,11 @@ where
 
     fn register_health(self: Arc<Self>, registry: &mut HealthRegistryBuilder) {
         registry.register_indicator(self);
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // As we're backed by GCS, this store doesn't actually drop stuff
+        // so we can actually just ignore this
     }
 }
 

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -46,7 +46,7 @@ use nativelink_util::proto_stream_utils::{
 };
 use nativelink_util::resource_info::ResourceInfo;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::store_trait::{StoreDriver, StoreKey, UploadSizeInfo};
+use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
 use nativelink_util::{default_health_status_indicator, tls_utils};
 use opentelemetry::context::Context;
 use parking_lot::Mutex;
@@ -499,7 +499,7 @@ impl StoreDriver for GrpcStore {
     // is incorrect.
     async fn has_with_results(
         self: Pin<&Self>,
-        keys: &[StoreKey<'_>],
+        keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         if matches!(self.store_type, nativelink_config::stores::StoreType::Ac) {
@@ -648,7 +648,7 @@ impl StoreDriver for GrpcStore {
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
@@ -766,6 +766,10 @@ impl StoreDriver for GrpcStore {
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // TODO(palfrey): implement error because remove callbacks are incompatible with gRPC stores
     }
 }
 

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::any::Any;
 use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::ops::Bound;
 use core::pin::Pin;
-use std::any::Any;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -103,11 +103,7 @@ impl StoreDriver for MemoryStore {
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         self.evicting_map
-            .sizes_for_keys(
-                keys.iter(),
-                results,
-                false, /* peek */
-            )
+            .sizes_for_keys(keys.iter(), results, false /* peek */)
             .await;
         // We need to do a special pass to ensure our zero digest exist.
         keys.iter()

--- a/nativelink-store/src/mongo_store.rs
+++ b/nativelink-store/src/mongo_store.rs
@@ -32,8 +32,8 @@ use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
 use nativelink_util::spawn;
 use nativelink_util::store_trait::{
-    BoolValue, SchedulerCurrentVersionProvider, SchedulerIndexProvider, SchedulerStore,
-    SchedulerStoreDataProvider, SchedulerStoreDecodeTo, SchedulerStoreKeyProvider,
+    BoolValue, RemoveItemCallback, SchedulerCurrentVersionProvider, SchedulerIndexProvider,
+    SchedulerStore, SchedulerStoreDataProvider, SchedulerStoreDecodeTo, SchedulerStoreKeyProvider,
     SchedulerSubscription, SchedulerSubscriptionManager, StoreDriver, StoreKey, UploadSizeInfo,
 };
 use nativelink_util::task::JoinHandleDropGuard;
@@ -288,7 +288,7 @@ impl ExperimentalMongoStore {
 impl StoreDriver for ExperimentalMongoStore {
     async fn has_with_results(
         self: Pin<&Self>,
-        keys: &[StoreKey<'_>],
+        keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         for (key, result) in keys.iter().zip(results.iter_mut()) {
@@ -478,7 +478,7 @@ impl StoreDriver for ExperimentalMongoStore {
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
@@ -572,6 +572,10 @@ impl StoreDriver for ExperimentalMongoStore {
 
     fn register_health(self: Arc<Self>, registry: &mut HealthRegistryBuilder) {
         registry.register_indicator(self);
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // drop because we don't remove anything from Mongo
     }
 }
 

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -22,7 +22,9 @@ use nativelink_metric::{
 };
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
-use nativelink_util::store_trait::{StoreDriver, StoreKey, StoreOptimizations, UploadSizeInfo};
+use nativelink_util::store_trait::{
+    RemoveItemCallback, StoreDriver, StoreKey, StoreOptimizations, UploadSizeInfo,
+};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NoopStore;
@@ -47,7 +49,7 @@ impl NoopStore {
 impl StoreDriver for NoopStore {
     async fn has_with_results(
         self: Pin<&Self>,
-        _keys: &[StoreKey<'_>],
+        _keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         results.iter_mut().for_each(|r| *r = None);
@@ -73,7 +75,7 @@ impl StoreDriver for NoopStore {
 
     async fn get_part(
         self: Pin<&Self>,
-        _key: StoreKey<'_>,
+        _key: StoreKey<'static>,
         _writer: &mut DropCloserWriteHalf,
         _offset: u64,
         _length: Option<u64>,
@@ -91,6 +93,10 @@ impl StoreDriver for NoopStore {
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // does nothing, so drop
     }
 }
 

--- a/nativelink-store/src/ontap_s3_existence_cache_store.rs
+++ b/nativelink-store/src/ontap_s3_existence_cache_store.rs
@@ -90,7 +90,7 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + Clone + 'static,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OntapS3CacheCallback")
             .field("cache", &self.cache)
             .finish()
@@ -113,7 +113,7 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + Clone + 'static,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OntapS3ExistenceCache")
             .field("inner_store", &self.inner_store)
             .field("s3_client", &self.s3_client)

--- a/nativelink-store/src/ontap_s3_existence_cache_store.rs
+++ b/nativelink-store/src/ontap_s3_existence_cache_store.rs
@@ -104,7 +104,7 @@ where
     NowFn: Fn() -> I + Send + Sync + Unpin + Clone + 'static,
 {
     async fn callback(&self, store_key: &StoreKey<'static>) {
-        self.cache.callback(store_key);
+        self.cache.callback(store_key).await;
     }
 }
 
@@ -537,7 +537,8 @@ where
     NowFn: Fn() -> I + Send + Sync + Unpin + Clone + 'static,
 {
     async fn callback(&self, store_key: &StoreKey<'static>) {
-        todo!()
+        let new_key = store_key.clone();
+        self.digests.write().await.remove(&new_key.into_digest());
     }
 }
 

--- a/nativelink-store/src/ontap_s3_store.rs
+++ b/nativelink-store/src/ontap_s3_store.rs
@@ -750,7 +750,6 @@ where
 
     fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
         // FIXME(palfrey): Cope with the expiry timeout
-        todo!();
     }
 }
 

--- a/nativelink-store/src/ontap_s3_store.rs
+++ b/nativelink-store/src/ontap_s3_store.rs
@@ -47,7 +47,7 @@ use nativelink_util::buf_channel::{
 use nativelink_util::health_utils::{HealthStatus, HealthStatusIndicator};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::store_trait::{StoreDriver, StoreKey, UploadSizeInfo};
+use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pemfile::certs as extract_certs;
 use sha2::{Digest, Sha256};
@@ -278,7 +278,7 @@ where
 {
     async fn has_with_results(
         self: Pin<&Self>,
-        keys: &[StoreKey<'_>],
+        keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         keys.iter()
@@ -622,7 +622,7 @@ where
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
@@ -746,6 +746,11 @@ where
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
         self
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // FIXME(palfrey): Cope with the expiry timeout
+        todo!();
     }
 }
 

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -22,8 +22,9 @@ use nativelink_error::{Code, Error, ResultExt, make_err, make_input_err};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
-use nativelink_util::store_trait::RemoveItemCallback;
-use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo};
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo,
+};
 use tracing::error;
 
 use crate::store_manager::StoreManager;

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -66,7 +66,7 @@ use nativelink_util::fs;
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::retry::{Retrier, RetryResult};
-use nativelink_util::store_trait::{StoreDriver, StoreKey, UploadSizeInfo};
+use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
 use rand::Rng;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
@@ -572,7 +572,7 @@ where
 {
     async fn has_with_results(
         self: Pin<&Self>,
-        keys: &[StoreKey<'_>],
+        keys: &[StoreKey<'static>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
         keys.iter()
@@ -862,7 +862,7 @@ where
 
     async fn get_part(
         self: Pin<&Self>,
-        key: StoreKey<'_>,
+        key: StoreKey<'static>,
         writer: &mut DropCloserWriteHalf,
         offset: u64,
         length: Option<u64>,
@@ -976,6 +976,11 @@ where
 
     fn register_health(self: Arc<Self>, registry: &mut HealthRegistryBuilder) {
         registry.register_indicator(self);
+    }
+
+    fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
+        // FIXME(palfrey): Cope with the expiry timeout
+        todo!();
     }
 }
 

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -167,7 +167,7 @@ impl StoreDriver for ShardStore {
             .collect();
         // Bucket each key into the store that it belongs to.
         keys.iter()
-        .cloned()
+            .cloned()
             .enumerate()
             .map(|(key_idx, key)| (key.clone(), key_idx, self.get_store_index(&key)))
             .for_each(|(key, key_idx, store_idx)| {

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -28,7 +28,7 @@ use nativelink_store::noop_store::NoopStore;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
-use nativelink_util::store_trait::{Store, StoreDriver, StoreKey, StoreLike};
+use nativelink_util::store_trait::{RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike};
 use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -240,7 +240,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
     impl StoreDriver for DropCheckStore {
         async fn has_with_results(
             self: Pin<&Self>,
-            digests: &[StoreKey<'_>],
+            digests: &[StoreKey<'static>],
             results: &mut [Option<u64>],
         ) -> Result<(), Error> {
             if let Some(has_digest) = self.digest {
@@ -276,7 +276,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
 
         async fn get_part(
             self: Pin<&Self>,
-            key: StoreKey<'_>,
+            key: StoreKey<'static>,
             writer: &mut nativelink_util::buf_channel::DropCloserWriteHalf,
             offset: u64,
             length: Option<u64>,
@@ -299,6 +299,9 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
 
         fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
             self
+        }
+
+        fn register_remove_callback(self: Arc<Self>, _callback: &Arc<Box<dyn RemoveItemCallback>>) {
         }
     }
 

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -48,7 +48,6 @@ rust_library(
         "//nativelink-error",
         "//nativelink-metric",
         "//nativelink-proto",
-        "@crates//:async-lock",
         "@crates//:base64",
         "@crates//:bitflags",
         "@crates//:blake3",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -14,7 +14,6 @@ nativelink-error = { path = "../nativelink-error" }
 nativelink-metric = { path = "../nativelink-metric" }
 nativelink-proto = { path = "../nativelink-proto" }
 
-async-lock = { version = "3.4.0", features = ["std"], default-features = false }
 async-trait = "0.1.88"
 base64 = { version = "0.22.1", default-features = false, features = ["std"] }
 bitflags = "2.9.0"
@@ -41,7 +40,7 @@ opentelemetry-semantic-conventions = { version = "0.29.0", default-features = fa
   "semconv_experimental",
 ] }
 opentelemetry_sdk = { version = "0.29.0", default-features = false }
-parking_lot = "0.12.3"
+parking_lot = { version = "0.12.3", features = ["send_guard"] }
 pin-project = "1.1.10"
 pin-project-lite = "0.2.16"
 prost = { version = "0.13.5", default-features = false }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -442,7 +442,8 @@ where
     pub async fn insert_with_time(&self, key: K, data: T, seconds_since_anchor: i32) -> Option<T> {
         let items_to_unref = {
             let mut state = self.state.lock();
-            self.inner_insert_many(&mut state, [(key, data)], seconds_since_anchor).await
+            self.inner_insert_many(&mut state, [(key, data)], seconds_since_anchor)
+                .await
         };
 
         // Unref items outside of lock
@@ -473,7 +474,8 @@ where
 
         let items_to_unref = {
             let state = &mut self.state.lock();
-            self.inner_insert_many(state, inserts, self.anchor_time.elapsed().as_secs() as i32).await
+            self.inner_insert_many(state, inserts, self.anchor_time.elapsed().as_secs() as i32)
+                .await
         };
 
         // Unref items outside of lock

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -21,11 +21,12 @@ use core::ops::RangeBounds;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use async_lock::Mutex;
 use lru::LruCache;
 use nativelink_config::stores::EvictionPolicy;
 use nativelink_metric::MetricsComponent;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use tonic::async_trait;
 use tracing::{debug, info};
 
 use crate::instant_wrapper::InstantWrapper;
@@ -85,8 +86,17 @@ impl<T: LenEntry + Send + Sync> LenEntry for Arc<T> {
     }
 }
 
+#[async_trait]
+pub trait RemoveStateCallback<Q>: Debug + Send + Sync {
+    async fn callback(&self, key: &Q);
+}
+
 #[derive(Debug, MetricsComponent)]
-struct State<K: Ord + Hash + Eq + Clone + Debug + Send, T: LenEntry + Debug + Send> {
+struct State<
+    K: Ord + Hash + Eq + Clone + Debug + Send + Borrow<Q>,
+    Q: Ord + Hash + Eq + Debug,
+    T: LenEntry + Debug + Send,
+> {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
     #[metric(help = "Total size of all items in the store")]
@@ -102,18 +112,21 @@ struct State<K: Ord + Hash + Eq + Clone + Debug + Send, T: LenEntry + Debug + Se
     replaced_items: CounterWithTime,
     #[metric(help = "Number of bytes inserted into the store since it was created")]
     lifetime_inserted_bytes: Counter,
+
+    remove_callbacks: Mutex<Vec<Box<dyn RemoveStateCallback<Q>>>>,
 }
 
-impl<K: Ord + Hash + Eq + Clone + Debug + Send + Sync, T: LenEntry + Debug + Sync + Send>
-    State<K, T>
+impl<
+    K: Ord + Hash + Eq + Clone + Debug + Send + Sync + Borrow<Q>,
+    Q: Ord + Hash + Eq + Debug + Sync,
+    T: LenEntry + Debug + Sync + Send,
+> State<K, Q, T>
 {
     /// Removes an item from the cache and returns the data for deferred cleanup.
     /// The caller is responsible for calling `unref()` on the returned data outside of the lock.
     #[must_use]
-    fn remove<Q>(&mut self, key: &Q, eviction_item: &EvictionItem<T>, replaced: bool) -> T
+    async fn remove(&mut self, key: &Q, eviction_item: &EvictionItem<T>, replaced: bool) -> T
     where
-        K: Borrow<Q>,
-        Q: Ord + Hash + Eq + Debug + Sync,
         T: Clone,
     {
         if let Some(btree) = &mut self.btree {
@@ -127,6 +140,12 @@ impl<K: Ord + Hash + Eq + Clone + Debug + Send + Sync, T: LenEntry + Debug + Syn
             self.evicted_items.inc();
             self.evicted_bytes.add(eviction_item.data.len());
         }
+
+        let locked_callbacks = self.remove_callbacks.lock();
+        for callback in locked_callbacks.iter() {
+            callback.callback(key).await;
+        }
+
         // Return the data for deferred unref outside of lock
         eviction_item.data.clone()
     }
@@ -134,7 +153,7 @@ impl<K: Ord + Hash + Eq + Clone + Debug + Send + Sync, T: LenEntry + Debug + Syn
     /// Inserts a new item into the cache. If the key already exists, the old item is returned
     /// for deferred cleanup.
     #[must_use]
-    fn put(&mut self, key: &K, eviction_item: EvictionItem<T>) -> Option<T>
+    async fn put(&mut self, key: &K, eviction_item: EvictionItem<T>) -> Option<T>
     where
         K: Clone,
         T: Clone,
@@ -144,21 +163,26 @@ impl<K: Ord + Hash + Eq + Clone + Debug + Send + Sync, T: LenEntry + Debug + Syn
             btree.insert(key.clone());
         }
         if let Some(old_item) = self.lru.put(key.clone(), eviction_item) {
-            let old_data = self.remove(key, &old_item, true);
+            let old_data = self.remove(key.borrow(), &old_item, true).await;
             return Some(old_data);
         }
         None
+    }
+
+    fn add_remove_callback(&self, callback: Box<dyn RemoveStateCallback<Q>>) {
+        self.remove_callbacks.lock().push(callback)
     }
 }
 
 #[derive(Debug, MetricsComponent)]
 pub struct EvictingMap<
-    K: Ord + Hash + Eq + Clone + Debug + Send,
+    K: Ord + Hash + Eq + Clone + Debug + Send + Borrow<Q>,
+    Q: Ord + Hash + Eq + Debug,
     T: LenEntry + Debug + Send,
     I: InstantWrapper,
 > {
     #[metric]
-    state: Mutex<State<K, T>>,
+    state: Mutex<State<K, Q, T>>,
     anchor_time: I,
     #[metric(help = "Maximum size of the store in bytes")]
     max_bytes: u64,
@@ -170,9 +194,10 @@ pub struct EvictingMap<
     max_count: u64,
 }
 
-impl<K, T, I> EvictingMap<K, T, I>
+impl<K, Q, T, I> EvictingMap<K, Q, T, I>
 where
-    K: Ord + Hash + Eq + Clone + Debug + Send + Sync,
+    K: Ord + Hash + Eq + Clone + Debug + Send + Sync + Borrow<Q>,
+    Q: Ord + Hash + Eq + Debug + Sync,
     T: LenEntry + Debug + Clone + Send + Sync,
     I: InstantWrapper,
 {
@@ -189,6 +214,7 @@ where
                 replaced_bytes: Counter::default(),
                 replaced_items: CounterWithTime::default(),
                 lifetime_inserted_bytes: Counter::default(),
+                remove_callbacks: Mutex::new(vec![]),
             }),
             anchor_time,
             max_bytes: config.max_bytes as u64,
@@ -199,13 +225,13 @@ where
     }
 
     pub async fn enable_filtering(&self) {
-        let mut state = self.state.lock().await;
+        let mut state = self.state.lock();
         if state.btree.is_none() {
             Self::rebuild_btree_index(&mut state);
         }
     }
 
-    fn rebuild_btree_index(state: &mut State<K, T>) {
+    fn rebuild_btree_index(state: &mut State<K, Q, T>) {
         state.btree = Some(state.lru.iter().map(|(k, _)| k).cloned().collect());
     }
 
@@ -213,13 +239,12 @@ where
     /// and return the number of items that were processed.
     /// The `handler` function should return `true` to continue processing the next item
     /// or `false` to stop processing.
-    pub async fn range<F, Q>(&self, prefix_range: impl RangeBounds<Q> + Send, mut handler: F) -> u64
+    pub async fn range<F>(&self, prefix_range: impl RangeBounds<Q> + Send, mut handler: F) -> u64
     where
         F: FnMut(&K, &T) -> bool + Send,
-        K: Borrow<Q> + Ord,
-        Q: Ord + Hash + Eq + Debug + Sync,
+        K: Ord,
     {
-        let mut state = self.state.lock().await;
+        let mut state = self.state.lock();
         let btree = if let Some(ref btree) = state.btree {
             btree
         } else {
@@ -241,7 +266,7 @@ where
     /// Returns the number of key-value pairs that are currently in the the cache.
     /// Function is not for production code paths.
     pub async fn len_for_test(&self) -> usize {
-        self.state.lock().await.lru.len()
+        self.state.lock().lru.len()
     }
 
     fn should_evict(
@@ -264,7 +289,7 @@ where
     }
 
     #[must_use]
-    fn evict_items(&self, state: &mut State<K, T>) -> Vec<T> {
+    async fn evict_items(&self, state: &mut State<K, Q, T>) -> Vec<T> {
         let Some((_, mut peek_entry)) = state.lru.peek_lru() else {
             return Vec::new();
         };
@@ -290,7 +315,7 @@ where
                 .pop_lru()
                 .expect("Tried to peek() then pop() but failed");
             debug!(?key, "Evicting",);
-            let data = state.remove(&key, &eviction_item, false);
+            let data = state.remove(key.borrow(), &eviction_item, false).await;
             items_to_unref.push(data);
 
             peek_entry = if let Some((_, entry)) = state.lru.peek_lru() {
@@ -304,10 +329,9 @@ where
     }
 
     /// Return the size of a `key`, if not found `None` is returned.
-    pub async fn size_for_key<Q>(&self, key: &Q) -> Option<u64>
+    pub async fn size_for_key(&self, key: &Q) -> Option<u64>
     where
-        K: Borrow<Q>,
-        Q: Ord + Hash + Eq + Debug + Sync,
+        Q: Sync,
     {
         let mut results = [None];
         self.sizes_for_keys([key], &mut results[..], false).await;
@@ -320,7 +344,7 @@ where
     /// If no key is found in the internal map, `None` is filled in its place.
     /// If `peek` is set to `true`, the items are not promoted to the front of the
     /// LRU cache. Note: peek may still evict, but won't promote.
-    pub async fn sizes_for_keys<It, Q, R>(&self, keys: It, results: &mut [Option<u64>], peek: bool)
+    pub async fn sizes_for_keys<It, R>(&self, keys: It, results: &mut [Option<u64>], peek: bool)
     where
         It: IntoIterator<Item = R> + Send,
         // Note: It's not enough to have the inserts themselves be Send. The
@@ -331,11 +355,9 @@ where
         // * `R` (the input stream item type) must also be able to borrow `Q`
         // Note: That K and R do not need to be the same type, they just both need
         // to be able to borrow a `Q`.
-        K: Borrow<Q>,
         R: Borrow<Q> + Send,
-        Q: Ord + Hash + Eq + Debug + Sync,
     {
-        let mut state = self.state.lock().await;
+        let mut state = self.state.lock();
 
         let lru_len = state.lru.len();
         for (key, result) in keys.into_iter().zip(results.iter_mut()) {
@@ -353,7 +375,7 @@ where
                         *result = None;
                         if let Some((key, eviction_item)) = state.lru.pop_entry(key.borrow()) {
                             info!(?key, "Item expired, evicting");
-                            let data = state.remove(key.borrow(), &eviction_item, false);
+                            let data = state.remove(key.borrow(), &eviction_item, false).await;
                             // Store data for later unref - we can't drop state here as we're still iterating
                             // The unref will happen after the method completes
                             // For now, we just do inline unref
@@ -372,14 +394,10 @@ where
         }
     }
 
-    pub async fn get<Q>(&self, key: &Q) -> Option<T>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Hash + Eq + Debug + Sync,
-    {
+    pub async fn get(&self, key: &Q) -> Option<T> {
         // Fast path: Check if we need eviction before acquiring lock for eviction
         let needs_eviction = {
-            let state = self.state.lock().await;
+            let state = self.state.lock();
             if let Some((_, peek_entry)) = state.lru.peek_lru() {
                 self.should_evict(
                     state.lru.len(),
@@ -395,8 +413,8 @@ where
         // Perform eviction if needed
         if needs_eviction {
             let items_to_unref = {
-                let mut state = self.state.lock().await;
-                self.evict_items(&mut *state)
+                let mut state = self.state.lock();
+                self.evict_items(&mut *state).await
             };
             // Unref items outside of lock
             for item in items_to_unref {
@@ -405,14 +423,17 @@ where
         }
 
         // Now get the item
-        let mut state = self.state.lock().await;
+        let mut state = self.state.lock();
         let entry = state.lru.get_mut(key.borrow())?;
         entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
         Some(entry.data.clone())
     }
 
     /// Returns the replaced item if any.
-    pub async fn insert(&self, key: K, data: T) -> Option<T> {
+    pub async fn insert(&self, key: K, data: T) -> Option<T>
+    where
+        K: 'static,
+    {
         self.insert_with_time(key, data, self.anchor_time.elapsed().as_secs() as i32)
             .await
     }
@@ -420,8 +441,8 @@ where
     /// Returns the replaced item if any.
     pub async fn insert_with_time(&self, key: K, data: T, seconds_since_anchor: i32) -> Option<T> {
         let items_to_unref = {
-            let mut state = self.state.lock().await;
-            self.inner_insert_many(&mut state, [(key, data)], seconds_since_anchor)
+            let mut state = self.state.lock();
+            self.inner_insert_many(&mut state, [(key, data)], seconds_since_anchor).await
         };
 
         // Unref items outside of lock
@@ -442,6 +463,7 @@ where
         // Note: It's not enough to have the inserts themselves be Send. The
         // returned iterator should be Send as well.
         <It as IntoIterator>::IntoIter: Send,
+        K: 'static,
     {
         let mut inserts = inserts.into_iter().peekable();
         // Shortcut for cases where there are no inserts, so we don't need to lock.
@@ -450,8 +472,8 @@ where
         }
 
         let items_to_unref = {
-            let state = &mut self.state.lock().await;
-            self.inner_insert_many(state, inserts, self.anchor_time.elapsed().as_secs() as i32)
+            let state = &mut self.state.lock();
+            self.inner_insert_many(state, inserts, self.anchor_time.elapsed().as_secs() as i32).await
         };
 
         // Unref items outside of lock
@@ -464,9 +486,9 @@ where
         results
     }
 
-    fn inner_insert_many<It>(
+    async fn inner_insert_many<It>(
         &self,
-        state: &mut State<K, T>,
+        state: &mut State<K, Q, T>,
         inserts: It,
         seconds_since_anchor: i32,
     ) -> Vec<T>
@@ -484,7 +506,7 @@ where
                 data,
             };
 
-            if let Some(old_item) = state.put(&key, eviction_item) {
+            if let Some(old_item) = state.put(&key, eviction_item).await {
                 replaced_items.push(old_item);
             }
             state.sum_store_size += new_item_size;
@@ -492,7 +514,7 @@ where
         }
 
         // Perform eviction after all insertions
-        let items_to_unref = self.evict_items(state);
+        let items_to_unref = self.evict_items(state).await;
 
         // Note: We cannot drop the state lock here since we're borrowing it,
         // but the caller will handle unreffing these items after releasing the lock
@@ -503,20 +525,16 @@ where
         replaced_items
     }
 
-    pub async fn remove<Q>(&self, key: &Q) -> bool
-    where
-        K: Borrow<Q>,
-        Q: Ord + Hash + Eq + Debug + Sync,
-    {
+    pub async fn remove(&self, key: &Q) -> bool {
         let (items_to_unref, removed_item) = {
-            let mut state = self.state.lock().await;
+            let mut state = self.state.lock();
 
             // First perform eviction
-            let evicted_items = self.evict_items(&mut *state);
+            let evicted_items = self.evict_items(&mut *state).await;
 
             // Then try to remove the requested item
             let removed = if let Some(entry) = state.lru.pop(key.borrow()) {
-                Some(state.remove(key, &entry, false))
+                Some(state.remove(key, &entry, false).await)
             } else {
                 None
             };
@@ -540,23 +558,21 @@ where
 
     /// Same as `remove()`, but allows for a conditional to be applied to the
     /// entry before removal in an atomic fashion.
-    pub async fn remove_if<Q, F>(&self, key: &Q, cond: F) -> bool
+    pub async fn remove_if<F>(&self, key: &Q, cond: F) -> bool
     where
-        K: Borrow<Q>,
-        Q: Ord + Hash + Eq + Debug + Sync,
         F: FnOnce(&T) -> bool + Send,
     {
-        let mut state = self.state.lock().await;
+        let mut state = self.state.lock();
         if let Some(entry) = state.lru.get(key.borrow()) {
             if !cond(&entry.data) {
                 return false;
             }
             // First perform eviction
-            let evicted_items = self.evict_items(&mut state);
+            let evicted_items = self.evict_items(&mut state).await;
 
             // Then try to remove the requested item
             let removed_item = if let Some(entry) = state.lru.pop(key.borrow()) {
-                Some(state.remove(key, &entry, false))
+                Some(state.remove(key, &entry, false).await)
             } else {
                 None
             };
@@ -578,5 +594,9 @@ where
             return false;
         }
         false
+    }
+
+    pub fn add_remove_callback(&self, callback: Box<dyn RemoveStateCallback<Q>>) {
+        self.state.lock().add_remove_callback(callback);
     }
 }

--- a/nativelink-util/src/instant_wrapper.rs
+++ b/nativelink-util/src/instant_wrapper.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
 use core::future::Future;
 use core::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -20,7 +21,7 @@ use mock_instant::thread_local::{Instant as MockInstant, MockClock};
 
 /// Wrapper used to abstract away which underlying Instant impl we are using.
 /// This is needed for testing.
-pub trait InstantWrapper: Send + Sync + Unpin + 'static {
+pub trait InstantWrapper: Send + Sync + Unpin + Debug + 'static {
     fn from_secs(secs: u64) -> Self;
     fn unix_timestamp(&self) -> u64;
     fn now(&self) -> SystemTime;

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -55,7 +55,7 @@ const HASH4: &str = "3456789abcdef000000000000000000000000000000000123456789abcd
 
 #[nativelink_test]
 async fn insert_purges_at_max_count() -> Result<(), Error> {
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 3,
             max_seconds: 0,
@@ -112,7 +112,7 @@ async fn insert_purges_at_max_count() -> Result<(), Error> {
 #[nativelink_test]
 async fn insert_purges_at_max_bytes() -> Result<(), Error> {
     const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 0,
@@ -169,7 +169,7 @@ async fn insert_purges_at_max_bytes() -> Result<(), Error> {
 #[nativelink_test]
 async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
     const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 0,
@@ -227,7 +227,7 @@ async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
 async fn insert_purges_at_max_seconds() -> Result<(), Error> {
     const DATA: &str = "12345678";
 
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 5,
@@ -289,7 +289,7 @@ async fn insert_purges_at_max_seconds() -> Result<(), Error> {
 async fn get_refreshes_time() -> Result<(), Error> {
     const DATA: &str = "12345678";
 
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 3,
@@ -364,15 +364,16 @@ async fn unref_called_on_replace() -> Result<(), Error> {
     const DATA1: &str = "12345678";
     const DATA2: &str = "87654321";
 
-    let evicting_map = EvictingMap::<DigestInfo, Arc<MockEntry>, MockInstantWrapped>::new(
-        &EvictionPolicy {
-            max_count: 1,
-            max_seconds: 0,
-            max_bytes: 0,
-            evict_bytes: 0,
-        },
-        MockInstantWrapped::default(),
-    );
+    let evicting_map =
+        EvictingMap::<DigestInfo, DigestInfo, Arc<MockEntry>, MockInstantWrapped>::new(
+            &EvictionPolicy {
+                max_count: 1,
+                max_seconds: 0,
+                max_bytes: 0,
+                evict_bytes: 0,
+            },
+            MockInstantWrapped::default(),
+        );
 
     let (entry1, entry2) = {
         let entry1 = Arc::new(MockEntry {
@@ -409,7 +410,7 @@ async fn unref_called_on_replace() -> Result<(), Error> {
 async fn contains_key_refreshes_time() -> Result<(), Error> {
     const DATA: &str = "12345678";
 
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 3,
@@ -462,7 +463,7 @@ async fn contains_key_refreshes_time() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 0,
@@ -517,7 +518,7 @@ async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
 async fn get_evicts_on_time() -> Result<(), Error> {
     const DATA: &str = "12345678";
 
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 5,
@@ -550,7 +551,7 @@ async fn get_evicts_on_time() -> Result<(), Error> {
 async fn remove_evicts_on_time() -> Result<(), Error> {
     const DATA: &str = "12345678";
 
-    let evicting_map = EvictingMap::<DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 5,
@@ -584,7 +585,7 @@ async fn remove_evicts_on_time() -> Result<(), Error> {
 #[nativelink_test]
 async fn range_multiple_items_test() -> Result<(), Error> {
     async fn get_map_range(
-        evicting_map: &EvictingMap<String, BytesWrapper, MockInstantWrapped>,
+        evicting_map: &EvictingMap<String, String, BytesWrapper, MockInstantWrapped>,
         range: impl core::ops::RangeBounds<String> + Send,
     ) -> Vec<(String, Bytes)> {
         let mut found_values = Vec::new();
@@ -606,7 +607,7 @@ async fn range_multiple_items_test() -> Result<(), Error> {
     const KEY3: &str = "key-345";
     const DATA3: &str = "345";
 
-    let evicting_map = EvictingMap::<String, BytesWrapper, MockInstantWrapped>::new(
+    let evicting_map = EvictingMap::<String, String, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
             max_count: 0,
             max_seconds: 0,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -306,9 +306,9 @@ async fn upload_file(
             // Only upload if the digest doesn't already exist, this should be
             // a much cheaper operation than an upload.
             let cas_store = cas_store.as_store_driver_pin();
-            let store_key: nativelink_util::store_trait::StoreKey<'_> = digest.into();
+            let store_key: nativelink_util::store_trait::StoreKey<'static> = digest.into();
             if cas_store
-                .has(store_key.borrow())
+                .has(store_key.clone())
                 .await
                 .is_ok_and(|result| result.is_some())
             {


### PR DESCRIPTION
# Description

There's an issue with the existence cache if one or more of it's underlying stores evicts items. Namely, when they do so, they don't tell anyone about it, and so the existence cache still says "yup, got that" and then clients will fail when they try to retrieve the item. This is believed (but not certain) as the source of the `not found in either fast or slow store` errors that have been cropping up. This PR adds a callback mechanism for evictions so compound stores that need to know about their inner stores evicting things can get notified.

Consequences of this change:
* Various configs that were previously regarded as valid are no longer, primarily existence caches with `GrpcStore` as an internal store, as we don't get "I evicted this" feedback from those. These will now fail at runtime (FIXME: actually make this fail)
* A bunch of `StoreKey<'_>` have become `StoreKey<'static>` and the `EvictingMap` type has become more complicated to support using the borrow key there as the callback key. This has resulted in some extra `clone`'s and probably some slowdowns. This is believed to be the best option we have that gets us the improved stability from this PR.

## Type of change

Please delete options that aren't relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
