### PR TITLE
Do not need to store zero-length filesystem files

### DIFF
--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -54,6 +54,7 @@ use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::
 use nativelink_store::ac_utils::{
     ESTIMATED_DIGEST_SIZE, compute_buf_digest, get_and_decode_digest, serialize_and_upload_message,
 };
+use nativelink_store::cas_utils::is_zero_digest;
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::filesystem_store::{FileEntry, FilesystemStore};
 use nativelink_store::grpc_store::GrpcStore;
@@ -71,7 +72,7 @@ use prost::Message;
 use relative_path::RelativePath;
 use scopeguard::{ScopeGuard, guard};
 use serde::Deserialize;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::process;
 use tokio::sync::{Notify, oneshot, watch};
 use tokio::time::Instant;
@@ -150,34 +151,40 @@ pub fn download_to_directory<'a>(
                 cas_store
                     .populate_fast_store(digest.into())
                     .and_then(move |()| async move {
-                        let file_entry = filesystem_store
-                            .get_file_entry_for_digest(&digest)
-                            .await
-                            .err_tip(|| "During hard link")?;
-                        // TODO: add a test for #2051: deadlock with large number of files
-                        let src_path = file_entry.get_file_path_locked(|src| async move { Ok(PathBuf::from(src)) }).await?;
-                        fs::hard_link(&src_path, &dest)
-                            .await
-                            .map_err(|e| {
-                                if e.code == Code::NotFound {
-                                    make_err!(
-                                        Code::Internal,
-                                        "Could not make hardlink, file was likely evicted from cache. {e:?} : {dest}\n\
-                                        This error often occurs when the filesystem store's max_bytes is too small for your workload.\n\
-                                        To fix this issue:\n\
-                                        1. Increase the 'max_bytes' value in your filesystem store configuration\n\
-                                        2. Example: Change 'max_bytes: 10000000000' to 'max_bytes: 50000000000' (or higher)\n\
-                                        3. The setting is typically found in your nativelink.json config under:\n\
-                                           stores -> [your_filesystem_store] -> filesystem -> eviction_policy -> max_bytes\n\
-                                        4. Restart NativeLink after making the change\n\n\
-                                        If this error persists after increasing max_bytes several times, please report at:\n\
-                                        https://github.com/TraceMachina/nativelink/issues\n\
-                                        Include your config file and both server and client logs to help us assist you."
-                                    )
-                                } else {
-                                    make_err!(Code::Internal, "Could not make hardlink, {e:?} : {dest}")
-                                }
-                            })?;
+                        if is_zero_digest(digest) {
+                            let mut file_slot = fs::create_file(&dest).await?;
+                            file_slot.write_all(&[]).await?;
+                        }
+                        else {
+                            let file_entry = filesystem_store
+                                .get_file_entry_for_digest(&digest)
+                                .await
+                                .err_tip(|| "During hard link")?;
+                            // TODO: add a test for #2051: deadlock with large number of files
+                            let src_path = file_entry.get_file_path_locked(|src| async move { Ok(PathBuf::from(src)) }).await?;
+                            fs::hard_link(&src_path, &dest)
+                                .await
+                                .map_err(|e| {
+                                    if e.code == Code::NotFound {
+                                        make_err!(
+                                            Code::Internal,
+                                            "Could not make hardlink, file was likely evicted from cache. {e:?} : {dest}\n\
+                                            This error often occurs when the filesystem store's max_bytes is too small for your workload.\n\
+                                            To fix this issue:\n\
+                                            1. Increase the 'max_bytes' value in your filesystem store configuration\n\
+                                            2. Example: Change 'max_bytes: 10000000000' to 'max_bytes: 50000000000' (or higher)\n\
+                                            3. The setting is typically found in your nativelink.json config under:\n\
+                                            stores -> [your_filesystem_store] -> filesystem -> eviction_policy -> max_bytes\n\
+                                            4. Restart NativeLink after making the change\n\n\
+                                            If this error persists after increasing max_bytes several times, please report at:\n\
+                                            https://github.com/TraceMachina/nativelink/issues\n\
+                                            Include your config file and both server and client logs to help us assist you."
+                                        )
+                                    } else {
+                                        make_err!(Code::Internal, "Could not make hardlink, {e:?} : {dest}")
+                                    }
+                                })?;
+                            }
                         #[cfg(target_family = "unix")]
                         if let Some(unix_mode) = unix_mode {
                             fs::set_permissions(&dest, Permissions::from_mode(unix_mode))


### PR DESCRIPTION
# Description

Ran into issues during https://github.com/TraceMachina/nativelink/pull/2024 and I _think_ they're due to filesystem not handling zero-length file storage correctly. Namely, it happily retrieves zero-length files, but it shouldn't need to store zero-length ones. Previously there was a partial implementation of zero-length special casing, this just expands it to all the other upload/retrieve cases.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2033)
<!-- Reviewable:end -->
