### PR TITLE
Fix config parse control flow

### DIFF
--- a/nativelink-config/src/backcompat.rs
+++ b/nativelink-config/src/backcompat.rs
@@ -65,8 +65,8 @@ where
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum ByteStreamKind {
-    Old(OldByteStreamConfig),
     New(Vec<WithInstanceName<ByteStreamConfig>>),
+    Old(OldByteStreamConfig),
 }
 
 /// Use `#[serde(default, deserialize_with = "backcompat::opt_bytestream")]` for backwards


### PR DESCRIPTION
# Description

Existing config examples were breaking with "some_store": "some_value" does not exist errors, even though configured correctly. 

In the `ByteStreamKind` enum `nativelink-config/src/backcompat.rs` the old variant was listed before the new variant. Serde's untagged enum deserialization tries variants in order. When it encountered, say:

```json5
bytestream: [
    {
      instance_name: "main",
      cas_store: "WORKER_FAST_SLOW_STORE",
    },
  ]
```
from basic_cas.json5 it would incorrectly match the old variant first, deserializing the object as a HashMap<String, String> where:

  - Key: "instance_name" → Value: "main"
  - Key: "cas_store" → Value: "WORKER_FAST_SLOW_STORE"

Then the backcompat code swapped these, trying to use "main" as the store name (instead of as the instance name), causing the "store not found" error.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1957)
<!-- Reviewable:end -->
