### PR TITLE
Forward client headers and OTEL trace context to upstream gRPC stores

### DIFF
--- a/nativelink-config/examples/stores-config.json5
+++ b/nativelink-config/examples/stores-config.json5
@@ -270,7 +270,16 @@
        ],
        "connections_per_endpoint": "5",
        "rpc_timeout_s": "5m",
-       "store_type": "ac"
+       "store_type": "ac",
+       // Static headers attached to every outgoing request to the upstream
+       // remote cache. Useful for fixed service-account credentials.
+       "headers": {
+         "authorization": "Bearer my-static-token"
+       },
+       // Header names to copy from the inbound client request and forward to
+       // the upstream remote cache. Use this to pass through dynamic
+       // credentials such as a JWT sent by the build client.
+       "forward_headers": ["authorization", "x-custom-token"]
      }
     },
     {

--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::time::Duration;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use rand::Rng;
@@ -500,7 +501,16 @@ pub enum StoreSpec {
     ///   ],
     ///   "connections_per_endpoint": "5",
     ///   "rpc_timeout_s": "5m",
-    ///   "store_type": "ac"
+    ///   "store_type": "ac",
+    ///   // Static headers attached to every outgoing request to the upstream
+    ///   // remote cache. Useful for fixed service-account credentials.
+    ///   "headers": {
+    ///     "authorization": "Bearer my-static-token"
+    ///   },
+    ///   // Header names to copy from the inbound client request and forward to
+    ///   // the upstream remote cache. Use this to pass through dynamic
+    ///   // credentials such as a JWT sent by the build client.
+    ///   "forward_headers": ["authorization", "x-custom-token"]
     /// }
     /// ```
     ///
@@ -1234,6 +1244,24 @@ pub struct GrpcSpec {
     /// Default: false
     #[serde(default, deserialize_with = "convert_boolean_with_shellexpand")]
     pub use_legacy_resource_names: bool,
+
+    /// Static headers to attach to every outgoing gRPC request sent to this
+    /// store's upstream endpoints. Useful for fixed authentication tokens
+    /// (e.g. `{"authorization": "Bearer <token>"}`) and other static metadata.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+
+    /// Header names to forward from the incoming client request to every
+    /// outgoing upstream request. The header value is taken from the client
+    /// request that triggered this store operation. Use this to pass through
+    /// dynamic credentials such as JWT tokens sent by build clients.
+    ///
+    /// Example: `["authorization", "x-custom-token"]`
+    ///
+    /// `NativeLink` also automatically injects the current OpenTelemetry trace
+    /// context (`traceparent` / `tracestate`) into every outgoing request.
+    #[serde(default)]
+    pub forward_headers: Vec<String>,
 }
 
 /// The possible error codes that might occur on an upstream request.

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -88,7 +88,7 @@ fn enrich_request<T>(
         && let Some(client_headers) = Context::current().get::<ClientHeaders>()
     {
         for name in forward_headers {
-            if let Some(value) = client_headers.0.get(name)
+            if let Some(value) = client_headers.0.get(&name.to_lowercase())
                 && let (Ok(k), Ok(v)) = (
                     MetadataKey::from_bytes(name.as_bytes()),
                     MetadataValue::try_from(value.as_str()),
@@ -147,7 +147,8 @@ impl GrpcStore {
 
         let mut headers = Vec::with_capacity(spec.headers.len());
         for (name, value) in &spec.headers {
-            let key = MetadataKey::from_bytes(name.as_bytes()).map_err(|_| {
+            // We lowercase keys as HTTP headers are case-insensitive so we should match all cases
+            let key = MetadataKey::from_bytes(name.to_lowercase().as_bytes()).map_err(|_| {
                 make_err!(Code::InvalidArgument, "Invalid gRPC metadata key: {name}")
             })?;
             let val = MetadataValue::try_from(value.as_str()).map_err(|_| {
@@ -177,7 +178,12 @@ impl GrpcStore {
             rpc_timeout,
             use_legacy_resource_names: spec.use_legacy_resource_names,
             headers,
-            forward_headers: spec.forward_headers.clone(),
+            // We lowercase keys as HTTP headers are case-insensitive so we should match all cases
+            forward_headers: spec
+                .forward_headers
+                .iter()
+                .map(|s| s.to_lowercase())
+                .collect(),
         }))
     }
 

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -22,7 +22,7 @@ use bytes::BytesMut;
 use futures::stream::{FuturesUnordered, unfold};
 use futures::{Future, Stream, StreamExt, TryFutureExt, TryStreamExt, future};
 use nativelink_config::stores::GrpcSpec;
-use nativelink_error::{Error, ResultExt, error_if};
+use nativelink_error::{Error, ResultExt, error_if, make_err};
 use nativelink_metric::MetricsComponent;
 use nativelink_proto::build::bazel::remote::execution::v2::action_cache_client::ActionCacheClient;
 use nativelink_proto::build::bazel::remote::execution::v2::content_addressable_storage_client::ContentAddressableStorageClient;
@@ -47,14 +47,62 @@ use nativelink_util::proto_stream_utils::{
 use nativelink_util::resource_info::ResourceInfo;
 use nativelink_util::retry::{Retrier, RetryResult};
 use nativelink_util::store_trait::{RemoveItemCallback, StoreDriver, StoreKey, UploadSizeInfo};
+use nativelink_util::telemetry::ClientHeaders;
 use nativelink_util::{default_health_status_indicator, tls_utils};
 use opentelemetry::context::Context;
+use opentelemetry::global;
+use opentelemetry::propagation::Injector;
 use parking_lot::Mutex;
 use prost::Message;
 use tokio::time::sleep;
+use tonic::metadata::{Ascii, MetadataKey, MetadataValue};
 use tonic::{Code, IntoRequest, Request, Response, Status, Streaming};
 use tracing::{error, trace, warn};
 use uuid::Uuid;
+
+struct TonicMetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
+
+impl Injector for TonicMetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(k), Ok(v)) = (
+            MetadataKey::from_bytes(key.as_bytes()),
+            MetadataValue::try_from(&value),
+        ) {
+            self.0.insert(k, v);
+        }
+    }
+}
+
+/// Adds configured static headers, forwards nominated client request headers,
+/// and injects the current OpenTelemetry trace context into an outgoing gRPC
+/// request.
+fn enrich_request<T>(
+    mut request: Request<T>,
+    headers: &[(MetadataKey<Ascii>, MetadataValue<Ascii>)],
+    forward_headers: &[String],
+) -> Request<T> {
+    for (key, value) in headers {
+        request.metadata_mut().insert(key.clone(), value.clone());
+    }
+    if !forward_headers.is_empty()
+        && let Some(client_headers) = Context::current().get::<ClientHeaders>()
+    {
+        for name in forward_headers {
+            if let Some(value) = client_headers.0.get(name)
+                && let (Ok(k), Ok(v)) = (
+                    MetadataKey::from_bytes(name.as_bytes()),
+                    MetadataValue::try_from(value.as_str()),
+                )
+            {
+                request.metadata_mut().insert(k, v);
+            }
+        }
+    }
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject(&mut TonicMetadataInjector(request.metadata_mut()));
+    });
+    request
+}
 
 // This store is usually a pass-through store, but can also be used as a CAS store. Using it as an
 // AC store has one major side-effect... The has() function may not give the proper size of the
@@ -69,6 +117,8 @@ pub struct GrpcStore {
     /// Per-RPC timeout. `Duration::ZERO` means disabled.
     rpc_timeout: Duration,
     use_legacy_resource_names: bool,
+    headers: Vec<(MetadataKey<Ascii>, MetadataValue<Ascii>)>,
+    forward_headers: Vec<String>,
 }
 
 impl GrpcStore {
@@ -95,6 +145,20 @@ impl GrpcStore {
 
         let rpc_timeout = Duration::from_secs(spec.rpc_timeout_s);
 
+        let mut headers = Vec::with_capacity(spec.headers.len());
+        for (name, value) in &spec.headers {
+            let key = MetadataKey::from_bytes(name.as_bytes()).map_err(|_| {
+                make_err!(Code::InvalidArgument, "Invalid gRPC metadata key: {name}")
+            })?;
+            let val = MetadataValue::try_from(value.as_str()).map_err(|_| {
+                make_err!(
+                    Code::InvalidArgument,
+                    "Invalid gRPC metadata value for key: {name}"
+                )
+            })?;
+            headers.push((key, val));
+        }
+
         Ok(Arc::new(Self {
             instance_name: spec.instance_name.clone(),
             store_type: spec.store_type,
@@ -112,6 +176,8 @@ impl GrpcStore {
             ),
             rpc_timeout,
             use_legacy_resource_names: spec.use_legacy_resource_names,
+            headers,
+            forward_headers: spec.forward_headers.clone(),
         }))
     }
 
@@ -165,7 +231,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in find_missing_blobs")?;
             ContentAddressableStorageClient::new(channel)
-                .find_missing_blobs(Request::new(request))
+                .find_missing_blobs(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::find_missing_blobs")
         })
@@ -190,7 +260,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in batch_update_blobs")?;
             ContentAddressableStorageClient::new(channel)
-                .batch_update_blobs(Request::new(request))
+                .batch_update_blobs(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::batch_update_blobs")
         })
@@ -215,7 +289,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in batch_read_blobs")?;
             ContentAddressableStorageClient::new(channel)
-                .batch_read_blobs(Request::new(request))
+                .batch_read_blobs(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::batch_read_blobs")
         })
@@ -240,7 +318,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in get_tree")?;
             ContentAddressableStorageClient::new(channel)
-                .get_tree(Request::new(request))
+                .get_tree(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::get_tree")
         })
@@ -267,7 +349,11 @@ impl GrpcStore {
             .await
             .err_tip(|| "in read_internal")?;
         let mut response = ByteStreamClient::new(channel)
-            .read(Request::new(request))
+            .read(enrich_request(
+                Request::new(request),
+                &self.headers,
+                &self.forward_headers,
+            ))
             .await
             .err_tip(|| "in GrpcStore::read")?
             .into_inner();
@@ -356,7 +442,11 @@ impl GrpcStore {
                             let local_state_for_rpc = local_state.clone();
                             async move {
                                 let res = ByteStreamClient::new(channel)
-                                    .write(WriteStateWrapper::new(local_state_for_rpc))
+                                    .write(enrich_request(
+                                        Request::new(WriteStateWrapper::new(local_state_for_rpc)),
+                                        &self.headers,
+                                        &self.forward_headers,
+                                    ))
                                     .await
                                     .err_tip(|| "in GrpcStore::write");
                                 let rpc_elapsed_ms = u64::try_from(rpc_start.elapsed().as_millis())
@@ -466,7 +556,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in query_write_status")?;
             ByteStreamClient::new(channel)
-                .query_write_status(Request::new(request))
+                .query_write_status(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::query_write_status")
         })
@@ -486,7 +580,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in get_action_result")?;
             ActionCacheClient::new(channel)
-                .get_action_result(Request::new(request))
+                .get_action_result(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::get_action_result")
         })
@@ -506,7 +604,11 @@ impl GrpcStore {
                 .await
                 .err_tip(|| "in update_action_result")?;
             ActionCacheClient::new(channel)
-                .update_action_result(Request::new(request))
+                .update_action_result(enrich_request(
+                    Request::new(request),
+                    &self.headers,
+                    &self.forward_headers,
+                ))
                 .await
                 .err_tip(|| "in GrpcStore::update_action_result")
         })

--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -1,5 +1,6 @@
 use core::pin::Pin;
 use core::time::Duration;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_lock::Mutex;
@@ -49,6 +50,8 @@ fn test_spec<T: Into<String>>(endpoint: T, use_legacy_resource_names: bool) -> G
         connections_per_endpoint: 0,
         rpc_timeout_s: 1,
         use_legacy_resource_names,
+        headers: HashMap::new(),
+        forward_headers: vec![],
     }
 }
 

