### PR TITLE
Add attic nix cache

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -1,6 +1,9 @@
 ---
 name: Prepare Nix
 description: "Common setup for all runs using Nix."
+inputs:
+  nativelink_attic_token:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -13,13 +16,13 @@ runs:
       with:
         source-tag: v3.13.0
 
-    # FIXME(palfrey): Replace with better cache. Workers are currently taking minutes to upload data
-    # all the time, probably because we're at ~500GB of 10GB in the cache storage and it's breaking.
-    # We've tried Flakehub, but it doesn't work for us because it assumes "branches on an org repo"
-    # not our "fork and branch on your own repo" setup for it's auth so we can't currently use that.
-
-    # - name: Add Nix magic cache
-    #   uses: >- # https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v13
-    #     DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
-    #   with:
-    #     source-tag: v0.1.6
+    - name: Setup attic cache
+      run: |
+        nix build nixpkgs#attic-client
+        # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access
+        ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ $NATIVELINK_ATTIC_TOKEN
+        ./result/bin/attic use nativelink
+        ./result/bin/attic watch-store nativelink &
+      shell: bash
+      env:
+        NATIVELINK_ATTIC_TOKEN: ${{ inputs.nativelink_attic_token }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       # Ubuntu 24.04 restricts unprivileged user namespaces by default, which breaks
       # the worker tests that use namespaces (e.g. for sandboxing).

--- a/.github/workflows/custom-image.yaml
+++ b/.github/workflows/custom-image.yaml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Upload image
         id: upload

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Test image
         run: |

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Build example with ${{ matrix.toolchain }} toolchain
         env:
@@ -65,6 +67,8 @@ jobs:
 
 #       - name: Prepare Worker
 #         uses: ./.github/actions/prepare-nix
+#         with:
+#           nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
 #       - name: Start Kubernetes cluster
 #         run: >

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Invoke Bazel build in Nix shell
         run: |
@@ -65,6 +67,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Invoke Cargo build in Nix shell
         run: >
@@ -88,6 +92,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Test nix run
         run: |
@@ -107,6 +113,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Test ${{ matrix.test-name }} run
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Run pre-commit hooks
         run: nix flake check

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Test image
         run: |

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
       - name: Test Build
         if: github.event_name == 'pull_request'

--- a/flake.nix
+++ b/flake.nix
@@ -525,6 +525,7 @@
               pkgs.lre.lre-cc.lre-cc-configs-gen
               pkgs.nativelink-tools.local-image-test
               pkgs.nativelink-tools.create-local-image
+              pkgs.attic-client
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
               pkgs.apple-sdk_14


### PR DESCRIPTION
# Description

Adding [attic](https://docs.attic.rs/) cache to the build for nix object cache. This drops runtime for various builds  e.g. Coverage builds go from ~54m to [~8m](https://github.com/TraceMachina/nativelink/actions/runs/24353798706/job/71115174508?pr=2274).

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

CI, some local stuff with attic

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2274)
<!-- Reviewable:end -->
