### PR TITLE
Testing and logging around worker keepalive

### DIFF
--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -166,23 +166,27 @@ impl<'a, T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorke
     async fn start_keep_alive(&self) -> Result<(), Error> {
         // According to tonic's documentation this call should be cheap and is the same stream.
         let mut grpc_client = self.grpc_client.clone();
+        let timeout = self
+            .config
+            .worker_api_endpoint
+            .timeout
+            .unwrap_or(DEFAULT_ENDPOINT_TIMEOUT_S);
+
+        info!(timeout, "Started KeepAlive");
 
         loop {
-            let timeout = self
-                .config
-                .worker_api_endpoint
-                .timeout
-                .unwrap_or(DEFAULT_ENDPOINT_TIMEOUT_S);
             // We always send 2 keep alive requests per timeout. Http2 should manage most of our
             // timeout issues, this is a secondary check to ensure we can still send data.
             sleep(Duration::from_secs_f32(timeout / 2.)).await;
             if let Err(e) = grpc_client.keep_alive(KeepAliveRequest {}).await {
+                error!(?e, "Failed to send KeepAlive in LocalWorker");
                 return Err(make_err!(
                     Code::Internal,
                     "Failed to send KeepAlive in LocalWorker : {:?}",
                     e
                 ));
             }
+            debug!("Sent KeepAlive");
         }
     }
 
@@ -773,7 +777,7 @@ impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T,
             Some(Update::ConnectionResult(connection_result)) => connection_result.worker_id,
             other => {
                 return Err(make_input_err!(
-                    "Expected first response from scheduler to be a ConnectResult got : {:?}",
+                    "Expected first response from scheduler to be a ConnectionResult got : {:?}",
                     other
                 ));
             }
@@ -805,6 +809,8 @@ impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T,
                     continue; // Try to connect again.
                 }
             };
+
+            debug!("Connected to endpoint");
 
             // Next register our worker with the scheduler.
             let (inner, update_for_worker_stream) = match self.register_worker(&mut client).await {

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -29,7 +29,7 @@ mod utils {
 }
 
 use hyper::body::Frame;
-use nativelink_config::cas_server::{LocalWorkerConfig, WorkerProperty};
+use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use nativelink_config::stores::{
     FastSlowSpec, FilesystemSpec, MemorySpec, StoreDirection, StoreSpec,
 };
@@ -59,6 +59,7 @@ use pretty_assertions::assert_eq;
 use prost::Message;
 use rand::Rng;
 use tokio::io::AsyncWriteExt;
+use tokio::time::sleep;
 use utils::local_worker_test_utils::{
     setup_grpc_stream, setup_local_worker, setup_local_worker_with_config,
 };
@@ -553,7 +554,7 @@ async fn experimental_precondition_script_fails() -> Result<(), Error> {
         std::fs::rename(&precondition_script_tmp, &precondition_script).unwrap();
         // Add a small delay to ensure the file system has fully released the file
         // This helps avoid "Text file busy" errors on some Linux environments
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
         precondition_script
     };
     #[cfg(target_family = "windows")]
@@ -973,4 +974,56 @@ async fn preconditions_met_extra_envs() -> Result<(), Error> {
     preconditions_met(Some("bash -c \"echo $DEMO_ENV\"".to_string()), &extra_envs).await?;
     assert!(logs_contain("test_value_for_demo_env"));
     Ok(())
+}
+
+#[nativelink_test]
+async fn keep_alive_fail_logs() -> Result<(), Error> {
+    let local_worker_config = LocalWorkerConfig {
+        platform_properties: HashMap::new(),
+        worker_api_endpoint: EndpointConfig {
+            timeout: Some(0.01),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut test_context = setup_local_worker_with_config(local_worker_config).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    // Ensure our worker connects and properties were sent.
+    let props = test_context
+        .client
+        .expect_connect_worker(Ok(streaming_response))
+        .await;
+    assert_eq!(props, ConnectWorkerRequest::default());
+
+    // handle connection result to scheduler
+    let tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    tx_stream
+        .send(Frame::data(
+            encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: "foobar".to_string(),
+                })),
+            })
+            .unwrap(),
+        ))
+        .await
+        .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+
+    for _ in 0..30 {
+        if logs_contain("Started KeepAlive timeout=0.0") // plus some extra digits, because floating point fun
+            && logs_contain("nativelink_worker::local_worker: Sent KeepAlive") // first one succeeds
+            && logs_contain(
+                "Failed to send KeepAlive in LocalWorker e=Error { code: Internal, messages: [\"KeepAlive fail\"] }", // second should fail
+            )
+        {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    Err(make_err!(
+        Code::DeadlineExceeded,
+        "Timed out looking for KeepAlive logs"
+    ))
 }

--- a/nativelink-worker/tests/utils/local_worker_test_utils.rs
+++ b/nativelink-worker/tests/utils/local_worker_test_utils.rs
@@ -19,7 +19,7 @@ use async_lock::Mutex;
 use bytes::Bytes;
 use hyper::body::Frame;
 use nativelink_config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
-use nativelink_error::Error;
+use nativelink_error::{Error, make_err};
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
     ConnectWorkerRequest, ExecuteComplete, ExecuteResult, GoingAwayRequest, KeepAliveRequest,
     UpdateForWorker,
@@ -31,7 +31,7 @@ use nativelink_util::task::JoinHandleDropGuard;
 use nativelink_worker::local_worker::LocalWorker;
 use nativelink_worker::worker_api_client_wrapper::WorkerApiClientTrait;
 use tokio::sync::{broadcast, mpsc};
-use tonic::Status;
+use tonic::{Code, Status};
 use tonic::{
     Response,
     Streaming,
@@ -39,6 +39,7 @@ use tonic::{
     codec::CompressionEncoding,
     codec::ProstCodec,
 };
+use tracing::debug;
 
 use super::mock_running_actions_manager::MockRunningActionsManager;
 
@@ -72,6 +73,7 @@ pub(crate) struct MockWorkerApiClient {
     tx_call: mpsc::UnboundedSender<WorkerClientApiCalls>,
     rx_resp: Arc<Mutex<mpsc::UnboundedReceiver<WorkerClientApiReturns>>>,
     tx_resp: mpsc::UnboundedSender<WorkerClientApiReturns>,
+    keep_alives_count: u8,
 }
 
 impl MockWorkerApiClient {
@@ -83,6 +85,7 @@ impl MockWorkerApiClient {
             tx_call,
             rx_resp: Arc::new(Mutex::new(rx_resp)),
             tx_resp,
+            keep_alives_count: 0,
         }
     }
 }
@@ -159,7 +162,13 @@ impl WorkerApiClientTrait for MockWorkerApiClient {
     }
 
     async fn keep_alive(&mut self, _request: KeepAliveRequest) -> Result<(), Error> {
-        unreachable!();
+        debug!("Got KeepAlive");
+        if self.keep_alives_count == 0 {
+            self.keep_alives_count += 1;
+            Ok(())
+        } else {
+            Err(make_err!(Code::Internal, "KeepAlive fail"))
+        }
     }
 
     async fn going_away(&mut self, _request: GoingAwayRequest) -> Result<(), Error> {


### PR DESCRIPTION
# Description

I've been seeing various cases of `Worker timed out, removing from pool` and this would imply the keepalive's aren't working. This PR adds some extra logging around them, along with a test of them running and failing.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2302)
<!-- Reviewable:end -->
