### PR TITLE
Bound CAS leader-wait + per-blob batch deadline; tolerate empty FT.AGGREGATE

### DIFF
--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -72,6 +72,9 @@ serde_json = { version = "1.0.140", default-features = false, features = [
   "std",
 ] }
 sha2 = { version = "0.10.8", default-features = false }
+tokio = { version = "1.52.2", features = [
+  "test-util",
+], default-features = false }
 tracing-test = { version = "0.2.5", default-features = false, features = [
   "no-env-filter",
 ] }

--- a/nativelink-service/src/cas_server.rs
+++ b/nativelink-service/src/cas_server.rs
@@ -14,13 +14,14 @@
 
 use core::convert::Into;
 use core::pin::Pin;
+use core::time::Duration;
 use std::collections::{HashMap, VecDeque};
 
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, Stream};
 use futures::{StreamExt, TryStreamExt};
 use nativelink_config::cas_server::{CasStoreConfig, WithInstanceName};
-use nativelink_error::{Code, Error, ResultExt, error_if, make_input_err};
+use nativelink_error::{Code, Error, ResultExt, error_if, make_err, make_input_err};
 use nativelink_proto::build::bazel::remote::execution::v2::content_addressable_storage_server::{
     ContentAddressableStorage, ContentAddressableStorageServer as Server,
 };
@@ -47,6 +48,9 @@ pub struct CasServer {
 }
 
 type GetTreeStream = Pin<Box<dyn Stream<Item = Result<GetTreeResponse, Status>> + Send + 'static>>;
