### PR TITLE
Correct ignore handling for PlatformProperties

### DIFF
--- a/nativelink-util/src/platform_properties.rs
+++ b/nativelink-util/src/platform_properties.rs
@@ -46,6 +46,9 @@ impl PlatformProperties {
     #[must_use]
     pub fn is_satisfied_by(&self, worker_properties: &Self, full_worker_logging: bool) -> bool {
         for (property, check_value) in &self.properties {
+            if let PlatformPropertyValue::Ignore(_) = check_value {
+                continue; // always matches
+            }
             if let Some(worker_value) = worker_properties.properties.get(property) {
                 if !check_value.is_satisfied_by(worker_value) {
                     if full_worker_logging {

--- a/nativelink-util/tests/platform_properties_tests.rs
+++ b/nativelink-util/tests/platform_properties_tests.rs
@@ -1,9 +1,21 @@
-use nativelink_util::platform_properties::PlatformPropertyValue;
+use std::collections::HashMap;
+
+use nativelink_util::platform_properties::{PlatformProperties, PlatformPropertyValue};
 
 #[test]
-fn ignore_properties_match_all() {
+fn ignore_property_value_match_all() {
     let ignore_property = PlatformPropertyValue::Ignore("foo".to_string());
     let other_property = PlatformPropertyValue::Exact("bar".to_string());
     assert!(ignore_property.is_satisfied_by(&ignore_property));
     assert!(ignore_property.is_satisfied_by(&other_property));
+}
+
+#[test]
+fn ignore_property_match_all() {
+    let ignore_property = PlatformPropertyValue::Ignore("foo".to_string());
+    let mut ignore_property_map = HashMap::new();
+    ignore_property_map.insert("foo".into(), ignore_property);
+    let ignore_properties = PlatformProperties::new(ignore_property_map);
+
+    assert!(ignore_properties.is_satisfied_by(&PlatformProperties::new(HashMap::new()), true));
 }


### PR DESCRIPTION
# Description

https://github.com/TraceMachina/nativelink/pull/2120 implemented ignorable properties, but the match case was only dealt with in `PlatformPropertyValue.is_satisfied_by`. This only gets called by `PlatformProperties.is_satisfied_by` and that only does that call _if_ the worker has the property key at all, which means ignorable properties weren't being fully handled. This PR adds that support to `PlatformProperties.is_satisfied_by`.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2126)
<!-- Reviewable:end -->
