### PR TITLE
Support ignorable platform properties

### DIFF
--- a/nativelink-config/examples/basic_cas.json5
+++ b/nativelink-config/examples/basic_cas.json5
@@ -60,6 +60,7 @@
           "container-image": "priority",
           "lre-rs": "priority",
           ISA: "exact",
+          InputRootAbsolutePath: "ignore", // used by chromium builds, but we can drop it
         },
       },
     },

--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -53,6 +53,10 @@ pub enum PropertyType {
     /// to cause the scheduler to prefer certain workers over others, but not
     /// restrict them based on these values.
     Priority,
+
+    //// Allows jobs to be requested with said key, but without requiring workers
+    //// to have that key
+    Ignore,
 }
 
 /// When a worker is being searched for to run a job, this will be used

--- a/nativelink-scheduler/src/platform_property_manager.rs
+++ b/nativelink-scheduler/src/platform_property_manager.rs
@@ -88,6 +88,7 @@ impl PlatformPropertyManager {
                 )),
                 PropertyType::Exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
                 PropertyType::Priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
+                PropertyType::Ignore => Ok(PlatformPropertyValue::Ignore(value.to_string())),
             };
         }
         Err(make_input_err!("Unknown platform property '{}'", key))

--- a/nativelink-scheduler/src/worker_capability_index.rs
+++ b/nativelink-scheduler/src/worker_capability_index.rs
@@ -90,9 +90,11 @@ impl WorkerCapabilityIndex {
                         .or_default()
                         .insert(worker_id.clone());
                 }
-                PlatformPropertyValue::Minimum(_) => {
+                PlatformPropertyValue::Minimum(_) | PlatformPropertyValue::Ignore(_) => {
                     // Minimum properties are tracked via property_presence only.
                     // Their actual values are checked at runtime since they're dynamic.
+
+                    // Ignore properties we just drop
                 }
             }
         }
@@ -200,6 +202,7 @@ impl WorkerCapabilityIndex {
                     }
                     candidates = Some(internal_candidates);
                 }
+                PlatformPropertyValue::Ignore(_) => {}
             }
         }
 

--- a/nativelink-scheduler/tests/worker_capability_index_test.rs
+++ b/nativelink-scheduler/tests/worker_capability_index_test.rs
@@ -214,3 +214,25 @@ fn test_priority_property() {
     let result = index.find_matching_workers(&props, true);
     assert_eq!(result.len(), 2);
 }
+
+#[test]
+fn test_ignore_property() {
+    let mut index = WorkerCapabilityIndex::new();
+
+    let worker1 = make_worker_id("worker1");
+    let worker2 = make_worker_id("worker2");
+
+    index.add_worker(
+        &worker1,
+        &make_properties(&[("foo", PlatformPropertyValue::Priority("high".to_string()))]),
+    );
+    index.add_worker(
+        &worker2,
+        &make_properties(&[("bar", PlatformPropertyValue::Priority("low".to_string()))]),
+    );
+
+    // Ignore doesn't care if the worker has the property, so both workers with and without it should match
+    let props = make_properties(&[("foo", PlatformPropertyValue::Ignore("any".to_string()))]);
+    let result = index.find_matching_workers(&props, true);
+    assert_eq!(result.len(), 2);
+}

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -103,6 +103,7 @@ rust_test_suite(
         "tests/metrics_test.rs",
         "tests/operation_id_tests.rs",
         "tests/origin_event_test.rs",
+        "tests/platform_properties_tests.rs",
         "tests/proto_stream_utils_test.rs",
         "tests/resource_info_test.rs",
         "tests/retry_test.rs",

--- a/nativelink-util/tests/platform_properties_tests.rs
+++ b/nativelink-util/tests/platform_properties_tests.rs
@@ -1,0 +1,9 @@
+use nativelink_util::platform_properties::PlatformPropertyValue;
+
+#[test]
+fn ignore_properties_match_all() {
+    let ignore_property = PlatformPropertyValue::Ignore("foo".to_string());
+    let other_property = PlatformPropertyValue::Exact("bar".to_string());
+    assert!(ignore_property.is_satisfied_by(&ignore_property));
+    assert!(ignore_property.is_satisfied_by(&other_property));
+}


### PR DESCRIPTION
# Description

In certain cases (Chromium builds with `InputRootAbsolutePath` are a good example here), builds provide extra properties that they want workers to have. However, some of these properties are ignorable, especially if say all your workers match the criteria. Right now however, Nativelink requires at a minimum for all workers to have all properties specified in the job, even if they're not needed.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual running

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2120)
<!-- Reviewable:end -->
