### PR TITLE
Introduce JuiceFS Configuration

### DIFF
--- a/.github/styles/config/vocabularies/TraceMachina/accept.txt
+++ b/.github/styles/config/vocabularies/TraceMachina/accept.txt
@@ -33,6 +33,7 @@ Machina
 Makefile
 [Mm]etamaterials
 [Mm]onorepo
+Memory Store
 Nvidia
 NVMe
 hello@nativelink.com

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ The setups below are **production-grade** installations. See the [contribution d
 
 You can find a few example deployments in the [Docs](https://nativelink.com/docs/deployment-examples/kubernetes).
 
+> **🚀 Multi-Worker Deployments with JuiceFS**
+>
+> For production-grade multi-worker setups with distributed shared storage, check out our [JuiceFS Integration Guide](deployment-examples/docker-compose/README-JUICEFS.md). Get started in minutes with our automated setup:
+> ```bash
+> cd deployment-examples/docker-compose
+> ./setup-juicefs.sh
+> ```
+> Includes Redis, MinIO, and production-ready configurations for both Docker Compose and Kubernetes.
+
 ### 📦 Prebuilt images
 
 Fast to spin up, but currently limited to `x86_64` systems. See the [container

--- a/deployment-examples/docker-compose/README-JUICEFS.md
+++ b/deployment-examples/docker-compose/README-JUICEFS.md
@@ -1,0 +1,398 @@
+# JuiceFS Multi-Worker Deployment for NativeLink
+
+This directory contains a production-ready Docker Compose configuration for running NativeLink with multiple workers backed by JuiceFS distributed storage.
+
+## What's Included
+
+- **Redis**: JuiceFS metadata engine
+- **MinIO**: S3-compatible object storage for JuiceFS data
+- **JuiceFS Mount**: Dedicated container maintaining the FUSE filesystem
+- **CAS Server**: NativeLink Content Addressable Storage server
+- **Scheduler**: Work distribution coordinator
+- **Workers (3)**: Build execution workers with shared CAS via JuiceFS
+
+## Architecture
+
+```
+                    ┌─────────────────┐
+                    │  Bazel Client   │
+                    └────────┬────────┘
+                             │
+            ┌────────────────┼────────────────┐
+            │                │                │
+      ┌─────▼─────┐    ┌────▼────┐    ┌─────▼─────┐
+      │  Worker 1 │    │Worker 2 │    │  Worker 3 │
+      └─────┬─────┘    └────┬────┘    └─────┬─────┘
+            │               │               │
+            └───────────────┼───────────────┘
+                            │
+                     ┌──────▼──────┐
+                     │  Scheduler  │
+                     └──────┬──────┘
+                            │
+                     ┌──────▼──────┐
+                     │ CAS Server  │
+                     └─────────────┘
+
+    All workers share CAS via JuiceFS:
+
+      ┌──────┬──────┬──────┐
+      │  W1  │  W2  │  W3  │
+      └───┬──┴───┬──┴───┬──┘
+          │      │      │
+          └──────┼──────┘
+                 │
+          ┌──────▼──────┐
+          │   JuiceFS   │
+          │  Filesystem │
+          └──────┬──────┘
+                 │
+      ┌──────────┴──────────┐
+      │                     │
+┌─────▼─────┐      ┌────────▼────────┐
+│   Redis   │      │     MinIO       │
+│ (Metadata)│      │ (Object Store)  │
+└───────────┘      └─────────────────┘
+```
+
+## Quick Start
+
+### Option 1: Automated Setup (Recommended)
+
+```bash
+# Run the setup script
+./setup-juicefs.sh
+
+# The script will:
+# - Check prerequisites
+# - Build NativeLink image
+# - Start all services
+# - Verify JuiceFS mount
+# - Display status and commands
+```
+
+### Option 2: Manual Setup
+
+```bash
+# Build the NativeLink image
+docker-compose -f docker-compose-juicefs.yml build
+
+# Start all services
+docker-compose -f docker-compose-juicefs.yml up -d
+
+# Check service status
+docker-compose -f docker-compose-juicefs.yml ps
+
+# View logs
+docker-compose -f docker-compose-juicefs.yml logs -f
+```
+
+## Configuration Files
+
+- **`docker-compose-juicefs.yml`**: Main Docker Compose configuration
+- **`worker-juicefs.json5`**: Worker configuration using JuiceFS-backed storage
+- **`cas-server-multi-worker.json5`**: CAS server configuration
+- **`scheduler-multi-worker.json5`**: Scheduler configuration
+
+## Verifying the Setup
+
+### 1. Check Service Health
+
+```bash
+# All services should show "healthy" or "running"
+docker-compose -f docker-compose-juicefs.yml ps
+```
+
+Expected output:
+```
+NAME                            STATUS
+nativelink-cas-server-1         Up (healthy)
+nativelink-juicefs-mount-1      Up (healthy)
+nativelink-minio-1              Up (healthy)
+nativelink-redis-1              Up (healthy)
+nativelink-scheduler-1          Up (healthy)
+nativelink-worker-1-1           Up
+nativelink-worker-2-1           Up
+nativelink-worker-3-1           Up
+```
+
+### 2. Verify JuiceFS Mount
+
+```bash
+# Check JuiceFS status
+docker exec nativelink-juicefs-mount-1 juicefs status redis://redis:6379/1
+
+# Check filesystem
+docker exec nativelink-juicefs-mount-1 df -h /mnt/jfs
+
+# Verify .stats directory (JuiceFS health indicator)
+docker exec nativelink-juicefs-mount-1 ls -la /mnt/jfs/.stats/
+```
+
+### 3. Test Worker Access to JuiceFS
+
+```bash
+# Exec into a worker
+docker exec -it nativelink-worker-1-1 sh
+
+# Inside the worker container:
+ls -la /mnt/jfs/cas/
+touch /mnt/jfs/cas/test-file
+ls -la /mnt/jfs/cas/test-file
+
+# Exit the worker
+exit
+
+# Verify from another worker (should see the same file)
+docker exec nativelink-worker-2-1 ls -la /mnt/jfs/cas/test-file
+```
+
+### 4. Test Build Execution
+
+```bash
+# In your Bazel workspace, run:
+bazel build \
+  --remote_cache=grpc://localhost:50051 \
+  --remote_executor=grpc://localhost:50052 \
+  //your:target
+
+# Check worker logs to see which worker executed the action
+docker-compose -f docker-compose-juicefs.yml logs worker-1 worker-2 worker-3 | grep "Executing action"
+```
+
+## Scaling Workers
+
+### Add More Workers
+
+Edit `docker-compose-juicefs.yml` and add:
+
+```yaml
+worker-4:
+  image: nativelink:latest
+  privileged: true
+  cap_add:
+    - SYS_ADMIN
+  devices:
+    - /dev/fuse
+  volumes:
+    - type: volume
+      source: juicefs-mount
+      target: /mnt/jfs
+      volume:
+        nocopy: true
+    - worker4-work:/tmp/worker4
+    - ./worker-juicefs.json5:/nativelink-config.json5
+  environment:
+    - RUST_LOG=info,nativelink=debug
+    - SCHEDULER_ENDPOINT=scheduler
+    - CAS_ENDPOINT=cas-server
+    - WORKER_NAME=worker-4
+    - WORKER_ID=4
+  command: nativelink /nativelink-config.json5
+  depends_on:
+    scheduler:
+      condition: service_healthy
+    juicefs-mount:
+      condition: service_healthy
+  networks:
+    - nativelink-network
+```
+
+Don't forget to add the volume:
+```yaml
+volumes:
+  worker4-work:
+    driver: local
+```
+
+Then restart:
+```bash
+docker-compose -f docker-compose-juicefs.yml up -d
+```
+
+## Monitoring
+
+### View Logs
+
+```bash
+# All services
+docker-compose -f docker-compose-juicefs.yml logs -f
+
+# Specific service
+docker-compose -f docker-compose-juicefs.yml logs -f worker-1
+
+# JuiceFS mount
+docker-compose -f docker-compose-juicefs.yml logs -f juicefs-mount
+```
+
+### JuiceFS Statistics
+
+```bash
+# Real-time stats
+docker exec nativelink-juicefs-mount-1 juicefs stats /mnt/jfs
+
+# Detailed status
+docker exec nativelink-juicefs-mount-1 juicefs status redis://redis:6379/1
+```
+
+### Resource Usage
+
+```bash
+# Container resource usage
+docker stats
+
+# JuiceFS cache usage
+docker exec nativelink-juicefs-mount-1 du -sh /var/jfsCache
+```
+
+### MinIO Console
+
+Access MinIO web console:
+```
+http://localhost:9001
+Username: minioadmin
+Password: minioadmin
+```
+
+## Troubleshooting
+
+### JuiceFS Mount Not Working
+
+```bash
+# Check JuiceFS logs
+docker-compose -f docker-compose-juicefs.yml logs juicefs-mount
+
+# Verify Redis is accessible
+docker exec nativelink-juicefs-mount-1 redis-cli -h redis ping
+
+# Check FUSE device
+docker exec nativelink-juicefs-mount-1 ls -la /dev/fuse
+```
+
+### Workers Can't Access JuiceFS
+
+```bash
+# Check if volume is properly mounted
+docker exec nativelink-worker-1-1 df -h | grep jfs
+
+# Verify permissions
+docker exec nativelink-worker-1-1 ls -la /mnt/jfs/
+
+# Check for FUSE capability
+docker exec nativelink-worker-1-1 cat /proc/filesystems | grep fuse
+```
+
+### Slow Performance
+
+```bash
+# Check JuiceFS cache hit rate
+docker exec nativelink-juicefs-mount-1 juicefs stats /mnt/jfs
+
+# Increase cache size in docker-compose-juicefs.yml:
+# --cache-size 20480  # 20GB
+
+# Increase max-uploads:
+# --max-uploads 50
+
+# Then recreate the juicefs-mount container:
+docker-compose -f docker-compose-juicefs.yml up -d --force-recreate juicefs-mount
+```
+
+### Out of Space
+
+```bash
+# Check available space
+docker exec nativelink-juicefs-mount-1 df -h /mnt/jfs
+
+# Check cache usage
+docker exec nativelink-juicefs-mount-1 du -sh /var/jfsCache
+
+# Clean up old cache (JuiceFS does this automatically based on --cache-size)
+```
+
+## Cleanup
+
+### Stop Services (Keep Data)
+
+```bash
+docker-compose -f docker-compose-juicefs.yml down
+```
+
+### Stop Services and Delete Volumes
+
+```bash
+docker-compose -f docker-compose-juicefs.yml down -v
+```
+
+### Complete Cleanup
+
+```bash
+# Stop and remove everything
+docker-compose -f docker-compose-juicefs.yml down -v --remove-orphans
+
+# Remove NativeLink image
+docker rmi nativelink:latest
+
+# Clean up JuiceFS mount directory
+rm -rf /tmp/juicefs-mount
+```
+
+## Production Considerations
+
+### Use External Services
+
+For production deployments, replace MinIO and Redis with managed services:
+
+1. **Replace MinIO with AWS S3**:
+   - Update `juicefs format` command in docker-compose-juicefs.yml
+   - Use S3 bucket URL instead of MinIO
+
+2. **Replace Redis with managed Redis**:
+   - AWS ElastiCache, Google Cloud Memory Store, or Azure Cache
+   - Update metadata URL in format and mount commands
+
+3. **Use PostgreSQL for metadata**:
+   - More reliable for large-scale deployments
+   - Better for billions of files
+
+### Security Hardening
+
+1. **Enable TLS**:
+   ```bash
+   juicefs mount rediss://redis:6379/1 /mnt/jfs  # Note: rediss
+   ```
+
+2. **Encrypt data at rest**:
+   ```bash
+   juicefs format --encrypt-rsa-key /path/to/key.pem ...
+   ```
+
+3. **Use secrets management**:
+   - Don't hard code credentials
+   - Use Docker secrets or Kubernetes secrets
+
+### High Availability
+
+1. **Redis HA**:
+   - Use Redis Sentinel or Redis Cluster
+   - Multiple Redis instances with automatic failover
+
+2. **Multiple JuiceFS Mounts**:
+   - Each worker can have its own mount
+   - Automatic metadata cache synchronization
+
+3. **Object Storage Redundancy**:
+   - S3 with cross-region replication
+   - MinIO with erasure coding
+
+## Next Steps
+
+- **Production Deployment**: See [juicefs-integration.md](../docs/juicefs-integration.md) for Kubernetes deployment
+- **Performance Tuning**: Optimize JuiceFS cache and concurrency settings
+- **Monitoring**: Set up Prometheus metrics collection
+- **Backup**: Configure metadata and object storage backups
+
+## Support
+
+- **NativeLink**: [Slack](https://forms.gle/LtaWSixEC6bYi5xF7) | [GitHub](https://github.com/TraceMachina/nativelink)
+- **JuiceFS**: [Docs](https://juicefs.com/docs/) | [Slack](https://juicefs.com/docs/community/slack)

--- a/deployment-examples/docker-compose/README.md
+++ b/deployment-examples/docker-compose/README.md
@@ -2,6 +2,9 @@
 
 This guide explains how to run NativeLink with multiple workers using Docker Compose for distributed build execution.
 
+> **💡 Looking for production-grade distributed storage?**
+> Check out our **[JuiceFS Integration](./README-JUICEFS.md)** for multi-worker setups with shared CAS using JuiceFS distributed filesystem. Includes Redis, MinIO, and automated setup scripts.
+
 ## Prerequisites
 
 - **Architecture**: This setup currently only works on **x86_64/amd64** architectures. ARM64/Apple Silicon isn't supported for the test client container.
@@ -117,6 +120,12 @@ services:
 - [`cas-server-multi-worker.json5`](./cas-server-multi-worker.json5) - CAS server configuration for multi-worker deployment
 - [`scheduler-multi-worker.json5`](./scheduler-multi-worker.json5) - Scheduler configuration for multi-worker deployment
 - [`worker-shared-cas.json5`](./worker-shared-cas.json5) - Worker configuration template with shared CAS storage
+
+### JuiceFS Distributed Storage Setup (Recommended for Production)
+- [`docker-compose-juicefs.yml`](./docker-compose-juicefs.yml) - Complete stack with JuiceFS, Redis, MinIO, and 3 workers
+- [`worker-juicefs.json5`](./worker-juicefs.json5) - Worker configuration for JuiceFS-backed shared CAS
+- [`setup-juicefs.sh`](./setup-juicefs.sh) - Automated setup script
+- [`README-JUICEFS.md`](./README-JUICEFS.md) - Complete JuiceFS deployment guide
 
 ### Single Worker Setup
 - [`docker-compose.yml`](./docker-compose.yml) - Docker Compose file for single worker deployment
@@ -268,10 +277,11 @@ bazel build //... \
 ## Production Considerations
 
 For production deployments:
-1. Use persistent volumes backed by SSD
-2. Implement health checks in docker-compose.yml
-3. Use external storage (NFS, S3, etc.) for CAS
-4. Monitor worker metrics
-5. Set up log aggregation
+1. **Use distributed storage**: See our **[JuiceFS Integration Guide](./README-JUICEFS.md)** for production-grade shared CAS with Redis and S3-compatible storage
+2. Use persistent volumes backed by SSD
+3. Implement health checks in docker-compose.yml
+4. Use external storage (NFS, S3, etc.) for CAS if not using JuiceFS
+5. Monitor worker metrics
+6. Set up log aggregation
 
-See [Kubernetes deployment](../kubernetes/) for production-grade configurations.
+See [Kubernetes deployment](../kubernetes/) for production-grade configurations or [JuiceFS with Kubernetes](../kubernetes/juicefs-deployment.yaml) for distributed storage on K8s.

--- a/deployment-examples/docker-compose/docker-compose-juicefs.yml
+++ b/deployment-examples/docker-compose/docker-compose-juicefs.yml
@@ -1,0 +1,297 @@
+version: '3.8'
+
+# Multi-worker NativeLink deployment with JuiceFS distributed storage
+# This configuration provides:
+# - Shared CAS across all workers via JuiceFS
+# - Redis for JuiceFS metadata
+# - S3-compatible storage (MinIO) for JuiceFS data backend
+# - Scalable worker architecture
+
+services:
+  # Redis - JuiceFS metadata engine
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    networks:
+      - nativelink-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # MinIO - S3-compatible object storage for JuiceFS backend
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    networks:
+      - nativelink-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # MinIO bucket initialization
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 minioadmin minioadmin;
+      mc mb myminio/nativelink-cas --ignore-existing;
+      mc anonymous set download myminio/nativelink-cas;
+      exit 0;
+      "
+    networks:
+      - nativelink-network
+
+  # JuiceFS formatter and mount service
+  # This container formats the JuiceFS volume and keeps it mounted
+  juicefs-mount:
+    image: juicedata/juicefs:latest
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    volumes:
+      - juicefs-cache:/var/jfsCache
+      - type: volume
+        source: juicefs-mount
+        target: /mnt/jfs
+        volume:
+          nocopy: true
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    depends_on:
+      redis:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    command: >
+      sh -c "
+        # Format JuiceFS (only on first run)
+        juicefs format \
+          --storage minio \
+          --bucket http://minio:9000/nativelink-cas \
+          --access-key minioadmin \
+          --secret-key minioadmin \
+          redis://redis:6379/1 \
+          nativelink-cas || true;
+
+        # Mount JuiceFS
+        juicefs mount \
+          --cache-dir /var/jfsCache \
+          --cache-size 10240 \
+          --writeback \
+          --max-uploads 20 \
+          --max-deletes 10 \
+          --buffer-size 300 \
+          --prefetch 3 \
+          --open-cache 0 \
+          --attr-cache 1 \
+          --entry-cache 1 \
+          --dir-entry-cache 1 \
+          redis://redis:6379/1 \
+          /mnt/jfs;
+      "
+    networks:
+      - nativelink-network
+    healthcheck:
+      test: ["CMD", "sh", "-c", "[ -d /mnt/jfs/.stats ]"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # CAS/AC server
+  cas-server:
+    image: nativelink:latest
+    build:
+      context: ../..
+      dockerfile: deployment-examples/docker-compose/Dockerfile
+    volumes:
+      - ./cas-server-multi-worker.json5:/nativelink-config.json5
+    ports:
+      - "50051:50051"
+    environment:
+      - RUST_LOG=info,nativelink=debug
+    command: nativelink /nativelink-config.json5
+    networks:
+      - nativelink-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:50051/status"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Scheduler
+  scheduler:
+    image: nativelink:latest
+    volumes:
+      - ./scheduler-multi-worker.json5:/nativelink-config.json5
+    ports:
+      - "50052:50052"
+      - "50061:50061"
+    environment:
+      - RUST_LOG=info,nativelink=debug
+      - CAS_ENDPOINT=cas-server
+    command: nativelink /nativelink-config.json5
+    depends_on:
+      cas-server:
+        condition: service_healthy
+    networks:
+      - nativelink-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:50052/status"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Worker 1 - Uses JuiceFS shared storage
+  worker-1:
+    image: nativelink:latest
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    volumes:
+      - type: volume
+        source: juicefs-mount
+        target: /mnt/jfs
+        volume:
+          nocopy: true
+      - worker1-work:/tmp/worker1
+      - ./worker-juicefs.json5:/nativelink-config.json5
+    environment:
+      - RUST_LOG=info,nativelink=debug
+      - SCHEDULER_ENDPOINT=scheduler
+      - CAS_ENDPOINT=cas-server
+      - WORKER_NAME=worker-1
+      - WORKER_ID=1
+    command: nativelink /nativelink-config.json5
+    depends_on:
+      scheduler:
+        condition: service_healthy
+      juicefs-mount:
+        condition: service_healthy
+    networks:
+      - nativelink-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+
+  # Worker 2 - Uses JuiceFS shared storage
+  worker-2:
+    image: nativelink:latest
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    volumes:
+      - type: volume
+        source: juicefs-mount
+        target: /mnt/jfs
+        volume:
+          nocopy: true
+      - worker2-work:/tmp/worker2
+      - ./worker-juicefs.json5:/nativelink-config.json5
+    environment:
+      - RUST_LOG=info,nativelink=debug
+      - SCHEDULER_ENDPOINT=scheduler
+      - CAS_ENDPOINT=cas-server
+      - WORKER_NAME=worker-2
+      - WORKER_ID=2
+    command: nativelink /nativelink-config.json5
+    depends_on:
+      scheduler:
+        condition: service_healthy
+      juicefs-mount:
+        condition: service_healthy
+    networks:
+      - nativelink-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+
+  # Worker 3 - Uses JuiceFS shared storage
+  worker-3:
+    image: nativelink:latest
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    volumes:
+      - type: volume
+        source: juicefs-mount
+        target: /mnt/jfs
+        volume:
+          nocopy: true
+      - worker3-work:/tmp/worker3
+      - ./worker-juicefs.json5:/nativelink-config.json5
+    environment:
+      - RUST_LOG=info,nativelink=debug
+      - SCHEDULER_ENDPOINT=scheduler
+      - CAS_ENDPOINT=cas-server
+      - WORKER_NAME=worker-3
+      - WORKER_ID=3
+    command: nativelink /nativelink-config.json5
+    depends_on:
+      scheduler:
+        condition: service_healthy
+      juicefs-mount:
+        condition: service_healthy
+    networks:
+      - nativelink-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+
+networks:
+  nativelink-network:
+    driver: bridge
+
+volumes:
+  redis-data:
+    driver: local
+  minio-data:
+    driver: local
+  juicefs-cache:
+    driver: local
+  juicefs-mount:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /tmp/juicefs-mount
+  worker1-work:
+    driver: local
+  worker2-work:
+    driver: local
+  worker3-work:
+    driver: local

--- a/deployment-examples/docker-compose/setup-juicefs.sh
+++ b/deployment-examples/docker-compose/setup-juicefs.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# NativeLink JuiceFS Multi-Worker Setup Script
+# This script sets up a complete NativeLink deployment with JuiceFS shared storage
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+COMPOSE_FILE="docker-compose-juicefs.yml"
+WORKER_COUNT=3
+JUICEFS_MOUNT_DIR="/tmp/juicefs-mount"
+
+echo -e "${GREEN}==================================${NC}"
+echo -e "${GREEN}NativeLink JuiceFS Setup${NC}"
+echo -e "${GREEN}==================================${NC}"
+echo ""
+
+# Check prerequisites
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Error: Docker is not installed${NC}"
+    echo "Please install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+    echo -e "${RED}Error: Docker Compose is not installed${NC}"
+    echo "Please install Docker Compose: https://docs.docker.com/compose/install/"
+    exit 1
+fi
+
+# Detect which docker compose command to use
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
+echo -e "${GREEN}✓ Docker installed${NC}"
+echo -e "${GREEN}✓ Docker Compose installed (using: $DOCKER_COMPOSE)${NC}"
+echo ""
+
+# Create JuiceFS mount directory
+echo -e "${YELLOW}Creating JuiceFS mount directory...${NC}"
+mkdir -p "$JUICEFS_MOUNT_DIR"
+echo -e "${GREEN}✓ Created $JUICEFS_MOUNT_DIR${NC}"
+echo ""
+
+# Build NativeLink image
+echo -e "${YELLOW}Building NativeLink image...${NC}"
+if $DOCKER_COMPOSE -f "$COMPOSE_FILE" build; then
+    echo -e "${GREEN}✓ NativeLink image built successfully${NC}"
+else
+    echo -e "${RED}✗ Failed to build NativeLink image${NC}"
+    exit 1
+fi
+echo ""
+
+# Start services
+echo -e "${YELLOW}Starting services...${NC}"
+echo "  - Redis (JuiceFS metadata)"
+echo "  - MinIO (Object storage)"
+echo "  - JuiceFS mount"
+echo "  - CAS server"
+echo "  - Scheduler"
+echo "  - Workers (x${WORKER_COUNT})"
+echo ""
+
+if $DOCKER_COMPOSE -f "$COMPOSE_FILE" up -d; then
+    echo -e "${GREEN}✓ All services started${NC}"
+else
+    echo -e "${RED}✗ Failed to start services${NC}"
+    exit 1
+fi
+echo ""
+
+# Wait for services to be healthy
+echo -e "${YELLOW}Waiting for services to be healthy...${NC}"
+
+wait_for_service() {
+    local service=$1
+    local max_attempts=30
+    local attempt=0
+
+    while [ $attempt -lt $max_attempts ]; do
+        if $DOCKER_COMPOSE -f "$COMPOSE_FILE" ps "$service" | grep -q "healthy"; then
+            echo -e "${GREEN}✓ $service is healthy${NC}"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        echo -n "."
+        sleep 2
+    done
+
+    echo -e "${RED}✗ $service did not become healthy${NC}"
+    return 1
+}
+
+echo -n "Redis: "
+wait_for_service redis
+
+echo -n "MinIO: "
+wait_for_service minio
+
+echo -n "JuiceFS: "
+wait_for_service juicefs-mount
+
+echo -n "CAS Server: "
+wait_for_service cas-server
+
+echo -n "Scheduler: "
+wait_for_service scheduler
+
+echo ""
+
+# Verify JuiceFS mount
+echo -e "${YELLOW}Verifying JuiceFS mount...${NC}"
+if docker exec nativelink-juicefs-mount-1 sh -c "[ -d /mnt/jfs/.stats ]" 2> /dev/null; then
+    echo -e "${GREEN}✓ JuiceFS mounted successfully${NC}"
+else
+    echo -e "${RED}✗ JuiceFS mount verification failed${NC}"
+    echo "Check logs: $DOCKER_COMPOSE -f $COMPOSE_FILE logs juicefs-mount"
+    exit 1
+fi
+echo ""
+
+# Show JuiceFS status
+echo -e "${YELLOW}JuiceFS Status:${NC}"
+docker exec nativelink-juicefs-mount-1 juicefs status redis://redis:6379/1
+echo ""
+
+# Check worker status
+echo -e "${YELLOW}Checking workers...${NC}"
+for i in $(seq 1 $WORKER_COUNT); do
+    if $DOCKER_COMPOSE -f "$COMPOSE_FILE" ps "worker-$i" | grep -q "Up"; then
+        echo -e "${GREEN}✓ worker-$i is running${NC}"
+    else
+        echo -e "${RED}✗ worker-$i is not running${NC}"
+    fi
+done
+echo ""
+
+# Display service endpoints
+echo -e "${GREEN}==================================${NC}"
+echo -e "${GREEN}Deployment Complete!${NC}"
+echo -e "${GREEN}==================================${NC}"
+echo ""
+echo "Service Endpoints:"
+echo "  - CAS Server (gRPC):     grpc://localhost:50051"
+echo "  - Scheduler (gRPC):      grpc://localhost:50052"
+echo "  - Worker API (gRPC):     grpc://localhost:50061"
+echo "  - MinIO Console:         http://localhost:9001"
+echo "  - Redis:                 redis://localhost:6379"
+echo ""
+echo "Useful Commands:"
+echo "  - View logs:             $DOCKER_COMPOSE -f $COMPOSE_FILE logs -f"
+echo "  - View worker logs:      $DOCKER_COMPOSE -f $COMPOSE_FILE logs -f worker-1"
+echo "  - Check JuiceFS status:  docker exec nativelink-juicefs-mount-1 juicefs status redis://redis:6379/1"
+echo "  - Scale workers:         $DOCKER_COMPOSE -f $COMPOSE_FILE up -d --scale worker-1=5"
+echo "  - Stop all services:     $DOCKER_COMPOSE -f $COMPOSE_FILE down"
+echo "  - Clean volumes:         $DOCKER_COMPOSE -f $COMPOSE_FILE down -v"
+echo ""
+echo "Test the setup with Bazel:"
+cat << 'EOF'
+  bazel build \
+    --remote_cache=grpc://localhost:50051 \
+    --remote_executor=grpc://localhost:50052 \
+    //your:target
+EOF
+echo ""
+echo -e "${GREEN}Happy building! 🚀${NC}"

--- a/deployment-examples/docker-compose/worker-juicefs.json5
+++ b/deployment-examples/docker-compose/worker-juicefs.json5
@@ -1,0 +1,128 @@
+{
+  // Worker configuration for JuiceFS-backed shared CAS
+  // This configuration uses a JuiceFS mount at /mnt/jfs for shared CAS storage
+  // All workers share the same CAS, enabling efficient artifact sharing
+  stores: [
+    {
+      name: "JUICEFS_SHARED_CAS",
+
+      // JuiceFS-backed filesystem store
+      // All workers mount the same JuiceFS volume, providing truly shared CAS
+      filesystem: {
+        content_path: "/mnt/jfs/cas/content",
+        temp_path: "/tmp/${WORKER_NAME}/cas-temp",
+        eviction_policy: {
+          // 100GB shared across all workers via JuiceFS
+          // JuiceFS handles distributed caching automatically
+          max_bytes: 100000000000,
+        },
+
+        // Larger read buffer for distributed filesystem
+        read_buffer_size: 65536,
+      },
+    },
+    {
+      name: "LOCAL_AC_STORE",
+
+      // Action Cache uses local memory for fast lookups
+      // Each worker has its own AC cache
+      memory: {
+        eviction_policy: {
+          max_bytes: 1000000000, // 1GB
+        },
+      },
+    },
+    {
+      name: "GRPC_CAS_BACKUP",
+
+      // Backup GRPC store for CAS server
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
+        ],
+        store_type: "cas",
+      },
+    },
+    {
+      name: "GRPC_AC_STORE",
+
+      // GRPC store for Action Cache
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpc://${CAS_ENDPOINT:-127.0.0.1}:50051",
+          },
+        ],
+        store_type: "ac",
+      },
+    },
+    {
+      name: "FAST_SLOW_CAS",
+
+      // Fast-slow pattern: Local JuiceFS cache (fast) + GRPC backup (slow)
+      fast_slow: {
+        fast: {
+          ref_store: {
+            name: "JUICEFS_SHARED_CAS",
+          },
+        },
+        slow: {
+          ref_store: {
+            name: "GRPC_CAS_BACKUP",
+          },
+        },
+      },
+    },
+  ],
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://${SCHEDULER_ENDPOINT:-127.0.0.1}:50061",
+        },
+
+        // Use fast-slow CAS with JuiceFS as fast tier
+        cas_fast_slow_store: "FAST_SLOW_CAS",
+        upload_action_result: {
+          // Upload results to GRPC AC store
+          ac_store: "GRPC_AC_STORE",
+        },
+
+        // Worker-specific work directory (not shared)
+        work_directory: "/tmp/${WORKER_NAME}/work",
+        platform_properties: {
+          cpu_count: {
+            query_cmd: "nproc",
+          },
+          OSFamily: {
+            values: [
+              "linux",
+            ],
+          },
+          "container-image": {
+            values: [
+              "docker://alpine@sha256:...",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+
+          // JuiceFS-specific property to identify workers with shared storage
+          storage_type: {
+            values: [
+              "juicefs",
+            ],
+          },
+        },
+      },
+    },
+  ],
+  servers: [],
+}