--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -22,8 +22,11 @@ use nativelink_util::background_spawn;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
+use nativelink_util::telemetry::ClientHeaders;
+use opentelemetry::Context;
 use regex::Regex;
 use tokio::time::timeout;
+use tonic::metadata::KeyAndValueRef;
 use tonic::transport::Server;
 use tonic::transport::server::TcpIncoming;
 use tonic::{Request, Response, Status, Streaming};
@@ -74,9 +77,15 @@ async fn fast_find_missing_blobs() -> Result<(), Error> {
 }
 
 #[derive(Debug, Clone)]
+struct ReadRequestHolder {
+    request: ReadRequest,
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
 struct FakeStreamServer {
     write_requests: Arc<Mutex<Vec<WriteRequest>>>,
-    read_requests: Arc<Mutex<Vec<ReadRequest>>>,
+    read_requests: Arc<Mutex<Vec<ReadRequestHolder>>>,
 }
 
 impl FakeStreamServer {
@@ -102,8 +111,26 @@ impl ByteStream for FakeStreamServer {
         &self,
         grpc_request: Request<ReadRequest>,
     ) -> Result<Response<Self::ReadStream>, Status> {
+        let mut request_metadata: HashMap<String, String> = HashMap::new();
+        for kv in grpc_request.metadata().iter() {
+            match kv {
+                KeyAndValueRef::Ascii(metadata_key, metadata_value) => {
+                    request_metadata.insert(
+                        metadata_key.to_string(),
+                        metadata_value.to_str().unwrap().to_string(),
+                    );
+                }
+                KeyAndValueRef::Binary(metadata_key, metadata_value) => {
+                    request_metadata
+                        .insert(metadata_key.to_string(), format!("{metadata_value:#?}"));
+                }
+            }
+        }
         let read_request = grpc_request.into_inner();
-        self.read_requests.lock().await.push(read_request);
+        self.read_requests.lock().await.push(ReadRequestHolder {
+            request: read_request,
+            metadata: request_metadata,
+        });
 
         let folded = unfold(ReaderState { responded: false }, async move |state| {
             if state.responded {
@@ -211,15 +238,19 @@ async fn write_update_works_with_legacy_resource_names() -> Result<(), Error> {
     write_update_works_core(true, upload_pattern).await
 }
 
-async fn read_works_core(
+async fn read_works_core<F>(
     use_legacy_resource_names: bool,
     upload_pattern: &str,
-) -> Result<(), Error> {
+    edit_spec: F,
+) -> Result<ReadRequestHolder, Error>
+where
+    F: FnOnce(GrpcSpec) -> GrpcSpec,
+{
     let (server, port) = make_fake_bytestream_server().await;
-    let spec = test_spec(
+    let spec = edit_spec(test_spec(
         format!("http://localhost:{port}"),
         use_legacy_resource_names,
-    );
+    ));
     let store = GrpcStore::new(&spec).await?;
     let digest = DigestInfo::try_new(VALID_HASH, RAW_INPUT.len()).unwrap();
 
@@ -231,21 +262,59 @@ async fn read_works_core(
     let read_requests = server.read_requests.lock().await;
     assert_eq!(read_requests.len(), 1);
     let read_request = read_requests.first().unwrap();
-    assert_eq!(upload_pattern, &read_request.resource_name,);
+    assert_eq!(upload_pattern, &read_request.request.resource_name);
 
-    Ok(())
+    Ok(read_request.clone())
 }
 
 #[nativelink_test]
 async fn read_works() -> Result<(), Error> {
     let upload_pattern =
         "/blobs/sha256/0123456789abcdef000000000000000000010000000000000123456789abcdef/3";
-    read_works_core(false, upload_pattern).await
+    read_works_core(false, upload_pattern, core::convert::identity)
+        .await
+        .unwrap();
+    Ok(())
 }
 
 #[nativelink_test]
 async fn read_works_with_legacy_resource_names() -> Result<(), Error> {
     let upload_pattern =
         "/blobs/0123456789abcdef000000000000000000010000000000000123456789abcdef/3";
-    read_works_core(true, upload_pattern).await
+    read_works_core(true, upload_pattern, core::convert::identity)
+        .await
+        .unwrap();
+    Ok(())
+}
+
+#[nativelink_test]
+async fn read_works_with_headers() -> Result<(), Error> {
+    fn set_spec(mut spec: GrpcSpec) -> GrpcSpec {
+        spec.headers.insert("foo".into(), "bar".into());
+        spec.forward_headers.push("something".into());
+        spec
+    }
+
+    let upload_pattern =
+        "/blobs/sha256/0123456789abcdef000000000000000000010000000000000123456789abcdef/3";
+
+    let client_headers = {
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert("something".to_string(), "from outside".to_string());
+        ClientHeaders(Arc::new(headers))
+    };
+
+    let cx_guard = Context::map_current(|cx| cx.with_value(client_headers)).attach();
+
+    let read_request = read_works_core(false, upload_pattern, set_spec)
+        .await
+        .unwrap();
+    assert_eq!(read_request.metadata.get("foo"), Some(&"bar".to_string()));
+    assert_eq!(
+        read_request.metadata.get("something"),
+        Some(&"from outside".to_string())
+    );
+    drop(cx_guard);
+
+    Ok(())
 }

--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -291,7 +291,8 @@ async fn read_works_with_legacy_resource_names() -> Result<(), Error> {
 async fn read_works_with_headers() -> Result<(), Error> {
     fn set_spec(mut spec: GrpcSpec) -> GrpcSpec {
         spec.headers.insert("foo".into(), "bar".into());
-        spec.forward_headers.push("something".into());
+        // Testing with mixed case, as it gets lowercased internally
+        spec.forward_headers.push("SomeTHING".into());
         spec
     }
 
@@ -300,7 +301,8 @@ async fn read_works_with_headers() -> Result<(), Error> {
 
     let client_headers = {
         let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert("something".to_string(), "from outside".to_string());
+        // We're inserting a lowercase one here as the telemetry insertion uses a lowercase one
+        headers.insert("something".to_string(), "From outside".to_string());
         ClientHeaders(Arc::new(headers))
     };
 
@@ -312,7 +314,9 @@ async fn read_works_with_headers() -> Result<(), Error> {
     assert_eq!(read_request.metadata.get("foo"), Some(&"bar".to_string()));
     assert_eq!(
         read_request.metadata.get("something"),
-        Some(&"from outside".to_string())
+        Some(&"From outside".to_string()),
+        "{:#?}",
+        read_request.metadata
     );
     drop(cx_guard);
 

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -134,6 +134,7 @@ rust_test_suite(
         "@crates//:hyper-1.7.0",
         "@crates//:mock_instant",
         "@crates//:opentelemetry",
+        "@crates//:opentelemetry-http",
         "@crates//:parking_lot",
         "@crates//:pretty_assertions",
         "@crates//:rand",

--- a/nativelink-util/src/telemetry.rs
+++ b/nativelink-util/src/telemetry.rs
@@ -259,7 +259,7 @@ where
                     value
                         .to_str()
                         .ok()
-                        .map(|v| (name.as_str().to_string(), v.to_string()))
+                        .map(|v| (name.as_str().to_lowercase(), v.to_string()))
                 })
                 .collect(),
         ));

--- a/nativelink-util/src/telemetry.rs
+++ b/nativelink-util/src/telemetry.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use core::default::Default;
+use std::collections::HashMap;
 use std::env;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD_NO_PAD;
@@ -202,6 +203,11 @@ const BAZEL_REQUESTMETADATA_HEADER: &str = "build.bazel.remote.execution.v2.requ
 use opentelemetry::baggage::BaggageExt;
 use opentelemetry::context::FutureExt;
 
+/// ASCII headers from an inbound client request, stored in the task context
+/// so that outgoing upstream calls can forward them (e.g. JWT auth tokens).
+#[derive(Clone, Debug, Default)]
+pub struct ClientHeaders(pub Arc<HashMap<String, String>>);
+
 #[derive(Debug, Clone)]
 pub struct OtlpMiddleware<S> {
     inner: S,
@@ -243,6 +249,20 @@ where
         // See: https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
         let clone = self.inner.clone();
         let mut inner = core::mem::replace(&mut self.inner, clone);
+
+        // Capture all ASCII-valued request headers before req is consumed, so
+        // they can be forwarded to upstream services (e.g. JWT auth tokens).
+        let client_headers = ClientHeaders(Arc::new(
+            req.headers()
+                .iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .to_str()
+                        .ok()
+                        .map(|v| (name.as_str().to_string(), v.to_string()))
+                })
+                .collect(),
+        ));
 
         let parent_cx = global::get_text_map_propagator(|propagator| {
             propagator.extract(&HeaderExtractor(req.headers()))
@@ -293,6 +313,7 @@ NativeLink instance configured to require this OpenTelemetry Baggage header:
             ]);
         }
 
+        let cx = cx.with_value(client_headers);
         Box::pin(async move { inner.call(req).with_context(cx).await })
     }
 }

--- a/nativelink-util/tests/telemetry_test.rs
+++ b/nativelink-util/tests/telemetry_test.rs
@@ -1,44 +1,102 @@
-use axum::Router;
-use hyper::{Request, StatusCode, Uri};
-use nativelink_macro::nativelink_test;
-use opentelemetry::baggage::BaggageExt;
-use opentelemetry::{Context, KeyValue};
-use tonic::body::Body;
-use tonic::service::Routes;
-use tower::{Service, ServiceExt};
-use tracing::warn;
+use std::sync::{Arc, Mutex};
 
-fn demo_service() -> Router {
-    let tonic_services = Routes::builder().routes();
-    tonic_services
-        .into_axum_router()
+use axum::extract::{FromRequestParts, State};
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::{Router, middleware};
+use hyper::{Request, Response, StatusCode, Uri};
+use nativelink_macro::nativelink_test;
+use nativelink_util::telemetry::ClientHeaders;
+use opentelemetry::baggage::BaggageExt;
+use opentelemetry::{Context, KeyValue, global};
+use opentelemetry_http::HeaderExtractor as OTELHeaderExtractor;
+use tonic::body::Body;
+use tower::{Service, ServiceBuilder, ServiceExt};
+use tracing::{debug, error, warn};
+
+struct ExtractClientHeaders(ClientHeaders);
+
+impl<S> FromRequestParts<S> for ExtractClientHeaders
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let context = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&OTELHeaderExtractor(&parts.headers))
+        });
+        if let Some(client_headers) = context.get::<ClientHeaders>() {
+            Ok(Self(client_headers.clone()))
+        } else {
+            error!("Missing OTEL headers");
+            Err((StatusCode::BAD_REQUEST, "OTEL headers are missing"))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    client_headers: Arc<Mutex<Vec<ClientHeaders>>>,
+}
+
+impl AppState {
+    fn new() -> Self {
+        Self {
+            client_headers: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+
+async fn header_extract(
+    ExtractClientHeaders(client_headers): ExtractClientHeaders,
+    State(state): State<Arc<AppState>>,
+    request: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    debug!(?client_headers, "Client headers");
+    state
+        .client_headers
+        .lock()
+        .unwrap()
+        .push(client_headers.clone());
+    next.run(request).await
+}
+
+fn demo_service(app_state: Arc<AppState>) -> Router {
+    Router::default()
+        .with_state(app_state.clone())
         .fallback(|uri: Uri| async move {
             warn!("No route for {uri}");
             (StatusCode::NOT_FOUND, format!("No route for {uri}"))
         })
-        .layer(nativelink_util::telemetry::OtlpLayer::new(false))
+        .layer(
+            ServiceBuilder::new()
+                .layer(nativelink_util::telemetry::OtlpLayer::new(false))
+                .layer(middleware::from_fn_with_state(app_state, header_extract)),
+        )
 }
 
 async fn run_request(
     svc: &mut Router,
     request: Request<Body>,
 ) -> Result<(), Box<dyn core::error::Error>> {
-    let response: hyper::Response<axum::body::Body> =
+    let response: Response<axum::body::Body> =
         svc.as_service().ready().await?.call(request).await?;
-    assert_eq!(response.status(), 404);
-
-    let response = String::from_utf8(
+    let status = response.status();
+    let body = String::from_utf8(
         axum::body::to_bytes(response.into_body(), usize::MAX)
             .await?
             .to_vec(),
     )?;
-    assert_eq!(response, String::from("No route for /demo"));
+    assert_eq!(status, 404, "{body}");
+    assert_eq!(body, String::from("No route for /demo"));
     Ok(())
 }
 
 #[nativelink_test]
 async fn oltp_logs_no_baggage() -> Result<(), Box<dyn core::error::Error>> {
-    let mut svc = demo_service();
+    let mut svc = demo_service(Arc::new(AppState::new()));
 
     let request: Request<Body> = Request::builder()
         .method("GET")
@@ -53,7 +111,7 @@ async fn oltp_logs_no_baggage() -> Result<(), Box<dyn core::error::Error>> {
 
 #[nativelink_test]
 async fn oltp_logs_with_baggage() -> Result<(), Box<dyn core::error::Error>> {
-    let mut svc = demo_service();
+    let mut svc = demo_service(Arc::new(AppState::new()));
 
     let mut request: Request<Body> = Request::builder()
         .method("GET")
@@ -72,6 +130,26 @@ async fn oltp_logs_with_baggage() -> Result<(), Box<dyn core::error::Error>> {
 
     assert!(logs_contain("Baggage enduser.id: foobar"));
     drop(cx_guard);
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn oltp_logs_with_headers() -> Result<(), Box<dyn core::error::Error>> {
+    let app_state = Arc::new(AppState::new());
+    let mut svc = demo_service(app_state.clone());
+
+    let request: Request<Body> = Request::builder()
+        .method("GET")
+        .header("foo", "bar")
+        .uri("/demo")
+        .body(Body::empty())?;
+    run_request(&mut svc, request).await?;
+
+    let client_headers = app_state.client_headers.lock().unwrap();
+    assert_eq!(client_headers.len(), 1, "{client_headers:#?}");
+    let client_header = client_headers.first().unwrap();
+    assert_eq!(client_header.0.get("foo"), Some(&"bar".to_string()));
 
     Ok(())
 }

--- a/nativelink-util/tests/telemetry_test.rs
+++ b/nativelink-util/tests/telemetry_test.rs
@@ -141,7 +141,7 @@ async fn oltp_logs_with_headers() -> Result<(), Box<dyn core::error::Error>> {
 
     let request: Request<Body> = Request::builder()
         .method("GET")
-        .header("foo", "bar")
+        .header("Foo", "bar")
         .uri("/demo")
         .body(Body::empty())?;
     run_request(&mut svc, request).await?;

--- a/nativelink-worker/src/namespace_utils.rs
+++ b/nativelink-worker/src/namespace_utils.rs
@@ -172,13 +172,13 @@ pub fn namespaces_supported(mount: bool) -> bool {
                         );
                     }
                 }
-                return false;
+            } else {
+                error!(
+                    exit_code = status,
+                    "Namespaces: waitpid exit with non-exit code"
+                );
             }
-            error!(
-                exit_code = status,
-                "Namespaces: waitpid exit with non-exit code"
-            );
-            return false;
+            false
         }
         _ => false,
     }

--- a/web/platform/src/content/docs/docs/config/production-config.mdx
+++ b/web/platform/src/content/docs/docs/config/production-config.mdx
@@ -586,3 +586,53 @@ root in a new mount namespace. Note, `use_mount_namespace` only works if `use_na
 
 Note this only applies for non-Dockerised workers, as workers in Docker don't have permissions to make a new user
 namespace. If however you use privileged containers, this works as per non-Docker setups.
+
+## Authenticating to Upstream gRPC Stores
+
+When NativeLink proxies to an upstream remote cache, two fields on the `grpc`
+store control how credentials are attached to outgoing requests.
+
+### Static credentials (`headers`)
+
+Use `headers` for fixed service-account tokens or API keys that don't change
+per request:
+
+```json5
+"grpc": {
+  "endpoints": [{"address": "grpcs://remote-cache.example.com:8980"}],
+  "store_type": "cas",
+  "headers": {
+    "authorization": "Bearer my-service-account-token"
+  }
+}
+```
+
+### Forwarding client credentials (`forward_headers`)
+
+Use `forward_headers` to pass through credentials that the build client sends
+with each request. For example a short-lived JWT supplied via Bazel's
+`--remote_header=authorization=Bearer <token>` flag:
+
+```json5
+"grpc": {
+  "endpoints": [{"address": "grpcs://remote-cache.example.com:8980"}],
+  "store_type": "cas",
+  "forward_headers": ["authorization"]
+}
+```
+
+NativeLink captures every ASCII header from the inbound client request and
+stores it in the request context. Any name listed in `forward_headers` is then
+injected into the corresponding outgoing upstream call, so the upstream cache
+sees the same credential the build client presented.
+
+Both fields can be used together. `forward_headers` values are applied after
+`headers`, so a forwarded value will override a static one if both name the
+same header.
+
+### Distributed tracing
+
+Every outgoing upstream request also automatically receives the current W3C
+trace context (`traceparent` / `tracestate`), so traces span correctly across
+multiple NativeLink instances and into upstream services without any additional
+configuration.


### PR DESCRIPTION
# Description

Adds two complementary mechanisms to GrpcStore for propagating headers to upstream remote caches (e.g. Buildbarn):

1. `headers` (GrpcSpec): static key/value pairs attached to every outgoing request, useful for fixed auth tokens.

2. `forward_headers` (GrpcSpec): header names to forward from the inbound client request. OtlpMiddleware captures all ASCII-valued headers from the client into a ClientHeaders value stored in the task context; enrich_request reads them back and injects whichever names are listed here. This enables JWT pass-through so build clients can authenticate directly with upstream caches.

Additionally, every outgoing request now has the current W3C trace context (traceparent/tracestate) injected via the OpenTelemetry propagator, fixing distributed trace continuity across NativeLink instances and into upstream services.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2288)
<!-- Reviewable:end -->
