### PR TITLE
Add tracing to hyper-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,9 @@ clap = { version = "4.5.35", features = [
 ], default-features = false }
 futures = { version = "0.3.31", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
-hyper-util = { version = "0.1.11", default-features = false }
+hyper-util = { version = "0.1.11", default-features = false, features = [
+  "tracing",
+] }
 mimalloc = { version = "0.1.44", default-features = false }
 rand = { version = "0.9.0", default-features = false, features = [
   "thread_rng",


### PR DESCRIPTION
# Description

Periodically, we get a log message of the form
> ```{"timestamp":"2026-02-02T16:17:33.966673Z","level":"ERROR","fields":{"message":"Failed running service","err":"hyper::Error(Io, Kind(ConnectionReset))"},"target":"nativelink::services","span":{"remote_addr":"10.40.7.7:44912","socket_addr":"0.0.0.0:50052","name":"http_connection"},"spans":[{"remote_addr":"10.40.7.7:44912","socket_addr":"0.0.0.0:50052","name":"http_connection"}]}```

There generally isn't anything else associated with said log, and it's very hard to figure out _why_ this is occurring. My previous working theory was disconnecting workers, but I can't seem to find anything related to that in worker logs. https://github.com/hyperium/hyper/issues/3904#issuecomment-3765614854 indicates other people have seen similar issues to this and got more logging out of things by adding `hyper-util/tracing` feature, which is what this PR does.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I need to do some more local testing on this one, as it's not trivially reproducible, but I've got some large enough builds I can make it happen.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2132)
<!-- Reviewable:end -->
