### PR TITLE
Add use_legacy_resource_names option to GrpcSpec

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1218,6 +1218,22 @@ pub struct GrpcSpec {
     /// Default: 0 (disabled)
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
     pub rpc_timeout_s: u64,
+
+    /// Use legacy ByteStream resource name format, omitting the digest
+    /// function component from the path.
+    ///
+    /// Modern NativeLink generates resource names like:
+    ///   `{instance}/blobs/{digest_function}/{hash}/{size}`
+    ///
+    /// Older backends (e.g. Buildbarn pre-v0.3) expect the original format:
+    ///   `{instance}/blobs/{hash}/{size}`
+    ///
+    /// Set this to `true` when connecting to such backends to avoid
+    /// `InvalidArgument: Unsupported digest function` errors.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub use_legacy_resource_names: bool,
 }
 
 /// The possible error codes that might occur on an upstream request.

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1232,7 +1232,7 @@ pub struct GrpcSpec {
     /// `InvalidArgument: Unsupported digest function` errors.
     ///
     /// Default: false
-    #[serde(default)]
+    #[serde(default, deserialize_with = "convert_boolean_with_shellexpand")]
     pub use_legacy_resource_names: bool,
 }
 

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1219,10 +1219,10 @@ pub struct GrpcSpec {
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
     pub rpc_timeout_s: u64,
 
-    /// Use legacy ByteStream resource name format, omitting the digest
+    /// Use legacy `ByteStream` resource name format, omitting the digest
     /// function component from the path.
     ///
-    /// Modern NativeLink generates resource names like:
+    /// Modern `NativeLink` generates resource names like:
     ///   `{instance}/blobs/{digest_function}/{hash}/{size}`
     ///
     /// Older backends (e.g. Buildbarn pre-v0.3) expect the original format:

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -68,6 +68,7 @@ pub struct GrpcStore {
     connection_manager: ConnectionManager,
     /// Per-RPC timeout. `Duration::ZERO` means disabled.
     rpc_timeout: Duration,
+    use_legacy_resource_names: bool,
 }
 
 impl GrpcStore {
@@ -110,6 +111,7 @@ impl GrpcStore {
                 jitter_fn,
             ),
             rpc_timeout,
+            use_legacy_resource_names: spec.use_legacy_resource_names,
         }))
     }
 
@@ -676,22 +678,31 @@ impl StoreDriver for GrpcStore {
             return self.update_action_result_from_bytes(digest, reader).await;
         }
 
-        let digest_function = Context::current()
-            .get::<DigestHasherFunc>()
-            .map_or_else(default_digest_hasher_func, |v| *v)
-            .proto_digest_func()
-            .as_str_name()
-            .to_ascii_lowercase();
-
         let mut buf = Uuid::encode_buffer();