+
+/// Per-blob deadline applied inside `BatchReadBlobs` / `BatchUpdateBlobs`.
+const BATCH_PER_BLOB_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl CasServer {
     pub fn new(
@@ -135,10 +139,22 @@ impl CasServer {
                     size_bytes,
                     request_data.len()
                 );
-                let result = store_ref
-                    .update_oneshot(digest_info, request_data)
-                    .await
-                    .err_tip(|| "Error writing to store");
+                // Apply a per-blob deadline so one slow upload does not
+                // make the whole batch hit the client's overall deadline.
+                let result = match tokio::time::timeout(
+                    BATCH_PER_BLOB_TIMEOUT,
+                    store_ref.update_oneshot(digest_info, request_data),
+                )
+                .await
+                {
+                    Ok(r) => r.err_tip(|| "Error writing to store"),
+                    Err(_elapsed) => Err(make_err!(
+                        Code::DeadlineExceeded,
+                        "BatchUpdateBlobs per-blob timeout ({} s) elapsed for digest {}",
+                        BATCH_PER_BLOB_TIMEOUT.as_secs(),
+                        digest_info,
+                    )),
+                };
                 Ok::<_, Error>(batch_update_blobs_response::Response {
                     digest: Some(digest),
                     status: Some(result.map_or_else(Into::into, |()| GrpcStatus::default())),
@@ -178,10 +194,22 @@ impl CasServer {
             .map(|digest| async move {
                 let digest_copy = DigestInfo::try_from(digest.clone())?;
                 // TODO(palfrey) There is a security risk here of someone taking all the memory on the instance.
-                let result = store_ref
-                    .get_part_unchunked(digest_copy, 0, None)
-                    .await
-                    .err_tip(|| "Error reading from store");
+                // Apply a per-blob deadline so one slow read does not
+                // make the whole batch hit the client's overall deadline.
+                let result = match tokio::time::timeout(
+                    BATCH_PER_BLOB_TIMEOUT,
+                    store_ref.get_part_unchunked(digest_copy, 0, None),
+                )
+                .await
+                {
+                    Ok(r) => r.err_tip(|| "Error reading from store"),
+                    Err(_elapsed) => Err(make_err!(
+                        Code::DeadlineExceeded,
+                        "BatchReadBlobs per-blob timeout ({} s) elapsed for digest {}",
+                        BATCH_PER_BLOB_TIMEOUT.as_secs(),
+                        digest_copy,
+                    )),
+                };
                 let (status, data) = result.map_or_else(
                     |mut e| {
                         if e.code == Code::NotFound {

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 use core::pin::Pin;
+use core::time::Duration;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use futures::StreamExt;
 use nativelink_config::cas_server::WithInstanceName;
 use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
+use nativelink_metric::MetricsComponent;
 use nativelink_proto::build::bazel::remote::execution::v2::content_addressable_storage_server::ContentAddressableStorage;
 use nativelink_proto::build::bazel::remote::execution::v2::{
     BatchReadBlobsRequest, BatchReadBlobsResponse, BatchUpdateBlobsRequest,
@@ -32,9 +35,13 @@ use nativelink_service::cas_server::CasServer;
 use nativelink_store::ac_utils::serialize_and_upload_message;
 use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
+use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
-use nativelink_util::store_trait::{StoreKey, StoreLike};
+use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo,
+};
 use pretty_assertions::assert_eq;
 use prost_types::Timestamp;
 use tonic::{Code, Request};
@@ -664,5 +671,163 @@ async fn batch_update_blobs_two_items_existence_with_third_missing()
         let response = raw_response.unwrap().into_inner();
         assert_eq!(response.missing_blob_digests, vec![missing_digest]);
     }
+    Ok(())
+}
+
+#[derive(Debug, MetricsComponent)]
+struct StallStore {
+    delay: Duration,
+}
+
+#[async_trait]
+impl StoreDriver for StallStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        _digests: &[StoreKey<'_>],
+        results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        for r in results.iter_mut() {
+            *r = None;
+        }
+        Ok(())
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        _reader: DropCloserReadHalf,
+        _size_info: UploadSizeInfo,
+    ) -> Result<(), Error> {
+        tokio::time::sleep(self.delay).await;
+        Ok(())
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        _writer: &mut DropCloserWriteHalf,
+        _offset: u64,
+        _length: Option<u64>,
+    ) -> Result<(), Error> {
+        tokio::time::sleep(self.delay).await;
+        Ok(())
+    }
+
+    fn inner_store(&self, _digest: Option<StoreKey>) -> &'_ dyn StoreDriver {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+default_health_status_indicator!(StallStore);
+
+fn make_cas_server_with_stall_store(delay: Duration) -> Result<CasServer, Error> {
+    let store_manager = Arc::new(StoreManager::new());
+    store_manager.add_store("main_cas", Store::new(Arc::new(StallStore { delay })));
+    CasServer::new(
+        &[WithInstanceName {
+            instance_name: INSTANCE_NAME.to_string(),
+            config: nativelink_config::cas_server::CasStoreConfig {
+                cas_store: "main_cas".to_string(),
+            },
+        }],
+        &store_manager,
+    )
+}
+
+#[nativelink_test(start_paused = true)]
+async fn batch_update_blobs_per_blob_timeout_returns_deadline_exceeded()
+-> Result<(), Box<dyn core::error::Error>> {
+    const VALUE: &str = "1";
+
+    // Stall longer than `BATCH_PER_BLOB_TIMEOUT` (30 s) so the
+    // per-blob timeout fires before the store ever resolves.
+    let cas_server = make_cas_server_with_stall_store(Duration::from_secs(120))?;
+
+    let digest = Digest {
+        hash: HASH1.to_string(),
+        size_bytes: VALUE.len() as i64,
+    };
+    let raw_response = cas_server
+        .batch_update_blobs(Request::new(BatchUpdateBlobsRequest {
+            instance_name: INSTANCE_NAME.to_string(),
+            requests: vec![batch_update_blobs_request::Request {
+                digest: Some(digest.clone()),
+                data: VALUE.into(),
+                compressor: compressor::Value::Identity.into(),
+            }],
+            digest_function: digest_function::Value::Sha256.into(),
+        }))
+        .await;
+
+    let response = raw_response.unwrap().into_inner();
+    assert_eq!(response.responses.len(), 1);
+    let entry = &response.responses[0];
+    assert_eq!(entry.digest.as_ref(), Some(&digest));
+    let status = entry.status.as_ref().expect("status set");
+    assert_eq!(
+        status.code,
+        Code::DeadlineExceeded as i32,
+        "expected DeadlineExceeded, got status: {status:?}",
+    );
+    assert!(
+        status.message.contains("BatchUpdateBlobs per-blob timeout"),
+        "unexpected message: {}",
+        status.message,
+    );
+    Ok(())
+}
+
+#[nativelink_test(start_paused = true)]
+async fn batch_read_blobs_per_blob_timeout_returns_deadline_exceeded()
+-> Result<(), Box<dyn core::error::Error>> {
+    let cas_server = make_cas_server_with_stall_store(Duration::from_secs(120))?;
+
+    let digest = Digest {
+        hash: HASH1.to_string(),
+        size_bytes: 1,
+    };
+    let raw_response = cas_server
+        .batch_read_blobs(Request::new(BatchReadBlobsRequest {
+            instance_name: INSTANCE_NAME.to_string(),
+            digests: vec![digest.clone()],
+            acceptable_compressors: vec![compressor::Value::Identity.into()],
+            digest_function: digest_function::Value::Sha256.into(),
+        }))
+        .await;
+
+    let response = raw_response.unwrap().into_inner();
+    assert_eq!(response.responses.len(), 1);
+    let entry = &response.responses[0];
+    assert_eq!(entry.digest.as_ref(), Some(&digest));
+    assert!(
+        entry.data.is_empty(),
+        "no data should be returned on timeout"
+    );
+    let status = entry.status.as_ref().expect("status set");
+    assert_eq!(
+        status.code,
+        Code::DeadlineExceeded as i32,
+        "expected DeadlineExceeded, got status: {status:?}",
+    );
+    assert!(
+        status.message.contains("BatchReadBlobs per-blob timeout"),
+        "unexpected message: {}",
+        status.message,
+    );
     Ok(())
 }

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -17,6 +17,7 @@ use core::cmp::{max, min};
 use core::ops::Range;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::sync::{Arc, Weak};
@@ -72,6 +73,7 @@ struct LoaderGuard<'a> {
     weak_store: Weak<FastSlowStore>,
     key: StoreKey<'a>,
     loader: Option<Loader>,
+    is_leader: bool,
 }
 
 impl LoaderGuard<'_> {
@@ -142,6 +144,7 @@ impl FastSlowStore {
     fn get_loader<'a>(&self, key: StoreKey<'a>) -> LoaderGuard<'a> {
         // Get a single loader instance that's used to populate the fast store
         // for this digest.  If another request comes in then it's de-duplicated.
+        let mut is_leader = false;
         let loader = match self
             .populating_digests
             .lock()
@@ -151,6 +154,7 @@ impl FastSlowStore {
                 occupied_entry.get().clone()
             }
             std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                is_leader = true;
                 vacant_entry.insert(Arc::new(OnceCell::new())).clone()
             }
         };
@@ -158,6 +162,7 @@ impl FastSlowStore {
             weak_store: self.weak_self.clone(),
             key,
             loader: Some(loader),
+            is_leader,
         }
     }
 
@@ -640,11 +645,51 @@ impl StoreDriver for FastSlowStore {
         }
 
         let mut writer = Some(writer);
-        self.get_loader(key.borrow())
-            .get_or_try_init(|| {
-                self.populate_and_maybe_stream(key.borrow(), writer.take(), offset, length)
-            })
-            .await?;
+
+        let needs_slow_store_fallback: bool = {
+            let loader_guard = self.get_loader(key.borrow());
+            let is_leader = loader_guard.is_leader;
+            if is_leader {
+                loader_guard
+                    .get_or_try_init(|| {
+                        self.populate_and_maybe_stream(key.borrow(), writer.take(), offset, length)
+                    })
+                    .await?;
+                false
+            } else {
+                let load_fut = loader_guard.get_or_try_init(|| async {
+                    self.populate_and_maybe_stream(key.borrow(), writer.take(), offset, length)
+                        .await
+                });
+                match tokio::time::timeout(LEADER_WAIT_TIMEOUT, load_fut).await {
+                    Ok(result) => {
+                        result?;
+                        false
+                    }
+                    Err(_elapsed) => {
+                        self.metrics
+                            .leader_wait_timeouts
+                            .fetch_add(1, Ordering::Acquire);
+                        warn!(
+                            %key,
+                            timeout_secs = LEADER_WAIT_TIMEOUT.as_secs(),
+                            "FastSlowStore::get_part: leader-wait exceeded timeout, bypassing dedup and reading slow store directly",
+                        );
+                        true
+                    }
+                }
+            }
+        };
+
+        if needs_slow_store_fallback && let Some(writer) = writer.take() {
+            return self
+                .slow_store
+                .get_part(key, writer, offset, length)
+                .await
+                .err_tip(
+                    || "In FastSlowStore::get_part slow_store fallback after leader-wait timeout",
+                );
+        }
 
         // If we didn't stream then re-enter which will stream from the fast
         // store, or retry the download.  We should not get in a loop here
@@ -691,6 +736,19 @@ struct FastSlowStoreMetrics {
     slow_store_hit_count: AtomicU64,
     #[metric(help = "Downloaded bytes from the slow store")]
     slow_store_downloaded_bytes: AtomicU64,
+    #[metric(
+        help = "Number of times a follower bypassed the populating-digests dedup because the leader exceeded LEADER_WAIT_TIMEOUT"
+    )]
+    leader_wait_timeouts: AtomicU64,
 }
+
+/// Maximum time a follower will wait on the leader-populator before
+/// bypassing the dedup map and reading directly from the slow store.
+///
+/// Without this bound a single wedged populator would block every
+/// concurrent reader of the same digest until each one's own `gRPC`
+/// deadline fired (e.g. Bazel's `--remote_timeout`), turning a
+/// single slow read into a fan-out of `DEADLINE_EXCEEDED` errors.
+const LEADER_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 default_health_status_indicator!(FastSlowStore);

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -646,6 +646,25 @@ impl StoreDriver for FastSlowStore {
 
         let mut writer = Some(writer);
 
+        // Drive the dedup loader. Two distinct paths:
+        //
+        //   * Leader (created the OnceCell entry): runs `populate` with
+        //     OUR `writer`, streaming directly to the caller while
+        //     filling the fast cache. No timeout: a multi-GB blob
+        //     legitimately takes minutes to stream, and cancelling our
+        //     own populate would propagate the failure to every other
+        //     reader of this digest.
+        //
+        //   * Follower: bound the wait so a wedged leader does not pin
+        //     us until the upstream `gRPC` deadline fires. The follower
+        //     closure passes `None` for `writer`. This is critical: if
+        //     the OnceCell ever promotes our follower closure to leader
+        //     (because the original leader's future was dropped), and
+        //     our `tokio::time::timeout` then cancels it, *no* caller
+        //     `writer` was ever moved into the populate stream, so no
+        //     `gRPC` sender is dropped without EOF. The follower then
+        //     re-enters `get_part` below and reads from the now-warm
+        //     fast cache, OR falls back to the slow store on timeout.
         let needs_slow_store_fallback: bool = {
             let loader_guard = self.get_loader(key.borrow());
             let is_leader = loader_guard.is_leader;
@@ -657,9 +676,8 @@ impl StoreDriver for FastSlowStore {
                     .await?;
                 false
             } else {
-                let load_fut = loader_guard.get_or_try_init(|| async {
-                    self.populate_and_maybe_stream(key.borrow(), writer.take(), offset, length)
-                        .await
+                let load_fut = loader_guard.get_or_try_init(|| {
+                    self.populate_and_maybe_stream(key.borrow(), None, offset, length)
                 });
                 match tokio::time::timeout(LEADER_WAIT_TIMEOUT, load_fut).await {
                     Ok(result) => {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -383,13 +383,36 @@ impl LenEntry for FileEntryImpl {
         let to_path = to_full_path_from_key(&encoded_file_path.shared_context.temp_path, &new_key);
 
         if let Err(err) = fs::rename(&from_path, &to_path).await {
-            warn!(
-                key = ?encoded_file_path.key,
-                ?from_path,
-                ?to_path,
-                ?err,
-                "Failed to rename file",
-            );
+            // ENOENT here means the file we expected at `from_path`
+            // was already gone — typically because another thread's
+            // eviction beat us to the unref, or because the entry
+            // ended up in our map without its file ever landing on
+            // disk (the "phantom-map" case the runtime recovers from
+            // via `FastSlowStore::get_part`'s slow-store fallback).
+            // It is benign at this site — there is no file to move
+            // — and historically dominates the log volume of this
+            // store under heavy write+evict concurrency, fast enough
+            // to drown the runtime under sustained pressure. Demote
+            // to `debug` and drop the per-emission path fields so it
+            // stops costing serialization in the hot path.
+            //
+            // Other rename failures (EACCES, EXDEV, EBUSY, …) are
+            // genuinely unexpected and stay at `warn` with full
+            // context.
+            if err.code == Code::NotFound {
+                debug!(
+                    key = ?encoded_file_path.key,
+                    "Failed to rename file (already gone, treating as benign)",
+                );
+            } else {
+                warn!(
+                    key = ?encoded_file_path.key,
+                    ?from_path,
+                    ?to_path,
+                    ?err,
+                    "Failed to rename file",
+                );
+            }
         } else {
             debug!(
                 key = ?encoded_file_path.key,

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1100,8 +1100,59 @@ where
         "RedisStore"
     }
 
-    async fn check_health(&self, namespace: Cow<'static, str>) -> HealthStatus {
-        StoreDriver::check_health(Pin::new(self), namespace).await
+    /// Lightweight health check: just `PING` the master, bounded by a
+    /// short physical timeout. The default `StoreDriver::check_health`
+    /// performs a full `update_oneshot` + `has` + `get_part_unchunked`
+    /// roundtrip, which queues behind real production traffic on the
+    /// same connection-permit semaphore and Redis master. When the
+    /// store is even moderately loaded that easily exceeds the
+    /// `HealthServer` per-indicator budget (default 5 s), each
+    /// RedisStore-backed indicator (AC, small-blob CAS, scheduler)
+    /// reports `HealthStatus::Timeout`, and `/status` returns 503 —
+    /// surfaced as a readiness-probe failure that sheds traffic from
+    /// an otherwise-functional pod. A `PING` proves the connection
+    /// is reachable and the master is accepting commands; that is
+    /// the only invariant a kubelet probe needs.
+    async fn check_health(&self, _namespace: Cow<'static, str>) -> HealthStatus {
+        /// Per-check physical ceiling. Tight enough to stay well
+        /// under `HealthServer`'s default per-indicator budget;
+        /// loose enough to absorb a normally-slow PING during a
+        /// `BGSAVE` fork or sentinel rebalance.
+        const PING_TIMEOUT: Duration = Duration::from_secs(2);
+
+        let mut client = match self.get_client().await {
+            Ok(c) => c,
+            Err(e) => {
+                return HealthStatus::new_failed(
+                    self,
+                    format!("RedisStore::check_health: failed to acquire connection: {e}").into(),
+                );
+            }
+        };
+
+        // Hold the `ClientWithPermit` for the duration of the call so
+        // its `Drop` releases the semaphore permit on exit. We just
+        // need a `&mut` to the connection manager underneath.
+        let ping = async {
+            redis::cmd("PING")
+                .query_async::<()>(&mut client.connection_manager)
+                .await
+        };
+        match tokio::time::timeout(PING_TIMEOUT, ping).await {
+            Ok(Ok(())) => HealthStatus::new_ok(self, "RedisStore::check_health: PING ok".into()),
+            Ok(Err(e)) => HealthStatus::new_failed(
+                self,
+                format!("RedisStore::check_health: PING errored: {e}").into(),
+            ),
+            Err(_) => HealthStatus::new_failed(
+                self,
+                format!(
+                    "RedisStore::check_health: PING exceeded {} s timeout",
+                    PING_TIMEOUT.as_secs()
+                )
+                .into(),
+            ),
+        }
     }
 }
 

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1755,6 +1755,10 @@ where
                 }
             };
 
+            if matches!(raw_redis_map, Value::Int(_)) {
+                return None;
+            }
+
             let Some(redis_map) = raw_redis_map.as_sequence() else {
                 return Some(Err(Error::new(
                     Code::Internal,

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1138,7 +1138,7 @@ where
                 .query_async::<()>(&mut client.connection_manager)
                 .await
         };
-        match tokio::time::timeout(PING_TIMEOUT, ping).await {
+        match timeout(PING_TIMEOUT, ping).await {
             Ok(Ok(())) => HealthStatus::new_ok(self, "RedisStore::check_health: PING ok".into()),
             Ok(Err(e)) => HealthStatus::new_failed(
                 self,

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 use core::pin::Pin;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::time::Duration;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::future::join_all;
 use nativelink_config::stores::{FastSlowSpec, MemorySpec, NoopSpec, StoreDirection, StoreSpec};
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
@@ -25,10 +27,14 @@ use nativelink_metric::MetricsComponent;
 use nativelink_store::fast_slow_store::FastSlowStore;
 use nativelink_store::memory_store::MemoryStore;
 use nativelink_store::noop_store::NoopStore;
-use nativelink_util::buf_channel::make_buf_channel_pair;
+use nativelink_util::buf_channel::{
+    DropCloserReadHalf, DropCloserWriteHalf, make_buf_channel_pair,
+};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
-use nativelink_util::store_trait::{RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike};
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo,
+};
 use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -265,8 +271,8 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
         async fn update(
             self: Pin<&Self>,
             _digest: StoreKey<'_>,
-            mut reader: nativelink_util::buf_channel::DropCloserReadHalf,
-            _size_info: nativelink_util::store_trait::UploadSizeInfo,
+            mut reader: DropCloserReadHalf,
+            _size_info: UploadSizeInfo,
         ) -> Result<(), Error> {
             // Gets called in the fast store and we don't need to do
             // anything.  Should only complete when drain has finished.
@@ -286,7 +292,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
         async fn get_part(
             self: Pin<&Self>,
             key: StoreKey<'_>,
-            writer: &mut nativelink_util::buf_channel::DropCloserWriteHalf,
+            writer: &mut DropCloserWriteHalf,
             offset: u64,
             length: Option<u64>,
         ) -> Result<(), Error> {
@@ -592,8 +598,8 @@ fn make_stores_with_lazy_slow() -> (Store, Store, Store) {
         async fn update(
             self: Pin<&Self>,
             digest: StoreKey<'_>,
-            reader: nativelink_util::buf_channel::DropCloserReadHalf,
-            size_info: nativelink_util::store_trait::UploadSizeInfo,
+            reader: DropCloserReadHalf,
+            size_info: UploadSizeInfo,
         ) -> Result<(), Error> {
             Pin::new(self.inner.as_ref())
                 .update(digest, reader, size_info)
@@ -603,7 +609,7 @@ fn make_stores_with_lazy_slow() -> (Store, Store, Store) {
         async fn get_part(
             self: Pin<&Self>,
             key: StoreKey<'_>,
-            writer: &mut nativelink_util::buf_channel::DropCloserWriteHalf,
+            writer: &mut DropCloserWriteHalf,
             offset: u64,
             length: Option<u64>,
         ) -> Result<(), Error> {
@@ -703,5 +709,209 @@ async fn lazy_not_found_syncs_to_fast_store() -> Result<(), Error> {
         fast_store.has(digest).await?.is_some(),
         "Expected data to be synced to fast store"
     );
+    Ok(())
+}
+
+#[derive(MetricsComponent)]
+struct InstrumentedSlowStore {
+    digest: DigestInfo,
+    data: Vec<u8>,
+    get_part_count: AtomicU64,
+    /// If set, awaited at the start of `get_part` before any data flows.
+    gate: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+}
+
+#[async_trait]
+impl StoreDriver for InstrumentedSlowStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        keys: &[StoreKey<'_>],
+        results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        for (key, result) in keys.iter().zip(results.iter_mut()) {
+            if *key == self.digest.into() {
+                *result = Some(self.digest.size_bytes());
+            }
+        }
+        Ok(())
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        mut reader: DropCloserReadHalf,
+        _size_info: UploadSizeInfo,
+    ) -> Result<(), Error> {
+        // Drain anything sent so the writer side does not deadlock.
+        reader.drain().await
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        writer: &mut DropCloserWriteHalf,
+        _offset: u64,
+        _length: Option<u64>,
+    ) -> Result<(), Error> {
+        self.get_part_count.fetch_add(1, Ordering::Acquire);
+        // If a gate is configured, wait for the test to release it so the
+        // populate can be held in flight long enough to exercise the
+        // dedup paths.
+        let gate = self.gate.lock().unwrap().take();
+        if let Some(rx) = gate {
+            let _ = rx.await;
+        }
+        writer.send(Bytes::copy_from_slice(&self.data)).await?;
+        writer.send_eof()
+    }
+
+    fn inner_store(&self, _key: Option<StoreKey>) -> &'_ dyn StoreDriver {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+default_health_status_indicator!(InstrumentedSlowStore);
+
+fn make_fast_slow_with_instrumented_slow(
+    digest: DigestInfo,
+    data: Vec<u8>,
+    gate: Option<tokio::sync::oneshot::Receiver<()>>,
+) -> (Store, Arc<InstrumentedSlowStore>) {
+    let slow = Arc::new(InstrumentedSlowStore {
+        digest,
+        data,
+        get_part_count: AtomicU64::new(0),
+        gate: Mutex::new(gate),
+    });
+    let fast = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let fast_slow = Store::new(FastSlowStore::new(
+        &FastSlowSpec {
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
+            fast_direction: StoreDirection::default(),
+            slow_direction: StoreDirection::default(),
+        },
+        fast,
+        Store::new(slow.clone()),
+    ));
+    (fast_slow, slow)
+}
+
+/// Many concurrent reads of the same digest must dedup down to a single
+/// `slow_store.get_part` call.
+#[nativelink_test]
+async fn concurrent_reads_dedup_to_a_single_slow_store_call() -> Result<(), Error> {
+    const N_CONCURRENT: usize = 16;
+    let original_data = make_random_data(2048);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+
+    let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+    let (fast_slow_store, slow) =
+        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx));
+
+    let mut handles = Vec::with_capacity(N_CONCURRENT);
+    for _ in 0..N_CONCURRENT {
+        let store = fast_slow_store.clone();
+        handles.push(tokio::spawn(async move {
+            store.get_part_unchunked(digest, 0, None).await
+        }));
+    }
+
+    // Give the spawned tasks a chance to register as followers on the
+    // OnceCell before we let the leader's slow read complete.
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+
+    gate_tx
+        .send(())
+        .map_err(|_| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
+
+    let results = join_all(handles).await;
+    for r in results {
+        let bytes = r
+            .map_err(|e| make_err!(Code::Internal, "join error: {e:?}"))?
+            .err_tip(|| "Concurrent get_part_unchunked failed")?;
+        assert_eq!(
+            bytes.as_ref(),
+            original_data.as_slice(),
+            "Every concurrent reader must observe the full, correct payload"
+        );
+    }
+
+    let slow_calls = slow.get_part_count.load(Ordering::Acquire);
+    assert_eq!(
+        slow_calls, 1,
+        "Expected the LoaderGuard dedup to collapse {N_CONCURRENT} concurrent reads to a single slow_store.get_part call, got {slow_calls}",
+    );
+
+    Ok(())
+}
+
+/// Dropping a follower's outer future must not cancel the leader's
+/// populate.
+#[nativelink_test]
+async fn dropping_a_follower_does_not_cancel_the_leader() -> Result<(), Error> {
+    let original_data = make_random_data(1024);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+
+    let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+    let (fast_slow_store, slow) =
+        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx));
+
+    let store_for_a = fast_slow_store.clone();
+    let leader_handle =
+        tokio::spawn(async move { store_for_a.get_part_unchunked(digest, 0, None).await });
+
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
+    let store_for_b = fast_slow_store.clone();
+    let b_result = tokio::time::timeout(
+        Duration::from_millis(50),
+        store_for_b.get_part_unchunked(digest, 0, None),
+    )
+    .await;
+    assert!(
+        b_result.is_err(),
+        "Follower should still be waiting on the leader at this point",
+    );
+
+    gate_tx
+        .send(())
+        .map_err(|_| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
+
+    let leader_bytes = leader_handle
+        .await
+        .map_err(|e| make_err!(Code::Internal, "leader join error: {e:?}"))?
+        .err_tip(|| "Leader's get_part_unchunked failed after follower drop")?;
+    assert_eq!(
+        leader_bytes.as_ref(),
+        original_data.as_slice(),
+        "Leader must observe the full, correct payload after a follower drop",
+    );
+
+    let slow_calls = slow.get_part_count.load(Ordering::Acquire);
+    assert_eq!(
+        slow_calls, 1,
+        "Leader's populate must complete exactly once, got {slow_calls} slow_store.get_part calls",
+    );
+
     Ok(())
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -1321,6 +1321,89 @@ fn test_search_by_index_resp3() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+fn test_search_by_index_skips_int_from_cursor_read() -> Result<(), Error> {
+    fn make_ft_aggregate() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.AGGREGATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("@content_prefix:{ Searchable }")
+                .arg("LOAD")
+                .arg(2)
+                .arg("data")
+                .arg("version")
+                .arg("WITHCURSOR")
+                .arg("COUNT")
+                .arg(1500)
+                .arg("MAXIDLE")
+                .arg(30000)
+                .arg("SORTBY")
+                .arg(2usize)
+                .arg("@sort_key")
+                .arg("ASC"),
+            // First page: one entry, cursor=42 so the stream issues
+            // FT.CURSOR READ for a second page.
+            Ok(Value::Array(vec![
+                Value::Array(vec![
+                    Value::Int(2),
+                    Value::Array(vec![
+                        Value::BulkString(b"data".to_vec()),
+                        Value::BulkString(b"first".to_vec()),
+                        Value::BulkString(b"version".to_vec()),
+                        Value::BulkString(b"1".to_vec()),
+                    ]),
+                ]),
+                Value::Int(42),
+            ])),
+        )
+    }
+
+    fn make_ft_cursor_read() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("ft.cursor")
+                .arg("read")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .cursor_arg(42),
+            Ok(Value::Array(vec![
+                Value::Array(vec![
+                    // Leading integer that the filter must drop.
+                    Value::Int(1),
+                    Value::Array(vec![
+                        Value::BulkString(b"data".to_vec()),
+                        Value::BulkString(b"second".to_vec()),
+                        Value::BulkString(b"version".to_vec()),
+                        Value::BulkString(b"2".to_vec()),
+                    ]),
+                ]),
+                // cursor=0 ends the stream.
+                Value::Int(0),
+            ])),
+        )
+    }
+
+    let store = make_mock_store(vec![make_ft_aggregate(), make_ft_cursor_read()]).await;
+    let search_provider = SearchByContentPrefix {
+        prefix: "Searchable".to_string(),
+    };
+
+    let search_results: Vec<TestSchedulerDataUnversioned> = store
+        .search_by_index_prefix(search_provider)
+        .await
+        .err_tip(|| "Failed to search by index")?
+        .try_collect()
+        .await?;
+
+    assert_eq!(
+        search_results.len(),
+        2,
+        "Both entries should be returned with the leading Int from cursor read filtered out",
+    );
+    assert_eq!(search_results[0].content, "first");
+    assert_eq!(search_results[1].content, "second");
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn no_items_from_none_subscription_channel() -> Result<(), Error> {
     let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let subscription_manager = RedisSubscriptionManager::new(rx);


### PR DESCRIPTION
# Description

Two regression fixes to the read-dedup timeout introduced in the previous CAS-hang patch.                                                                           

1. The leader's populate was being cancelled by tokio::time::timeout(60s, ...), failing every concurrent reader of multi-GB blobs with DEADLINE_EXCEEDED: populate cancelled after 60 s leader-wait. Tagged is_leader on LoaderGuard; the leader now waits unbounded (its populate is the actual work), only followers honour the 60 s wait.                                                                           
2. A follower whose closure was promoted to leader by tokio's OnceCell then lost its caller's gRPC writer to that promoted-leader closure; if the timeout subsequently cancelled it, the writer was dropped without send_eof, surfacing as INTERNAL: Sender dropped before sending EOF. Followers now pass None for the writer; if their closure is ever promoted, it populates only the fast cache and the follower reads from it via the existing recursion.     
                                                                                                                                                                                                               Restores correct behaviour for Container Push Digest input fetches on layers ≳ 1 GB while keeping the original goal of preventing wedged-leader fan-out into client-side DEADLINE_EXCEEDED storms. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this in the actual environment where we were facing this issue. 
## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2298)
<!-- Reviewable:end -->
