### PR TITLE
Advise the kernel to drop page cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ dependencies = [
  "humantime",
  "hyper 1.7.0",
  "hyper-util",
+ "libc",
  "lru 0.16.3",
  "mock_instant",
  "nativelink-config",

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -755,6 +755,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             .await
             .err_tip(|| "Failed to sync_data in filesystem store")?;
 
+        temp_file.advise_dontneed();
         trace!(?temp_file, "Dropping file to update_file");
         drop(temp_file);
 
@@ -957,6 +958,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
             .await
             .err_tip(|| "Failed to sync_data in filesystem store update_oneshot")?;
 
+        temp_file.advise_dontneed();
         drop(temp_file);
 
         *entry.data_size_mut() = data.len() as u64;
@@ -995,6 +997,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         // We are done with the file, if we hold a reference to the file here, it could
         // result in a deadlock if `emplace_file()` also needs file descriptors.
         trace!(?file, "Dropping file to to update_with_whole_file");
+        file.advise_dontneed();
         drop(file);
         self.emplace_file(key.into_owned(), Arc::new(entry))
             .await
@@ -1054,6 +1057,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
                 .await
                 .err_tip(|| "Failed to send chunk in filesystem store get_part")?;
         }
+        temp_file.get_ref().advise_dontneed();
         writer
             .send_eof()
             .err_tip(|| "Filed to send EOF in filesystem store get_part")?;

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -59,6 +59,7 @@ rust_library(
         "@crates//:humantime",
         "@crates//:hyper-1.7.0",
         "@crates//:hyper-util",
+        "@crates//:libc",
         "@crates//:lru",
         "@crates//:mock_instant",
         "@crates//:opentelemetry",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -24,6 +24,7 @@ hex = { version = "0.4.3", default-features = false, features = ["std"] }
 humantime = { version = "2.3.0", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.11", default-features = false }
+libc = { version = "0.2.177", default-features = false }
 lru = { version = "0.16.0", default-features = false }
 mock_instant = { version = "0.5.3", default-features = false }
 opentelemetry = { version = "0.29.0", default-features = false }

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -41,6 +41,29 @@ pub struct FileSlot {
     inner: tokio::fs::File,
 }
 
+impl FileSlot {
+    /// Advise the kernel to drop page cache for this file's contents.
+    /// Only available on Linux;
+    #[cfg(target_os = "linux")]
+    pub fn advise_dontneed(&self) {
+        use std::os::unix::io::AsRawFd;
+        let fd = self.inner.as_raw_fd();
+        let ret = unsafe { libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED) };
+        if ret != 0 {
+            tracing::debug!(
+                fd,
+                ret,
+                "posix_fadvise(DONTNEED) returned non-zero (best-effort, ignoring)",
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub const fn advise_dontneed(&self) {
+        // No-op: posix_fadvise is not available on Mac or Windows.
+    }
+}
+
 impl AsRef<tokio::fs::File> for FileSlot {
     fn as_ref(&self) -> &tokio::fs::File {
         &self.inner


### PR DESCRIPTION
# Description

Page cache creates huge chunk of memory pressure on workers resulting in workers getting OOMKilled. This PR reduces that memory pressure somewhat. Also, this should be paired with reducing the max_bytes for the workers, and both of these changes results in lower possibility of workers getting OOMKilled. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2149)
<!-- Reviewable:end -->