-        let resource_name = format!(
-            "{}/uploads/{}/blobs/{}/{}/{}",
-            &self.instance_name,
-            Uuid::new_v4().hyphenated().encode_lower(&mut buf),
-            digest_function,
-            digest.packed_hash(),
-            digest.size_bytes(),
-        );
+        let resource_name = if self.use_legacy_resource_names {
+            format!(
+                "{}/uploads/{}/blobs/{}/{}",
+                &self.instance_name,
+                Uuid::new_v4().hyphenated().encode_lower(&mut buf),
+                digest.packed_hash(),
+                digest.size_bytes(),
+            )
+        } else {
+            let digest_function = Context::current()
+                .get::<DigestHasherFunc>()
+                .map_or_else(default_digest_hasher_func, |v| *v)
+                .proto_digest_func()
+                .as_str_name()
+                .to_ascii_lowercase();
+            format!(
+                "{}/uploads/{}/blobs/{}/{}/{}",
+                &self.instance_name,
+                Uuid::new_v4().hyphenated().encode_lower(&mut buf),
+                digest_function,
+                digest.packed_hash(),
+                digest.size_bytes(),
+            )
+        };
         trace!(
             resource_name = %resource_name,
             digest_hash = %digest.packed_hash(),
@@ -779,20 +790,28 @@ impl StoreDriver for GrpcStore {
             return writer.send_eof();
         }
 
-        let digest_function = Context::current()
-            .get::<DigestHasherFunc>()
-            .map_or_else(default_digest_hasher_func, |v| *v)
-            .proto_digest_func()
-            .as_str_name()
-            .to_ascii_lowercase();
-
-        let resource_name = format!(
-            "{}/blobs/{}/{}/{}",
-            &self.instance_name,
-            digest_function,
-            digest.packed_hash(),
-            digest.size_bytes(),
-        );
+        let resource_name = if self.use_legacy_resource_names {
+            format!(
+                "{}/blobs/{}/{}",
+                &self.instance_name,
+                digest.packed_hash(),
+                digest.size_bytes(),
+            )
+        } else {
+            let digest_function = Context::current()
+                .get::<DigestHasherFunc>()
+                .map_or_else(default_digest_hasher_func, |v| *v)
+                .proto_digest_func()
+                .as_str_name()
+                .to_ascii_lowercase();
+            format!(
+                "{}/blobs/{}/{}/{}",
+                &self.instance_name,
+                digest_function,
+                digest.packed_hash(),
+                digest.size_bytes(),
+            )
+        };
 
         let local_state = LocalState {
             resource_name,

--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -29,7 +29,7 @@ use tracing::info;
 
 const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-fn test_spec<T: Into<String>>(endpoint: T) -> GrpcSpec {
+fn test_spec<T: Into<String>>(endpoint: T, use_legacy_resource_names: bool) -> GrpcSpec {
     GrpcSpec {
         instance_name: String::new(),
         endpoints: vec![GrpcEndpoint {
@@ -46,12 +46,13 @@ fn test_spec<T: Into<String>>(endpoint: T) -> GrpcSpec {
         max_concurrent_requests: 0,
         connections_per_endpoint: 0,
         rpc_timeout_s: 1,
+        use_legacy_resource_names,
     }
 }
 
 #[nativelink_test]
 async fn fast_find_missing_blobs() -> Result<(), Error> {
-    let spec = test_spec("http://foobar");
+    let spec = test_spec("http://foobar", false);
     let store = GrpcStore::new(&spec).await?;
     let request = Request::new(FindMissingBlobsRequest {
         instance_name: String::new(),
@@ -137,12 +138,17 @@ async fn make_fake_bytestream_server() -> (FakeStreamServer, u16) {
     (fake_stream_server, port)
 }
 
-#[nativelink_test]
-async fn write_update_works() -> Result<(), Error> {
+async fn write_update_works_core(
+    use_legacy_resource_names: bool,
+    upload_pattern: Regex,
+) -> Result<(), Error> {
     const RAW_INPUT: &str = "123";
 
     let (server, port) = make_fake_bytestream_server().await;
-    let spec = test_spec(format!("http://localhost:{port}"));
+    let spec = test_spec(
+        format!("http://localhost:{port}"),
+        use_legacy_resource_names,
+    );
     let store = GrpcStore::new(&spec).await?;
     let digest = DigestInfo::try_new(VALID_HASH, RAW_INPUT.len()).unwrap();
 
@@ -164,7 +170,6 @@ async fn write_update_works() -> Result<(), Error> {
     let write_requests = server.write_requests.lock().await;
     assert_eq!(write_requests.len(), 1);
     let write_request = write_requests.first().unwrap();
-    let upload_pattern = Regex::new("/uploads/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/blobs/sha256/0123456789abcdef000000000000000000010000000000000123456789abcdef/3").unwrap();
     assert!(
         upload_pattern.is_match(&write_request.resource_name),
         "resource name: {}",
@@ -172,4 +177,16 @@ async fn write_update_works() -> Result<(), Error> {
     );
     assert_eq!(write_request.data, RAW_INPUT.as_bytes());
     Ok(())
+}
+
+#[nativelink_test]
+async fn write_update_works() -> Result<(), Error> {
+    let upload_pattern = Regex::new("/uploads/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/blobs/sha256/0123456789abcdef000000000000000000010000000000000123456789abcdef/3").unwrap();
+    write_update_works_core(false, upload_pattern).await
+}
+
+#[nativelink_test]
+async fn write_update_works_with_legacy_resource_names() -> Result<(), Error> {
+    let upload_pattern = Regex::new("/uploads/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/blobs/0123456789abcdef000000000000000000010000000000000123456789abcdef/3").unwrap();
+    write_update_works_core(true, upload_pattern).await
 }


### PR DESCRIPTION
# Description

Some older backends (e.g. Buildbarn) do not understand the modern ByteStream resource name format that includes the digest function:

  {instance}/blobs/{digest_function}/{hash}/{size}

They expect the original format without the digest function component:

  {instance}/blobs/{hash}/{size}

Add a `use_legacy_resource_names` boolean to GrpcSpec (default false) that, when enabled, omits the digest function from ByteStream resource names for both reads and writes. This fixes InvalidArgument errors when proxying to such backends.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with a local instance of nativelink configured as a pull through proxy for a remote buildbarn instance.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2285)
<!-- Reviewable:end -->
