### PR TITLE
Log NotFound as info, not error

### DIFF
--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -56,7 +56,7 @@ where
             .next()
             .await
             .err_tip(|| "Error receiving first message in stream")?
-            .err_tip(|| "Expected WriteRequest struct in stream")?;
+            .err_tip(|| "Expected WriteRequest struct in stream (from)")?;
 
         let resource_info = ResourceInfo::new(&first_msg.resource_name, true)
             .err_tip(|| {
@@ -120,7 +120,9 @@ where
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(maybe_message)) => maybe_message
                     .err_tip(|| format!("Stream error at byte {}", self.bytes_received)),
-                Poll::Ready(None) => Err(make_input_err!("Expected WriteRequest struct in stream")),
+                Poll::Ready(None) => Err(make_input_err!(
+                    "Expected WriteRequest struct in stream (got None)"
+                )),
             }
         };
 

--- a/nativelink-util/src/retry.rs
+++ b/nativelink-util/src/retry.rs
@@ -20,7 +20,7 @@ use futures::future::Future;
 use futures::stream::StreamExt;
 use nativelink_config::stores::{ErrorCode, Retry};
 use nativelink_error::{Code, Error, make_err};
-use tracing::error;
+use tracing::{error, info};
 
 struct ExponentialBackoff {
     current: Duration,
@@ -163,7 +163,11 @@ impl Retrier {
                     }
                     Some(RetryResult::Retry(err)) => {
                         if !self.should_retry(err.code) {
-                            error!(?attempt, ?err, "Not retrying permanent error");
+                            if err.code == Code::NotFound {
+                                info!(?err, "Not found, not retrying");
+                            } else {
+                                error!(?attempt, ?err, "Not retrying permanent error");
+                            }
                             return Err(err);
                         }
                         (self.sleep_fn)(

--- a/nativelink-util/tests/metrics_test.rs
+++ b/nativelink-util/tests/metrics_test.rs
@@ -137,7 +137,7 @@ fn test_action_stage_to_execution_stage_conversion() {
     // Test that Completed variants map to ExecutionStage::Completed
     let action_result = ActionResult::default();
     assert_eq!(
-        ExecutionStage::from(ActionStage::Completed(action_result.clone())),
+        ExecutionStage::from(ActionStage::Completed(action_result)),
         ExecutionStage::Completed
     );
 
@@ -192,7 +192,6 @@ fn test_action_stage_conversion_avoids_clone() {
     // In practice, 10000 conversions should take less than 1ms
     assert!(
         elapsed.as_millis() < 100,
-        "Reference conversion took too long: {:?}",
-        elapsed
+        "Reference conversion took too long: {elapsed:?}"
     );
 }

--- a/nativelink-util/tests/retry_test.rs
+++ b/nativelink-util/tests/retry_test.rs
@@ -85,6 +85,39 @@ async fn retry_fails_after_3_runs() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn dont_retry_for_not_found() -> Result<(), Error> {
+    let retrier = Retrier::new(
+        Arc::new(|_duration| Box::pin(ready(()))),
+        Arc::new(move |_delay| Duration::from_millis(1)),
+        Retry {
+            max_retries: 2,
+            ..Default::default()
+        },
+    );
+    let run_count = Arc::new(AtomicI32::new(0));
+    let result = Pin::new(&retrier)
+        .retry(repeat_with(|| {
+            run_count.fetch_add(1, Ordering::Relaxed);
+            RetryResult::<bool>::Retry(make_err!(Code::NotFound, "Dummy failure",))
+        }))
+        .await;
+    assert_eq!(
+        run_count.load(Ordering::Relaxed),
+        1,
+        "Expected function to be called once"
+    );
+    assert_eq!(result.is_err(), true, "Expected result to error");
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Error { code: NotFound, messages: [\"Dummy failure\"] }"
+    );
+    assert!(logs_contain("Not found, not retrying"));
+    assert!(!logs_contain("ERROR"));
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn retry_success_after_2_runs() -> Result<(), Error> {
     let retrier = Retrier::new(
         Arc::new(|_duration| Box::pin(ready(()))),


### PR DESCRIPTION
# Description

We get a lot of errors on Chromium builds like this, which aren't errors, they're just the build looking for objects that aren't there yet.
>```{"timestamp":"2026-02-16T12:15:40.669000Z","level":"ERROR","fields":{"message":"Not retrying permanent error","attempt":"1","err":"Error { code: NotFound, messages: [\"status: NotFound, message: \\\"\\\", details: [], metadata: MetadataMap { headers: {\\\"content-type\\\": \\\"application/grpc\\\", \\\"date\\\": \\\"Mon, 16 Feb 2026 12:15:40 GMT\\\"} }\", \"in GrpcStore::get_action_result\"] }"},"target":"nativelink_util::retry","span":{"name":"ac_server_get_action_result"},"spans":[{"remote_addr":"10.40.10.45:44432","socket_addr":"0.0.0.0:50052","name":"http_connection"},{"name":"http_executor"},{"request":"GetActionResultRequest { instance_name: \"main\", action_digest: Some(Digest { hash: \"8141bac16da5ede726ab9b933f32139419cccfe1a8664ad6e24582ed953f396f\", size_bytes: 328 }), inline_stdout: false, inline_stderr: false, inline_output_files: [], digest_function: Unknown }","name":"get_action_result"},{"name":"ac_server_get_action_result"}]}```

This PR drops those down to `info` level

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2171)
<!-- Reviewable:end -->
