### PR TITLE
Fix Redis index creation race

### DIFF
--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1414,7 +1414,10 @@ impl SchedulerStore for RedisStore {
                     },
                 });
             }
-            let create_result: Result<(), Error> = {
+            // Try to create the index. If it already exists, that's OK - we'll
+            // proceed to retry the aggregate query. Using async block to capture
+            // the error in create_result rather than propagating immediately.
+            let create_result: Result<(), Error> = async {
                 let create_client = self.get_client().await?;
                 create_client
                     .client
@@ -1440,7 +1443,8 @@ impl SchedulerStore for RedisStore {
                         )
                     })?;
                 Ok(())
-            };
+            }
+            .await;
             let retry_client = Arc::new(self.get_client().await?);
             let retry_result =
                 run_ft_aggregate(retry_client, index_name.clone(), sanitized_field.clone()).await;


### PR DESCRIPTION
# Description

If Nativelink is trying to create a Redis that already exists, it fails instead of handling it gracefully. Basically, the code in `RedisStore::search_by_index_prefix` or `ft.create` should:

Try to create an index (text index)

If an "Index already exists" proceed with the existing index and not error out. That is my suspicion anyway. 

I think that await errors on the existence of the index, which should never happen.
I think that create_result should proceed to retry the aggregate query as:

Fixes # none reported

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

With customer workloads

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2111)
<!-- Reviewable:end -->
