### PR TITLE
Fix old Apple SDK refs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
             buildInputs =
               [p.cacert]
               ++ pkgs.lib.optionals p.stdenv.targetPlatform.isDarwin [
-                p.darwin.apple_sdk.frameworks.Security
+                p.apple-sdk
                 p.libiconv
               ];
             nativeBuildInputs =
@@ -143,7 +143,7 @@
                 else [pkgs.llvmPackages_20.lld]
               )
               ++ pkgs.lib.optionals p.stdenv.targetPlatform.isDarwin [
-                p.darwin.apple_sdk.frameworks.Security
+                p.apple-sdk
                 p.libiconv
               ];
             CARGO_BUILD_TARGET = targetArch;
@@ -510,8 +510,7 @@
               pkgs.nativelink-tools.create-local-image
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.apple-sdk
               pkgs.libiconv
             ]
             ++ pkgs.lib.optionals (pkgs.stdenv.system != "x86_64-darwin") [

--- a/tools/darwin/flake-module.nix
+++ b/tools/darwin/flake-module.nix
@@ -33,8 +33,8 @@
       config.${namespace} = lib.mkIf cfg.enable {
         installationScript = let
           bazelrcContent = ''
-            build --@rules_rust//:extra_rustc_flags=-L${pkgs.libiconv}/lib,-Lframework=${pkgs.darwin.Security}/Library/Frameworks,-Lframework=${pkgs.darwin.CF}/Library/Frameworks
-            build --@rules_rust//:extra_exec_rustc_flags=-L${pkgs.libiconv}/lib,-Lframework=${pkgs.darwin.Security}/Library/Frameworks,-Lframework=${pkgs.darwin.CF}/Library/Frameworks
+            build --@rules_rust//:extra_rustc_flags=-L${pkgs.libiconv}/lib
+            build --@rules_rust//:extra_exec_rustc_flags=-L${pkgs.libiconv}/lib
           '';
         in
           import ../installation-script.nix {


### PR DESCRIPTION
# Description

Nix [has changed over how it does Apple SDK refs](https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks) and we were getting warnings like the following in the build. It's not a big deal now, but makes later upgrades easier.

`evaluation warning: darwin.apple_sdk_11_0.CoreFoundation: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.`

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2224)
<!-- Reviewable:end -->
