### PR TITLE
Drop MacOS 14 support

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -78,7 +78,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-14
           - macos-15
     name: Installation / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Description

Doing build steps on a Mac at all is useful, duplicating it on two different OS versions just chews up time waiting for builds. We haven't seen a failure on just one of them for some time.

## Type of change

Please delete options that aren't relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)

Note this doesn't _remove_ MacOS 14 support, just means we're not testing it anymore.

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1973)
<!-- Reviewable:end -->
