### PR TITLE
Allows setting environment variables from the environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,7 +136,8 @@
                 p.libiconv
               ];
             nativeBuildInputs =
-              (
+              [p.bashNonInteractive] # needed for some command tests
+              ++ (
                 if isLinuxBuild
                 then [pkgs.mold]
                 else [pkgs.llvmPackages_20.lld]

--- a/nativelink-config/examples/basic_cas.json5
+++ b/nativelink-config/examples/basic_cas.json5
@@ -76,6 +76,15 @@
           ac_store: "AC_MAIN_STORE",
         },
         work_directory: "/tmp/nativelink/work",
+        additional_environment: {
+          foo: "from_environment",
+          bar: {
+            value: "something",
+          },
+          baz: "timeout_millis",
+          channel: "side_channel_file",
+          action: "action_directory",
+        },
         platform_properties: {
           cpu_count: {
             values: [

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -609,6 +609,9 @@ pub enum EnvironmentSource {
     /// The raw value to set.
     Value(#[serde(deserialize_with = "convert_string_with_shellexpand")] String),
 
+    /// Take the value from the local environment corresponding to the name key
+    FromEnvironment,
+
     /// The max amount of time in milliseconds the command is allowed to run
     /// (requested by the client).
     TimeoutMillis,

--- a/nativelink-worker/BUILD.bazel
+++ b/nativelink-worker/BUILD.bazel
@@ -54,6 +54,7 @@ rust_test_suite(
     srcs = [
         "tests/local_worker_test.rs",
         "tests/running_actions_manager_test.rs",
+        "tests/worker_utils_test.rs",
     ],
     compile_data = [
         "tests/utils/local_worker_test_utils.rs",

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -16,13 +16,16 @@ use core::pin::Pin;
 use core::str;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::time::Duration;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::env;
 use std::process::Stdio;
 use std::sync::{Arc, Weak};
 
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{Future, FutureExt, StreamExt, TryFutureExt, select};
-use nativelink_config::cas_server::LocalWorkerConfig;
+use nativelink_config::cas_server::{EnvironmentSource, LocalWorkerConfig};
 use nativelink_error::{Code, Error, ResultExt, make_err, make_input_err};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::update_for_worker::Update;
@@ -45,7 +48,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::Streaming;
-use tracing::{Level, debug, error, event, info, info_span, instrument, warn};
+use tracing::{Level, debug, error, event, info, info_span, instrument, trace, warn};
 
 use crate::running_actions_manager::{
     ExecutionConfiguration, Metrics as RunningActionManagerMetrics, RunningAction,
@@ -85,7 +88,10 @@ struct LocalWorkerImpl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsM
     metrics: Arc<Metrics>,
 }
 
-async fn preconditions_met(precondition_script: Option<String>) -> Result<(), Error> {
+pub async fn preconditions_met(
+    precondition_script: Option<String>,
+    extra_envs: &HashMap<String, String>,
+) -> Result<(), Error> {
     let Some(precondition_script) = &precondition_script else {
         // No script means we are always ok to proceed.
         return Ok(());
@@ -96,15 +102,31 @@ async fn preconditions_met(precondition_script: Option<String>) -> Result<(), Er
     //       future to pass useful information through?  Or perhaps we'll
     //       have a pre-condition and a pre-execute script instead, although
     //       arguably entrypoint already gives us that.
-    let precondition_process = process::Command::new(precondition_script)
+
+    let maybe_split_cmd = shlex::split(precondition_script);
+    let (command, args) = match &maybe_split_cmd {
+        Some(split_cmd) => (&split_cmd[0], &split_cmd[1..]),
+        None => {
+            return Err(make_input_err!(
+                "Could not parse the value of precondition_script: '{}'",
+                precondition_script,
+            ));
+        }
+    };
+
+    let precondition_process = process::Command::new(command)
+        .args(args)
         .kill_on_drop(true)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .env_clear()
+        .envs(extra_envs)
         .spawn()
         .err_tip(|| format!("Could not execute precondition command {precondition_script:?}"))?;
     let output = precondition_process.wait_with_output().await?;
+    let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+    trace!(status = %output.status, %stdout, "Preconditions script returned");
     if output.status.code() == Some(0) {
         Ok(())
     } else {
@@ -112,7 +134,7 @@ async fn preconditions_met(precondition_script: Option<String>) -> Result<(), Er
             Code::ResourceExhausted,
             "Preconditions script returned status {} - {}",
             output.status,
-            str::from_utf8(&output.stdout).unwrap_or("")
+            stdout
         ))
     }
 }
@@ -255,6 +277,23 @@ impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorke
 
                             let start_action_fut = {
                                 let precondition_script_cfg = self.config.experimental_precondition_script.clone();
+                                let mut extra_envs: HashMap<String, String> = HashMap::new();
+                                if let Some(ref additional_environment) = self.config.additional_environment {
+                                    for (name, source) in additional_environment {
+                                        let value = match source {
+                                            EnvironmentSource::Property(property) => start_execute
+                                                .platform.as_ref().and_then(|p|p.properties.iter().find(|pr| &pr.name == property))
+                                                .map_or_else(|| Cow::Borrowed(""), |v| Cow::Borrowed(v.value.as_str())),
+                                            EnvironmentSource::Value(value) => Cow::Borrowed(value.as_str()),
+                                            EnvironmentSource::FromEnvironment => Cow::Owned(env::var(name).unwrap_or_default()),
+                                            other => {
+                                                debug!(?other, "Worker doesn't support this type of additional environment");
+                                                continue;
+                                            }
+                                        };
+                                        extra_envs.insert(name.clone(), value.into_owned());
+                                    }
+                                }
                                 let actions_in_transit = self.actions_in_transit.clone();
                                 let worker_id = self.worker_id.clone();
                                 let running_actions_manager = self.running_actions_manager.clone();
@@ -263,7 +302,7 @@ impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorke
                                     operation_id: operation_id.clone(),
                                 };
                                 self.metrics.clone().wrap(move |metrics| async move {
-                                    metrics.preconditions.wrap(preconditions_met(precondition_script_cfg))
+                                    metrics.preconditions.wrap(preconditions_met(precondition_script_cfg, &extra_envs))
                                     .and_then(|()| running_actions_manager.create_and_add_action(worker_id, start_execute))
                                     .map(move |r| {
                                         // Now that we either failed or registered our action, we can
@@ -614,9 +653,30 @@ impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T,
         &self,
         client: &mut T,
     ) -> Result<(String, Streaming<UpdateForWorker>), Error> {
+        let mut extra_envs: HashMap<String, String> = HashMap::new();
+        if let Some(ref additional_environment) = self.config.additional_environment {
+            for (name, source) in additional_environment {
+                let value = match source {
+                    EnvironmentSource::Value(value) => Cow::Borrowed(value.as_str()),
+                    EnvironmentSource::FromEnvironment => {
+                        Cow::Owned(env::var(name).unwrap_or_default())
+                    }
+                    other => {
+                        debug!(
+                            ?other,
+                            "Worker registration doesn't support this type of additional environment"
+                        );
+                        continue;
+                    }
+                };
+                extra_envs.insert(name.clone(), value.into_owned());
+            }
+        }
+
         let connect_worker_request = make_connect_worker_request(
             self.config.name.clone(),
             &self.config.platform_properties,
+            &extra_envs,
             self.config.max_inflight_tasks,
         )
         .await?;

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -21,6 +21,7 @@ use core::time::Duration;
 use std::borrow::Cow;
 use std::collections::vec_deque::VecDeque;
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::ffi::{OsStr, OsString};
 #[cfg(target_family = "unix")]
 use std::fs::Permissions;
@@ -942,6 +943,9 @@ impl RunningActionImpl {
                         .get(property)
                         .map_or_else(|| Cow::Borrowed(""), |v| Cow::Borrowed(v.as_str())),
                     EnvironmentSource::Value(value) => Cow::Borrowed(value.as_str()),
+                    EnvironmentSource::FromEnvironment => {
+                        Cow::Owned(env::var(name).unwrap_or_default())
+                    }
                     EnvironmentSource::TimeoutMillis => {
                         Cow::Owned(requested_timeout.as_millis().to_string())
                     }

--- a/nativelink-worker/src/worker_utils.rs
+++ b/nativelink-worker/src/worker_utils.rs
@@ -30,6 +30,7 @@ use tracing::info;
 pub async fn make_connect_worker_request<S: BuildHasher>(
     worker_id_prefix: String,
     worker_properties: &HashMap<String, WorkerProperty, S>,
+    extra_envs: &HashMap<String, String>,
     max_inflight_tasks: u64,
 ) -> Result<ConnectWorkerRequest, Error> {
     let mut futures = vec![];
@@ -60,6 +61,7 @@ pub async fn make_connect_worker_request<S: BuildHasher>(
                     };
                     let mut process = process::Command::new(command);
                     process.env_clear();
+                    process.envs(extra_envs);
                     process.args(args);
                     process.stdin(Stdio::null());
                     let err_fn =

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -53,6 +53,8 @@ use nativelink_util::common::{DigestInfo, encode_stream_proto, fs};
 use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::store_trait::Store;
 use nativelink_worker::local_worker::new_local_worker;
+#[cfg(target_family = "unix")]
+use nativelink_worker::local_worker::preconditions_met;
 use pretty_assertions::assert_eq;
 use prost::Message;
 use rand::Rng;
@@ -747,5 +749,19 @@ async fn kill_action_request_kills_action() -> Result<(), Error> {
     // Make sure that the killed action is the one we intended
     assert_eq!(killed_operation_id, operation_id);
 
+    Ok(())
+}
+
+#[cfg(target_family = "unix")]
+#[nativelink_test]
+async fn preconditions_met_extra_envs() -> Result<(), Error> {
+    let mut extra_envs = HashMap::new();
+    extra_envs.insert("DEMO_ENV".into(), "test_value_for_demo_env".into());
+
+    // So we have bash for nix cases, because the PATH gets reset
+    extra_envs.insert("PATH".into(), env::var("PATH").unwrap());
+
+    preconditions_met(Some("bash -c \"echo $DEMO_ENV\"".to_string()), &extra_envs).await?;
+    assert!(logs_contain("test_value_for_demo_env"));
     Ok(())
 }

--- a/nativelink-worker/tests/worker_utils_test.rs
+++ b/nativelink-worker/tests/worker_utils_test.rs
@@ -1,0 +1,34 @@
+#![cfg(target_family = "unix")]
+use std::collections::HashMap;
+use std::env;
+
+use nativelink_config::cas_server::WorkerProperty;
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_proto::build::bazel::remote::execution::v2::platform::Property;
+use nativelink_worker::worker_utils::make_connect_worker_request;
+
+#[nativelink_test]
+async fn make_connect_worker_request_with_extra_envs() -> Result<(), Error> {
+    let mut worker_properties: HashMap<String, WorkerProperty> = HashMap::new();
+    worker_properties.insert(
+        "test".into(),
+        WorkerProperty::QueryCmd("bash -c \"echo $DEMO_ENV\"".to_string()),
+    );
+    let mut extra_envs = HashMap::new();
+    extra_envs.insert("DEMO_ENV".into(), "test_value_for_demo_env".into());
+
+    // So we have bash for nix cases, because the PATH gets reset
+    extra_envs.insert("PATH".into(), env::var("PATH").unwrap());
+
+    let res =
+        make_connect_worker_request("1234".to_string(), &worker_properties, &extra_envs, 1).await?;
+    assert_eq!(
+        res.properties.first(),
+        Some(&Property {
+            name: "test".into(),
+            value: "test_value_for_demo_env".into()
+        })
+    );
+    Ok(())
+}


### PR DESCRIPTION
# Description

This solves cases like https://github.com/TraceMachina/nativelink/issues/2048 where the environment variable will vary depending on the worker image. Originally, I was going to add an environment allow list, but then I spotted all the existing `additional_environment` bits, and re-using that seems like a better path.

Along the way I've also:
* Added support for precondition commands that aren't just a single command, but a command with args
* Precondition commands also get the specified environment as well

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...` mostly

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2143)
<!-- Reviewable:end -->
