### PR TITLE
Fix attic push

### DIFF
--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -1,0 +1,11 @@
+---
+# This should be a post step, but can't do it in composite actions easily. See https://github.com/actions/runner/issues/1478
+name: Teardown Nix
+description: "Common teardown for all runs using Nix."
+runs:
+  using: "composite"
+  steps:
+      - name: Check attic push
+        run: |
+          cat attic-push.log
+        shell: bash

--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -7,5 +7,6 @@ runs:
   steps:
       - name: Check attic push
         run: |
+          cd /tmp
           cat attic-push.log
         shell: bash

--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -2,6 +2,9 @@
 # This should be a post step, but can't do it in composite actions easily. See https://github.com/actions/runner/issues/1478
 name: Teardown Nix
 description: "Common teardown for all runs using Nix."
+inputs:
+  nix_name:
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -9,4 +12,11 @@ runs:
         run: |
           cd /tmp
           cat attic-push.log
+        shell: bash
+
+      - name: Attic push
+        if: ${{ inputs.nix_name != '' }}
+        run: |
+          cd /tmp
+          ./result/bin/attic push nativelink $(nix eval --raw ${{ inputs.nix_name }})
         shell: bash

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -29,11 +29,13 @@ runs:
           ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ ${{ inputs.nativelink_attic_token }}
           ./result/bin/attic use nativelink
 
-          # Replace with more reliable attic for working around https://github.com/zhaofengli/attic/issues/226
+          # Replace with more reliable attic for working around
+          # * https://github.com/zhaofengli/attic/issues/226
+          # * https://github.com/zhaofengli/attic/pull/317
           # We use the original one first to get caching of this
-          nix build github:antifuchs/attic/watch-renew-sessions
+          nix build github:TraceMachina/attic
           RUST_BACKTRACE=full RUST_LOG=debug,hyper_util=info,rustls=info ./result/bin/attic watch-store nativelink &> attic-push.log &
 
           # For the cases where we don't have a cache of it, push anyways
-          ./result/bin/attic push nativelink $(nix eval --raw github:antifuchs/attic/watch-renew-sessions)
+          ./result/bin/attic push nativelink $(nix eval --raw github:TraceMachina/attic)
         shell: bash

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -27,5 +27,5 @@ runs:
           # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access
           ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ ${{ inputs.nativelink_attic_token }}
           ./result/bin/attic use nativelink
-          ./result/bin/attic watch-store nativelink &
+          ./result/bin/attic watch-store nativelink &> attic-push.log &
         shell: bash

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -23,9 +23,10 @@ runs:
         timeout_minutes: 10
         max_attempts: 3
         command: |
+          cd /tmp
           nix build nixpkgs#attic-client
           # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access
           ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ ${{ inputs.nativelink_attic_token }}
           ./result/bin/attic use nativelink
-          ./result/bin/attic watch-store nativelink &> attic-push.log &
+          RUST_BACKTRACE=full RUST_LOG=debug ./result/bin/attic watch-store nativelink &> attic-push.log &
         shell: bash

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -28,5 +28,9 @@ runs:
           # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access
           ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ ${{ inputs.nativelink_attic_token }}
           ./result/bin/attic use nativelink
+
+          # Replace with more reliable attic for working around https://github.com/zhaofengli/attic/issues/226
+          # We use the original one first to get caching of this
+          nix build github:antifuchs/attic/watch-renew-sessions
           RUST_BACKTRACE=full RUST_LOG=debug ./result/bin/attic watch-store nativelink &> attic-push.log &
         shell: bash

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -20,7 +20,7 @@ runs:
       uses: >- # v4
         nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
-        timeout_minutes: 10
+        timeout_minutes: 30
         max_attempts: 3
         command: |
           cd /tmp

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -32,5 +32,8 @@ runs:
           # Replace with more reliable attic for working around https://github.com/zhaofengli/attic/issues/226
           # We use the original one first to get caching of this
           nix build github:antifuchs/attic/watch-renew-sessions
-          RUST_BACKTRACE=full RUST_LOG=debug ./result/bin/attic watch-store nativelink &> attic-push.log &
+          RUST_BACKTRACE=full RUST_LOG=debug,hyper_util=info,rustls=info ./result/bin/attic watch-store nativelink &> attic-push.log &
+
+          # For the cases where we don't have a cache of it, push anyways
+          ./result/bin/attic push nativelink $(nix eval --raw github:antifuchs/attic/watch-renew-sessions)
         shell: bash

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -53,6 +53,8 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nix_name: .#nativelinkCoverageForHost
 
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -50,6 +50,10 @@ jobs:
         with:
           path: result/html
 
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
+
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Deploy Coverage

--- a/.github/workflows/custom-image.yaml
+++ b/.github/workflows/custom-image.yaml
@@ -144,3 +144,7 @@ jobs:
               issue_number: context.payload.issue.number,
               body: `Image built and pushed!\n\n\`\`\`\n${{ steps.upload.outputs.image_tag }}\n\`\`\``
             });
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -59,3 +59,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
         if: github.ref == 'refs/heads/main'
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -52,6 +52,10 @@ jobs:
            --verbose_failures \
            @local-remote-execution//examples:${TOOLCHAIN}"
 
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
+
 #   remote:
 #     strategy:
 #       fail-fast: false

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -52,6 +52,10 @@ jobs:
           fi
         shell: bash
 
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
+
   nix-cargo:
     strategy:
       fail-fast: false
@@ -74,6 +78,10 @@ jobs:
         run: >
           nix develop --fallback --impure --command
           bash -c "cargo test --all --profile=smol"
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
 
   installation:
     strategy:
@@ -99,6 +107,10 @@ jobs:
         run: |
           nix run -L .#nativelink-is-executable-test
 
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
+
   integration:
     name: ${{ matrix.test-name }}
     strategy:
@@ -119,3 +131,7 @@ jobs:
       - name: Test ${{ matrix.test-name }} run
         run: |
           nix run -L .#${{ matrix.test-name }}-with-nativelink-test
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -110,6 +110,8 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nix_name: .#nativelink-is-executable-test
 
   integration:
     name: ${{ matrix.test-name }}
@@ -135,3 +137,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nix_name: .#${{ matrix.test-name }}-with-nativelink-test

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -30,3 +30,7 @@ jobs:
 
       - name: Run pre-commit hooks
         run: nix flake check
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -43,3 +43,7 @@ jobs:
           GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -47,3 +47,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nix_name: .#${{ matrix.image }}

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -66,3 +66,7 @@ jobs:
             bun prod --project=nativelink --org=nativelink \
             --token=$DENO_DEPLOY_TOKEN \
           "
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()


### PR DESCRIPTION
# Description

This PR does a bunch of fixes to the attic push, resulting in much faster MacOS steps due to actually caching things. Biggest item is that we've got our [own fork of attic](https://github.com/TraceMachina/attic) folding in a pair of PRs that upstream hasn't merged yet. These two fix errors I was seeing in the `attic watch-store` logs post build in MacOS.

`Prepare Worker` build step is now often quite a bit slower, but most of that is pulling in Nix cached items which speeds up later steps, and the overall runtimes of the build is notably faster.

e.g. this PR's `Installation / macos-26` took [8m 8s](https://github.com/TraceMachina/nativelink/actions/runs/25503568813/job/74842885224?pr=2310) v.s. main's latest took [24m 15s](https://github.com/TraceMachina/nativelink/actions/runs/25491649283/job/74803334904). In the first case, Prepare Worker was 5m59s of that, and in the latter 3m10s.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2310)
<!-- Reviewable:end -->
