### PR TITLE
fix(worker): Resolve deadlock due to file permit exhaustion (#2051)

### DIFF
--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -273,6 +273,7 @@ pub async fn create_dir_all(path: impl AsRef<Path>) -> Result<(), Error> {
 
 #[cfg(target_family = "unix")]
 pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Error> {
+    // TODO: add a test for #2051: deadlock with large number of files
     let _permit = get_permit().await?;
     tokio::fs::symlink(src, dst).await.map_err(Into::into)
 }

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -154,6 +154,7 @@ pub fn download_to_directory<'a>(
                             .get_file_entry_for_digest(&digest)
                             .await
                             .err_tip(|| "During hard link")?;
+                        // TODO: add a test for #2051: deadlock with large number of files
                         let src_path = file_entry.get_file_path_locked(|src| async move { Ok(PathBuf::from(src)) }).await?;
                         fs::hard_link(&src_path, &dest)
                             .await


### PR DESCRIPTION
# Description

A deadlock occurs during concurrent actions with many input files. This is caused by tasks holding locks on `FileEntry` while waiting for file permits from the global `OPEN_FILE_SEMAPHORE`, leading to a circular dependency and application hang.

This was observed in two places:
1. `hard_link` operations holding a `FileEntry` read lock.
2. `symlink` operations misusing `spawn_blocking` and `block_on`.

This commit resolves the deadlock by:
- Modifying `download_to_directory` to release the `FileEntry` lock before calling `hard_link`.
- Refactoring `fs::symlink` to be fully asynchronous, removing the `spawn_blocking`/`block_on` anti-pattern.

Fixes #2051 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2052)
<!-- Reviewable:end -->
