### PR TITLE
GCS do not upload zero

### DIFF
--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -228,6 +228,15 @@ where
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error> {
+        if is_zero_digest(digest.borrow()) {
+            return reader.recv().await.and_then(|should_be_empty| {
+                should_be_empty
+                    .is_empty()
+                    .then_some(())
+                    .ok_or_else(|| make_err!(Code::Internal, "Zero byte hash not empty"))
+            });
+        }
+
         let object_path = self.make_object_path(&digest);
 
         reader.set_max_recent_data_size(


### PR DESCRIPTION
# Description

We take pains not to attempt to fetch the zero byte digest from the GCS store, so we should avoid uploading it too.  The stdout is usually zero bytes and uploading loads of them causes a lot of 429 errors.

Add a check for the zero byte digest and error if it's not zero bytes.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with my Chromium build.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1995)
<!-- Reviewable:end -->
