### PR TITLE
Update the default max permits for redis

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1221,7 +1221,7 @@ pub struct RedisSpec {
 
     /// Maximum number of permitted actions to the Redis store at any one time
     /// This stops problems with timeouts due to many, many inflight actions
-    /// Default: 100
+    /// Default: 500
     #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_client_permits: usize,
 }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -96,7 +96,7 @@ const DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE: usize = 10;
 /// Note: If this changes it should be updated in the config documentation.
 const DEFAULT_SCAN_COUNT: u32 = 10_000;
 
-const DEFAULT_CLIENT_PERMITS: usize = 100;
+const DEFAULT_CLIENT_PERMITS: usize = 500;
 
 /// A [`StoreDriver`] implementation that uses Redis as a backing store.
 #[derive(Debug, MetricsComponent)]


### PR DESCRIPTION
# Description
Increases the MAX PERMITS for redis to 500.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2063)
<!-- Reviewable:end -->
