### PR TITLE
Increase FT.AGGREGATE cursor size from 256 to 1500

### DIFF
--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -842,7 +842,8 @@ impl HealthStatusIndicator for RedisStore {
 // -------------------------------------------------------------------
 
 /// The maximum number of results to return per cursor.
-const MAX_COUNT_PER_CURSOR: u64 = 256;
+/// Increased from 256 to reduce round-trips for large task queues.
+const MAX_COUNT_PER_CURSOR: u64 = 1500;
 /// The time in milliseconds that a redis cursor can be idle before it is closed.
 const CURSOR_IDLE_MS: u64 = 2_000;
 /// The name of the field in the Redis hash that stores the data.


### PR DESCRIPTION

# Description

Reduces Redis round-trips by 83% for large task queues.

Before: 90,000 tasks ÷ 256 = 352 round-trips
After:  90,000 tasks ÷ 1500 = 60 round-trips

This significantly reduces Redis query pressure from scheduler pagination operations.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2109)
<!-- Reviewable:end -->
