### PR TITLE
Use common_s3_utils in s3_store

### DIFF
--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use core::cmp;
-use core::future::Future;
 use core::pin::Pin;
-use core::task::{Context, Poll};
 use core::time::Duration;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -23,7 +21,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use aws_config::default_provider::credentials;
 use aws_config::provider_config::ProviderConfig;
-use aws_config::retry::ErrorKind::TransientError;
 use aws_config::{AppName, BehaviorVersion};
 use aws_sdk_s3::Client;
 use aws_sdk_s3::config::Region;
@@ -32,26 +29,10 @@ use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::primitives::ByteStream; // SdkBody
 use aws_sdk_s3::types::builders::{CompletedMultipartUploadBuilder, CompletedPartBuilder};
-use aws_smithy_runtime_api::client::http::{
-    HttpClient as SmithyHttpClient, HttpConnector as SmithyHttpConnector, HttpConnectorFuture,
-    HttpConnectorSettings, SharedHttpConnector,
-};
-use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
-use aws_smithy_runtime_api::client::result::ConnectorError;
-use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
-use aws_smithy_runtime_api::http::Response;
 use aws_smithy_types::body::SdkBody;
-use bytes::{Bytes, BytesMut};
 use futures::future::FusedFuture;
 use futures::stream::{FuturesUnordered, unfold};
-use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
-use http_body::{Frame, SizeHint};
-use http_body_util::BodyExt;
-use hyper::{Method, Request};
-use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-use hyper_util::client::legacy::Client as LegacyClient;
-use hyper_util::client::legacy::connect::HttpConnector as LegacyHttpConnector;
-use hyper_util::rt::TokioExecutor;
+use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use nativelink_config::stores::ExperimentalAwsSpec;
 // Note: S3 store should be very careful about the error codes it returns
 // when in a retryable wrapper. Always prefer Code::Aborted or another
@@ -62,18 +43,17 @@ use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
     DropCloserReadHalf, DropCloserWriteHalf, make_buf_channel_pair,
 };
-use nativelink_util::fs;
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::retry::{Retrier, RetryResult};
 use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
 use parking_lot::Mutex;
-use rand::Rng;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::{error, info};
 
 use crate::cas_utils::is_zero_digest;
+use crate::common_s3_utils::{BodyWrapper, TlsClient};
 
 // S3 parts cannot be smaller than this number. See:
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
@@ -94,328 +74,6 @@ const DEFAULT_MAX_RETRY_BUFFER_PER_REQUEST: usize = 5 * 1024 * 1024; // 5MB.
 // Default limit for concurrent part uploads per multipart upload.
 // Note: If you change this, adjust the docs in the config.
 const DEFAULT_MULTIPART_MAX_CONCURRENT_UPLOADS: usize = 10;
