### PR TITLE
Add Rust test to RBE work

### DIFF
--- a/toolchain-examples/rbe-toolchain-test.nix
+++ b/toolchain-examples/rbe-toolchain-test.nix
@@ -32,7 +32,7 @@ writeShellScriptBin "rbe-toolchain-test" ''
             "test //cpp $LLVM_PLATFORM"
             "test //python"
             "test //go $ZIG_PLATFORM"
-            # "test //rust $ZIG_PLATFORM" # rules_rust isn't RBE-compatible
+            "test //rust $ZIG_PLATFORM"
             "test //java:HelloWorld --config=java"
             "build @curl//... $ZIG_PLATFORM"
             "build @zstd//... $ZIG_PLATFORM"

--- a/web/platform/src/content/docs/docs/rbe/remote-execution-examples.mdx
+++ b/web/platform/src/content/docs/docs/rbe/remote-execution-examples.mdx
@@ -233,22 +233,11 @@ bazel test //go \
 
 ### Rust
 
-:::caution
-This one *shouldn't* work as `rules_rust` doesn't support remote execution.
-If this build passes there is a high chance that you have an hermeticity issue
-in your worker image.
-:::
-
 ```bash
 bazel test //rust \
     --config=zig-cc \
     --remote_cache=grpc://localhost:50051 \
     --remote_executor=grpc://localhost:50051
-
-# Should raise and error like this if your toolchain is correctly hermetic:
-#
-# error: the self-contained linker was requested, but it wasn't found in the
-# target's sysroot, or in rustc's sysroot
 ```
 
 ### Java


### PR DESCRIPTION
# Description

Adds the rust test to the RBE toolchain test. This was previously believed broken, and may well have been the case without the zig config, but seems to work now at this point, so enabling.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

`nix run -L .#rbe-toolchain-with-nativelink-test`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1992)
<!-- Reviewable:end -->
