### PR TITLE
Use display, not debug formatting for operation ids

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -133,7 +133,7 @@ impl ApiWorkerSchedulerImpl {
                 .is_err()
             {
                 error!(
-                    ?operation_id,
+                    %operation_id,
                     ?worker_id,
                     "OperationKeepAliveTx stream closed"
                 );
@@ -279,7 +279,7 @@ impl ApiWorkerSchedulerImpl {
                 .err_tip(|| "in update_operation on SimpleScheduler::update_action");
             if let Err(err) = update_operation_res {
                 error!(
-                    ?operation_id,
+                    %operation_id,
                     ?worker_id,
                     ?err,
                     "Failed to update_operation on update_action"
@@ -353,7 +353,7 @@ impl ApiWorkerSchedulerImpl {
         } else {
             warn!(
                 ?worker_id,
-                ?operation_id,
+                %operation_id,
                 ?action_info,
                 "Worker not found in worker map in worker_notify_run_action"
             );

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -375,7 +375,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                     // Cleanup operation_id_to_awaited_action.
                     let Some(tx) = self.operation_id_to_awaited_action.remove(&operation_id) else {
                         error!(
-                            ?operation_id,
+                            %operation_id,
                             "operation_id_to_awaited_action does not have operation_id"
                         );
                         continue;
@@ -392,7 +392,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                         }
                         Entry::Vacant(_) => {
                             error!(
-                                ?operation_id,
+                                %operation_id,
                                 "connected_clients_for_operation_id does not have operation_id"
                             );
                             0
@@ -411,7 +411,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                             .insert(operation_id, connected_clients);
                         continue;
                     }
-                    debug!(?operation_id, "Clearing operation from state manager");
+                    debug!(%operation_id, "Clearing operation from state manager");
                     let awaited_action = tx.borrow().clone();
                     // Cleanup action_info_hash_key_to_awaited_action if it was marked cached.
                     match &awaited_action.action_info().unique_qualifier {
@@ -423,7 +423,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                                 && maybe_awaited_action.is_none()
                             {
                                 error!(
-                                    ?operation_id,
+                                    %operation_id,
                                     ?awaited_action,
                                     ?action_key,
                                     "action_info_hash_key_to_awaited_action and operation_id_to_awaited_action are out of sync",
@@ -448,7 +448,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                         });
                     if maybe_sorted_awaited_action.is_none() {
                         error!(
-                            ?operation_id,
+                            %operation_id,
                             ?sort_key,
                             "Expected maybe_sorted_awaited_action to have {sort_key:?}",
                         );
@@ -709,7 +709,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
 
         debug!(
             ?client_operation_id,
-            ?operation_id,
+            %operation_id,
             ?client_awaited_action,
             "Adding action"
         );
@@ -725,7 +725,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
                 .insert(unique_key, operation_id.clone());
             if let Some(old_value) = old_value {
                 error!(
-                    ?operation_id,
+                    %operation_id,
                     ?old_value,
                     "action_info_hash_key_to_awaited_action already has unique_key"
                 );

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -581,7 +581,7 @@ where
                     _ => {
                         return Err(make_err!(
                             Code::Internal,
-                            "Action {operation_id:?} is already completed with state {:?} - maybe_worker_id: {:?}",
+                            "Action {operation_id} is already completed with state {:?} - maybe_worker_id: {:?}",
                             awaited_action.state().stage,
                             maybe_worker_id,
                         ));

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -352,7 +352,7 @@ impl WorkerConnection {
                         UpdateOperationType::UpdateWithActionStage(action_stage),
                     )
                     .await
-                    .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
+                    .err_tip(|| format!("Failed to operation {operation_id}"))?;
             }
             execute_result::Result::InternalError(e) => {
                 self.scheduler
@@ -362,7 +362,7 @@ impl WorkerConnection {
                         UpdateOperationType::UpdateWithError(e.into()),
                     )
                     .await
-                    .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
+                    .err_tip(|| format!("Failed to operation {operation_id}"))?;
             }
         }
         Ok(())
@@ -377,7 +377,7 @@ impl WorkerConnection {
                 UpdateOperationType::ExecutionComplete,
             )
             .await
-            .err_tip(|| format!("Failed to operation {operation_id:?}"))?;
+            .err_tip(|| format!("Failed to operation {operation_id}"))?;
         Ok(())
     }
 }

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -219,7 +219,7 @@ impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorke
                             let operation_id = OperationId::from(kill_operation_request.operation_id);
                             if let Err(err) = self.running_actions_manager.kill_operation(&operation_id).await {
                                 error!(
-                                    ?operation_id,
+                                    %operation_id,
                                     ?err,
                                     "Failed to send kill request for operation"
                                 );

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -630,10 +630,10 @@ async fn do_cleanup(
         .err_tip(|| format!("Could not remove working directory {action_directory}"));
 
     if let Err(err) = running_actions_manager.cleanup_action(operation_id) {
-        error!(?operation_id, ?err, "Error cleaning up action");
+        error!(%operation_id, ?err, "Error cleaning up action");
         Result::<(), Error>::Err(err).merge(remove_dir_result)
     } else if let Err(err) = remove_dir_result {
-        error!(?operation_id, ?err, "Error removing working directory");
+        error!(%operation_id, ?err, "Error removing working directory");
         Err(err)
     } else {
         Ok(())
@@ -1367,7 +1367,7 @@ impl Drop for RunningActionImpl {
         }
         let operation_id = self.operation_id.clone();
         error!(
-            ?operation_id,
+            %operation_id,
             "RunningActionImpl did not cleanup. This is a violation of the requirements, will attempt to do it in the background."
         );
         let running_actions_manager = self.running_actions_manager.clone();
@@ -1379,7 +1379,7 @@ impl Drop for RunningActionImpl {
                 return;
             };
             error!(
-                ?operation_id,
+                %operation_id,
                 ?action_directory,
                 ?err,
                 "Error cleaning up action"
@@ -2012,7 +2012,7 @@ impl RunningActionsManagerImpl {
     fn cleanup_action(&self, operation_id: &OperationId) -> Result<(), Error> {
         let mut running_actions = self.running_actions.lock();
         let result = running_actions.remove(operation_id).err_tip(|| {
-            format!("Expected action id '{operation_id:?}' to exist in RunningActionsManagerImpl")
+            format!("Expected operation id '{operation_id}' to exist in RunningActionsManagerImpl")
         });
         // No need to copy anything, we just are telling the receivers an event happened.
         self.action_done_tx.send_modify(|()| {});


### PR DESCRIPTION
# Description

We have logs that look like `"operation_id":"Uuid(a22904a2-659b-4e25-a8b3-8d3a646ec008)"}` and `"Expected action id 'Uuid(2717d0f4-5384-46c8-a12a-f2dc9a0314a3)'` when they should drop the `Uuid(` bit. This is because we were displaying `OperationId`'s with `Debug` formatting, not `Display`, which this PR fixes.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2028)
<!-- Reviewable:end -->
