### PR TITLE
Redo worker_find_logging as config

### DIFF
--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -50,7 +50,3 @@ jobs:
 
       - name: Test on ${{ runner.os }}
         run: cargo test --all --profile=smol
-
-      # Not a default target, but need to make sure we don't actually break it
-      - name: Test worker_find_logging
-        run: cargo build --features worker_find_logging --all-targets

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,8 +14,6 @@ rust_binary(
     srcs = [
         "src/bin/nativelink.rs",
     ],
-    # Enable this to get extra debug about workers that are not being used by the CAS
-    # crate_features = ["worker_find_logging"],
     deps = [
         "//nativelink-config",
         "//nativelink-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,6 @@ name = "nativelink"
 [features]
 nix = ["nativelink-worker/nix"]
 
-# Enable this to get extra debug about workers that are not being used by the CAS
-# for some reason. We don't enable this by default, as it's part of a hot path in
-# the scheduling system, and also that a worker not matching isn't necessarily bad.
-worker_find_logging = [
-  "nativelink-scheduler/worker_find_logging",
-  "nativelink-util/worker_find_logging",
-]
-
 [dependencies]
 nativelink-config = { path = "nativelink-config" }
 nativelink-error = { path = "nativelink-error" }

--- a/flake.nix
+++ b/flake.nix
@@ -160,8 +160,6 @@
           (craneLibFor p).buildPackage ((commonArgsFor p)
             // {
               cargoArtifacts = cargoArtifactsFor p;
-              # Enable this for debugging worker scheduler issues
-              # cargoExtraArgs = "--features worker_find_logging";
             });
 
         nativeTargetPkgs =

--- a/nativelink-config/examples/scheduler_match_logging_disable.json5
+++ b/nativelink-config/examples/scheduler_match_logging_disable.json5
@@ -1,0 +1,12 @@
+{
+  stores: [],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        worker_match_logging_interval_s: -1,
+      },
+    },
+  ],
+  servers: [],
+}

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -16,7 +16,10 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::serde_utils::{convert_duration_with_shellexpand, convert_numeric_with_shellexpand};
+use crate::serde_utils::{
+    convert_duration_with_shellexpand, convert_duration_with_shellexpand_and_negative,
+    convert_numeric_with_shellexpand,
+};
 use crate::stores::{GrpcEndpoint, Retry, StoreRefName};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -63,6 +66,11 @@ pub enum WorkerAllocationStrategy {
     LeastRecentlyUsed,
     /// Prefer workers that have been most recently used to run a job.
     MostRecentlyUsed,
+}
+
+// defaults to every 10s
+const fn default_worker_match_logging_interval_s() -> i64 {
+    10
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
@@ -129,6 +137,15 @@ pub struct SimpleSpec {
     /// The storage backend to use for the scheduler.
     /// Default: memory
     pub experimental_backend: Option<ExperimentalSimpleSchedulerBackend>,
+
+    /// Every N seconds, do logging of worker matching
+    /// e.g. "worker busy", "can't find any worker"
+    /// Defaults to 10s. Can be set to -1 to disable
+    #[serde(
+        default = "default_worker_match_logging_interval_s",
+        deserialize_with = "convert_duration_with_shellexpand_and_negative"
+    )]
+    pub worker_match_logging_interval_s: i64,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/nativelink-config/src/serde_utils.rs
+++ b/nativelink-config/src/serde_utils.rs
@@ -280,12 +280,12 @@ where
                 return Err(de::Error::custom("Negative duration is not allowed"));
             }
             let v_u64 = u64::try_from(v).map_err(de::Error::custom)?;
-            T::try_from(v_u64).map_err(de::Error::custom)
+            self.visit_u64(v_u64)
         }
 
         fn visit_u128<E: de::Error>(self, v: u128) -> Result<Self::Value, E> {
             let v_u64 = u64::try_from(v).map_err(de::Error::custom)?;
-            T::try_from(v_u64).map_err(de::Error::custom)
+            self.visit_u64(v_u64)
         }
 
         fn visit_i128<E: de::Error>(self, v: i128) -> Result<Self::Value, E> {
@@ -293,7 +293,7 @@ where
                 return Err(de::Error::custom("Negative duration is not allowed"));
             }
             let v_u64 = u64::try_from(v).map_err(de::Error::custom)?;
-            T::try_from(v_u64).map_err(de::Error::custom)
+            self.visit_u64(v_u64)
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
@@ -301,7 +301,62 @@ where
             let expanded = expanded.as_ref().trim();
             let duration = parse_duration(expanded).map_err(de::Error::custom)?;
             let secs = duration.as_secs();
