### PR TITLE
If namespacing fails, give clearer errors as to why

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,6 +88,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
     - name: Checkout
       uses: >- # v6.0.2

--- a/deployment-examples/docker-compose/docker-compose.yml
+++ b/deployment-examples/docker-compose/docker-compose.yml
@@ -55,6 +55,7 @@ services:
 
   nativelink_executor:
     image: trace_machina/nativelink:latest
+    privileged: true # So we can do use_namespaces
     build:
       context: ../..
       dockerfile: ./deployment-examples/docker-compose/Dockerfile

--- a/deployment-examples/docker-compose/worker.json5
+++ b/deployment-examples/docker-compose/worker.json5
@@ -86,6 +86,8 @@
             ],
           },
         },
+        use_namespaces: true,
+        use_mount_namespace: true,
       },
     },
   ],

--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -858,6 +858,11 @@ pub struct LocalWorkerConfig {
     /// on Linux.  It is highly recommended as it avoids a number of issues with
     /// zombie processes and also provides additional hermeticity.  If explicitly set
     /// to true and it is not supported the worker will exit with an error.
+    ///
+    /// Note: this will fail for non-privileged Dockerised workers, as workers in
+    /// Docker don't have permissions to make a new user namespace. Privileged
+    /// containers can do this.
+    ///
     /// Default: False.
     pub use_namespaces: Option<bool>,
 

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -627,14 +627,20 @@ pub async fn new_local_worker(
 
     #[cfg(not(target_os = "linux"))]
     if config.use_namespaces.is_some_and(core::convert::identity) {
-        return Err(make_err!(Code::Unavailable, "Namespaces not supported"));
+        return Err(make_err!(
+            Code::Unavailable,
+            "Namespaces not supported on non-Linux OSes"
+        ));
     }
     #[cfg(not(target_os = "linux"))]
     if config
         .use_mount_namespace
         .is_some_and(core::convert::identity)
     {
-        return Err(make_err!(Code::Unavailable, "Namespaces not supported"));
+        return Err(make_err!(
+            Code::Unavailable,
+            "Mount namespaces not supported on non-Linux OSes"
+        ));
     }
 
     let running_actions_manager =

--- a/nativelink-worker/src/namespace_utils.rs
+++ b/nativelink-worker/src/namespace_utils.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Error;
+
+use tracing::error;
+
 /// A wrapper around a Child to send SIGTERM to kill the process instead
 /// of SIGKILL as it's wrapped by the stub.
 #[derive(Debug)]
@@ -27,7 +31,7 @@ impl MaybeNamespacedChild {
 
     /// Send SIGTERM if namespaced which sends SIGKILL to the child, otherwise
     /// send SIGKILL to the child.
-    pub async fn kill(&mut self) -> Result<(), std::io::Error> {
+    pub async fn kill(&mut self) -> Result<(), Error> {
         if self.namespaced {
             // It would be safer to call send_signal to use the pidfd to avoid
             // races, however this is still an experimental API, see:
@@ -44,14 +48,28 @@ impl MaybeNamespacedChild {
         self.child.kill().await
     }
 
-    pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>, std::io::Error> {
+    pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>, Error> {
         self.child.try_wait()
     }
 
-    pub async fn wait(&mut self) -> Result<std::process::ExitStatus, std::io::Error> {
+    pub async fn wait(&mut self) -> Result<std::process::ExitStatus, Error> {
         self.child.wait().await
     }
 }
+
+fn exit(status: i32) -> ! {
+    // SAFETY: It is always safe to _exit.
+    unsafe { libc::_exit(status) };
+}
+
+enum NamespaceErrorType {
+    Unshare = 1,
+    WriteSignalSafe,
+    Mount,
+}
+
+const NS_ERROR_TYPE_BITS: u8 = 2; // This is 2 because the highest value (NamespaceErrorType::Mount) is 3 and so we can store all of this in two bits
+const NS_ERROR_TYPE_MASK: i32 = 0x3; // 11 - i.e. NS_ERROR_TYPE_BITS lowest bits
 
 /// Determines whether the namespaces provided by this module are supported
 /// on the currently running system by forking a process and trying to enter
@@ -71,38 +89,96 @@ pub fn namespaces_supported(mount: bool) -> bool {
             }
             // SAFETY: Unshare does not have any unsafe effects and modifies no
             // memory, it is also async-signal-safe.
-            if unsafe { libc::unshare(flags) } == 0
-                && write_signal_safe(c"/proc/self/uid_map", uid_map.as_bytes()).is_ok()
-            {
-                // SAFETY: Mount uses no memory and is async-signal-safe.
-                if !mount
-                    || unsafe {
-                        libc::mount(
-                            core::ptr::null(),
-                            c"/".as_ptr(),
-                            core::ptr::null(),
-                            libc::MS_REC | libc::MS_PRIVATE,
-                            core::ptr::null(),
-                        )
-                    } == 0
-                {
-                    // SAFETY: It is always safe to _exit.
-                    unsafe { libc::_exit(0) };
+            if unsafe { libc::unshare(flags) } == 0 {
+                match write_signal_safe(c"/proc/self/uid_map", uid_map.as_bytes()) {
+                    Ok(()) => {
+                        if !mount {
+                            exit(0);
+                        }
+                        // SAFETY: Mount uses no memory and is async-signal-safe.
+                        if unsafe {
+                            libc::mount(
+                                core::ptr::null(),
+                                c"/".as_ptr(),
+                                core::ptr::null(),
+                                libc::MS_REC | libc::MS_PRIVATE,
+                                core::ptr::null(),
+                            )
+                        } == 0
+                        {
+                            exit(0);
+                        } else {
+                            // SAFETY: We just called a libc function that failed (-1).
+                            let errno = unsafe { *libc::__errno_location() };
+                            exit(
+                                (NamespaceErrorType::Mount as i32) | (errno << NS_ERROR_TYPE_BITS),
+                            );
+                        }
+                    }
+                    Err(uid_map_err) => {
+                        exit(
+                            (NamespaceErrorType::WriteSignalSafe as i32)
+                                | (uid_map_err << NS_ERROR_TYPE_BITS),
+                        );
+                    }
                 }
+            } else {
+                // SAFETY: We just called a libc function that failed (-1).
+                let errno = unsafe { *libc::__errno_location() };
+                exit((NamespaceErrorType::Unshare as i32) | (errno << NS_ERROR_TYPE_BITS));
             }
-            // SAFETY: It is always safe to _exit.
-            unsafe { libc::_exit(1) };
         }
         pid if pid > 0 => {
             let mut status = 0;
             // SAFETY: The pid is valid and created by us and the status is our own stack.
             while unsafe { libc::waitpid(pid, &raw mut status, 0) } == -1 {
                 // SAFETY: We just called a libc function that failed (-1).
-                if unsafe { *libc::__errno_location() } != libc::EINTR {
+                let errno = unsafe { *libc::__errno_location() };
+                if errno != libc::EINTR {
+                    error!(errno = errno, "Namespaces: Failure in waitpid");
                     return false;
                 }
             }
-            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0
+            if libc::WIFEXITED(status) {
+                match libc::WEXITSTATUS(status) {
+                    0 => {
+                        return true;
+                    }
+                    s if s & NS_ERROR_TYPE_MASK == NamespaceErrorType::Unshare as i32 => {
+                        let errno = s >> NS_ERROR_TYPE_BITS;
+                        error!(errno, "Namespaces: Error during unshare");
+                        if errno == libc::EPERM {
+                            error!(
+                                "If the worker is inside Docker, namespaces don't work unless it's a privileged container"
+                            );
+                        }
+                    }
+                    s if s & NS_ERROR_TYPE_MASK == NamespaceErrorType::WriteSignalSafe as i32 => {
+                        error!(
+                            errno = s >> NS_ERROR_TYPE_BITS,
+                            "Namespaces: Error while writing to /proc/self/uid_map"
+                        );
+                    }
+                    s if s & NS_ERROR_TYPE_MASK == NamespaceErrorType::Mount as i32 => {
+                        error!(
+                            errno = s >> NS_ERROR_TYPE_BITS,
+                            "Failure to mount during namespace checking"
+                        );
+                    }
+                    other => {
+                        error!(
+                            exit_code = other,
+                            "Namespace check failure with unknown exit code"
+                        );
+                    }
+                }
+                return false;
+            }
+            error!(
+                exit_code = status,
+                "Namespaces: waitpid exit with non-exit code"
+            );
+            return false;
         }
         _ => false,
     }
@@ -219,7 +295,7 @@ impl Drop for OwnedFd {
 fn perform_remount(
     root_action_directory: &core::ffi::CStr,
     action_directory: &core::ffi::CStr,
-) -> Result<(), std::io::Error> {
+) -> Result<(), Error> {
     // Make the mount namespace private to avoid changes propagating back to the host.
     // SAFETY: mount is async-signal-safe. We pass a null pointer for the source and valid
     // C-string pointers for the target. The parameters match POSIX requirements.
@@ -233,7 +309,7 @@ fn perform_remount(
         )
     } != 0
     {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     // Bind mount the action directory to itself to "save" its current contents before
@@ -249,14 +325,14 @@ fn perform_remount(
         )
     } != 0
     {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     // Open the directory with O_PATH so we can find it after masking the parent.
     // SAFETY: open is async-signal-safe. The path is a valid C-string.
     let fd = unsafe { libc::open(action_directory.as_ptr(), libc::O_PATH) };
     if fd < 0 {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
     let fd = OwnedFd(fd);
 
@@ -272,13 +348,13 @@ fn perform_remount(
         )
     } != 0
     {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     // Recreate the specific operation's directory inside the empty tmpfs.
     // SAFETY: mkdir is async-signal-safe and the path is a valid C-string.
     if unsafe { libc::mkdir(action_directory.as_ptr(), 0o777) } != 0 {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     // Bind mount the saved directory back from the file descriptor to the new path.
@@ -303,7 +379,7 @@ fn perform_remount(
         )
     } != 0
     {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     Ok(())
@@ -334,20 +410,20 @@ pub fn configure_namespace(
     // SAFETY: Unshare does not have any unsafe effects and modifies no
     // memory, it is also async-signal-safe.
     if unsafe { libc::unshare(flags) } != 0 {
-        return Err(std::io::Error::last_os_error());
+        return Err(Error::last_os_error());
     }
 
     if let Err(e) = write_signal_safe(c"/proc/self/setgroups", b"deny") {
         // If we fail to write this it will just make gid_map fail later,
         // but we may be able to continue anyway.
         if e != libc::EPERM && e != libc::EACCES && e != libc::ENOENT {
-            return Err(std::io::Error::from_raw_os_error(e));
+            return Err(Error::from_raw_os_error(e));
         }
     }
 
     let mut buffer = [0u8; 32];
     write_signal_safe(c"/proc/self/uid_map", create_map_line(uid, &mut buffer))
-        .map_err(std::io::Error::from_raw_os_error)?;
+        .map_err(Error::from_raw_os_error)?;
 
     // If we can't write to gid_map, we just ignore it. This usually happens if
     // setgroups was not written to (because of permissions) or if we are in a
@@ -356,7 +432,7 @@ pub fn configure_namespace(
         // If this fails then we can probably continue just fine, it's just
         // the uid that's important.
         if e != libc::EPERM && e != libc::EACCES {
-            return Err(std::io::Error::from_raw_os_error(e));
+            return Err(Error::from_raw_os_error(e));
         }
     }
 
@@ -373,7 +449,7 @@ pub fn configure_namespace(
         // SAFETY: We just called a libc function that failed.
         let err = unsafe { *libc::__errno_location() };
         if err != libc::EPERM && err != libc::EACCES {
-            return Err(std::io::Error::from_raw_os_error(err));
+            return Err(Error::from_raw_os_error(err));
         }
     }
 
@@ -384,8 +460,7 @@ pub fn configure_namespace(
         0 => {
             // SAFETY: This function is async-signal-safe and references no memory or resources.
             if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) } != 0 {
-                // SAFETY: It's always safe to _exit.
-                unsafe { libc::_exit(1) };
+                exit(1);
             }
             Ok(())
         }
@@ -417,8 +492,7 @@ pub fn configure_namespace(
                     let res = unsafe { libc::waitpid(-1, &raw mut status, libc::WNOHANG) };
                     if res == pid {
                         if libc::WIFEXITED(status) {
-                            // SAFETY: It's always safe to _exit.
-                            unsafe { libc::_exit(libc::WEXITSTATUS(status)) };
+                            exit(libc::WEXITSTATUS(status));
                         } else if libc::WIFSIGNALED(status) {
                             // Try to exit with the same signal as the child.
                             // SAFETY: The sigset was previously allocated and used on the stack.
@@ -432,14 +506,12 @@ pub fn configure_namespace(
                             // SAFETY: It's always safe to raise and as a fallback we _exit below.
                             unsafe { libc::raise(libc::WTERMSIG(status)) };
                             // We shouldn't get here, but it's a fallback in case.
-                            // SAFETY: It's always safe to _exit.
-                            unsafe { libc::_exit(libc::WTERMSIG(status)) };
+                            exit(libc::WTERMSIG(status));
                         }
                     } else if res <= 0 {
                         // SAFETY: We just called a libc function that failed.
                         if res == -1 && unsafe { *libc::__errno_location() } != libc::EINTR {
-                            // SAFETY: It's always safe to _exit.
-                            unsafe { libc::_exit(255) };
+                            exit(255);
                         }
                         // Break the reaping loop to wait for signals.
                         break;
@@ -456,6 +528,6 @@ pub fn configure_namespace(
                 }
             }
         }
-        _ => Err(std::io::Error::last_os_error()),
+        _ => Err(Error::last_os_error()),
     }
 }

--- a/web/platform/src/content/docs/docs/config/production-config.mdx
+++ b/web/platform/src/content/docs/docs/config/production-config.mdx
@@ -569,7 +569,7 @@ prevent timeouts and reduce pressure during spikes.
 
 We've seen in some client configurations issues where Bazel in particular can leave zombie processes around on workers.
 To solve this, we've two options around sandboxing that are currently switched off by default for backwards
-compatibility, but are recommended for production configurations
+compatibility, but are recommended for production configurations.
 
 ```json5
 workers: [{
@@ -583,3 +583,6 @@ workers: [{
 
 `use_namespaces` enables process namespacing for workers, and `use_mount_namespace` then also isolates the worker
 root in a new mount namespace. Note, `use_mount_namespace` only works if `use_namespaces` is switched on as well.
+
+Note this only applies for non-Dockerised workers, as workers in Docker don't have permissions to make a new user
+namespace. If however you use privileged containers, this works as per non-Docker setups.


### PR DESCRIPTION
# Description

Primarily built to aid debug of https://github.com/TraceMachina/nativelink/issues/2173#issuecomment-4198107285 but investigation noted that it just doesn't work inside Docker!

We previously had 3 different locations all saying "Namespaces not supported" with no clarity as to _why_. This PR clarifies the reason in two cases (not running Linux), and in the 3rd case it adds logging for each of the possible failure paths.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...` and adding `use_namespaces` to the integration tests

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2290)
<!-- Reviewable:end -->
