### PR TITLE
Add testing for running action manager failure logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -462,7 +462,7 @@ NativeLink Code of Conduct is available in the
 You can generate branch-based coverage reports via:
 
 ```
-nix run .#nativelinkCoverageForHost
+nix build .#nativelinkCoverageForHost
 ```
 
 The `result` symlink contains a webpage with the visualized report.

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -706,7 +706,7 @@ pub struct RunningActionImpl {
 }
 
 impl RunningActionImpl {
-    fn new(
+    pub fn new(
         execution_metadata: ExecutionMetadata,
         operation_id: OperationId,
         action_directory: String,
@@ -747,7 +747,7 @@ impl RunningActionImpl {
         &self.running_actions_manager.metrics
     }
 
-    /// Prepares any actions needed to execution this action. This action will do the following:
+    /// Prepares any actions needed to execute this action. This action will do the following:
     ///
     /// * Download any files needed to execute the action
     /// * Build a folder with all files needed to execute the action.
@@ -971,16 +971,22 @@ impl RunningActionImpl {
             .err_tip(|| "Expected stderr to exist on command this should never happen")?;
 
         let mut child_process_guard = guard(child_process, |mut child_process| {
-            if child_process.try_wait().is_ok_and(|res| res.is_some()) {
-                // The child already exited, probably a timeout or kill operation.
-                return;
+            let result: Result<Option<std::process::ExitStatus>, std::io::Error> =
+                child_process.try_wait();
+            match result {
+                Ok(res) if res.is_some() => {
+                    // The child already exited, probably a timeout or kill operation
+                }
+                result => {
+                    error!(
+                        ?result,
+                        "Child process was not cleaned up before dropping the call to execute(), killing in background spawn."
+                    );
+                    background_spawn!("running_actions_manager_kill_child_process", async move {
+                        child_process.kill().await
+                    });
+                }
             }
-            error!(
-                "Child process was not cleaned up before dropping the call to execute(), killing in background spawn."
-            );
-            background_spawn!("running_actions_manager_kill_child_process", async move {
-                child_process.kill().await
-            });
         });
 
         let all_stdout_fut = spawn!("stdout_reader", async move {
@@ -1025,12 +1031,19 @@ impl RunningActionImpl {
                         );
                     }
                     {
+                        let joined_command = args.join(OsStr::new(" "));
+                        let command = joined_command.to_string_lossy();
+                        info!(
+                            seconds = self.action_info.timeout.as_secs_f32(),
+                            %command,
+                            "Command timed out"
+                        );
                         let mut state = self.state.lock();
                         state.error = Error::merge_option(state.error.take(), Some(Error::new(
                             Code::DeadlineExceeded,
                             format!(
                                 "Command '{}' timed out after {} seconds",
-                                args.join(OsStr::new(" ")).to_string_lossy(),
+                                command,
                                 self.action_info.timeout.as_secs_f32()
                             )
                         )));
@@ -1394,31 +1407,47 @@ impl RunningAction for RunningActionImpl {
     }
 
     async fn prepare_action(self: Arc<Self>) -> Result<Arc<Self>, Error> {
-        self.metrics()
+        let res = self
+            .metrics()
             .clone()
             .prepare_action
             .wrap(Self::inner_prepare_action(self))
-            .await
+            .await;
+        if let Err(ref e) = res {
+            warn!(?e, "Error during prepare_action");
+        }
+        res
     }
 
     async fn execute(self: Arc<Self>) -> Result<Arc<Self>, Error> {
-        self.metrics()
+        let res = self
+            .metrics()
             .clone()
             .execute
             .wrap(Self::inner_execute(self))
-            .await
+            .await;
+        if let Err(ref e) = res {
+            warn!(?e, "Error during prepare_action");
+        }
+        res
     }
 
     async fn upload_results(self: Arc<Self>) -> Result<Arc<Self>, Error> {
-        self.metrics()
+        let res = self
+            .metrics()
             .clone()
             .upload_results
             .wrap(Self::inner_upload_results(self))
-            .await
+            .await;
+        if let Err(ref e) = res {
+            warn!(?e, "Error during upload_results");
+        }
+        res
     }
 
     async fn cleanup(self: Arc<Self>) -> Result<Arc<Self>, Error> {
-        self.metrics()
+        let res = self
+            .metrics()
             .clone()
             .cleanup
             .wrap(async move {
@@ -1432,7 +1461,11 @@ impl RunningAction for RunningActionImpl {
                 self.did_cleanup.store(true, Ordering::Release);
                 result.map(move |()| self)
             })
-            .await
+            .await;
+        if let Err(ref e) = res {
+            warn!(?e, "Error during cleanup");
+        }
+        res
     }
 
     async fn get_finished_result(self: Arc<Self>) -> Result<ActionResult, Error> {

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -30,9 +30,12 @@ mod tests {
     use std::sync::{Arc, LazyLock, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use bytes::Bytes;
     use futures::prelude::*;
     use nativelink_config::cas_server::EnvironmentSource;
-    use nativelink_config::stores::{FastSlowSpec, FilesystemSpec, MemorySpec, StoreSpec};
+    use nativelink_config::stores::{
+        FastSlowSpec, FilesystemSpec, MemorySpec, StoreDirection, StoreSpec,
+    };
     use nativelink_error::{Code, Error, ResultExt, make_input_err};
     use nativelink_macro::nativelink_test;
     use nativelink_proto::build::bazel::remote::execution::v2::command::EnvironmentVariable;
@@ -113,8 +116,8 @@ mod tests {
             &FastSlowSpec {
                 fast: StoreSpec::Filesystem(fast_config),
                 slow: StoreSpec::Memory(slow_config),
-                fast_direction: Default::default(),
-                slow_direction: Default::default(),
+                fast_direction: StoreDirection::default(),
+                slow_direction: StoreDirection::default(),
             },
             Store::new(fast_store.clone()),
             Store::new(slow_store.clone()),
@@ -1870,7 +1873,7 @@ exit 0
             .compute_from_reader(Cursor::new(expected_stderr))
             .await?;
 
-        let actual_stderr: bytes::Bytes = cas_store
+        let actual_stderr: Bytes = cas_store
             .as_ref()
             .get_part_unchunked(result.stderr_digest, 0, None)
             .await?;
@@ -2889,6 +2892,18 @@ exit 1
             tx.send(()).expect("Could not send timeout signal");
         });
         assert_eq!(results?.error.unwrap().code, Code::DeadlineExceeded);
+
+        assert!(!logs_contain(
+            "Child process was not cleaned up before dropping the call to execute(), killing in background spawn"
+        ));
+        #[cfg(target_family = "unix")]
+        assert!(logs_contain(
+            "Command timed out seconds=0.0 command=sh -c sleep infinity"
+        ));
+        #[cfg(target_family = "windows")]
+        assert!(logs_contain(
+            "Command timed out seconds=0.0 command=cmd /C ping -n 99999 127.0.0.1"
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
# Description

We've been seeing various intermittent instances of `Child process was not cleaned up before dropping the call to execute(), killing in background spawn` from `running_actions_manager` with little in the way of logging. I haven't yet been able to reproduce this in tests, but this PR adds some new test checks around timeout logging in the same area as well as various other bits of extra logging around the failure cases to try and aid future investigations

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2031)
<!-- Reviewable:end -->
