### PR TITLE
Publish lre-rs image

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [image, nativelink-worker-init, nativelink-worker-lre-cc]
+        image: [image, nativelink-worker-init, nativelink-worker-lre-cc, nativelink-worker-lre-rs]
     name: Publish ${{ matrix.image }}
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
# Description

Needed for building nativelink with nativelink. https://github.com/TraceMachina/nativelink/blob/main/local-remote-execution/rust/platforms/BUILD.bazel#L75 sets an `lre-rs` property, but what we actually need is a `container-image` with the nativelink-lre-rs image tagged, which this PR enables.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2270)
<!-- Reviewable:end -->