--- a/deployment-examples/juicefs-native-setup.sh
+++ b/deployment-examples/juicefs-native-setup.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Native JuiceFS Setup for NativeLink Multi-Worker
+# This script sets up JuiceFS WITHOUT Docker
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}NativeLink JuiceFS Native Setup${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+
+# Configuration
+JUICEFS_MOUNT_POINT="/tmp/nativelink-jfs"
+
+# Step 1: Install JuiceFS
+echo -e "${YELLOW}Step 1: Installing JuiceFS...${NC}"
+if command -v juicefs &> /dev/null; then
+    echo -e "${GREEN}✓ JuiceFS already installed${NC}"
+    juicefs version
+else
+    echo "Installing JuiceFS..."
+    curl -sSL https://d.juicefs.com/install | sh -
+    if command -v juicefs &> /dev/null; then
+        echo -e "${GREEN}✓ JuiceFS installed successfully${NC}"
+        juicefs version
+    else
+        echo -e "${RED}✗ Failed to install JuiceFS${NC}"
+        exit 1
+    fi
+fi
+echo ""
+
+# Step 2: Check for Redis
+echo -e "${YELLOW}Step 2: Checking Redis...${NC}"
+if command -v redis-server &> /dev/null; then
+    echo -e "${GREEN}✓ Redis is installed${NC}"
+    # Check if Redis is running
+    if redis-cli ping &> /dev/null; then
+        echo -e "${GREEN}✓ Redis is running${NC}"
+    else
+        echo -e "${YELLOW}⚠ Redis is not running. Starting Redis...${NC}"
+        echo "You can start Redis with: redis-server --daemonize yes"
+        echo "Or install via: brew install redis (macOS) / apt-get install redis (Linux)"
+    fi
+else
+    echo -e "${YELLOW}⚠ Redis not found${NC}"
+    echo "Install Redis:"
+    echo "  macOS: brew install redis && brew services start redis"
+    echo "  Linux: sudo apt-get install redis-server && sudo systemctl start redis"
+    echo ""
+    echo "Or use Docker for just Redis and MinIO:"
+    echo "  docker run -d --name redis -p 6379:6379 redis:7-alpine"
+fi
+echo ""
+
+# Step 3: Check for MinIO (or use S3)
+echo -e "${YELLOW}Step 3: Object Storage Setup...${NC}"
+echo "You have two options:"
+echo "  1. Use MinIO locally (requires Docker or binary)"
+echo "  2. Use AWS S3 (requires AWS credentials)"
+echo ""
+echo "For MinIO with Docker:"
+cat << 'EOF'
+  docker run -d --name minio \
+    -p 9000:9000 -p 9001:9001 \
+    -v /tmp/minio-data:/data \
+    -e MINIO_ROOT_USER=minioadmin \
+    -e MINIO_ROOT_PASSWORD=minioadmin \
+    minio/minio server /data --console-address ':9001'
+
+  # Create bucket:
+  docker run --rm --network host minio/mc \
+    mc alias set local http://localhost:9000 minioadmin minioadmin && \
+    mc mb local/nativelink-cas
+EOF
+echo ""
+
+# Step 4: Format JuiceFS
+echo -e "${YELLOW}Step 4: Format JuiceFS filesystem...${NC}"
+echo ""
+read -r -p "Enter Redis URL (default: redis://localhost:6379/1): " REDIS_URL
+REDIS_URL=${REDIS_URL:-redis://localhost:6379/1}
+
+read -r -p "Enter storage type (minio/s3) (default: minio): " STORAGE_TYPE
+STORAGE_TYPE=${STORAGE_TYPE:-minio}
+
+if [ "$STORAGE_TYPE" = "minio" ]; then
+    read -r -p "Enter MinIO endpoint (default: http://localhost:9000): " MINIO_ENDPOINT
+    MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://localhost:9000}
+
+    read -r -p "Enter MinIO access key (default: minioadmin): " MINIO_ACCESS_KEY
+    MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
+
+    read -r -p "Enter MinIO secret key (default: minioadmin): " MINIO_SECRET_KEY
+    MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
+
+    BUCKET="${MINIO_ENDPOINT}/nativelink-cas"
+
+    echo ""
+    echo "Formatting JuiceFS with MinIO backend..."
+    juicefs format \
+        --storage minio \
+        --bucket "$BUCKET" \
+        --access-key "$MINIO_ACCESS_KEY" \
+        --secret-key "$MINIO_SECRET_KEY" \
+        "$REDIS_URL" \
+        nativelink-cas || echo -e "${YELLOW}⚠ Filesystem may already be formatted${NC}"
+else
+    read -r -p "Enter S3 bucket (s3://your-bucket): " S3_BUCKET
+    read -r -p "Enter AWS access key: " AWS_ACCESS_KEY
+    read -r -p "Enter AWS secret key: " AWS_SECRET_KEY
+
+    echo ""
+    echo "Formatting JuiceFS with S3 backend..."
+    juicefs format \
+        --storage s3 \
+        --bucket "$S3_BUCKET" \
+        --access-key "$AWS_ACCESS_KEY" \
+        --secret-key "$AWS_SECRET_KEY" \
+        "$REDIS_URL" \
+        nativelink-cas || echo -e "${YELLOW}⚠ Filesystem may already be formatted${NC}"
+fi
+echo ""
+
+# Step 5: Create mount point
+echo -e "${YELLOW}Step 5: Creating mount point...${NC}"
+mkdir -p "$JUICEFS_MOUNT_POINT"
+mkdir -p /var/jfsCache
+echo -e "${GREEN}✓ Mount point created: $JUICEFS_MOUNT_POINT${NC}"
+echo ""
+
+# Step 6: Mount JuiceFS
+echo -e "${YELLOW}Step 6: Mounting JuiceFS...${NC}"
+if mountpoint -q "$JUICEFS_MOUNT_POINT" 2> /dev/null; then
+    echo -e "${GREEN}✓ JuiceFS already mounted at $JUICEFS_MOUNT_POINT${NC}"
+else
+    echo "Mounting JuiceFS with optimized settings..."
+    juicefs mount \
+        --cache-dir /var/jfsCache \
+        --cache-size 10240 \
+        --writeback \
+        --max-uploads 20 \
+        --max-deletes 10 \
+        --buffer-size 300 \
+        --prefetch 3 \
+        --background \
+        "$REDIS_URL" \
+        "$JUICEFS_MOUNT_POINT"
+
+    sleep 2
+    if mountpoint -q "$JUICEFS_MOUNT_POINT" 2> /dev/null || [ -d "$JUICEFS_MOUNT_POINT/.stats" ]; then
+        echo -e "${GREEN}✓ JuiceFS mounted successfully${NC}"
+    else
+        echo -e "${RED}✗ Failed to mount JuiceFS${NC}"
+        exit 1
+    fi
+fi
+echo ""
+
+# Step 7: Create CAS directory structure
+echo -e "${YELLOW}Step 7: Creating CAS directory structure...${NC}"
+mkdir -p "$JUICEFS_MOUNT_POINT/cas/content"
+mkdir -p "$JUICEFS_MOUNT_POINT/cas/temp"
+echo -e "${GREEN}✓ Directory structure created${NC}"
+echo ""
+
+# Step 8: Display status
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Setup Complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "JuiceFS Mount Point: $JUICEFS_MOUNT_POINT"
+echo "JuiceFS Status:"
+juicefs status "$REDIS_URL"
+echo ""
+echo "Directory Structure:"
+ls -la "$JUICEFS_MOUNT_POINT/cas/"
+echo ""
+echo -e "${YELLOW}Next Steps:${NC}"
+echo ""
+echo "1. Update your NativeLink worker configuration to use:"
+echo "   content_path: \"$JUICEFS_MOUNT_POINT/cas/content\""
+echo ""
+echo "2. Start NativeLink workers:"
+echo "   ./nativelink /path/to/worker-config.json5"
+echo ""
+echo "3. Monitor JuiceFS:"
+echo "   juicefs stats $JUICEFS_MOUNT_POINT"
+echo ""
+echo "4. Unmount when done:"
+echo "   juicefs umount $JUICEFS_MOUNT_POINT"
+echo ""
+echo -e "${GREEN}Happy building! 🚀${NC}"


### PR DESCRIPTION
# Description

There are limitations to a distributed system where a cluster of workers are independently working through the same queue of tasks. This configuration will enable workers in a cluster to have immediate visibility into updates to the CAS. Worker 1 can upload digest 59859858y5, and Workers 2-100 can immediately read it immediately.

There have been some interesting race conditions and other related issues with the filesystem that have come up recently (https://github.com/TraceMachina/nativelink/issues/1863, https://github.com/TraceMachina/nativelink/issues/1928, https://github.com/TraceMachina/nativelink/issues/1931, https://github.com/TraceMachina/nativelink/issues/1934, etc.). The list is much longer in reality because this was always an issue.

Fixes #1949 

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
