### PR TITLE
Log failures to update actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ nixos.bazelrc
 rust-project.json
 darwin.bazelrc
 nativelink.bazelrc
-integration_tests/**/*.log
-toolchain-examples/*.log
+*.log
 buck-out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,7 @@ dependencies = [
  "serde_json5",
  "tokio",
  "tonic 0.13.1",
+ "uuid",
  "walkdir",
 ]
 

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -22,6 +22,7 @@ rust_library(
         "@crates//:serde_json5",
         "@crates//:tokio",
         "@crates//:tonic",
+        "@crates//:uuid",
         "@crates//:walkdir",
     ],
 )

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -31,4 +31,5 @@ tonic = { version = "0.13.0", features = [
   "tls-ring",
   "transport",
 ], default-features = false }
+uuid = { version = "1.16.0", default-features = false }
 walkdir = { version = "2.5.0", default-features = false }

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -283,6 +283,12 @@ impl From<walkdir::Error> for Error {
     }
 }
 
+impl From<uuid::Error> for Error {
+    fn from(value: uuid::Error) -> Self {
+        Self::new(Code::Internal, value.to_string())
+    }
+}
+
 pub trait ResultExt<T> {
     /// # Errors
     ///

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -64,6 +64,7 @@ rust_test_suite(
         "tests/cache_lookup_scheduler_test.rs",
         "tests/property_modifier_scheduler_test.rs",
         "tests/redis_store_awaited_action_db_test.rs",
+        "tests/simple_scheduler_state_manager_test.rs",
         "tests/simple_scheduler_test.rs",
     ],
     compile_data = [

--- a/nativelink-scheduler/src/lib.rs
+++ b/nativelink-scheduler/src/lib.rs
@@ -22,7 +22,7 @@ pub mod mock_scheduler;
 pub mod platform_property_manager;
 pub mod property_modifier_scheduler;
 pub mod simple_scheduler;
-mod simple_scheduler_state_manager;
+pub mod simple_scheduler_state_manager;
 pub mod store_awaited_action_db;
 pub mod worker;
 pub mod worker_scheduler;

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -244,8 +244,8 @@ where
 /// Scheduler state includes the actions that are queued, active, and recently completed.
 /// It also includes the workers that are available to execute actions based on allocation
 /// strategy.
-#[derive(MetricsComponent)]
-pub(crate) struct SimpleSchedulerStateManager<T, I, NowFn>
+#[derive(MetricsComponent, Debug)]
+pub struct SimpleSchedulerStateManager<T, I, NowFn>
 where
     T: AwaitedActionDb,
     I: InstantWrapper,
@@ -293,7 +293,7 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
 {
-    pub(crate) fn new(
+    pub fn new(
         max_job_retries: usize,
         no_event_action_timeout: Duration,
         client_action_timeout: Duration,
@@ -532,6 +532,10 @@ where
                 // No action found. It is ok if the action was not found. It
                 // probably means that the action was dropped, but worker was
                 // still processing it.
+                warn!(
+                    %operation_id,
+                    "Unable to update action due to it being missing, probably dropped"
+                );
                 return Ok(());
             };
 

--- a/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
@@ -1,0 +1,44 @@
+use core::time::Duration;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_scheduler::default_scheduler_factory::memory_awaited_action_db_factory;
+use nativelink_scheduler::simple_scheduler_state_manager::SimpleSchedulerStateManager;
+use nativelink_util::action_messages::{OperationId, WorkerId};
+use nativelink_util::instant_wrapper::MockInstantWrapped;
+use nativelink_util::operation_state_manager::{UpdateOperationType, WorkerStateManager};
+use tokio::sync::Notify;
+
+#[nativelink_test]
+async fn drops_missing_actions() -> Result<(), Error> {
+    let task_change_notify = Arc::new(Notify::new());
+    let awaited_action_db = memory_awaited_action_db_factory(
+        0,
+        &task_change_notify.clone(),
+        MockInstantWrapped::default,
+    );
+    let state_manager = SimpleSchedulerStateManager::new(
+        0,
+        Duration::from_secs(10),
+        Duration::from_secs(10),
+        awaited_action_db,
+        SystemTime::now,
+    );
+    state_manager
+        .update_operation(
+            &OperationId::Uuid(uuid::Uuid::parse_str(
+                "c458c1f4-136e-486d-b9cd-cea07460cde4",
+            )?),
+            &WorkerId::default(),
+            UpdateOperationType::ExecutionComplete,
+        )
+        .await
+        .unwrap();
+
+    assert!(logs_contain(
+        "Unable to update action due to it being missing, probably dropped operation_id=c458c1f4-136e-486d-b9cd-cea07460cde4"
+    ));
+    Ok(())
+}


### PR DESCRIPTION
# Description

Adds logging when we can't find an action we were meant to update. These are usually fine, but I think there are cases where they're not, and we should log them anyways.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2022)
<!-- Reviewable:end -->
