### PR TITLE
Re-enable mongo integration test

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -103,7 +103,7 @@ jobs:
     name: ${{ matrix.test-name }}
     strategy:
       matrix:
-          test-name: [buildstream, buck2, rbe-toolchain] # Disabling mongo as it has to build all of mongo from scratch for some reason
+          test-name: [buildstream, buck2, rbe-toolchain, mongo]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
# Description

I disabled it before because it was very slow, but now we've got Attic caching the mongo builds, it runs in ~2m v.s. IIRC somewhere over half an hour before.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2284)
<!-- Reviewable:end -->
