### PR TITLE
Add cache to native-cargo step

### DIFF
--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -41,6 +41,9 @@ jobs:
         run: rustup update && rustup default ${{ matrix.toolchain }}
         shell: bash
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Build on ${{ runner.os }}
         run: cargo build --all --profile=smol
 


### PR DESCRIPTION
# Description

The native cargo step (especially the Windows variant) is starting to be our slowest build step, mainly because it does everything from scratch. This PR adds caching to that step, reducing build times by ~50%

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Previously:
- [Windows](https://github.com/TraceMachina/nativelink/actions/runs/18472312246/job/52647220827) ~23 minutes
- [Linux](https://github.com/TraceMachina/nativelink/actions/runs/18472312246/job/52647221040) ~11 minutes

Now:
- [Windows](https://github.com/TraceMachina/nativelink/actions/runs/18490938883/job/52684174419) ~9 minutes
- [Linux](https://github.com/TraceMachina/nativelink/actions/runs/18490938883/job/52684174417) ~5 minutes

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1974)
<!-- Reviewable:end -->
