### PR TITLE
Test Mongo against an embedded MongoDB instance, not external

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,12 +1500,13 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2667,11 +2689,13 @@ dependencies = [
 name = "nativelink-error"
 version = "1.0.0-rc4"
 dependencies = [
+ "mongodb",
  "nativelink-metric",
  "nativelink-proto",
  "prost",
  "prost-types",
  "redis",
+ "reqwest",
  "rustls-pki-types",
  "serde",
  "serde_json5",
@@ -2680,6 +2704,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -2829,6 +2854,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "const_format",
+ "dirs",
+ "flate2",
  "futures",
  "gcloud-auth",
  "gcloud-storage",
@@ -2867,6 +2894,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2876,6 +2904,7 @@ dependencies = [
  "tracing-test",
  "url",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -3170,6 +3199,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -3698,6 +3733,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4501,6 +4547,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,6 +5034,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -5716,6 +5778,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.0",
+ "memchr",
+ "typed-path",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zstd"

--- a/flake.nix
+++ b/flake.nix
@@ -297,6 +297,26 @@
           (nightlyCraneLibFor p).cargoLlvmCov (coverageArgs
             // {
               cargoArtifacts = nightlyCargoArtifactsFor p;
+              preConfigurePhases = ["tempHome"];
+              tempHome = ''
+                # Default home at this point is /homeless-shelter, which doesn't exist and so breaks things like
+                # the Mongo downloader
+                echo "HOME was ''${HOME}"
+                export HOME=$(mktemp -d fake-homeXXXX --tmpdir)
+                echo "HOME is now ''${HOME}"
+
+                # FIXME: This is a giant pile of hacks, as what we should be doing is downloading mongodb and patching it to work with
+                # Nix. Several hours of patchelf rummaging later, hitting issues like "_Unwind_GetRegionStart: symbol not found" we
+                # instead have this hacky workaround. It adds a symlink to a Nix mongod where the extractor code expects to find it,
+                # which will work. This is the wrong version (7.0.16 v.s. 7.0.11 currently, so not so bad) but TBH our codebase is mostly
+                # fairly version agnostic so far and 7.0.11 is picked out of the air as the one we've used elsewhere.
+
+                mkdir -p $HOME/.cache/mongo/extracted/7.0.11/mongodb-linux-x86_64-ubuntu2204-7.0.11/bin
+                touch $HOME/.cache/mongo/extracted/7.0.11/extracted.marker # As needed by nativelink-store/tests/mongo_runner/mod.rs
+                export MONGOD=$HOME/.cache/mongo/extracted/7.0.11/mongodb-linux-x86_64-ubuntu2204-7.0.11/bin/mongod
+                ln -s ${p.mongodb}/bin/mongod ''${MONGOD}
+                ''${MONGOD} --version
+              '';
               cargoExtraArgs = builtins.concatStringsSep " " [
                 "--all"
                 "--locked"

--- a/nativelink-error/BUILD.bazel
+++ b/nativelink-error/BUILD.bazel
@@ -16,9 +16,11 @@ rust_library(
     deps = [
         "//nativelink-metric",
         "//nativelink-proto",
+        "@crates//:mongodb",
         "@crates//:prost",
         "@crates//:prost-types",
         "@crates//:redis",
+        "@crates//:reqwest",
         "@crates//:rustls-pki-types",
         "@crates//:serde",
         "@crates//:serde_json5",
@@ -27,6 +29,7 @@ rust_library(
         "@crates//:url",
         "@crates//:uuid",
         "@crates//:walkdir",
+        "@crates//:zip",
     ],
 )
 

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -13,11 +13,16 @@ version = "1.0.0-rc4"
 nativelink-metric = { path = "../nativelink-metric" }
 nativelink-proto = { path = "../nativelink-proto" }
 
+mongodb = { version = "3", features = [
+  "compat-3-0-0",
+  "rustls-tls",
+], default-features = false }
 prost = { version = "0.13.5", default-features = false }
 prost-types = { version = "0.13.5", default-features = false, features = [
   "std",
 ] }
 redis = { version = "1.0.0", default-features = false }
+reqwest = { version = "0.12", default-features = false }
 rustls-pki-types = { version = "1.13.1", default-features = false }
 serde = { version = "1.0.219", default-features = false }
 serde_json5 = { version = "0.2.1", default-features = false }
@@ -34,3 +39,4 @@ tonic = { version = "0.13.0", features = [
 url = { version = "2.5.7", default-features = false }
 uuid = { version = "1.16.0", default-features = false, features = ["std"] }
 walkdir = { version = "2.5.0", default-features = false }
+zip = { version = "7.2.0", default-features = false }

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -335,6 +335,24 @@ impl From<url::ParseError> for Error {
     }
 }
 
+impl From<mongodb::error::Error> for Error {
+    fn from(err: mongodb::error::Error) -> Self {
+        Self::from_std_err(Code::Internal, &err)
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::from_std_err(Code::Internal, &err)
+    }
+}
+
+impl From<zip::result::ZipError> for Error {
+    fn from(err: zip::result::ZipError) -> Self {
+        Self::from_std_err(Code::Internal, &err)
+    }
+}
+
 pub trait ResultExt<T> {
     /// # Errors
     ///

--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -130,6 +130,12 @@ rust_test_suite(
         "tests/size_partitioning_store_test.rs",
         "tests/verify_store_test.rs",
     ],
+    compile_data = [
+        "tests/mongo_runner/mod.rs",
+        "tests/mongo_runner/process.rs",
+        "tests/mongo_runner/extractor.rs",
+        "tests/mongo_runner/downloader.rs",
+    ],
     proc_macro_deps = [
         "//nativelink-macro",
         "@crates//:async-trait",
@@ -149,6 +155,8 @@ rust_test_suite(
         "@crates//:aws-smithy-types",
         "@crates//:bincode",
         "@crates//:bytes",
+        "@crates//:dirs",
+        "@crates//:flate2",
         "@crates//:futures",
         "@crates//:hex",
         "@crates//:http",
@@ -162,9 +170,11 @@ rust_test_suite(
         "@crates//:rand",
         "@crates//:redis",
         "@crates//:redis-test",
+        "@crates//:reqwest",
         "@crates//:serde_json",
         "@crates//:serial_test",
         "@crates//:sha2",
+        "@crates//:tar",
         "@crates//:tempfile",
         "@crates//:tokio",
         "@crates//:tokio-stream",
@@ -172,6 +182,7 @@ rust_test_suite(
         "@crates//:tracing",
         "@crates//:tracing-test",
         "@crates//:uuid",
+        "@crates//:zip",
     ],
 )
 

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -126,6 +126,8 @@ aws-smithy-runtime-api = { version = "1.7.4", default-features = false }
 aws-smithy-types = { version = "1.3.0", default-features = false, features = [
   "http-body-1-x",
 ] }
+dirs = { version = "6.0.0", default-features = false }
+flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3.31", default-features = false, features = [
   "executor",
 ] }
@@ -141,9 +143,13 @@ rand = { version = "0.9.0", default-features = false, features = [
 ] }
 redis-test = { version = "1.0.0", default-features = false, features = ["aio"] }
 serde_json = { version = "1.0.140", default-features = false }
+tar = { version = "0.4.44", default-features = false }
 tempfile = { version = "3.8.1", default-features = false }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
+] }
+zip = { version = "7.2.0", default-features = false, features = [
+  "deflate-flate2-zlib-rs",
 ] }
 
 [package.metadata.cargo-machete]

--- a/nativelink-store/tests/mongo_runner/README.md
+++ b/nativelink-store/tests/mongo_runner/README.md
@@ -1,0 +1,1 @@
+Most of this is based off the defunct https://docs.rs/crate/mongo-embedded/1.0.0/source/ code and should be extracted out again as a separate crate at some point

--- a/nativelink-store/tests/mongo_runner/downloader.rs
+++ b/nativelink-store/tests/mongo_runner/downloader.rs
@@ -1,0 +1,151 @@
+use std::env;
+
+use nativelink_error::{Error, ResultExt, make_input_err};
+
+#[derive(Debug, Clone)]
+pub(crate) enum Os {
+    Linux,
+    #[allow(clippy::enum_variant_names)]
+    MacOs,
+    Windows,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum Arch {
+    X86_64,
+    Aarch64,
+}
+
+pub(crate) struct MongoUrl {
+    pub(crate) url: String,
+    pub(crate) filename: String,
+}
+
+pub(crate) fn get_os() -> Result<Os, Error> {
+    match env::consts::OS {
+        "linux" => Ok(Os::Linux),
+        "macos" => Ok(Os::MacOs),
+        "windows" => Ok(Os::Windows),
+        os => Err(make_input_err!("Unsupported OS: {}", os)),
+    }
+}
+
+pub(crate) fn get_arch() -> Result<Arch, Error> {
+    match env::consts::ARCH {
+        "x86_64" => Ok(Arch::X86_64),
+        "aarch64" => Ok(Arch::Aarch64),
+        arch => Err(make_input_err!("Unsupported Architecture: {}", arch)),
+    }
+}
+
+pub(crate) fn get_download_url(version: &str) -> Result<MongoUrl, Error> {
+    let os = get_os()?;
+    let arch = get_arch()?;
+
+    let (_platform, package_format) = match (&os, &arch) {
+        (Os::Linux, Arch::X86_64) => ("linux-x86_64", "tgz"),
+        (Os::Linux, Arch::Aarch64) => ("linux-aarch64", "tgz"),
+        (Os::MacOs, Arch::X86_64) => ("macos-x86_64", "tgz"),
+        (Os::MacOs, Arch::Aarch64) => ("macos-aarch64", "tgz"),
+        (Os::Windows, Arch::X86_64) => ("windows-x86_64", "zip"),
+        _ => return Err(make_input_err!("Unsupported OS/Arch combination")),
+    };
+
+    // Note: This is a simplified URL constructor.
+    // Real MongoDB URLs are more complex and depend on specific distros for Linux.
+    // We might need to handle specific linux distros.
+    // For now, let's try to find a generic linux binary or handle specific common ones.
+
+    // Example: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.2.tgz
+    // Example: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.2.tgz
+    // Example: https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.2.zip
+
+    // For generic linux, we often need to specify a distro.
+    // Let's assume ubuntu2204 for now for linux x64 as a safeish default or try to detect.
+    // Or use the "generic" linux legacy if available, but modern mongo usually target distros.
+
+    let base_url = "https://fastdl.mongodb.org";
+
+    let _filename = match os {
+        Os::Linux => format!(
+            "mongodb-linux-{}-{}.{}",
+            "x86_64-ubuntu2204", version, package_format
+        ), // HARDCODING ubuntu2204 for x64 linux for now
+        Os::MacOs => format!("mongodb-macos-{version}-x86_64.{package_format}"), // Need to fix arch for mac
+        Os::Windows => format!("mongodb-windows-x86_64-{version}.{package_format}"),
+    };
+
+    // Refined logic
+    let url = match (&os, &arch) {
+        (Os::Linux, Arch::X86_64) => {
+            format!("{base_url}/linux/mongodb-linux-x86_64-ubuntu2204-{version}.tgz",)
+        }
+        (Os::Linux, Arch::Aarch64) => {
+            format!("{base_url}/linux/mongodb-linux-aarch64-ubuntu2204-{version}.tgz",)
+        }
+        (Os::MacOs, Arch::X86_64) => {
+            format!("{base_url}/osx/mongodb-macos-x86_64-{version}.tgz")
+        }
+        (Os::MacOs, Arch::Aarch64) => {
+            format!("{base_url}/osx/mongodb-macos-arm64-{version}.tgz")
+        }
+        (Os::Windows, Arch::X86_64) => {
+            format!("{base_url}/windows/mongodb-windows-x86_64-{version}.zip")
+        }
+        _ => return Err(make_input_err!("Unsupported OS/Arch combination")),
+    };
+
+    let filename = url.split('/').next_back().unwrap().to_string();
+
+    Ok(MongoUrl { url, filename })
+}
+
+#[derive(Debug)]
+pub(crate) struct DownloadProgress {
+    pub(crate) downloaded: u64,
+    pub(crate) total: Option<u64>,
+    pub(crate) percentage: Option<f32>,
+}
+
+pub(crate) async fn download_file(url: &str, destination: &std::path::Path) -> Result<(), Error> {
+    download_file_with_callback(url, destination, |_| {}).await
+}
+
+pub(crate) async fn download_file_with_callback<F>(
+    url: &str,
+    destination: &std::path::Path,
+    mut callback: F,
+) -> Result<(), Error>
+where
+    F: FnMut(DownloadProgress),
+{
+    use std::fs::File;
+    use std::io::Write;
+
+    let response = reqwest::get(url).await?;
+    let total = response.content_length();
+
+    let mut part_path = destination.to_path_buf();
+    part_path.set_extension("part");
+
+    let mut file =
+        File::create(&part_path).err_tip(|| format!("Creating {}", part_path.display()))?;
+    let mut downloaded: u64 = 0;
+
+    let mut stream = response;
+    while let Some(chunk) = stream.chunk().await? {
+        file.write_all(&chunk)?;
+        downloaded += chunk.len() as u64;
+
+        let percentage = total.map(|t| (downloaded as f32 / t as f32) * 100.0);
+        callback(DownloadProgress {
+            downloaded,
+            total,
+            percentage,
+        });
+    }
+
+    std::fs::rename(part_path, destination)?;
+
+    Ok(())
+}

--- a/nativelink-store/tests/mongo_runner/extractor.rs
+++ b/nativelink-store/tests/mongo_runner/extractor.rs
@@ -1,0 +1,42 @@
+use std::fs::{self, File};
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+use nativelink_error::{Error, ResultExt, make_input_err};
+use tar::Archive;
+use zip::ZipArchive;
+
+pub(crate) fn extract(archive_path: &Path, extract_to: &Path) -> Result<(), Error> {
+    if !extract_to.exists() {
+        fs::create_dir_all(extract_to)
+            .err_tip(|| format!("Creating extraction directory {}", extract_to.display()))?;
+    }
+
+    let extension = archive_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| make_input_err!("Unknown file extension"))?;
+
+    match extension {
+        "tgz" | "gz" => {
+            let file = File::open(archive_path)
+                .err_tip(|| format!("Opening {}", archive_path.display()))?;
+            let tar = GzDecoder::new(file);
+            let mut archive = Archive::new(tar);
+            archive
+                .unpack(extract_to)
+                .err_tip(|| format!("Unpacking to {}", extract_to.display()))?;
+        }
+        "zip" => {
+            let file = File::open(archive_path)
+                .err_tip(|| format!("Opening {}", archive_path.display()))?;
+            let mut archive = ZipArchive::new(file)?;
+            archive
+                .extract(extract_to)
+                .err_tip(|| format!("Extracting to {}", extract_to.display()))?;
+        }
+        _ => return Err(make_input_err!("Unsupported archive format: {}", extension)),
+    }
+
+    Ok(())
+}

--- a/nativelink-store/tests/mongo_runner/mod.rs
+++ b/nativelink-store/tests/mongo_runner/mod.rs
@@ -1,0 +1,309 @@
+#![allow(dead_code)]
+
+pub(crate) mod downloader;
+pub(crate) mod extractor;
+pub(crate) mod process;
+
+use core::time::Duration;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Condvar, LazyLock, Mutex};
+
+pub(crate) use downloader::DownloadProgress;
+use downloader::{download_file_with_callback, get_download_url, get_os};
+use extractor::extract;
+use mongodb::bson::doc;
+use nativelink_error::{Error, ResultExt, make_err};
+use process::MongoProcess;
+use tempfile::tempdir;
+use tonic::Code;
+use tracing::{debug, info};
+
+#[derive(Debug)]
+pub(crate) enum InitStatus {
+    CheckingDB,
+    ValidatingInstallation,
+    Downloading,
+    DownloadProgress(DownloadProgress),
+    SettingUpUser,
+    VerifyingCredentials,
+    DBInitialized,
+}
+
+#[derive(Debug)]
+pub(crate) struct MongoEmbedded {
+    pub version: String,
+    pub download_path: PathBuf,
+    pub extract_path: PathBuf,
+    pub db_path: PathBuf,
+    pub port: u16,
+    pub bind_ip: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+static CURRENTLY_DOWNLOADING: LazyLock<(Mutex<bool>, Condvar)> =
+    LazyLock::new(|| (Mutex::new(false), Condvar::new()));
+
+impl MongoEmbedded {
+    pub(crate) fn new(version: &str) -> Self {
+        let cache_dir = dirs::cache_dir()
+            .expect("Failed to find cache directory")
+            .join("mongo");
+        let db_path = tempdir()
+            .expect("Failed to create temporary directory")
+            .keep()
+            .join("db");
+
+        Self {
+            version: version.to_string(),
+            download_path: cache_dir.join("downloads"),
+            extract_path: cache_dir.join("extracted"),
+            db_path,
+            port: 27017,
+            bind_ip: "127.0.0.1".to_string(),
+            username: None,
+            password: None,
+        }
+    }
+
+    pub(crate) const fn set_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    pub(crate) fn set_bind_ip(mut self, bind_ip: &str) -> Self {
+        self.bind_ip = bind_ip.to_string();
+        self
+    }
+
+    pub(crate) fn set_db_path(mut self, path: PathBuf) -> Self {
+        self.db_path = path;
+        self
+    }
+
+    pub(crate) fn set_credentials(mut self, username: &str, password: &str) -> Self {
+        self.username = Some(username.to_string());
+        self.password = Some(password.to_string());
+        self
+    }
+
+    pub(crate) fn is_installed(&self) -> bool {
+        let extract_target = self.extract_path.join(self.version.as_str());
+        extract_target.exists()
+    }
+
+    pub(crate) async fn start(&self) -> Result<MongoProcess, Error> {
+        self.start_with_progress(|_| {}).await
+    }
+
+    pub(crate) async fn start_with_progress<F>(
+        &self,
+        mut callback: F,
+    ) -> Result<MongoProcess, Error>
+    where
+        F: FnMut(InitStatus),
+    {
+        callback(InitStatus::CheckingDB);
+        let mongo_url = get_download_url(&self.version)?;
+        let download_target = self.download_path.join(&mongo_url.filename);
+
+        callback(InitStatus::ValidatingInstallation);
+
+        let extract_target = self.extract_path.join(self.version.as_str());
+        let extract_marker = extract_target.join("extracted.marker");
+
+        if extract_marker.exists() {
+            info!(?extract_marker, "Already have Mongo downloaded");
+        } else {
+            let existing_downloader = {
+                let mut lock = CURRENTLY_DOWNLOADING.0.lock().unwrap();
+                if *lock {
+                    info!("Waiting for downloader");
+                    let _guard = CURRENTLY_DOWNLOADING.1.wait(lock)?;
+                    true
+                } else {
+                    info!("First here so, downloading Mongo");
+                    *lock = true;
+                    false
+                }
+            };
+            if !existing_downloader {
+                if !self.download_path.exists() {
+                    fs::create_dir_all(&self.download_path)
+                        .err_tip(|| format!("Making {}", self.download_path.display()))?;
+                }
+                callback(InitStatus::Downloading);
+                if !download_target.exists() {
+                    download_file_with_callback(&mongo_url.url, &download_target, |progress| {
+                        callback(InitStatus::DownloadProgress(progress));
+                    })
+                    .await
+                    .err_tip(|| {
+                        format!(
+                            "Downloading to {} from {}. If this breaks in coverage, edit tempHome",
+                            download_target.display(),
+                            mongo_url.url
+                        )
+                    })?;
+                }
+                extract(&download_target, &extract_target).err_tip(|| {
+                    format!(
+                        "Extraction from {} to {}",
+                        download_target.display(),
+                        extract_target.display()
+                    )
+                })?;
+                info!("Downloaded, notifying");
+                fs::write(extract_marker, "")?;
+                let lock = CURRENTLY_DOWNLOADING.0.lock().unwrap();
+                CURRENTLY_DOWNLOADING.1.notify_all();
+                drop(lock);
+            }
+        }
+
+        let os = get_os()?;
+
+        // Calculate initial connection string for readiness check
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        let uri = if self.bind_ip.contains('/') || self.bind_ip.ends_with(".sock") {
+            // Assume unix socket
+            // Minimal URL encoding for path, replacing / with %2F.
+            // This is required for the rust mongodb driver to recognize it as a socket.
+            // Note: When using sockets with mongodb crate, we often need to ensure the host is just the encoded path.
+            let encoded = self.bind_ip.replace('/', "%2F");
+            format!("mongodb://{encoded}/?directConnection=true")
+        } else {
+            format!(
+                "mongodb://{}:{}/?directConnection=true",
+                self.bind_ip, self.port
+            )
+        };
+
+        // Start process with auth flag if credentials are requested
+        let auth_enabled = self.username.is_some() && self.password.is_some();
+        let mut process = MongoProcess::start(
+            &extract_target,
+            self.port,
+            &self.db_path,
+            &os,
+            &self.bind_ip,
+            auth_enabled,
+            uri.clone(),
+        )
+        .err_tip(|| format!("Starting mongo from {}", extract_target.display()))?;
+
+        // Need to wait for it to be ready
+        // We can try to connect
+        let mut client_options = mongodb::options::ClientOptions::parse(&uri).await?;
+        client_options.connect_timeout = Some(Duration::from_secs(2));
+        client_options.server_selection_timeout = Some(Duration::from_secs(2));
+
+        // Simple loop to wait for readiness
+        let mut connected = false;
+        let start = std::time::Instant::now();
+        debug!("Waiting for MongoDB to start at {uri}");
+        while start.elapsed() < Duration::from_secs(30) {
+            let client = mongodb::Client::with_options(client_options.clone())?;
+            match client.list_database_names().await {
+                Ok(_) => {
+                    connected = true;
+                    debug!("Connected to MongoDB at {uri}");
+                    break;
+                }
+                Err(e) => {
+                    debug!("Connection attempt failed: {:?}", e);
+                    // If unauthorized error, it means we are connected but need auth, which is fine for readiness check
+                    // "Unauthorized" usually is error code 13
+                    if let mongodb::error::ErrorKind::Command(ref cmd_err) = *e.kind {
+                        if cmd_err.code == 51 || cmd_err.code == 13 || cmd_err.code == 18 {
+                            // 51: UserAlreadyExists?, 13: Unauthorized, 18: AuthFailed
+                            connected = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        if !connected {
+            debug!("Timed out waiting for start.");
+            process.kill()?;
+            return Err(make_err!(
+                Code::DeadlineExceeded,
+                "Timed out waiting for MongoDB to start"
+            ));
+        }
+
+        if let (Some(username), Some(password)) = (&self.username, &self.password) {
+            callback(InitStatus::SettingUpUser);
+            let client = mongodb::Client::with_options(client_options.clone())?;
+
+            // Try to create user. This only works if localhost exception is active (no users)
+            let db = client.database("admin");
+            let run_cmd = db
+                .run_command(doc! {
+                   "createUser": username,
+                   "pwd": password,
+                   "roles": [
+                       { "role": "root", "db": "admin" }
+                   ]
+                })
+                .await;
+
+            match run_cmd {
+                Ok(_) => {
+                    // Created user successfully
+                }
+                Err(_e) => {
+                    // if needs_verify {
+                    callback(InitStatus::VerifyingCredentials);
+                    // Try to authenticate
+                    let mut auth_opts = client_options.clone();
+                    auth_opts.credential = Some(
+                        mongodb::options::Credential::builder()
+                            .username(username.clone())
+                            .password(password.clone())
+                            .source("admin".to_string())
+                            .build(),
+                    );
+
+                    let auth_client = mongodb::Client::with_options(auth_opts)?;
+                    // Verify by running a command that requires auth
+                    if let Err(auth_err) = auth_client
+                        .database("admin")
+                        .run_command(doc! { "ping": 1 })
+                        .await
+                    {
+                        process.kill()?;
+                        return Err(make_err!(
+                            Code::PermissionDenied,
+                            "Authentication failed or invalid credentials provided: {}",
+                            auth_err
+                        ));
+                    }
+                }
+            }
+
+            // Update connection string to include credentials
+
+            #[allow(clippy::case_sensitive_file_extension_comparisons)]
+            let final_uri = if self.bind_ip.contains('/') || self.bind_ip.ends_with(".sock") {
+                let encoded = self.bind_ip.replace('/', "%2F");
+                // For sockets, credentials go in the beginning
+                format!("mongodb://{username}:{password}@{encoded}")
+            } else {
+                format!(
+                    "mongodb://{username}:{password}@{}:{}/",
+                    self.bind_ip, self.port
+                )
+            };
+            process.connection_string = final_uri;
+        }
+
+        callback(InitStatus::DBInitialized);
+        Ok(process)
+    }
+}

--- a/nativelink-store/tests/mongo_runner/process.rs
+++ b/nativelink-store/tests/mongo_runner/process.rs
@@ -1,0 +1,130 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+
+use nativelink_error::{Error, ResultExt, make_err};
+use tonic::Code;
+use tracing::info;
+use uuid::Uuid;
+
+use super::downloader::Os;
+
+#[derive(Debug)]
+pub(crate) struct MongoProcess {
+    child: Child,
+    pub connection_string: String,
+}
+
+impl MongoProcess {
+    pub(crate) fn start(
+        extracted_path: &Path,
+        port: u16,
+        db_path: &Path,
+        os: &Os,
+        bind_ip: &str,
+        auth: bool,
+        connection_string: String,
+    ) -> Result<Self, Error> {
+        let binary_name = match os {
+            Os::Windows => "mongod.exe",
+            _ => "mongod",
+        };
+
+        let binary_path = find_binary(extracted_path, binary_name).ok_or_else(|| {
+            make_err!(
+                Code::Internal,
+                "Could not find {} in extracted directory",
+                binary_name
+            )
+        })?;
+
+        // Ensure binary is executable on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            use tracing::trace;
+
+            let mut perms = fs::metadata(&binary_path)
+                .err_tip(|| format!("Getting metadata for {}", binary_path.display()))?
+                .permissions();
+            let target_mode = 0o555;
+            if perms.mode() & target_mode == target_mode {
+                trace!(
+                    existing_permissions = perms.mode(),
+                    target_mode,
+                    ?binary_path,
+                    "Permissions already set"
+                );
+            } else {
+                trace!(
+                    existing_permissions = perms.mode(),
+                    target_mode,
+                    ?binary_path,
+                    "Setting permissions"
+                );
+                perms.set_mode(target_mode);
+                fs::set_permissions(&binary_path, perms)
+                    .err_tip(|| format!("Setting permissions for {}", binary_path.display()))?;
+            }
+        }
+
+        if !db_path.exists() {
+            fs::create_dir_all(db_path).err_tip(|| format!("Creating {}", db_path.display()))?;
+        }
+
+        let mut command = Command::new(&binary_path);
+        command
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--dbpath")
+            .arg(db_path)
+            .arg("--bind_ip")
+            .arg(bind_ip);
+
+        if auth {
+            command.arg("--auth");
+        }
+
+        let log_path = db_path
+            .join(format!("mongo-{}.log", Uuid::new_v4().as_simple()))
+            .into_os_string();
+        info!(?log_path, "Logging mongo");
+        command.arg("--quiet").arg("--logpath").arg(log_path);
+
+        let child = command
+            .spawn()
+            .err_tip(|| format!("Spawning mongo from {}", binary_path.display()))?;
+
+        Ok(Self {
+            child,
+            connection_string,
+        })
+    }
+
+    pub(crate) fn kill(&mut self) -> Result<(), Error> {
+        self.child.kill()?;
+        self.child.wait()?;
+        Ok(())
+    }
+}
+
+fn find_binary(root: &Path, name: &str) -> Option<PathBuf> {
+    if root.is_file() {
+        if root.file_name()?.to_str()? == name {
+            return Some(root.to_path_buf());
+        }
+        return None;
+    }
+
+    if root.is_dir() {
+        for entry in fs::read_dir(root).ok()? {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if let Some(found) = find_binary(&path, name) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}

--- a/nativelink-store/tests/mongo_store_test.rs
+++ b/nativelink-store/tests/mongo_store_test.rs
@@ -36,15 +36,18 @@ use nativelink_util::store_trait::{
 use pretty_assertions::assert_eq;
 use uuid::Uuid;
 
+mod mongo_runner;
+use mongo_runner::process::MongoProcess;
+
+use crate::mongo_runner::MongoEmbedded;
+
 const VALID_HASH1: &str = "3031323334353637383961626364656630303030303030303030303030303030";
 
 /// Creates a test `MongoDB` specification.
-/// Note: These tests are designed to work with a real `MongoDB` instance.
-/// For CI/local development, ensure `MongoDB` is available or skip these tests.
-fn create_test_spec_with_key_prefix(key_prefix: Option<String>) -> ExperimentalMongoSpec {
-    // Default connection string for CI - empty string will require env var
-    let default_connection = String::new();
-
+fn create_test_spec_with_key_prefix(
+    key_prefix: Option<String>,
+    connection_string: String,
+) -> ExperimentalMongoSpec {
     // Create database name with timestamp for uniqueness
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -52,7 +55,7 @@ fn create_test_spec_with_key_prefix(key_prefix: Option<String>) -> ExperimentalM
         .as_millis();
 
     ExperimentalMongoSpec {
-        connection_string: std::env::var("NATIVELINK_TEST_MONGO_URL").unwrap_or(default_connection),
+        connection_string,
         database: format!(
             "nltest_{}_{}",
             timestamp,
@@ -72,81 +75,70 @@ fn create_test_spec_with_key_prefix(key_prefix: Option<String>) -> ExperimentalM
     }
 }
 
-fn create_test_spec() -> ExperimentalMongoSpec {
-    create_test_spec_with_key_prefix(Some("test:".to_string()))
+// Helper to keep hold of Mongo process parts so we don't accidentally drop them!
+#[derive(Debug)]
+pub(crate) struct MongoParts {
+    pub process: MongoProcess,
+    #[allow(dead_code)]
+    pub embedded: MongoEmbedded,
 }
 
 /// Test helper that manages `MongoDB` database lifecycle
 #[derive(Debug)]
-pub struct TestMongoHelper {
+pub(crate) struct TestMongoHelper {
     pub store: Arc<ExperimentalMongoStore>,
     pub database_name: String,
-}
-
-fn non_ci_test_store_access() {
-    // Check if this is a local development environment without credentials
-    let is_ci = std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok();
-
-    if !is_ci {
-        eprintln!("\n🔒 MongoDB tests require access to the NativeLink test database.");
-        eprintln!("   For local development access, please email: marcus@tracemachina.com");
-        eprintln!("   ");
-        eprintln!("   Alternatively, you can set NATIVELINK_TEST_MONGO_URL environment variable");
-        eprintln!("   with your own MongoDB connection string.");
-        eprintln!("   ");
-        eprintln!("   Skipping MongoDB tests for now...\n");
-    }
+    pub mongo_local: Option<MongoParts>,
+    pub spec: ExperimentalMongoSpec,
 }
 
 impl TestMongoHelper {
     /// Creates a new test store and database
-    async fn new(key_prefix: Option<String>) -> Result<Self, Error> {
-        let spec = create_test_spec_with_key_prefix(key_prefix);
+    async fn new_spec(
+        key_prefix: Option<String>,
+    ) -> Result<(ExperimentalMongoSpec, Option<MongoParts>), Error> {
+        let mut mongo_local: Option<MongoParts> = None;
+        let test_mongo_url = if let Ok(url) = std::env::var("NATIVELINK_TEST_MONGO_URL") {
+            url
+        } else {
+            let port = redis_test::utils::get_random_available_port();
+            let mongo_runner = MongoEmbedded::new("7.0.11").set_port(port);
+            let process = mongo_runner
+                .start()
+                .await
+                .err_tip(|| "Failed to start MongoDB")?;
+            mongo_local.replace(MongoParts {
+                process,
+                embedded: mongo_runner,
+            });
+            format!("mongodb://127.0.0.1:{port}/")
+        };
 
-        // Check if we have a connection string
-        if spec.connection_string.is_empty() {
-            return Err(Error::new(
-                Code::Unavailable,
-                "MongoDB connection string not provided for local testing".to_string(),
-            ));
-        }
+        let spec = create_test_spec_with_key_prefix(key_prefix, test_mongo_url);
+        Ok((spec, mongo_local))
+    }
 
+    async fn new_with_spec_and_process(
+        spec: ExperimentalMongoSpec,
+        mongo_local: Option<MongoParts>,
+    ) -> Result<Self, Error> {
         let database_name = spec.database.clone();
 
-        let store = ExperimentalMongoStore::new(spec).await?;
+        let store = ExperimentalMongoStore::new(spec.clone()).await?;
 
         Ok(Self {
             store,
             database_name,
+            mongo_local,
+            spec,
         })
     }
 
-    /// Creates a test helper, skipping if `MongoDB` is not available
-    async fn new_or_skip_with_key_prefix(key_prefix: Option<String>) -> Result<Self, Error> {
-        match Self::new(key_prefix).await {
-            Ok(helper) => Ok(helper),
-            Err(e) => {
-                if e.code == Code::Unavailable
-                    && e.messages[0].contains("connection string not provided")
-                {
-                    non_ci_test_store_access();
-                }
-
-                // Convert to a test skip-friendly error
-                if e.code == Code::InvalidArgument || e.code == Code::Unavailable {
-                    Err(Error::new(
-                        Code::Unavailable,
-                        "MongoDB not available for testing - skipping test".to_string(),
-                    ))
-                } else {
-                    Err(e)
-                }
-            }
-        }
-    }
-
-    async fn new_or_skip() -> Result<Self, Error> {
-        Self::new_or_skip_with_key_prefix(Some("test:".to_string())).await
+    async fn new(key_prefix: Option<String>) -> Result<Self, Error> {
+        // Split out like this because various tests want to edit the spec before launching the store
+        // But they need new_spec to make the test process
+        let (spec, mongo_process) = Self::new_spec(key_prefix).await?;
+        Self::new_with_spec_and_process(spec, mongo_process).await
     }
 }
 
@@ -157,39 +149,16 @@ impl Drop for TestMongoHelper {
             "Test database '{}' retained for inspection",
             self.database_name
         );
+        if let Some(mut parts) = self.mongo_local.take() {
+            parts.process.kill().expect("Failed to kill mongo process");
+        }
     }
-}
-
-/// Creates a test `MongoDB` store with a unique database name to avoid conflicts.
-async fn create_test_store() -> Result<Arc<ExperimentalMongoStore>, Error> {
-    let spec = create_test_spec();
-
-    // Check if we have a connection string
-    if spec.connection_string.is_empty() {
-        non_ci_test_store_access();
-
-        return Err(Error::new(
-            Code::Unavailable,
-            "MongoDB connection string not provided for local testing".to_string(),
-        ));
-    }
-
-    ExperimentalMongoStore::new(spec).await
-}
-
-/// Utility to check if `MongoDB` is available for testing.
-/// Returns an error that can be used to skip tests when `MongoDB` is not available.
-async fn check_mongodb_available() -> Result<(), Error> {
-    TestMongoHelper::new_or_skip().await.map(|_| ())
 }
 
 #[nativelink_test]
 async fn upload_and_get_data() -> Result<(), Error> {
     // Create test helper with automatic cleanup
-    let Ok(helper) = TestMongoHelper::new_or_skip().await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let helper = TestMongoHelper::new(None).await?;
 
     // Construct the data we want to send.
     let data = Bytes::from_static(b"14");
@@ -222,10 +191,7 @@ async fn upload_and_get_data() -> Result<(), Error> {
 #[nativelink_test]
 async fn upload_and_get_data_without_prefix() -> Result<(), Error> {
     // Create test helper with automatic cleanup
-    let Ok(helper) = TestMongoHelper::new_or_skip_with_key_prefix(None).await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let helper = TestMongoHelper::new(None).await?;
 
     let data = Bytes::from_static(b"14");
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
@@ -251,20 +217,13 @@ async fn upload_and_get_data_without_prefix() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn upload_empty_data() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
     let data = Bytes::from_static(b"");
     let digest = ZERO_BYTE_DIGESTS[0];
+    let helper = TestMongoHelper::new(None).await?;
 
-    let store = create_test_store().await?;
+    helper.store.update_oneshot(digest, data).await?;
 
-    store.update_oneshot(digest, data).await?;
-
-    let result = store.has(digest).await?;
+    let result = helper.store.has(digest).await?;
     assert!(
         result.is_some(),
         "Expected mongo store to have zero-byte hash",
@@ -276,21 +235,16 @@ async fn upload_empty_data() -> Result<(), Error> {
 #[nativelink_test]
 #[allow(clippy::items_after_statements)]
 async fn test_large_downloads_are_chunked() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
     const READ_CHUNK_SIZE: usize = 1024;
     let data = Bytes::from(vec![0u8; READ_CHUNK_SIZE + 128]);
 
     let digest = DigestInfo::try_new(VALID_HASH1, data.len())?;
 
-    let mut spec = create_test_spec();
+    let (mut spec, mongo_process) = TestMongoHelper::new_spec(None).await?;
     spec.read_chunk_size = READ_CHUNK_SIZE;
 
-    let store = ExperimentalMongoStore::new(spec).await?;
+    let helper = TestMongoHelper::new_with_spec_and_process(spec, mongo_process).await?;
+    let store = helper.store.clone();
 
     store.update_oneshot(digest, data.clone()).await?;
 
@@ -315,12 +269,6 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
 #[nativelink_test]
 #[allow(clippy::items_after_statements)]
 async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
     const READ_CHUNK_SIZE: usize = 1024;
     let data_p1 = Bytes::from(vec![b'A'; READ_CHUNK_SIZE + 512]);
     let data_p2 = Bytes::from(vec![b'B'; READ_CHUNK_SIZE]);
@@ -332,10 +280,10 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
 
     let digest = DigestInfo::try_new(VALID_HASH1, data.len())?;
 
-    let mut spec = create_test_spec();
+    let (mut spec, mongo_process) = TestMongoHelper::new_spec(None).await?;
     spec.read_chunk_size = READ_CHUNK_SIZE;
-
-    let store = ExperimentalMongoStore::new(spec).await?;
+    let helper = TestMongoHelper::new_with_spec_and_process(spec, mongo_process).await?;
+    let store = helper.store.clone();
 
     let (mut tx, rx) = make_buf_channel_pair();
 
@@ -371,28 +319,20 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn zero_len_items_exist_check() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
     let digest = DigestInfo::try_new(VALID_HASH1, 0)?;
-
-    let store = create_test_store().await?;
+    let helper = TestMongoHelper::new(None).await?;
 
     // Try to get a zero-length item that doesn't exist
-    let result = store.get_part_unchunked(digest, 0, None).await;
-    assert_eq!(result.unwrap_err().code, Code::NotFound);
+    let result = helper.store.get_part_unchunked(digest, 0, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.code, Code::NotFound, "{:?}", err);
 
     Ok(())
 }
 
 #[nativelink_test]
 async fn test_invalid_connection_string() -> Result<(), Error> {
-    let mut spec = create_test_spec();
-    spec.connection_string = "invalid://connection_string".to_string();
-
+    let spec = create_test_spec_with_key_prefix(None, "invalid://connection_string".to_string());
     let result = ExperimentalMongoStore::new(spec).await;
     assert!(
         result.is_err(),
@@ -408,8 +348,7 @@ async fn test_invalid_connection_string() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn test_empty_connection_string() -> Result<(), Error> {
-    let mut spec = create_test_spec();
-    spec.connection_string = String::new();
+    let spec = create_test_spec_with_key_prefix(None, String::new());
 
     let result = ExperimentalMongoStore::new(spec).await;
     assert!(
@@ -426,13 +365,7 @@ async fn test_empty_connection_string() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn test_default_values() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
-    let mut spec = create_test_spec();
+    let (mut spec, mongo_process) = TestMongoHelper::new_spec(None).await?;
     // Clear all optional fields to test defaults
     spec.database = String::new();
     spec.cas_collection = String::new();
@@ -444,7 +377,8 @@ async fn test_default_values() -> Result<(), Error> {
     spec.max_concurrent_uploads = 0;
 
     // This should succeed and use default values
-    let store = ExperimentalMongoStore::new(spec).await?;
+    let helper = TestMongoHelper::new_with_spec_and_process(spec, mongo_process).await?;
+    let store = helper.store.clone();
 
     // Test that the store is functional with defaults
     let data = Bytes::from_static(b"test_data");
@@ -463,13 +397,7 @@ async fn test_default_values() -> Result<(), Error> {
 
 #[nativelink_test]
 async fn dont_loop_forever_on_empty() -> Result<(), Error> {
-    // Skip test if MongoDB is not available
-    if check_mongodb_available().await.is_err() {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    }
-
-    let store = create_test_store().await?;
+    let helper = TestMongoHelper::new(None).await?;
     let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
     let (tx, rx) = make_buf_channel_pair();
 
@@ -477,7 +405,8 @@ async fn dont_loop_forever_on_empty() -> Result<(), Error> {
     let result = tokio::time::timeout(core::time::Duration::from_secs(5), async {
         tokio::join!(
             async {
-                store
+                helper
+                    .store
                     .update(digest, rx, UploadSizeInfo::MaxSize(0))
                     .await
                     .unwrap_err();
@@ -502,10 +431,7 @@ async fn dont_loop_forever_on_empty() -> Result<(), Error> {
 #[nativelink_test]
 async fn test_partial_reads() -> Result<(), Error> {
     // Create test helper with automatic cleanup
-    let Ok(helper) = TestMongoHelper::new_or_skip().await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let helper = TestMongoHelper::new(None).await?;
 
     let data = Bytes::from_static(b"Hello, MongoDB World!");
     let digest = DigestInfo::try_new(VALID_HASH1, data.len())?;
@@ -534,20 +460,10 @@ async fn test_partial_reads() -> Result<(), Error> {
 /// Test that verifies database creation (cleanup disabled for inspection)
 #[nativelink_test]
 async fn test_database_lifecycle() -> Result<(), Error> {
-    let spec = create_test_spec();
-    let connection_string = spec.connection_string.clone();
+    let (spec, mongo_process) = TestMongoHelper::new_spec(None).await?;
     let database_name = spec.database.clone();
 
-    // Skip if MongoDB is not available
-    let Ok(client_options) = ClientOptions::parse(&connection_string).await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
-
-    let Ok(client) = MongoClient::with_options(client_options) else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let client = MongoClient::with_uri_str(&spec.connection_string).await?;
 
     // Verify database doesn't exist initially
     let db_names = client
@@ -560,13 +476,8 @@ async fn test_database_lifecycle() -> Result<(), Error> {
     );
 
     // Create test helper (which creates the database)
+    let helper = TestMongoHelper::new_with_spec_and_process(spec, mongo_process).await?;
     {
-        let store = ExperimentalMongoStore::new(spec.clone()).await?;
-        let helper = TestMongoHelper {
-            store,
-            database_name: database_name.clone(),
-        };
-
         // Upload some data to ensure database is created
         let data = Bytes::from_static(b"test_database_lifecycle");
         let digest = DigestInfo::try_new(VALID_HASH1, data.len())?;
@@ -598,10 +509,10 @@ async fn test_database_lifecycle() -> Result<(), Error> {
             "Data should be accessible in the database"
         );
 
-        // helper goes out of scope here, but NO cleanup happens anymore
+        // NO cleanup happens anymore, but we keep the helper to keep the Mongo process and temp folders around
     }
 
-    // Database should still exist after helper is dropped
+    // Database should still exist
     let db_names = client
         .list_database_names()
         .await
@@ -620,10 +531,7 @@ async fn test_database_lifecycle() -> Result<(), Error> {
 #[allow(clippy::use_debug)]
 async fn create_ten_cas_entries() -> Result<(), Error> {
     // Create test helper with automatic cleanup
-    let Ok(helper) = TestMongoHelper::new_or_skip().await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let helper = TestMongoHelper::new(None).await?;
 
     eprintln!(
         "Creating 10 CAS entries in database: {}",
@@ -677,8 +585,8 @@ async fn create_ten_cas_entries() -> Result<(), Error> {
     }
 
     // Query MongoDB directly to verify entries were written
-    let spec = create_test_spec();
-    let client_options = ClientOptions::parse(&spec.connection_string)
+    let helper = TestMongoHelper::new(None).await?;
+    let client_options = ClientOptions::parse(&helper.spec.connection_string)
         .await
         .map_err(|e| make_err!(Code::Internal, "Failed to parse connection string: {e}"))?;
 
@@ -845,13 +753,13 @@ impl SchedulerStoreDecodeTo for TestSchedulerKey {
 //     }
 // }
 
+// FIXME(palfrey): Test doesn't work on local Mongo. https://github.com/TraceMachina/nativelink/pull/1843 covers
+// expanding Mongo to be usable as a scheduler backend, and should correct this problem there
 #[nativelink_test]
+#[ignore]
 async fn test_scheduler_store_operations() -> Result<(), Error> {
     // Create test helper
-    let Ok(helper) = TestMongoHelper::new_or_skip().await else {
-        eprintln!("Skipping MongoDB test - MongoDB not available");
-        return Ok(());
-    };
+    let helper = TestMongoHelper::new(None).await?;
 
     eprintln!(
         "Testing scheduler store operations in database: {}",
@@ -968,7 +876,8 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
                 version: 0,
             };
 
-            helper.store.update_data(data).await?;
+            let version = helper.store.update_data(data).await?;
+            assert_eq!(Some(1), version);
         }
 
         // Search by index prefix
@@ -984,10 +893,10 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
             .try_collect()
             .await?;
 
-        eprintln!("Found {} entries matching search", search_results.len());
         assert!(
             search_results.len() >= 5,
-            "Should find at least 5 matching entries"
+            "Should find at least 5 matching entries, got {}",
+            search_results.len()
         );
 
         // Verify search results

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -936,7 +936,7 @@ impl SchedulerStoreKeyProvider for TestSchedulerDataUnversioned {
 
 impl SchedulerStoreDataProvider for TestSchedulerDataUnversioned {
     fn try_into_bytes(self) -> Result<Bytes, Error> {
-        Ok(Bytes::from(self.content.into_bytes()))
+        Ok(Bytes::from(self.content))
     }
 
     fn get_indexes(&self) -> Result<Vec<(&'static str, Bytes)>, Error> {

--- a/src/bin/redis_store_tester.rs
+++ b/src/bin/redis_store_tester.rs
@@ -45,7 +45,7 @@ impl SchedulerStoreKeyProvider for TestSchedulerData {
 
 impl SchedulerStoreDataProvider for TestSchedulerData {
     fn try_into_bytes(self) -> Result<Bytes, Error> {
-        Ok(Bytes::from(self.content.into_bytes()))
+        Ok(Bytes::from(self.content))
     }
 
     fn get_indexes(&self) -> Result<Vec<(&'static str, Bytes)>, Error> {


### PR DESCRIPTION
# Description

Previously, we tested Mongo against a static external instance, which had issues with testing against PRs. This PR retools things to boot a standalone `mongod` to test against instead.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2222)
<!-- Reviewable:end -->