-
-#[derive(Clone)]
-pub struct TlsClient {
-    client: LegacyClient<HttpsConnector<LegacyHttpConnector>, SdkBody>,
-    retrier: Retrier,
-}
-
-impl TlsClient {
-    #[must_use]
-    pub fn new(
-        spec: &ExperimentalAwsSpec,
-        jitter_fn: Arc<dyn Fn(Duration) -> Duration + Send + Sync>,
-    ) -> Self {
-        let connector_with_roots = HttpsConnectorBuilder::new().with_platform_verifier();
-
-        let connector_with_schemes = if spec.common.insecure_allow_http {
-            connector_with_roots.https_or_http()
-        } else {
-            connector_with_roots.https_only()
-        };
-
-        let connector = if spec.common.disable_http2 {
-            connector_with_schemes.enable_http1().build()
-        } else {
-            connector_with_schemes.enable_http1().enable_http2().build()
-        };
-
-        let client = LegacyClient::builder(TokioExecutor::new()).build(connector);
-
-        Self {
-            client,
-            retrier: Retrier::new(
-                Arc::new(|duration| Box::pin(sleep(duration))),
-                jitter_fn,
-                spec.common.retry.clone(),
-            ),
-        }
-    }
-}
-
-impl core::fmt::Debug for TlsClient {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-        f.debug_struct("TlsClient").finish_non_exhaustive()
-    }
-}
-
-impl SmithyHttpClient for TlsClient {
-    fn http_connector(
-        &self,
-        _settings: &HttpConnectorSettings,
-        _components: &RuntimeComponents,
-    ) -> SharedHttpConnector {
-        SharedHttpConnector::new(self.clone())
-    }
-}
-
-enum BufferedBodyState {
-    Cloneable(SdkBody),
-    Buffered(Bytes),
-    Empty,
-}
-
-mod body_processing {
-    use super::{BodyExt, BufferedBodyState, BytesMut, ConnectorError, SdkBody, TransientError};
-
-    /// Buffer a request body fully into memory.
-    ///
-    /// TODO(palfrey): This could lead to OOMs in extremely constrained
-    ///                    environments. Probably better to implement something
-    ///                    like a rewindable stream logic.
-    #[inline]
-    pub(crate) async fn buffer_body(body: SdkBody) -> Result<BufferedBodyState, ConnectorError> {
-        let mut bytes = BytesMut::new();
-        let mut body_stream = body;
-        while let Some(frame) = body_stream.frame().await {
-            match frame {
-                Ok(frame) => {
-                    if let Some(data) = frame.data_ref() {
-                        bytes.extend_from_slice(data);
-                    }
-                }
-                Err(e) => {
-                    return Err(ConnectorError::other(
-                        format!("Failed to read request body: {e}").into(),
-                        Some(TransientError),
-                    ));
-                }
-            }
-        }
-
-        Ok(BufferedBodyState::Buffered(bytes.freeze()))
-    }
-}
-
-struct RequestComponents {
-    method: Method,
-    uri: hyper::Uri,
-    version: hyper::Version,
-    headers: hyper::HeaderMap,
-    body_data: BufferedBodyState,
-}
-
-mod conversions {
-    use super::{
-        BufferedBodyState, ConnectorError, Future, HttpRequest, Method, RequestComponents,
-        Response, SdkBody, TransientError, body_processing,
-    };
-
-    pub(crate) trait RequestExt {
-        fn into_components(self)
-        -> impl Future<Output = Result<RequestComponents, ConnectorError>>;
-    }
-
-    impl RequestExt for HttpRequest {
-        async fn into_components(self) -> Result<RequestComponents, ConnectorError> {
-            // Note: This does *not* refer the the HTTP protocol, but to the
-            //       version of the http crate.
-            let hyper_req = self.try_into_http1x().map_err(|e| {
-                ConnectorError::other(
-                    format!("Failed to convert to HTTP request: {e}").into(),
-                    Some(TransientError),
-                )
-            })?;
-
-            let method = hyper_req.method().clone();
-            let uri = hyper_req.uri().clone();
-            let version = hyper_req.version();
-            let headers = hyper_req.headers().clone();
-
-            let body = hyper_req.into_body();
-
-            // Only buffer bodies for methods likely to have payloads.
-            let needs_buffering = matches!(method, Method::POST | Method::PUT);
-
-            // Preserve the body in case we need to retry.
-            let body_data = if needs_buffering {
-                if let Some(cloneable_body) = body.try_clone() {
-                    BufferedBodyState::Cloneable(cloneable_body)
-                } else {
-                    body_processing::buffer_body(body).await?
-                }
-            } else {
-                BufferedBodyState::Empty
-            };
-
-            Ok(RequestComponents {
-                method,
-                uri,
-                version,
-                headers,
-                body_data,
-            })
-        }
-    }
-
-    pub(crate) trait ResponseExt {
-        fn into_smithy_response(self) -> Response<SdkBody>;
-    }
-
-    impl ResponseExt for hyper::Response<hyper::body::Incoming> {
-        fn into_smithy_response(self) -> Response<SdkBody> {
-            let (parts, body) = self.into_parts();
-            let sdk_body = SdkBody::from_body_1_x(body);
-            let mut smithy_resp = Response::new(parts.status.into(), sdk_body);
-            let header_pairs: Vec<(String, String)> = parts
-                .headers
-                .iter()
-                .filter_map(|(name, value)| {
-                    value
-                        .to_str()
-                        .ok()
-                        .map(|value_str| (name.as_str().to_owned(), value_str.to_owned()))
-                })
-                .collect();
-
-            for (name, value) in header_pairs {
-                smithy_resp.headers_mut().insert(name, value);
-            }
-
-            smithy_resp
-        }
-    }
-}
-
-struct RequestBuilder<'a> {
-    components: &'a RequestComponents,
-}
-
-impl<'a> RequestBuilder<'a> {
-    #[inline]
-    const fn new(components: &'a RequestComponents) -> Self {
-        Self { components }
-    }
-
-    #[inline]
-    #[allow(unused_qualifications, reason = "false positive on hyper::http::Error")]
-    fn build(&self) -> Result<Request<SdkBody>, hyper::http::Error> {
-        let mut req_builder = Request::builder()
-            .method(self.components.method.clone())
-            .uri(self.components.uri.clone())
-            .version(self.components.version);
-
-        let headers_map = req_builder.headers_mut().unwrap();
-        for (name, value) in &self.components.headers {
-            headers_map.insert(name, value.clone());
-        }
-
-        match &self.components.body_data {
-            BufferedBodyState::Cloneable(body) => {
-                let cloned_body = body.try_clone().expect("Body should be cloneable");
-                req_builder.body(cloned_body)
-            }
-            BufferedBodyState::Buffered(bytes) => req_builder.body(SdkBody::from(bytes.clone())),
-            BufferedBodyState::Empty => req_builder.body(SdkBody::empty()),
-        }
-    }
-}
-
-mod execution {
-    use super::conversions::ResponseExt;
-    use super::{
-        Code, HttpsConnector, LegacyClient, LegacyHttpConnector, RequestBuilder, RequestComponents,
-        Response, RetryResult, SdkBody, fs, make_err,
-    };
-
-    #[inline]
-    pub(crate) async fn execute_request(
-        client: LegacyClient<HttpsConnector<LegacyHttpConnector>, SdkBody>,
-        components: &RequestComponents,
-    ) -> RetryResult<Response<SdkBody>> {
-        let _permit = match fs::get_permit().await {
-            Ok(permit) => permit,
-            Err(e) => {
-                return RetryResult::Retry(make_err!(
-                    Code::Unavailable,
-                    "Failed to acquire permit: {e}"
-                ));
-            }
-        };
-
-        let request = match RequestBuilder::new(components).build() {
-            Ok(req) => req,
-            Err(e) => {
-                return RetryResult::Err(make_err!(
-                    Code::Internal,
-                    "Failed to create request: {e}",
-                ));
-            }
-        };
-
-        match client.request(request).await {
-            Ok(resp) => RetryResult::Ok(resp.into_smithy_response()),
-            Err(e) => RetryResult::Retry(make_err!(
-                Code::Unavailable,
-                "Failed request in S3Store: {e}"
-            )),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn create_retry_stream(
-        client: LegacyClient<HttpsConnector<LegacyHttpConnector>, SdkBody>,
-        components: RequestComponents,
-    ) -> impl futures::Stream<Item = RetryResult<Response<SdkBody>>> {
-        futures::stream::unfold(components, move |components| {
-            let client_clone = client.clone();
-            async move {
-                let result = execute_request(client_clone, &components).await;
-
-                Some((result, components))
-            }
-        })
-    }
-}
-
-impl SmithyHttpConnector for TlsClient {
-    fn call(&self, req: HttpRequest) -> HttpConnectorFuture {
-        use conversions::RequestExt;
-
-        let client = self.client.clone();
-        let retrier = self.retrier.clone();
-
-        HttpConnectorFuture::new(Box::pin(async move {
-            let components = req.into_components().await?;
-
-            let retry_stream = execution::create_retry_stream(client, components);
-
-            match retrier.retry(retry_stream).await {
-                Ok(response) => Ok(response),
-                Err(e) => Err(ConnectorError::other(
-                    format!("Connection failed after retries: {e}").into(),
-                    Some(TransientError),
-                )),
-            }
-        }))
-    }
-}
-
-#[derive(Debug)]
-pub struct BodyWrapper {
-    reader: DropCloserReadHalf,
-    size: u64,
-}
-
-impl http_body::Body for BodyWrapper {
-    type Data = Bytes;
-    type Error = std::io::Error;
-
-    fn poll_frame(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        let reader = Pin::new(&mut Pin::get_mut(self).reader);
-        reader
-            .poll_next(cx)
-            .map(|maybe_bytes_res| maybe_bytes_res.map(|res| res.map(Frame::data)))
-    }
-
-    fn size_hint(&self) -> SizeHint {
-        SizeHint::with_exact(self.size)
-    }
-}
 
 #[derive(Debug, MetricsComponent)]
 pub struct S3Store<NowFn> {
@@ -442,15 +100,9 @@ where
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
     pub async fn new(spec: &ExperimentalAwsSpec, now_fn: NowFn) -> Result<Arc<Self>, Error> {
-        let jitter_amt = spec.common.retry.jitter;
-        let jitter_fn = Arc::new(move |delay: Duration| {
-            if jitter_amt == 0. {
-                return delay;
-            }
-            delay.mul_f32(jitter_amt.mul_add(rand::rng().random::<f32>() - 0.5, 1.))
-        });
+        let jitter_fn = spec.common.retry.make_jitter_fn();
         let s3_client = {
-            let http_client = TlsClient::new(&spec.clone(), jitter_fn.clone());
+            let http_client = TlsClient::new(&spec.common.clone());
 
             let credential_provider = credentials::DefaultCredentialsChain::builder()
                 .configure(


### PR DESCRIPTION
# Description

The s3 store duplicates a bunch of functionality in `common_s3_utils`. This PR fixes that duplication.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2040)
<!-- Reviewable:end -->
