### PR TITLE
Don't complain about worker stream error if we're shutting down

### DIFF
--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -196,7 +196,7 @@ impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorke
 
         loop {
             select! {
-                maybe_update = update_for_worker_stream.next() => {
+                maybe_update = update_for_worker_stream.next() => if !shutting_down || (shutting_down && maybe_update.is_some()) {
                     match maybe_update
                         .err_tip(|| "UpdateForWorker stream closed early")?
                         .err_tip(|| "Got error in UpdateForWorker stream")?


### PR DESCRIPTION
# Description

Was seeing a bunch of this sort of error on the RBE test which I'm pretty sure is due to the worker stream trying to get items after the shutdown alert, which should be fine to fail (because the stream is meant to be closed)
```
  2025-11-17T16:17:43.103843Z  WARN nativelink_worker::local_worker: Worker loop received shutdown signal. Shutting down worker...
    at nativelink-worker/src/local_worker.rs:393
    in nativelink_worker::local_worker::run with shutdown_rx: broadcast::Receiver
    in nativelink::worker with name: "worker_0"

  2025-11-17T16:17:43.103894Z  WARN nativelink: Successfully shut down nativelink.
    at src/bin/nativelink.rs:783

  2025-11-17T16:17:43.103958Z  WARN nativelink_service::worker_api_server: UpdateForWorker channel was closed, thus closing connection to worker node, worker_id: 1f0c3cf2-98b8-6de3-9d00-45fa6c3536d7
    at nativelink-service/src/worker_api_server.rs:214
    in nativelink_util::task::http_executor
    in nativelink::services::http_connection with remote_addr: 127.0.0.1:53506, socket_addr: 0.0.0.0:50061

  2025-11-17T16:17:43.104113Z ERROR nativelink_worker::local_worker: Worker disconnected from scheduler, err: Error { code: Internal, messages: ["UpdateForWorker stream closed early"] }
    at nativelink-worker/src/local_worker.rs:704
    in nativelink_worker::local_worker::run with shutdown_rx: broadcast::Receiver
    in nativelink::worker with name: "worker_0"

  2025-11-17T16:17:43.104138Z ERROR nativelink_worker::local_worker: Error, err: Error { code: Internal, messages: ["UpdateForWorker stream closed early"] }
    at nativelink-worker/src/local_worker.rs:649
    in nativelink_worker::local_worker::run with shutdown_rx: broadcast::Receiver
    in nativelink::worker with name: "worker_0"
```
## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

RBE test

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2055)
<!-- Reviewable:end -->
