### PR TITLE
output_files can be very noisy, drop from debug

### DIFF
--- a/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
+++ b/nativelink-proto/genproto/build.bazel.remote.execution.v2.pb.rs
@@ -600,7 +600,9 @@ pub struct ExecutedActionMetadata {
 /// `ActionResult.execution_metadata.Worker`) have a non-default value, to
 /// ensure that the serialized value is non-empty, which can then be used
 /// as a basic data sanity check.
+#[derive(::derive_more::Debug)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(skip_debug)]
 pub struct ActionResult {
     /// The output files of the action. For each output file requested in the
     /// `output_files` or `output_paths` field of the Action, if the corresponding
@@ -614,6 +616,7 @@ pub struct ActionResult {
     /// will be omitted from the list. The server is free to arrange the output
     /// list as desired; clients MUST NOT assume that the output list is sorted.
     #[prost(message, repeated, tag = "2")]
+    #[debug(ignore)]
     pub output_files: ::prost::alloc::vec::Vec<OutputFile>,
     /// The output files of the action that are symbolic links to other files. Those
     /// may be links to other output files, or input files, or even absolute paths

--- a/nativelink-service/tests/ac_server_test.rs
+++ b/nativelink-service/tests/ac_server_test.rs
@@ -117,6 +117,7 @@ async fn empty_store() -> Result<(), Box<dyn core::error::Error>> {
     let err = raw_response.unwrap_err();
     assert_eq!(err.code(), Code::NotFound);
     assert!(err.message().is_empty());
+
     Ok(())
 }
 
@@ -133,6 +134,8 @@ async fn has_single_item() -> Result<(), Box<dyn core::error::Error>> {
 
     insert_into_store(ac_store.as_pin(), HASH1, HASH1_SIZE, &action_result).await?;
     let raw_response = get_action_result(&ac_server, HASH1, HASH1_SIZE).await;
+
+    assert!(!logs_contain(" output_files: ["));
 
     assert!(
         raw_response.is_ok(),


### PR DESCRIPTION
# Description

We've been seeing logs like
> ```2026-01-26T16:49:21.550606027Z {"timestamp":"2026-01-26T16:49:21.539381Z","level":"INFO","fields":{"return":"Response { metadata: MetadataMap { headers: {} }, message: ActionResult { output_files: [OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl.h\", digest: Some(Digest { hash: \"ac6c0342b43ac65dea712fce8db8ea6e0abbbbf7e0ca6e2bd5390dd25bc790bf\", size_bytes: 62740 }), is_executable: true, contents: b\"\", node_properties: None }, OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl.hpp\", digest: Some(Digest { hash: \"965b10881acb8389f7da49f07be63c22a7c449c9dd964427831768d267065ac9\", size_bytes: 298441 }), is_executable: true, contents: b\"\", node_properties: None }, OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl_egl.h\", digest: Some(Digest { hash: \"31e046f50c34b24ddb9dd2a9eb182c854703c862c5e10f0145175567d6b6e670\", size_bytes: 5164 }), is_executable: true, contents: b\"\", node_properties: None }, OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl_ext.h\", digest: Some(Digest { hash: \"c22b00295c73b58011c1ac7b9ec9aed7ac4ea5fef970c874efe8b62d7702f953\", size_bytes: 16107 }), is_executable: true, contents: b\"\", node_properties: None }, OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl_gl.h\", digest: Some(Digest { hash: \"0b53a3b04bbcd6c122acc0fe9ccdacf80d521a64bb29c02cddad60a4ea447bf8\", size_bytes: 7346 }), is_executable: true, contents: b\"\", node_properties: None }, OutputFile { path: \"bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/CL/cl_gl_ext.h```

(continue for many, many pages)

It's noisy, it swamps other logs, it's not very useful. This PR drops `output_files` from the debug output.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2123)
<!-- Reviewable:end -->
