### PR TITLE
CI config updates

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -53,8 +53,13 @@ runs:
       with:
         source-tag: v3.13.0
 
-    - name: Add Nix magic cache
-      uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v13
-        DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
-      with:
-        source-tag: v0.1.6
+    # FIXME(palfrey): Replace with better cache. Workers are currently taking minutes to upload data
+    # all the time, probably because we're at ~500GB of 10GB in the cache storage and it's breaking.
+    # We've tried Flakehub, but it doesn't work for us because it assumes "branches on an org repo"
+    # not our "fork and branch on your own repo" setup for it's auth so we can't currently use that.
+
+    # - name: Add Nix magic cache
+    #   uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v13
+    #     DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+    #   with:
+    #     source-tag: v0.1.6

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
       matchUpdateTypes: [
         "patch",
         "minor",
+        "digest",
       ],
       enabled: false,
     },


### PR DESCRIPTION
# Description

* Disable Nix magic cache as it's taking more time uploading than we save. See for example https://github.com/TraceMachina/nativelink/actions/runs/19487024248/job/55771361733?pr=2058 where the "Post Prepare worker" step is the longest part of things!
* Disable digest updates to stop PRs from Renovate like https://github.com/TraceMachina/nativelink/pull/2058. We really want to update to the named versions but store as a hash, but this isn't doable yet.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2059)
<!-- Reviewable:end -->
