### PR TITLE
Fix Redis subscribe race

### DIFF
--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -216,15 +216,9 @@ impl ExecutionServer {
                 match action_listener.changed().await {
                     Ok((action_update, _maybe_origin_metadata)) => {
                         debug!(?action_update, "Execute Resp Stream");
-                        // If the action is finished we won't be sending any more updates.
-                        let maybe_action_listener = if action_update.stage.is_finished() {
-                            None
-                        } else {
-                            Some(action_listener)
-                        };
                         Some((
                             Ok(action_update.as_operation(client_operation_id)),
-                            maybe_action_listener,
+                            (!action_update.stage.is_finished()).then_some(action_listener),
                         ))
                     }
                     Err(err) => {

--- a/nativelink-store/src/mongo_store.rs
+++ b/nativelink-store/src/mongo_store.rs
@@ -837,6 +837,10 @@ impl SchedulerSubscriptionManager for ExperimentalMongoSubscriptionManager {
 
         Ok(subscription)
     }
+
+    fn is_reliable() -> bool {
+        true
+    }
 }
 
 impl SchedulerStore for ExperimentalMongoStore {

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1038,6 +1038,10 @@ impl SchedulerSubscriptionManager for RedisSubscriptionManager {
 
         Ok(subscription)
     }
+
+    fn is_reliable() -> bool {
+        false
+    }
 }
 
 impl SchedulerStore for RedisStore {

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -867,6 +867,8 @@ pub trait SchedulerSubscriptionManager: Send + Sync {
     fn subscribe<K>(&self, key: K) -> Result<Self::Subscription, Error>
     where
         K: SchedulerStoreKeyProvider;
+
+    fn is_reliable() -> bool;
 }
 
 /// The API surface for a scheduler store.


### PR DESCRIPTION
# Description

When subscribing to an existing action with the Redis state store the subscription to changes is not performed until the call to changed(), however this introduces a race where the state could change between the call and the subscription.  This doesn't exist in the in-memory store since it sets up a channel immediately.

To resolve this, pull the action state immediately after subscribing to it and publish it if it's not a boring state (i.e. Queued).

Also, Redis pub-sub is not reliable.  Currently we poll the state for client updates anyway, so we can add a simple cache to ensure that we don't miss updates which is slightly more delayed than the pub-sub but actually reliable.  Since this is not necessary for MongoDB as it is reliable, a trait function is added to ensure that this is only performed when necessary.

Fixes #1960

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested yet, but this certainly appears to be a valid race condition that is now resolved.  It shouldn't be an issue to send a single extra state response even if it doesn't resolve the issue.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1970)
<!-- Reviewable:end -->
