### PR TITLE
Unify all the service setups with a macro

### DIFF
--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -145,6 +145,32 @@ impl RoutesExt for Routes {
 /// If this value changes update the documentation in the config definition.
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 
+macro_rules! service_setup {
+    ($v: tt, $http_config: tt) => {{
+        let mut service = $v.into_service();
+        let max_decoding_message_size = if $http_config.max_decoding_message_size == 0 {
+            DEFAULT_MAX_DECODING_MESSAGE_SIZE
+        } else {
+            $http_config.max_decoding_message_size
+        };
+        service = service.max_decoding_message_size(max_decoding_message_size);
+        let send_algo = &$http_config.compression.send_compression_algorithm;
+        if let Some(encoding) = into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None)) {
+            service = service.send_compressed(encoding);
+        }
+        for encoding in $http_config
+            .compression
+            .accepted_compression_algorithms
+            .iter()
+            // Filter None values.
+            .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
+        {
+            service = service.accept_compressed(encoding);
+        }
+        service
+    }};
+}
+
 async fn inner_main(
     cfg: CasConfig,
     shutdown_tx: broadcast::Sender<ShutdownGuard>,
@@ -230,25 +256,8 @@ async fn inner_main(
                 services
                     .ac
                     .map_or(Ok(None), |cfg| {
-                        AcServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        AcServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create AC service")?,
             )
@@ -256,25 +265,8 @@ async fn inner_main(
                 services
                     .cas
                     .map_or(Ok(None), |cfg| {
-                        CasServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        CasServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create CAS service")?,
             )
@@ -282,25 +274,8 @@ async fn inner_main(
                 services
                     .execution
                     .map_or(Ok(None), |cfg| {
-                        ExecutionServer::new(&cfg, &action_schedulers, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        ExecutionServer::new(&cfg, &action_schedulers, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create Execution service")?,
             )
@@ -308,25 +283,8 @@ async fn inner_main(
                 services
                     .fetch
                     .map_or(Ok(None), |cfg| {
-                        FetchServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        FetchServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create Fetch service")?,
             )
@@ -334,25 +292,8 @@ async fn inner_main(
                 services
                     .push
                     .map_or(Ok(None), |cfg| {
-                        PushServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        PushServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create Push service")?,
             )
@@ -360,33 +301,8 @@ async fn inner_main(
                 services
                     .bytestream
                     .map_or(Ok(None), |cfg| {
-                        ByteStreamServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            // TODO(palfrey): generalise this to all the services
-                            let max_decoding_message_size =
-                                if http_config.max_decoding_message_size == 0 {
-                                    DEFAULT_MAX_DECODING_MESSAGE_SIZE
-                                } else {
-                                    http_config.max_decoding_message_size
-                                };
-                            service = service.max_decoding_message_size(max_decoding_message_size);
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        ByteStreamServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create ByteStream service")?,
             )
@@ -395,62 +311,21 @@ async fn inner_main(
                     services
                         .capabilities
                         .as_ref()
-                        // Borrow checker fighting here...
-                        .map(|_| {
-                            CapabilitiesServer::new(
-                                services.capabilities.as_ref().unwrap(),
-                                &action_schedulers,
-                            )
-                        }),
+                        .map(|cfg| CapabilitiesServer::new(cfg, &action_schedulers)),
                 )
                 .await
                 .map_or(Ok::<Option<CapabilitiesServer>, Error>(None), |server| {
                     Ok(Some(server?))
                 })
                 .err_tip(|| "Could not create Capabilities service")?
-                .map(|v| {
-                    let mut service = v.into_service();
-                    let send_algo = &http_config.compression.send_compression_algorithm;
-                    if let Some(encoding) =
-                        into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                    {
-                        service = service.send_compressed(encoding);
-                    }
-                    for encoding in http_config
-                        .compression
-                        .accepted_compression_algorithms
-                        .iter()
-                        // Filter None values.
-                        .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                    {
-                        service = service.accept_compressed(encoding);
-                    }
-                    service
-                }),
+                .map(|v| service_setup!(v, http_config)),
             )
             .add_optional_service(
                 services
                     .worker_api
                     .map_or(Ok(None), |cfg| {
-                        WorkerApiServer::new(&cfg, &worker_schedulers).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        WorkerApiServer::new(&cfg, &worker_schedulers)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create WorkerApi service")?,
             )
@@ -458,25 +333,8 @@ async fn inner_main(
                 services
                     .experimental_bep
                     .map_or(Ok(None), |cfg| {
-                        BepServer::new(&cfg, &store_manager).map(|v| {
-                            let mut service = v.into_service();
-                            let send_algo = &http_config.compression.send_compression_algorithm;
-                            if let Some(encoding) =
-                                into_encoding(send_algo.unwrap_or(HttpCompressionAlgorithm::None))
-                            {
-                                service = service.send_compressed(encoding);
-                            }
-                            for encoding in http_config
-                                .compression
-                                .accepted_compression_algorithms
-                                .iter()
-                                // Filter None values.
-                                .filter_map(|from: &HttpCompressionAlgorithm| into_encoding(*from))
-                            {
-                                service = service.accept_compressed(encoding);
-                            }
-                            Some(service)
-                        })
+                        BepServer::new(&cfg, &store_manager)
+                            .map(|v| Some(service_setup!(v, http_config)))
                     })
                     .err_tip(|| "Could not create BEP service")?,
             );


### PR DESCRIPTION
# Description

The individual services all get setup with the same code, and it looks like the sort of thing you could unify with a function. Except, the functions that are being called have common signatures, but not common traits, because they're all generated by `protoc`. This PR instead unifies them with a macro, which also means everyone now gets the common `max_decoding_message_size` HTTP settings that were previously only applied to bytestream

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1996)
<!-- Reviewable:end -->
