### PR TITLE
Fix flake timestamp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,7 +134,7 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747744144,
+        "lastModified": 1747852984,
         "narHash": "sha256-q2PmaOxyR3zqOF54a3E1Cj1gh0sDu8APX9b+OkX4J5s=",
         "owner": "NixOS",
         "repo": "nixpkgs",


### PR DESCRIPTION
# Description

Our `nixpkgs` is locked to https://github.com/NixOS/nixpkgs/commit/8c441601c43232976179eac52dde704c8bdf81ed which we had a timestamp of 1747744144 for (Tue May 20 2025 12:29:04 GMT+0000). Now, _somehow_ the timestamp is 1747852984 (Wed May 21 2025 18:43:04 GMT+0000) about 36 hours later and we're getting build failures like https://github.com/TraceMachina/nativelink/actions/runs/19237205447/job/54990232263?pr=2035

This is very weird and I'm not sure what Github did here, because the timestamps should be integral to the commits. OTOH, the hashes haven't changed, and my local checkout of `nixpkgs` from about 2 months ago shows the new timestamp as well. 

Fundamentally, this fixes our builds, so we need it.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2036)
<!-- Reviewable:end -->
