### PR TITLE
fix: #2012 scheduler shutdown not guarded

### DIFF
--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -688,8 +688,8 @@ async fn inner_main(
     // Set up a shutdown handler for the worker schedulers.
     let mut shutdown_rx = shutdown_tx.subscribe();
     root_futures.push(Box::pin(async move {
-        let _ = scheduler_shutdown_tx.send(());
         if let Ok(shutdown_guard) = shutdown_rx.recv().await {
+            let _ = scheduler_shutdown_tx.send(());
             for (_name, scheduler) in worker_schedulers {
                 scheduler.shutdown(shutdown_guard.clone()).await;
             }


### PR DESCRIPTION
# Description

I'm sorry for misplaced the send line during pr, which make the order still not guarded. (>_<)

Fixes #2012

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2015)
<!-- Reviewable:end -->
