### PR TITLE
Adds testing to bytestream backwards compatibility

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -176,7 +176,12 @@ pub struct PushConfig {
     pub read_only: bool,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+// From https://github.com/serde-rs/serde/issues/818#issuecomment-287438544
+fn default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == Default::default()
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ByteStreamConfig {
     /// Name of the store in the "stores" configuration.
@@ -188,7 +193,11 @@ pub struct ByteStreamConfig {
     ///
     ///
     /// Default: 64KiB
-    #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
+    #[serde(
+        default,
+        deserialize_with = "convert_data_size_with_shellexpand",
+        skip_serializing_if = "default"
+    )]
     pub max_bytes_per_stream: usize,
 
     /// In the event a client disconnects while uploading a blob, we will hold
@@ -197,7 +206,11 @@ pub struct ByteStreamConfig {
     /// the same blob.
     ///
     /// Default: 10 (seconds)
-    #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
+    #[serde(
+        default,
+        deserialize_with = "convert_duration_with_shellexpand",
+        skip_serializing_if = "default"
+    )]
     pub persist_stream_on_disconnect_timeout: usize,
 }
 
@@ -208,11 +221,23 @@ pub struct ByteStreamConfig {
 #[serde(deny_unknown_fields)]
 pub struct OldByteStreamConfig {
     pub cas_stores: HashMap<InstanceName, StoreRefName>,
-    #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
+    #[serde(
+        default,
+        deserialize_with = "convert_data_size_with_shellexpand",
+        skip_serializing_if = "default"
+    )]
     pub max_bytes_per_stream: usize,
-    #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
+    #[serde(
+        default,
+        deserialize_with = "convert_data_size_with_shellexpand",
+        skip_serializing_if = "default"
+    )]
     pub max_decoding_message_size: usize,
-    #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
+    #[serde(
+        default,
+        deserialize_with = "convert_duration_with_shellexpand",
+        skip_serializing_if = "default"
+    )]
     pub persist_stream_on_disconnect_timeout: usize,
 }
 


### PR DESCRIPTION
# Description

This PR adds a test case for https://github.com/TraceMachina/nativelink/pull/1957 and also improves the logging when using the old config

Previously you got:
```
// Old:
{
  "cas_stores": {
    "": "WORKER_FAST_SLOW_STORE"
  },
  "max_bytes_per_stream": 0,
  "max_decoding_message_size": 0,
  "persist_stream_on_disconnect_timeout": 0
}
// New:
[
  {
    "instance_name": "",
    "cas_store": "WORKER_FAST_SLOW_STORE",
    "max_bytes_per_stream": 0,
    "persist_stream_on_disconnect_timeout": 0
  }
]
```
Now you get
```
// Old:
{
  "cas_stores": {
    "": "WORKER_FAST_SLOW_STORE"
  }
}
// New:
[
  {
    "instance_name": "",
    "cas_store": "WORKER_FAST_SLOW_STORE"
  }
]
```
(assuming you used the defaults)

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...` with some manual checks as the logging can't be fully checked due to https://github.com/dbrgn/tracing-test/issues/48

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1979)
<!-- Reviewable:end -->
