### PR TITLE
Add metadata checks to machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,6 @@ dependencies = [
  "tokio-util",
  "tonic 0.13.1",
  "tracing",
- "tracing-subscriber",
  "tracing-test",
  "uuid",
 ]
@@ -2820,7 +2819,6 @@ dependencies = [
  "formatx",
  "futures",
  "hyper 1.7.0",
- "hyper-util",
  "nativelink-config",
  "nativelink-error",
  "nativelink-macro",

--- a/nativelink-config/tests/deserialization_test.rs
+++ b/nativelink-config/tests/deserialization_test.rs
@@ -46,6 +46,8 @@ struct OptionalStringEntity {
 }
 
 mod duration_tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]
@@ -130,6 +132,8 @@ mod duration_tests {
 }
 
 mod data_size_tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]
@@ -218,6 +222,8 @@ mod data_size_tests {
 }
 
 mod optional_values_tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]
@@ -326,6 +332,8 @@ mod optional_values_tests {
 }
 
 mod shellexpand_tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -16,3 +16,7 @@ tonic = { version = "0.13.0", features = ["codegen", "prost", "transport", "tls-
 [dev-dependencies]
 prost-build = { version = "0.13.5", default-features = false }
 tonic-build = { version = "0.13.0", features = ["prost"], default-features = false }
+
+[package.metadata.cargo-machete]
+# Used by gen_protos_tool.rs
+ignored = ["prost-build", "tonic-build"]

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -62,3 +62,7 @@ pretty_assertions = { version = "1.4.1", features = ["std"] }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }
+
+[package.metadata.cargo-machete]
+# Used by nativelink_test macro
+ignored = ["tracing-test"]

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -72,3 +72,7 @@ sha2 = { version = "0.10.8", default-features = false }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }
+
+[package.metadata.cargo-machete]
+# Used by nativelink_test macro
+ignored = ["tracing-test"]

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -159,7 +159,6 @@ rust_test_suite(
         "@crates//:tokio",
         "@crates//:tokio-stream",
         "@crates//:tracing",
-        "@crates//:tracing-subscriber",
         "@crates//:tracing-test",
         "@crates//:uuid",
     ],
@@ -185,7 +184,6 @@ rust_test(
         "@crates//:rand",
         "@crates//:serde_json",
         "@crates//:sha2",
-        "@crates//:tracing-subscriber",
     ],
 )
 

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -133,7 +133,10 @@ rand = { version = "0.9.0", default-features = false, features = [
 ] }
 serde_json = "1.0.140"
 tempfile = { version = "3.8.1", default-features = false }
-tracing-subscriber = { version = "0.3.19", default-features = false }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }
+
+[package.metadata.cargo-machete]
+# Used by nativelink_test macro
+ignored = ["tracing-test"]

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -97,3 +97,7 @@ serde_json = { version = "1.0.140", default-features = false }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }
+
+[package.metadata.cargo-machete]
+# Used by nativelink_test macro
+ignored = ["tracing-test"]

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -95,7 +95,6 @@ rust_test(
     ],
     deps = [
         "@crates//:hyper",
-        "@crates//:hyper-util",
         "@crates//:pretty_assertions",
         "@crates//:prost-types",
         "@crates//:rand",

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -54,7 +54,6 @@ uuid = { version = "1.16.0", default-features = false, features = [
 nativelink-macro = { path = "../nativelink-macro" }
 
 hyper = "1.6.0"
-hyper-util = "0.1.11"
 pretty_assertions = { version = "1.4.1", features = ["std"] }
 prost-types = { version = "0.13.5", default-features = false }
 rand = { version = "0.9.0", default-features = false, features = [
@@ -66,3 +65,7 @@ serial_test = { version = "3.2.0", features = [
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }
+
+[package.metadata.cargo-machete]
+# Used by nativelink_test macro
+ignored = ["tracing-test"]

--- a/tools/pre-commit-hooks.nix
+++ b/tools/pre-commit-hooks.nix
@@ -217,7 +217,7 @@ in {
     description = "Detect unused cargo deps";
     enable = true;
     entry = "${pkgs.cargo-machete}/bin/cargo-machete";
-    args = ["."];
+    args = ["--with-metadata" "."];
     pass_filenames = false;
   };
 


### PR DESCRIPTION
# Description

https://github.com/TraceMachina/nativelink/pull/1839 removed a bunch of packages, but there was still some false positives. I've enabled the `--with-metadata` mode for Machete, which is a bit slower, but picks up some extra cases of unused packages which this PR fixes.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1952)
<!-- Reviewable:end -->
