### PR TITLE
Notify execution complete

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -57,6 +57,9 @@ service WorkerApi {
 
     /// Informs the scheduler about the result of an execution request.
     rpc ExecutionResponse(ExecuteResult) returns (google.protobuf.Empty);
+
+    /// Notify that the execution has completed, but result is uploading.
+    rpc ExecutionComplete(ExecuteComplete) returns (google.protobuf.Empty);
 }
 
 /// Request object for keep alive requests.
@@ -121,6 +124,15 @@ message ExecuteResult {
     }
 
     reserved 9; // NextId.
+}
+
+/// The result of an ExecutionComplete.
+message ExecuteComplete {
+    /// ID of the worker making the request.
+    string worker_id = 1;
+
+    /// The operation ID that was executed.
+    string operation_id = 2;
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -86,6 +86,16 @@ pub mod execute_result {
         InternalError(super::super::super::super::super::super::google::rpc::Status),
     }
 }
+/// / The result of an ExecutionComplete.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExecuteComplete {
+    /// / ID of the worker making the request.
+    #[prost(string, tag = "1")]
+    pub worker_id: ::prost::alloc::string::String,
+    /// / The operation ID that was executed.
+    #[prost(string, tag = "2")]
+    pub operation_id: ::prost::alloc::string::String,
+}
 /// / Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionResult {
@@ -388,6 +398,33 @@ pub mod worker_api_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// / Notify that the execution has completed, but result is uploading.
+        pub async fn execution_complete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ExecuteComplete>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "com.github.trace_machina.nativelink.remote_execution.WorkerApi",
+                        "ExecutionComplete",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -448,6 +485,11 @@ pub mod worker_api_server {
         async fn execution_response(
             &self,
             request: tonic::Request<super::ExecuteResult>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
+        /// / Notify that the execution has completed, but result is uploading.
+        async fn execution_complete(
+            &self,
+            request: tonic::Request<super::ExecuteComplete>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
     }
     /// / This API describes how schedulers communicate with Worker nodes.
@@ -697,6 +739,51 @@ pub mod worker_api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ExecutionResponseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/com.github.trace_machina.nativelink.remote_execution.WorkerApi/ExecutionComplete" => {
+                    #[allow(non_camel_case_types)]
+                    struct ExecutionCompleteSvc<T: WorkerApi>(pub Arc<T>);
+                    impl<
+                        T: WorkerApi,
+                    > tonic::server::UnaryService<super::ExecuteComplete>
+                    for ExecutionCompleteSvc<T> {
+                        type Response = ();
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ExecuteComplete>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as WorkerApi>::execution_complete(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ExecutionCompleteSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -259,6 +259,12 @@ impl ApiWorkerSchedulerImpl {
                 (true, err.code == Code::ResourceExhausted)
             }
             UpdateOperationType::UpdateWithDisconnect => (true, false),
+            UpdateOperationType::ExecutionComplete => {
+                // No update here, just restoring platform properties.
+                worker.execution_complete(operation_id);
+                self.worker_change_notify.notify_one();
+                return Ok(());
+            }
         };
 
         // Update the operation in the worker state manager.

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -629,6 +629,11 @@ where
                     }
                 }
                 UpdateOperationType::UpdateWithDisconnect => ActionStage::Queued,
+                // We shouldn't get here, but we just ignore it if we do.
+                UpdateOperationType::ExecutionComplete => {
+                    warn!("inner_update_operation got an ExecutionComplete, that's unexpected.");
+                    return Ok(());
+                }
             };
             let now = (self.now_fn)().now();
             if matches!(stage, ActionStage::Queued) {

--- a/nativelink-util/src/operation_state_manager.rs
+++ b/nativelink-util/src/operation_state_manager.rs
@@ -140,6 +140,9 @@ pub enum UpdateOperationType {
 
     /// Notification that the worker disconnected.
     UpdateWithDisconnect,
+
+    /// Notification that the execution stage has completed and it's just IO happening now.
+    ExecutionComplete,
 }
 
 #[async_trait]

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -28,7 +28,8 @@ use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker, execute_result,
+    ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    execute_result,
 };
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_util::action_messages::{ActionResult, ActionStage, OperationId};
@@ -69,7 +70,7 @@ const DEFAULT_ENDPOINT_TIMEOUT_S: f32 = 5.;
 /// If this value gets modified the documentation in `cas_server.rs` must also be updated.
 const DEFAULT_MAX_ACTION_TIMEOUT: Duration = Duration::from_secs(1200); // 20 mins.
 
-struct LocalWorkerImpl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> {
+struct LocalWorkerImpl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> {
     config: &'a LocalWorkerConfig,
     // According to the tonic documentation it is a cheap operation to clone this.
     grpc_client: T,
@@ -115,7 +116,7 @@ async fn preconditions_met(precondition_script: Option<String>) -> Result<(), Er
     }
 }
 
-impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, T, U> {
+impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorkerImpl<'a, T, U> {
     fn new(
         config: &'a LocalWorkerConfig,
         grpc_client: T,
@@ -262,6 +263,11 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                                 let actions_in_transit = self.actions_in_transit.clone();
                                 let worker_id = self.worker_id.clone();
                                 let running_actions_manager = self.running_actions_manager.clone();
+                                let mut grpc_client = self.grpc_client.clone();
+                                let complete = ExecuteComplete {
+                                    worker_id: worker_id.clone(),
+                                    operation_id: operation_id.clone(),
+                                };
                                 self.metrics.clone().wrap(move |metrics| async move {
                                     metrics.preconditions.wrap(preconditions_met(precondition_script_cfg))
                                     .and_then(|()| running_actions_manager.create_and_add_action(worker_id, start_execute))
@@ -280,6 +286,11 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
                                             .clone()
                                             .prepare_action()
                                             .and_then(RunningAction::execute)
+                                            .and_then(|result| async move {
+                                                // Notify that execution has completed so it can schedule a new action.
+                                                drop(grpc_client.execution_complete(complete).await);
+                                                Ok(result)
+                                            })
                                             .and_then(RunningAction::upload_results)
                                             .and_then(RunningAction::get_finished_result)
                                             // Note: We need ensure we run cleanup even if one of the other steps fail.
@@ -421,7 +432,7 @@ impl<'a, T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorkerImpl<'a, 
 
 type ConnectionFactory<T> = Box<dyn Fn() -> BoxFuture<'static, Result<T, Error>> + Send + Sync>;
 
-pub struct LocalWorker<T: WorkerApiClientTrait, U: RunningActionsManager> {
+pub struct LocalWorker<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> {
     config: Arc<LocalWorkerConfig>,
     running_actions_manager: Arc<U>,
     connection_factory: ConnectionFactory<T>,
@@ -429,8 +440,10 @@ pub struct LocalWorker<T: WorkerApiClientTrait, U: RunningActionsManager> {
     metrics: Arc<Metrics>,
 }
 
-impl<T: WorkerApiClientTrait + core::fmt::Debug, U: RunningActionsManager + core::fmt::Debug>
-    core::fmt::Debug for LocalWorker<T, U>
+impl<
+    T: WorkerApiClientTrait + core::fmt::Debug + 'static,
+    U: RunningActionsManager + core::fmt::Debug,
+> core::fmt::Debug for LocalWorker<T, U>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("LocalWorker")
@@ -535,7 +548,7 @@ pub async fn new_local_worker(
     Ok(local_worker)
 }
 
-impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
+impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T, U> {
     pub fn new_with_connection_factory_and_actions_manager(
         config: Arc<LocalWorkerConfig>,
         running_actions_manager: Arc<U>,

--- a/nativelink-worker/src/worker_api_client_wrapper.rs
+++ b/nativelink-worker/src/worker_api_client_wrapper.rs
@@ -16,7 +16,8 @@ use core::future::Future;
 
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::worker_api_client::WorkerApiClient;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
+    UpdateForWorker,
 };
 use tonic::codec::Streaming;
 use tonic::transport::Channel;
@@ -43,6 +44,11 @@ pub trait WorkerApiClientTrait: Clone + Sync + Send + Sized + Unpin {
     fn execution_response(
         &mut self,
         request: ExecuteResult,
+    ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
+
+    fn execution_complete(
+        &mut self,
+        request: ExecuteComplete,
     ) -> impl Future<Output = Result<Response<()>, Status>> + Send;
 }
 
@@ -75,5 +81,12 @@ impl WorkerApiClientTrait for WorkerApiClientWrapper {
 
     async fn execution_response(&mut self, request: ExecuteResult) -> Result<Response<()>, Status> {
         self.inner.execution_response(request).await
+    }
+
+    async fn execution_complete(
+        &mut self,
+        request: ExecuteComplete,
+    ) -> Result<Response<()>, Status> {
+        self.inner.execution_complete(request).await
     }
 }

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -21,7 +21,8 @@ use hyper::body::Frame;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_error::Error;
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ConnectWorkerRequest, ExecuteResult, GoingAwayRequest, KeepAliveRequest, UpdateForWorker,
+    ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
+    UpdateForWorker,
 };
 use nativelink_util::channel_body_for_tests::ChannelBody;
 use nativelink_util::shutdown_guard::ShutdownGuard;
@@ -180,6 +181,13 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
                 panic!("execution_response expected ExecutionResponse response, received {resp:?}")
             }
         }
+    }
+
+    async fn execution_complete(
+        &mut self,
+        _request: ExecuteComplete,
+    ) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
     }
 }
 


### PR DESCRIPTION
# Description

When execution is complete, there's a large amount of IO still to be done.  In the mean time a new action could be starting.

Previously an attempt to implement this was quite complex and caused panics.  In this implementation a very simple mechanism is used which only executes on success and keeps track of which operations have been notified on the scheduler.  This massively simplifies things.

Fixes #1903

## Type of change

Please delete options that aren't relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran up on my test cluster and it was running at 100% constantly.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1975)
<!-- Reviewable:end -->
