### PR TITLE
Add worker config option to limit maximum inflight tasks

### DIFF
--- a/nativelink-config/examples/worker_with_redis_scheduler.json5
+++ b/nativelink-config/examples/worker_with_redis_scheduler.json5
@@ -78,6 +78,7 @@
         worker_api_endpoint: {
           uri: "grpc://127.0.0.1:50061",
         },
+        max_inflight_tasks: 5,
         cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
         upload_action_result: {
           ac_store: "AC_MAIN_STORE",

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -727,6 +727,12 @@ pub struct LocalWorkerConfig {
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
     pub max_action_timeout: usize,
 
+    /// Maximum number of inflight tasks this worker can cope with.
+    ///
+    /// Default: 0 (infinite tasks)
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
+    pub max_inflight_tasks: u64,
+
     /// If timeout is handled in `entrypoint` or another wrapper script.
     /// If set to true `NativeLink` will not honor the timeout the action requested
     /// and instead will always force kill the action after `max_action_timeout`

--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -71,7 +71,11 @@ message ConnectWorkerRequest {
     /// append this prefix to the assigned worker_id followed by a UUIDv6.
     string worker_id_prefix = 2;
 
-    reserved 3; // NextId.
+    /// Maximum number of inflight tasks this worker can cope with at one time
+    /// The default (0) means unlimited.
+    uint64 max_inflight_tasks = 3;
+
+    reserved 4; // NextId.
 }
 
 /// The result of an ExecutionRequest.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -42,6 +42,10 @@ pub struct ConnectWorkerRequest {
     /// / append this prefix to the assigned worker_id followed by a UUIDv6.
     #[prost(string, tag = "2")]
     pub worker_id_prefix: ::prost::alloc::string::String,
+    /// / Maximum number of inflight tasks this worker can cope with at one time
+    /// / The default (0) means unlimited.
+    #[prost(uint64, tag = "3")]
+    pub max_inflight_tasks: u64,
 }
 /// / The result of an ExecutionRequest.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -259,8 +259,11 @@ impl ApiWorkerSchedulerImpl {
             if !w.can_accept_work() {
                 if full_worker_logging {
                     info!(
-                        "Worker {worker_id} cannot accept work: is_paused={}, is_draining={}",
-                        w.is_paused, w.is_draining
+                        "Worker {worker_id} cannot accept work: is_paused={}, is_draining={}, inflight={}/{}",
+                        w.is_paused,
+                        w.is_draining,
+                        w.running_action_infos.len(),
+                        w.max_inflight_tasks
                     );
                 }
                 return false;

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -369,7 +369,7 @@ async fn setup_new_worker(
     props: PlatformProperties,
 ) -> Result<mpsc::UnboundedReceiver<UpdateForWorker>, Error> {
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let worker = Worker::new(worker_id.clone(), props, tx, NOW_TIME);
+    let worker = Worker::new(worker_id.clone(), props, tx, NOW_TIME, 0);
     scheduler
         .add_worker(worker)
         .await

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -92,7 +92,7 @@ async fn setup_new_worker(
     props: PlatformProperties,
 ) -> Result<mpsc::UnboundedReceiver<UpdateForWorker>, Error> {
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let worker = Worker::new(worker_id.clone(), props, tx, NOW_TIME);
+    let worker = Worker::new(worker_id.clone(), props, tx, NOW_TIME, 0);
     scheduler
         .add_worker(worker)
         .await

--- a/nativelink-service/src/worker_api_server.rs
+++ b/nativelink-service/src/worker_api_server.rs
@@ -189,6 +189,7 @@ impl WorkerApiServer {
                 platform_properties,
                 tx,
                 (self.now_fn)()?.as_secs(),
+                connect_worker_request.max_inflight_tasks,
             );
             self.scheduler
                 .add_worker(worker)

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -607,9 +607,12 @@ impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T,
         &self,
         client: &mut T,
     ) -> Result<(String, Streaming<UpdateForWorker>), Error> {
-        let connect_worker_request =
-            make_connect_worker_request(self.config.name.clone(), &self.config.platform_properties)
-                .await?;
+        let connect_worker_request = make_connect_worker_request(
+            self.config.name.clone(),
+            &self.config.platform_properties,
+            self.config.max_inflight_tasks,
+        )
+        .await?;
         let mut update_for_worker_stream = client
             .connect_worker(connect_worker_request)
             .await

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -30,6 +30,7 @@ use tracing::info;
 pub async fn make_connect_worker_request<S: BuildHasher>(
     worker_id_prefix: String,
     worker_properties: &HashMap<String, WorkerProperty, S>,
+    max_inflight_tasks: u64,
 ) -> Result<ConnectWorkerRequest, Error> {
     let mut futures = vec![];
     for (property_name, worker_property) in worker_properties {
@@ -102,5 +103,6 @@ pub async fn make_connect_worker_request<S: BuildHasher>(
     Ok(ConnectWorkerRequest {
         worker_id_prefix,
         properties: try_join_all(futures).await?.into_iter().flatten().collect(),
+        max_inflight_tasks,
     })
 }

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -124,7 +124,8 @@ async fn platform_properties_smoke_test() -> Result<(), Error> {
                     name: "foo".to_string(),
                     value: "bar2".to_string(),
                 }
-            ]
+            ],
+            max_inflight_tasks: 0,
         }
     );
 


### PR DESCRIPTION
# Description

We've seen a number of cases recently of workers being overwhelmed when a scheduler gets a large number of tasks. This adds a new property to worker configs (`max_inflight_tasks`) allowing for limiting the max tasks in flight on a worker. Default is unlimited tasks, which is the current behaviour.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2125)
<!-- Reviewable:end -->