-            T::try_from(secs).map_err(de::Error::custom)
+            self.visit_u64(secs)
+        }
+    }
+
+    deserializer.deserialize_any(DurationVisitor::<T>(PhantomData))
+}
+
+/// # Errors
+///
+/// Will return `Err` if deserialization fails.
+pub fn convert_duration_with_shellexpand_and_negative<'de, D, T>(
+    deserializer: D,
+) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: TryFrom<i64>,
+    <T as TryFrom<i64>>::Error: fmt::Display,
+{
+    struct DurationVisitor<T: TryFrom<i64>>(PhantomData<T>);
+
+    impl<T> Visitor<'_> for DurationVisitor<T>
+    where
+        T: TryFrom<i64>,
+        <T as TryFrom<i64>>::Error: fmt::Display,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("either a number of seconds as an integer, or a string with a duration format (e.g., \"1h2m3s\", \"30m\", \"1d\")")
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+            let v_i64 = i64::try_from(v).map_err(de::Error::custom)?;
+            self.visit_i64(v_i64)
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+            T::try_from(v).map_err(de::Error::custom)
+        }
+
+        fn visit_u128<E: de::Error>(self, v: u128) -> Result<Self::Value, E> {
+            let v_i64 = i64::try_from(v).map_err(de::Error::custom)?;
+            self.visit_i64(v_i64)
+        }
+
+        fn visit_i128<E: de::Error>(self, v: i128) -> Result<Self::Value, E> {
+            let v_i64 = i64::try_from(v).map_err(de::Error::custom)?;
+            self.visit_i64(v_i64)
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            let expanded = shellexpand::env(v).map_err(de::Error::custom)?;
+            let expanded = expanded.as_ref().trim();
+            let duration = parse_duration(expanded).map_err(de::Error::custom)?;
+            let secs = duration.as_secs();
+            self.visit_u64(secs)
         }
     }
 

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2024"
 name = "nativelink-scheduler"
 version = "0.7.5"
 
-[features]
-worker_find_logging = ["nativelink-util/worker_find_logging"]
-
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-scheduler/src/memory_awaited_action_db.rs
+++ b/nativelink-scheduler/src/memory_awaited_action_db.rs
@@ -708,7 +708,7 @@ impl<I: InstantWrapper, NowFn: Fn() -> I + Clone + Send + Sync> AwaitedActionDbI
             self.make_client_awaited_action(&operation_id.clone(), awaited_action);
 
         debug!(
-            ?client_operation_id,
+            %client_operation_id,
             %operation_id,
             ?client_awaited_action,
             "Adding action"

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -35,7 +35,7 @@ use nativelink_util::store_trait::{
 };
 use nativelink_util::task::JoinHandleDropGuard;
 use tokio::sync::Notify;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::awaited_action_db::{
     AwaitedAction, AwaitedActionDb, AwaitedActionSubscriber, CLIENT_KEEPALIVE_DURATION,
@@ -461,8 +461,9 @@ async fn inner_update_awaited_action(
         .await
         .err_tip(|| "In RedisAwaitedActionDb::update_awaited_action")?;
     if maybe_version.is_none() {
-        tracing::warn!(
-            "Could not update AwaitedAction because the version did not match for {operation_id}"
+        warn!(
+            %operation_id,
+            "Could not update AwaitedAction because the version did not match"
         );
         return Err(make_err!(
             Code::Aborted,

--- a/nativelink-scheduler/src/worker.rs
+++ b/nativelink-scheduler/src/worker.rs
@@ -115,7 +115,7 @@ fn reduce_platform_properties(
     parent_props: &mut PlatformProperties,
     reduction_props: &PlatformProperties,
 ) {
-    debug_assert!(reduction_props.is_satisfied_by(parent_props));
+    debug_assert!(reduction_props.is_satisfied_by(parent_props, false));
     for (property, prop_value) in &reduction_props.properties {
         if let PlatformPropertyValue::Minimum(value) = prop_value {
             let worker_props = &mut parent_props.properties;

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2024"
 name = "nativelink-util"
 version = "0.7.5"
 
-[features]
-worker_find_logging = []
-
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -21,7 +21,6 @@ use nativelink_metric::{
 use nativelink_proto::build::bazel::remote::execution::v2::Platform as ProtoPlatform;
 use nativelink_proto::build::bazel::remote::execution::v2::platform::Property as ProtoProperty;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "worker_find_logging")]
 use tracing::info;
 
 /// `PlatformProperties` helps manage the configuration of platform properties to
@@ -45,12 +44,11 @@ impl PlatformProperties {
 
     /// Determines if the worker's `PlatformProperties` is satisfied by this struct.
     #[must_use]
-    pub fn is_satisfied_by(&self, worker_properties: &Self) -> bool {
+    pub fn is_satisfied_by(&self, worker_properties: &Self, full_worker_logging: bool) -> bool {
         for (property, check_value) in &self.properties {
             if let Some(worker_value) = worker_properties.properties.get(property) {
                 if !check_value.is_satisfied_by(worker_value) {
-                    #[cfg(feature = "worker_find_logging")]
-                    {
+                    if full_worker_logging {
                         info!(
                             "Property mismatch on worker property {property}. {worker_value:?} != {check_value:?}"
                         );
@@ -58,8 +56,7 @@ impl PlatformProperties {
                     return false;
                 }
             } else {
-                #[cfg(feature = "worker_find_logging")]
-                {
+                if full_worker_logging {
                     info!("Property missing on worker property {property}");
                 }
                 return false;

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -720,10 +720,6 @@ fn main() -> Result<(), Box<dyn core::error::Error>> {
     #[expect(clippy::disallowed_methods, reason = "tracing init on main runtime")]
     runtime.block_on(async { tokio::spawn(async { init_tracing() }).await? })?;
 
-    if cfg!(feature = "worker_find_logging") {
-        info!("worker_find_logging enabled");
-    }
-
     let mut cfg = get_config()?;
 
     let global_cfg = if let Some(global_cfg) = &mut cfg.global {


### PR DESCRIPTION
# Description

`worker_find_logging` outputted some really useful logging, but it was previously done as a feature because it would also be really noisy in regular setups. This PR redoes it as a config option instead. `worker_match_logging_interval_s` defaults to every 10s which is a reasonable setting for most setups, providing some logging without overloading things. Setting it to `0` is equivalent to `worker_find_logging` and `-1` will disable it.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2039)
<!-- Reviewable:end -->
