### PR TITLE
Only display Baggage enduser.id when identity is present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ name = "nativelink-util"
 version = "1.0.0-rc2"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bitflags 2.10.0",
  "blake3",

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -108,6 +108,7 @@ rust_test_suite(
         "tests/proto_stream_utils_test.rs",
         "tests/resource_info_test.rs",
         "tests/retry_test.rs",
+        "tests/telemetry_test.rs",
         "tests/tls_utils_test.rs",
     ],
     compile_data = [
@@ -124,6 +125,7 @@ rust_test_suite(
         "//nativelink-config",
         "//nativelink-error",
         "//nativelink-proto",
+        "@crates//:axum",
         "@crates//:bytes",
         "@crates//:futures",
         "@crates//:hex",
@@ -141,6 +143,7 @@ rust_test_suite(
         "@crates//:tokio-stream",
         "@crates//:tokio-util",
         "@crates//:tonic",
+        "@crates//:tower",
         "@crates//:tracing",
         "@crates//:tracing-test",
         "@crates//:uuid",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -70,6 +70,7 @@ tokio-stream = { version = "0.1.17", features = [
 ], default-features = false }
 tokio-util = { version = "0.7.14", default-features = false }
 tonic = { version = "0.13.0", features = [
+  "router",
   "tls-native-roots",
   "tls-ring",
   "transport",
@@ -96,6 +97,7 @@ walkdir = { version = "2.5.0", default-features = false }
 [dev-dependencies]
 nativelink-macro = { path = "../nativelink-macro" }
 
+axum = { version = "0.8.3", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
 pretty_assertions = { version = "1.4.1", features = [
   "std",

--- a/nativelink-util/src/telemetry.rs
+++ b/nativelink-util/src/telemetry.rs
@@ -254,22 +254,24 @@ where
             .map(|value| value.as_str().to_string())
             .unwrap_or_default();
 
-        if identity.is_empty() && self.identity_required {
-            return Box::pin(async move {
-                Ok(tonic::Status::failed_precondition(
-                    r"
+        if identity.is_empty() {
+            if self.identity_required {
+                return Box::pin(async move {
+                    Ok(tonic::Status::failed_precondition(
+                        r"
 
 NativeLink instance configured to require this OpenTelemetry Baggage header:
 
     `Baggage: enduser.id=YOUR_IDENTITY`
 
 ",
-                )
-                .into_http())
-            });
+                    )
+                    .into_http())
+                });
+            }
+        } else {
+            debug!("Baggage enduser.id: {identity}");
         }
-
-        debug!("Baggage enduser.id: {identity}");
 
         let tracer = global::tracer("origin_middleware");
         let span = tracer

--- a/nativelink-util/tests/telemetry_test.rs
+++ b/nativelink-util/tests/telemetry_test.rs
@@ -1,0 +1,77 @@
+use axum::Router;
+use hyper::{Request, StatusCode, Uri};
+use nativelink_macro::nativelink_test;
+use opentelemetry::baggage::BaggageExt;
+use opentelemetry::{Context, KeyValue};
+use tonic::body::Body;
+use tonic::service::Routes;
+use tower::{Service, ServiceExt};
+use tracing::warn;
+
+fn demo_service() -> Router {
+    let tonic_services = Routes::builder().routes();
+    tonic_services
+        .into_axum_router()
+        .fallback(|uri: Uri| async move {
+            warn!("No route for {uri}");
+            (StatusCode::NOT_FOUND, format!("No route for {uri}"))
+        })
+        .layer(nativelink_util::telemetry::OtlpLayer::new(false))
+}
+
+async fn run_request(
+    svc: &mut Router,
+    request: Request<Body>,
+) -> Result<(), Box<dyn core::error::Error>> {
+    let response: hyper::Response<axum::body::Body> =
+        svc.as_service().ready().await?.call(request).await?;
+    assert_eq!(response.status(), 404);
+
+    let response = String::from_utf8(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await?
+            .to_vec(),
+    )?;
+    assert_eq!(response, String::from("No route for /demo"));
+    Ok(())
+}
+
+#[nativelink_test]
+async fn oltp_logs_no_baggage() -> Result<(), Box<dyn core::error::Error>> {
+    let mut svc = demo_service();
+
+    let request: Request<Body> = Request::builder()
+        .method("GET")
+        .uri("/demo")
+        .body(Body::empty())?;
+    run_request(&mut svc, request).await?;
+
+    assert!(!logs_contain("Baggage enduser.id:"));
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn oltp_logs_with_baggage() -> Result<(), Box<dyn core::error::Error>> {
+    let mut svc = demo_service();
+
+    let mut request: Request<Body> = Request::builder()
+        .method("GET")
+        .uri("/demo")
+        .body(Body::empty())?;
+
+    let cx_guard =
+        Context::map_current(|cx| cx.with_baggage([KeyValue::new("enduser.id", "foobar")]))
+            .attach();
+
+    request
+        .headers_mut()
+        .insert("baggage", "enduser.id=foobar".parse().unwrap());
+
+    run_request(&mut svc, request).await?;
+
+    assert!(logs_contain("Baggage enduser.id: foobar"));
+    drop(cx_guard);
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

I'd been seeing a lot of `{"message":"Baggage enduser.id: "}` in CAS logs, and it was annoying me. This PR only displays the message when the identity is set, instead of when it's not as well.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2197)
<!-- Reviewable:end -->
