### PR TITLE
MacOS-specific free disk

### DIFF
--- a/.github/actions/free-disk/action.yaml
+++ b/.github/actions/free-disk/action.yaml
@@ -4,7 +4,8 @@ description: "Free up disk space on workers"
 runs:
   using: "composite"
   steps:
-    - name: Free disk space
+    - if: runner.os == 'Linux' # Only works on Linux
+      name: Free disk space
       uses: >- # v3.2.2
         endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1
       with:
@@ -32,3 +33,21 @@ runs:
           /usr/share/glade*
           /usr/local/share/chromium
           /usr/local/share/powershell
+
+    # using hints from https://github.com/actions/runner-images/issues/10511#issuecomment-3984466720
+    - if: runner.os == 'macOS'
+      name: Free Disk space
+      shell: bash
+      run: |
+        df -h /
+
+        # Remove unnecessary pre-installed tools (saves 5-10GB)
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /Library/Frameworks/Mono.framework
+
+        # Remove unused Xcode simulators (can save 2-5GB each)
+        xcrun simctl delete unavailable
+        xcrun simctl runtime list
+
+        df -h /


### PR DESCRIPTION
# Description

We need to free up disk to run things like Nix, and the existing disk free action only works on Linux. This PR disables that step on non-Linux and runs a new Mac-specific one instead

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2309)
<!-- Reviewable:end -->
