### PR TITLE
Curl 8.5.0-2ubuntu10.9

### DIFF
--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=builder /root/nativelink-bin /usr/local/bin/nativelink
 ARG ADDITIONAL_SETUP_WORKER_CMD
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.8 \
+    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && bash -ueo pipefail -c "${ADDITIONAL_SETUP_WORKER_CMD}" \

--- a/tools/toolchain-buck2/Dockerfile
+++ b/tools/toolchain-buck2/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
         git=1:2.43.0-1ubuntu7.3 \
         ca-certificates=20240203 \
-        curl=8.5.0-2ubuntu10.8 \
+        curl=8.5.0-2ubuntu10.9 \
         python3=3.12.3-0ubuntu2.1 \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \

--- a/tools/toolchain-nativelink/Dockerfile
+++ b/tools/toolchain-nativelink/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     gcc=4:13.2.0-7ubuntu1 \
     g++=4:13.2.0-7ubuntu1 \
     python3=3.12.3-0ubuntu2.1 \
-    curl=8.5.0-2ubuntu10.8 \
+    curl=8.5.0-2ubuntu10.9 \
     ca-certificates=20240203 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Description

New ubuntu curl security update, which broke CI (https://github.com/TraceMachina/nativelink/actions/runs/25376962986/job/74414669971?pr=2302). See https://launchpad.net/ubuntu/+source/curl/8.5.0-2ubuntu10.9

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`docker build -f deployment-examples/docker-compose/Dockerfile .`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2303)
<!-- Reviewable:end -->
