### PR TITLE
Release NativeLink v0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.10](https://github.com/TraceMachina/nativelink/compare/v0.7.9..v0.7.10) - 2025-12-29
+
+### 🐛 Bug Fixes
+
+- *(deps)* update module golang.org/x/crypto to v0.45.0 [security] ([#2062](https://github.com/TraceMachina/nativelink/issues/2062)) - ([7a4cdb6](https://github.com/TraceMachina/nativelink/commit/7a4cdb681fe23b90f68f1bcc897b5b9ce43c1e37))
+
+### 🧪 Testing & CI
+
+- New filesystem test for eviction breaking ([#2024](https://github.com/TraceMachina/nativelink/issues/2024)) - ([47ebd44](https://github.com/TraceMachina/nativelink/commit/47ebd44809657889f185d0cb36c4217012211c48))
+
+### ⚙️ Miscellaneous
+
+- *(deps)* update dependency abseil-cpp to v20250512 ([#2099](https://github.com/TraceMachina/nativelink/issues/2099)) - ([2bdb869](https://github.com/TraceMachina/nativelink/commit/2bdb869b7cb42ad1c2411f282d454fe2cb81cc65))
+- *(deps)* update actions/checkout action to v6 ([#2085](https://github.com/TraceMachina/nativelink/issues/2085)) - ([fbda7bb](https://github.com/TraceMachina/nativelink/commit/fbda7bbfd1910bda6abace60feef3645f6f92ab4))
+- *(deps)* update actions/github-script action to v8 ([#2098](https://github.com/TraceMachina/nativelink/issues/2098)) - ([f9f3b60](https://github.com/TraceMachina/nativelink/commit/f9f3b6031f400cb3ef327b2c956ea6c6d0d4ff54))
+- reduce worker disconnect cascades ([#2093](https://github.com/TraceMachina/nativelink/issues/2093)) - ([44ada84](https://github.com/TraceMachina/nativelink/commit/44ada84405f17696c04f363b98773692a1c122f6))
+- Replace rustls-pemfile to fix RUSTSEC-2025-0134 ([#2094](https://github.com/TraceMachina/nativelink/issues/2094)) - ([1b85f71](https://github.com/TraceMachina/nativelink/commit/1b85f71d977f61ff79391934e434af9c10d057e8))
+
 ## [0.7.9](https://github.com/TraceMachina/nativelink/compare/v0.7.8..v0.7.9) - 2025-12-10
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "axum",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "fred",
  "nativelink-metric",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-lock",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.87.0"
-version = "0.7.9"
+version = "0.7.10"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "0.7.9",
+    version = "0.7.10",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = false
 edition = "2024"
 name = "nativelink-error"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "0.7.9"
+version = "0.7.10"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "0.7.9"
+version = "0.7.10"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "0.7.9"
+version = "0.7.10"
 
 [lib]
 name = "nativelink_proto"

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "0.7.9"
+version = "0.7.10"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "0.7.9"
+version = "0.7.10"
 
 [features]
 nix = []


### PR DESCRIPTION
## Summary
- Bump version to 0.7.10 in MODULE.bazel, Cargo.toml, and all nativelink-*/Cargo.toml files
- Update CHANGELOG.md with git cliff

## Changes in v0.7.10

### 🐛 Bug Fixes
- Update module golang.org/x/crypto to v0.45.0 [security]

### 🧪 Testing & CI
- New filesystem test for eviction breaking

### ⚙️ Miscellaneous
- Update dependency abseil-cpp to v20250512
- Update actions/checkout action to v6
- Update actions/github-script action to v8
- Bugfix: reduce worker disconnect cascades
- Replace rustls-pemfile to fix RUSTSEC-2025-0134

## Test plan
- [ ] CI passes
- [ ] After merge, create signed tag `v0.7.10` and push to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2102)
<!-- Reviewable:end -->
