### PR TITLE
If all workers are fully allocated, shortcut find workers

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -238,6 +238,14 @@ impl ApiWorkerSchedulerImpl {
         platform_properties: &PlatformProperties,
         full_worker_logging: bool,
     ) -> Option<WorkerId> {
+        // Do a fast check to see if any workers are available at all for work allocation
+        if !self.workers.iter().any(|(_, w)| w.can_accept_work()) {
+            if full_worker_logging {
+                info!("All workers are fully allocated");
+            }
+            return None;
+        }
+
         // Use capability index to get candidate workers that match STATIC properties
         // (Exact, Unknown) and have the required property keys (Priority, Minimum).
         // This reduces complexity from O(W × P) to O(P × log(W)) for exact properties.

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -623,9 +623,7 @@ pub async fn workers_only_allow_max_tasks() -> Result<(), Box<dyn core::error::E
         "Expected not to be able to give worker a second task"
     );
 
-    assert!(logs_contain(
-        "cannot accept work: is_paused=false, is_draining=false, inflight=1/1"
-    ));
+    assert!(logs_contain("All workers are fully allocated"));
 
     Ok(())
 }


### PR DESCRIPTION
# Description

We've seen cases with many workers where things slow down, and this PR should shortcut the lookup operation a bit in cases where all workers are fully loaded.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2130)
<!-- Reviewable:end -->
