### PR TITLE
Lockdown and upgrade the nix action versions

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -48,9 +48,13 @@ runs:
         fi
 
     - name: Install Nix
-      uses: >- # https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v17
-        DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3
+      uses: >- # https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v20
+        DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196
+      with:
+        source-tag: v3.13.0
 
     - name: Add Nix magic cache
-      uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v11
-        DeterminateSystems/magic-nix-cache-action@def9f5a5c6a6b8751c0534e8813a5d0ad2635660
+      uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v13
+        DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+      with:
+        source-tag: v0.1.6


### PR DESCRIPTION
# Description

This was the source of the problem we saw at https://github.com/TraceMachina/nativelink/pull/2036 - the Determinate Systems actions were locked down, but the things they installed were not. This PR fixes that (and upgrades the actions while we're here)

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2038)
<!-- Reviewable:end -->
