### PR TITLE
Add expiry to completed redis actions

### DIFF
--- a/nativelink-config/src/schedulers.rs
+++ b/nativelink-config/src/schedulers.rs
@@ -112,7 +112,7 @@ pub struct SimpleSpec {
     /// config.
     pub supported_platform_properties: Option<HashMap<String, PropertyType>>,
 
-    /// The amount of time to retain completed actions in memory for in case
+    /// The amount of time to retain completed actions for in case
     /// a `WaitExecution` is called after the action has completed.
     /// Default: 60 (seconds)
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]

--- a/nativelink-redis-tester/src/dynamic_fake_redis.rs
+++ b/nativelink-redis-tester/src/dynamic_fake_redis.rs
@@ -49,7 +49,7 @@ impl<S: SubscriptionManagerNotify> fmt::Debug for FakeRedisBackend<S> {
     }
 }
 
-const FAKE_SCRIPT_SHA: &str = "b22b9926cbce9dd9ba97fa7ba3626f89feea1ed5";
+const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
 
 impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
     pub fn new() -> Self {
@@ -205,9 +205,9 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
                         let mut value: HashMap<_, Value> = HashMap::new();
                         value.insert(
                             "data".into(),
-                            Value::BulkString(args[4].as_bytes().unwrap().to_vec()),
+                            Value::BulkString(args[5].as_bytes().unwrap().to_vec()),
                         );
-                        for pair in args[5..].chunks(2) {
+                        for pair in args[6..].chunks(2) {
                             value.insert(
                                 str::from_utf8(pair[0].as_bytes().expect("Field name not bytes"))
                                     .expect("Unable to parse field name as string")
@@ -225,7 +225,17 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
                                 .unwrap()
                                 .parse()
                                 .expect("Unable to parse existing version field");
-                        trace!(%key, %expected_existing_version, ?value, "Want to insert with EVALSHA");
+                        let expiry: i64 = str::from_utf8(args[4].as_bytes().unwrap())
+                            .unwrap()
+                            .parse()
+                            .expect("Unable to parse expiry field");
+                        trace!(
+                            key,
+                            expected_existing_version,
+                            expiry,
+                            ?value,
+                            "Want to insert with EVALSHA"
+                        );
                         let version = match self.table.lock().unwrap().entry(key.clone()) {
                             Entry::Occupied(mut occupied_entry) => {
                                 let version = occupied_entry

--- a/nativelink-redis-tester/src/fake_redis.rs
+++ b/nativelink-redis-tester/src/fake_redis.rs
@@ -64,6 +64,14 @@ pub(crate) fn arg_as_string(output: &mut String, arg: Value) {
         Value::Nil => {
             write!(output, "_\r\n").unwrap();
         }
+        Value::Boolean(value) => {
+            if value {
+                write!(output, "#t\r\n")
+            } else {
+                write!(output, "#f\r\n")
+            }
+            .unwrap();
+        }
         _ => {
             panic!("No support for {arg:?}")
         }
@@ -249,9 +257,7 @@ where
     fake_redis_internal(listener, funcs).await;
 }
 
-pub async fn make_fake_redis_with_multiple_responses<
-    B: BuildHasher + Clone + Send + 'static + Sync,
->(
+async fn make_fake_redis_with_multiple_responses<B: BuildHasher + Clone + Send + 'static + Sync>(
     responses: Vec<HashMap<String, String, B>>,
 ) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/nativelink-redis-tester/src/lib.rs
+++ b/nativelink-redis-tester/src/lib.rs
@@ -20,8 +20,7 @@ mod read_only_redis;
 pub use dynamic_fake_redis::{FakeRedisBackend, SubscriptionManagerNotify};
 pub use fake_redis::{
     add_lua_script, add_to_response, add_to_response_raw, fake_redis_sentinel_master_stream,
-    fake_redis_sentinel_stream, fake_redis_stream, make_fake_redis_with_multiple_responses,
-    make_fake_redis_with_responses,
+    fake_redis_sentinel_stream, fake_redis_stream, make_fake_redis_with_responses,
 };
 pub use pubsub::MockPubSub;
 pub use read_only_redis::ReadOnlyRedis;

--- a/nativelink-redis-tester/src/read_only_redis.rs
+++ b/nativelink-redis-tester/src/read_only_redis.rs
@@ -26,7 +26,7 @@ use tracing::info;
 
 use crate::fake_redis::{arg_as_string, fake_redis_internal};
 
-const FAKE_SCRIPT_SHA: &str = "b22b9926cbce9dd9ba97fa7ba3626f89feea1ed5";
+const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
 
 #[derive(Clone, Debug)]
 pub struct ReadOnlyRedis {
@@ -119,6 +119,16 @@ impl ReadOnlyRedis {
                         }
                     }
                     "EVALSHA" => Either::Left(Value::Array(vec![Value::Int(1), Value::Int(0)])),
+                    "EXPIRE" => {
+                        assert_eq!(args[1], OwnedFrame::BulkString(b"60".to_vec()));
+                        let value = self.readonly_triggered.load(Ordering::Relaxed);
+                        if value {
+                            Either::Left(Value::Int(1))
+                        } else {
+                            self.readonly_triggered.store(true, Ordering::Relaxed);
+                            Either::Right(readonly_err.clone())
+                        }
+                    }
                     actual => {
                         panic!("Mock command not implemented! {actual:?}");
                     }

--- a/nativelink-scheduler/BUILD.bazel
+++ b/nativelink-scheduler/BUILD.bazel
@@ -70,6 +70,7 @@ rust_test_suite(
         "tests/redis_store_awaited_action_db_test.rs",
         "tests/simple_scheduler_state_manager_test.rs",
         "tests/simple_scheduler_test.rs",
+        "tests/store_awaited_action_db_test.rs",
         "tests/worker_capability_index_test.rs",
         "tests/worker_registry_test.rs",
     ],

--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -167,6 +167,16 @@ impl AwaitedAction {
         &self.state
     }
 
+    pub fn is_complete(&self) -> bool {
+        match &self.state.stage {
+            ActionStage::Unknown
+            | ActionStage::CacheCheck
+            | ActionStage::Queued
+            | ActionStage::Executing => false,
+            ActionStage::Completed(_) | ActionStage::CompletedFromCache(_) => true,
+        }
+    }
+
     pub(crate) const fn maybe_origin_metadata(&self) -> Option<&OriginMetadata> {
         self.maybe_origin_metadata.as_ref()
     }

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -151,6 +151,7 @@ async fn simple_scheduler_factory(
                 task_change_notify.clone(),
                 now_fn,
                 Default::default,
+                spec.retain_completed_for_s,
             )
             .await
             .err_tip(|| "In state_manager_factory::redis_state_manager")?;

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -69,6 +69,7 @@ pub struct OperationSubscriber<S: SchedulerStore, I: InstantWrapper, NowFn: Fn()
     // when the state is set to subscribed.  When set it causes the state to be polled
     // as well as listening for the publishing.
     maybe_last_stage: Option<Discriminant<ActionStage>>,
+    retain_completed_for: Duration,
 }
 
 impl<S: SchedulerStore, I: InstantWrapper, NowFn: Fn() -> I + core::fmt::Debug> core::fmt::Debug
@@ -100,6 +101,7 @@ where
         subscription_key: OperationIdToAwaitedAction<'static>,
         weak_store: Weak<S>,
         now_fn: NowFn,
+        retain_completed_for: Duration,
     ) -> Self {
         Self {
             maybe_client_operation_id,
@@ -109,6 +111,7 @@ where
             state: OperationSubscriberState::Unsubscribed,
             now_fn,
             maybe_last_stage: None,
+            retain_completed_for,
         }
     }
 
@@ -235,10 +238,13 @@ where
                 if USE_SEPARATE_CLIENT_KEEPALIVE_KEY {
                     let operation_id = self.subscription_key.0.as_ref();
                     let update_result = store
-                        .update_data(UpdateClientKeepalive {
-                            operation_id,
-                            timestamp: now_ts,
-                        })
+                        .update_data(
+                            UpdateClientKeepalive {
+                                operation_id,
+                                timestamp: now_ts,
+                            },
+                            None,
+                        )
                         .await;
 
                     if let Err(e) = update_result {
@@ -297,7 +303,14 @@ where
                                     != core::mem::discriminant(&awaited_action.state().stage)
                             })
                             .then(|| awaited_action.clone());
-                        match inner_update_awaited_action(store.as_ref(), awaited_action).await {
+                        let expiry = if awaited_action.is_complete() {
+                            Some(self.retain_completed_for)
+                        } else {
+                            None
+                        };
+                        match inner_update_awaited_action(store.as_ref(), awaited_action, expiry)
+                            .await
+                        {
                             Ok(()) => break,
                             err if attempt == MAX_RETRIES_FOR_CLIENT_KEEPALIVE => {
                                 err.err_tip_with_code(|_| {
@@ -498,7 +511,8 @@ const fn get_state_prefix(state: SortedAwaitedActionState) -> &'static str {
     }
 }
 
-struct UpdateOperationIdToAwaitedAction(AwaitedAction);
+#[derive(Debug)]
+pub struct UpdateOperationIdToAwaitedAction(AwaitedAction);
 impl SchedulerCurrentVersionProvider for UpdateOperationIdToAwaitedAction {
     fn current_version(&self) -> i64 {
         self.0.version()
@@ -568,9 +582,10 @@ impl SchedulerStoreDataProvider for UpdateClientIdToOperationId {
     }
 }
 
-async fn inner_update_awaited_action(
+pub async fn inner_update_awaited_action(
     store: &impl SchedulerStore,
     mut new_awaited_action: AwaitedAction,
+    expiry: Option<Duration>,
 ) -> Result<(), Error> {
     let operation_id = new_awaited_action.operation_id().clone();
     if new_awaited_action.state().client_operation_id != operation_id {
@@ -580,7 +595,7 @@ async fn inner_update_awaited_action(
     let _is_finished = new_awaited_action.state().stage.is_finished();
 
     let maybe_version = store
-        .update_data(UpdateOperationIdToAwaitedAction(new_awaited_action))
+        .update_data(UpdateOperationIdToAwaitedAction(new_awaited_action), expiry)
         .await
         .err_tip(|| "In RedisAwaitedActionDb::update_awaited_action")?;
 
@@ -610,6 +625,7 @@ where
     now_fn: NowFn,
     operation_id_creator: F,
     _pull_task_change_subscriber_spawn: JoinHandleDropGuard<()>,
+    retain_completed_for: Duration,
 }
 
 impl<S, F, I, NowFn> StoreAwaitedActionDb<S, F, I, NowFn>
@@ -624,6 +640,7 @@ where
         task_change_publisher: Arc<Notify>,
         now_fn: NowFn,
         operation_id_creator: F,
+        retain_completed_for_s: u32,
     ) -> Result<Self, Error> {
         let mut subscription = store
             .subscription_manager()
@@ -659,6 +676,7 @@ where
             now_fn,
             operation_id_creator,
             _pull_task_change_subscriber_spawn: pull_task_change_subscriber,
+            retain_completed_for: Duration::from_secs(retain_completed_for_s.into()),
         })
     }
 
@@ -786,6 +804,7 @@ where
             OperationIdToAwaitedAction(Cow::Owned(operation_id)),
             Arc::downgrade(&self.store),
             self.now_fn.clone(),
+            self.retain_completed_for,
         )))
     }
 }
@@ -816,11 +835,17 @@ where
             OperationIdToAwaitedAction(Cow::Owned(operation_id.clone())),
             Arc::downgrade(&self.store),
             self.now_fn.clone(),
+            self.retain_completed_for,
         )))
     }
 
     async fn update_awaited_action(&self, new_awaited_action: AwaitedAction) -> Result<(), Error> {
-        inner_update_awaited_action(self.store.as_ref(), new_awaited_action).await
+        let expiry = if new_awaited_action.is_complete() {
+            Some(self.retain_completed_for)
+        } else {
+            None
+        };
+        inner_update_awaited_action(self.store.as_ref(), new_awaited_action, expiry).await
     }
 
     async fn add_action(
@@ -866,9 +891,14 @@ where
             awaited_action.update_client_keep_alive((self.now_fn)().now());
 
             let version = awaited_action.version();
+            let expiry = if awaited_action.is_complete() {
+                Some(self.retain_completed_for)
+            } else {
+                None
+            };
             if self
                 .store
-                .update_data(UpdateOperationIdToAwaitedAction(awaited_action))
+                .update_data(UpdateOperationIdToAwaitedAction(awaited_action), expiry)
                 .await
                 .err_tip(|| "In RedisAwaitedActionDb::add_action")?
                 .is_none()
@@ -883,10 +913,13 @@ where
 
             // Add the client_operation_id to operation_id mapping
             self.store
-                .update_data(UpdateClientIdToOperationId {
-                    client_operation_id: client_operation_id.clone(),
-                    operation_id: operation_id.clone(),
-                })
+                .update_data(
+                    UpdateClientIdToOperationId {
+                        client_operation_id: client_operation_id.clone(),
+                        operation_id: operation_id.clone(),
+                    },
+                    None,
+                )
                 .await
                 .err_tip(|| "In RedisAwaitedActionDb::add_action while adding client mapping")?;
 
@@ -895,6 +928,7 @@ where
                 OperationIdToAwaitedAction(Cow::Owned(operation_id)),
                 Arc::downgrade(&self.store),
                 self.now_fn.clone(),
+                self.retain_completed_for,
             ));
         }
     }
@@ -937,6 +971,7 @@ where
                     OperationIdToAwaitedAction(Cow::Owned(awaited_action.operation_id().clone())),
                     Arc::downgrade(&self.store),
                     self.now_fn.clone(),
+                    self.retain_completed_for,
                 )
             }))
     }
@@ -955,6 +990,7 @@ where
                     OperationIdToAwaitedAction(Cow::Owned(awaited_action.operation_id().clone())),
                     Arc::downgrade(&self.store),
                     self.now_fn.clone(),
+                    self.retain_completed_for,
                 )
             }))
     }

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -152,6 +152,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || WORKER_OPERATION_ID.into(),
+        60,
     )
     .await
     .unwrap();
@@ -260,6 +261,7 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
+        60,
     )
     .await
     .unwrap();
@@ -416,6 +418,7 @@ async fn test_outdated_version() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
+        60,
     )
     .await
     .unwrap();
@@ -490,6 +493,7 @@ async fn test_orphaned_client_operation_id_returns_none() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
+        60,
     )
     .await
     .unwrap();

--- a/nativelink-scheduler/tests/store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/store_awaited_action_db_test.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::todo)]
+
+use core::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use bytes::Bytes;
+use futures::{Stream, stream};
+use nativelink_error::Error;
+use nativelink_macro::nativelink_test;
+use nativelink_scheduler::awaited_action_db::AwaitedAction;
+use nativelink_scheduler::store_awaited_action_db::inner_update_awaited_action;
+use nativelink_util::action_messages::{
+    ActionInfo, ActionUniqueKey, ActionUniqueQualifier, OperationId,
+};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::store_trait::{
+    SchedulerCurrentVersionProvider, SchedulerIndexProvider, SchedulerStore,
+    SchedulerStoreDataProvider, SchedulerStoreDecodeTo, SchedulerStoreKeyProvider,
+    SchedulerSubscription, SchedulerSubscriptionManager,
+};
+use pretty_assertions::assert_eq;
+use tokio::sync::Mutex;
+
+const INSTANCE_NAME: &str = "foo";
+
+struct FakeSchedulerStore {
+    #[allow(clippy::type_complexity)]
+    updates: Arc<Mutex<Vec<(Bytes, Option<Duration>)>>>,
+}
+
+impl FakeSchedulerStore {
+    fn new() -> Self {
+        Self {
+            updates: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+struct FakeSubscriptionManager {}
+struct FakeSubscription {}
+
+impl SchedulerSubscription for FakeSubscription {
+    async fn changed(&mut self) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+impl SchedulerSubscriptionManager for FakeSubscriptionManager {
+    type Subscription = FakeSubscription;
+
+    fn subscribe<K>(&self, _key: K) -> Result<Self::Subscription, Error>
+    where
+        K: SchedulerStoreKeyProvider,
+    {
+        todo!()
+    }
+
+    fn is_reliable() -> bool {
+        todo!()
+    }
+}
+
+impl SchedulerStore for FakeSchedulerStore {
+    type SubscriptionManager = FakeSubscriptionManager;
+
+    async fn subscription_manager(&self) -> Result<Arc<Self::SubscriptionManager>, Error> {
+        todo!()
+    }
+
+    async fn update_data<T>(&self, data: T, expiry: Option<Duration>) -> Result<Option<i64>, Error>
+    where
+        T: SchedulerStoreDataProvider
+            + SchedulerStoreKeyProvider
+            + SchedulerCurrentVersionProvider
+            + Send,
+    {
+        self.updates
+            .lock()
+            .await
+            .push((data.try_into_bytes()?, expiry));
+        Ok(Some(1))
+    }
+
+    async fn search_by_index_prefix<K>(
+        &self,
+        _index: K,
+    ) -> Result<
+        impl Stream<Item = Result<<K as SchedulerStoreDecodeTo>::DecodeOutput, Error>> + Send,
+        Error,
+    >
+    where
+        K: SchedulerIndexProvider + SchedulerStoreDecodeTo + Send,
+        <K as SchedulerStoreDecodeTo>::DecodeOutput: Send,
+    {
+        // todo!();
+        Ok(stream::empty())
+    }
+
+    async fn get_and_decode<K>(
+        &self,
+        _key: K,
+    ) -> Result<Option<<K as SchedulerStoreDecodeTo>::DecodeOutput>, Error>
+    where
+        K: SchedulerStoreKeyProvider + SchedulerStoreDecodeTo + Send,
+    {
+        todo!()
+    }
+}
+
+#[nativelink_test]
+async fn test_inner_update_awaited_action() -> Result<(), Error> {
+    let store = FakeSchedulerStore::new();
+    let action_digest = DigestInfo::new([3u8; 32], 10);
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: HashMap::new(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: action_digest,
+        }),
+    };
+
+    let awaited_action = AwaitedAction::new(
+        OperationId::from("DEMO_OPERATION_ID"),
+        action_info.into(),
+        SystemTime::UNIX_EPOCH,
+    );
+    inner_update_awaited_action(&store, awaited_action, Some(Duration::from_mins(5))).await?;
+    let updates = store.updates.lock().await;
+    assert_eq!(updates.len(), 1, "{updates:#?}");
+    let update = updates.first().unwrap();
+    assert_eq!(
+        update.0,
+        Bytes::from(
+            "{\"version\":0,\"action_info\":{\"command_digest\":\"0101010101010101010101010101010101010101010101010101010101010101-10\",\"input_root_digest\":\"0202020202020202020202020202020202020202020202020202020202020202-10\",\"timeout\":{\"secs\":1,\"nanos\":0},\"platform_properties\":{},\"priority\":0,\"load_timestamp\":{\"secs_since_epoch\":0,\"nanos_since_epoch\":0},\"insert_timestamp\":{\"secs_since_epoch\":0,\"nanos_since_epoch\":0},\"unique_qualifier\":{\"Uncacheable\":{\"instance_name\":\"foo\",\"digest_function\":\"Sha256\",\"digest\":\"0303030303030303030303030303030303030303030303030303030303030303-10\"}}},\"operation_id\":{\"String\":\"DEMO_OPERATION_ID\"},\"sort_key\":9223372041149743103,\"last_worker_updated_timestamp\":{\"secs_since_epoch\":0,\"nanos_since_epoch\":0},\"last_client_keepalive_timestamp\":{\"secs_since_epoch\":0,\"nanos_since_epoch\":0},\"worker_id\":null,\"state\":{\"stage\":\"Queued\",\"last_transition_timestamp\":{\"secs_since_epoch\":0,\"nanos_since_epoch\":0},\"client_operation_id\":{\"String\":\"DEMO_OPERATION_ID\"},\"action_digest\":\"0303030303030303030303030303030303030303030303030303030303030303-10\"},\"maybe_origin_metadata\":null,\"attempts\":0}"
+        ),
+        "{update:#?}"
+    );
+    assert_eq!(update.1, Some(Duration::from_mins(5)));
+    Ok(())
+}

--- a/nativelink-store/src/mongo_store.rs
+++ b/nativelink-store/src/mongo_store.rs
@@ -910,13 +910,19 @@ impl SchedulerStore for ExperimentalMongoStore {
         }
     }
 
-    async fn update_data<T>(&self, data: T) -> Result<Option<i64>, Error>
+    async fn update_data<T>(&self, data: T, expiry: Option<Duration>) -> Result<Option<i64>, Error>
     where
         T: SchedulerStoreDataProvider
             + SchedulerStoreKeyProvider
             + SchedulerCurrentVersionProvider
             + Send,
     {
+        if expiry.is_some() {
+            return Err(make_err!(
+                Code::InvalidArgument,
+                "Mongo store doesn't support expiry!"
+            ));
+        }
         let key = data.get_key();
         let encoded_key = self.encode_key(&key);
         let maybe_index = data.get_indexes().map_err(|e| {

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1174,8 +1174,9 @@ const INDEX_TTL_S: u64 = 60 * 60 * 24; // 24 hours.
 /// Args:
 ///   KEYS[1]: The key where the version is stored.
 ///   ARGV[1]: The expected version.
-///   ARGV[2]: The new data.
-///   ARGV[3*]: Key-value pairs of additional data to include.
+///   ARGV[2]: TTL in seconds, or 0 for forever
+///   ARGV[3]: The new data.
+///   ARGV[4*]: Key-value pairs of additional data to include.
 /// Returns:
 ///   The new version if the version matches. nil is returned if the
 ///   value was not set.
@@ -1183,7 +1184,8 @@ pub const LUA_VERSION_SET_SCRIPT: &str = formatcp!(
     r"
 local key = KEYS[1]
 local expected_version = tonumber(ARGV[1])
-local new_data = ARGV[2]
+local ttl = tonumber(ARGV[2])
+local new_data = ARGV[3]
 local new_version = redis.call('HINCRBY', key, '{VERSION_FIELD_NAME}', 1)
 local i
 local indexes = {{}}
@@ -1192,10 +1194,10 @@ if new_version-1 ~= expected_version then
     redis.call('HINCRBY', key, '{VERSION_FIELD_NAME}', -1)
     return {{ 0, new_version-1 }}
 end
--- Skip first 2 argvs, as they are known inputs.
+-- Skip first 3 argvs, as they are known inputs.
 -- Remember: Lua is 1-indexed.
-for i=3, #ARGV do
-    indexes[i-2] = ARGV[i]
+for i=4, #ARGV do
+    indexes[i-3] = ARGV[i]
 end
 
 -- In testing we witnessed redis sometimes not update our FT indexes
@@ -1204,6 +1206,9 @@ end
 redis.call('DEL', key)
 redis.call('HSET', key, '{DATA_FIELD_NAME}', new_data, '{VERSION_FIELD_NAME}', new_version, unpack(indexes))
 
+if ttl ~= 0 then
+    redis.call('EXPIRE', key, ttl)
+end
 return {{ 1, new_version }}
 "
 );
@@ -1553,7 +1558,7 @@ where
             .map(Clone::clone)
     }
 
-    async fn update_data<T>(&self, data: T) -> Result<Option<i64>, Error>
+    async fn update_data<T>(&self, data: T, expiry: Option<Duration>) -> Result<Option<i64>, Error>
     where
         T: SchedulerStoreDataProvider
             + SchedulerStoreKeyProvider
@@ -1572,7 +1577,10 @@ where
                 format!("Could not convert value to bytes in RedisStore::update_data::versioned for {redis_key}")
             })?;
             let mut script = self.connection_manager.update_script(redis_key.as_ref());
-            let mut script_invocation = script.arg(format!("{current_version}")).arg(data.to_vec());
+            let mut script_invocation = script
+                .arg(format!("{current_version}"))
+                .arg(expiry.unwrap_or(Duration::ZERO).as_secs())
+                .arg(data.to_vec());
             for (name, value) in maybe_index {
                 script_invocation = script_invocation.arg(name).arg(value.to_vec());
             }
@@ -1649,7 +1657,26 @@ where
                 .hset_multiple::<_, _, _, ()>(redis_key.as_ref(), &fields)
                 .await
             {
-                Ok(v) => v,
+                Ok(_v) => {
+                    if let Some(expiry_v) = expiry {
+                        let seconds =
+                            TryInto::<i64>::try_into(expiry_v.as_secs()).err_tip(|| {
+                                format!("Expiry seconds doesn't map to i64: {expiry_v:#?}")
+                            })?;
+                        let expiry_result: u8 = client
+                            .connection_manager
+                            .expire(redis_key.as_ref(), seconds)
+                            .await
+                            .err_tip(|| {
+                                format!(
+                                    "In RedisStore::update_data::noversion (expiry) for {redis_key}"
+                                )
+                            })?;
+                        if expiry_result != 1 {
+                            warn!(%redis_key, seconds, "Wasn't able to set expiry for Redis key");
+                        }
+                    }
+                }
                 Err(err)
                     if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
                 {
@@ -1658,7 +1685,18 @@ where
                         .connection_manager
                         .hset_multiple::<_, _, _, ()>(redis_key.as_ref(), &fields)
                         .await
-                        .err_tip(|| format!("(after reconnect) In RedisStore::update_data::noversion for {redis_key}"))?;
+                        .err_tip(|| format!("(after reconnect) In RedisStore::update_data::noversion (hset) for {redis_key}"))?;
+                    if let Some(expiry_v) = expiry {
+                        let seconds =
+                            TryInto::<i64>::try_into(expiry_v.as_secs()).err_tip(|| {
+                                format!("Expiry seconds doesn't map to i64: {expiry_v:#?}")
+                            })?;
+                        let expiry_result: u8 = client.connection_manager.expire(redis_key.as_ref(), seconds).await
+                        .err_tip(|| format!("(after reconnect) In RedisStore::update_data::noversion (expiry) for {redis_key}"))?;
+                        if expiry_result != 1 {
+                            warn!(%redis_key, seconds, "Wasn't able to set expiry for Redis key");
+                        }
+                    }
                 }
                 Err(err) => {
                     let mut error: Error = err.into();

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -840,7 +840,7 @@ async fn concurrent_reads_dedup_to_a_single_slow_store_call() -> Result<(), Erro
 
     gate_tx
         .send(())
-        .map_err(|_| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
+        .map_err(|()| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
 
     let results = join_all(handles).await;
     for r in results {
@@ -895,7 +895,7 @@ async fn dropping_a_follower_does_not_cancel_the_leader() -> Result<(), Error> {
 
     gate_tx
         .send(())
-        .map_err(|_| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
+        .map_err(|()| make_err!(Code::Internal, "Failed to release slow-store gate"))?;
 
     let leader_bytes = leader_handle
         .await

--- a/nativelink-store/tests/mongo_store_test.rs
+++ b/nativelink-store/tests/mongo_store_test.rs
@@ -779,7 +779,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         // Update data in the scheduler store
         let version = helper
             .store
-            .update_data(data.clone())
+            .update_data(data.clone(), None)
             .await
             .err_tip(|| "Failed to update scheduler data")?
             .ok_or_else(|| make_err!(Code::Internal, "Expected version from update"))?;
@@ -811,7 +811,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         // First update
         let version1 = helper
             .store
-            .update_data(data.clone())
+            .update_data(data.clone(), None)
             .await?
             .ok_or_else(|| make_err!(Code::Internal, "Expected version"))?;
 
@@ -820,7 +820,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         data.version = version1;
         let version2 = helper
             .store
-            .update_data(data.clone())
+            .update_data(data.clone(), None)
             .await?
             .ok_or_else(|| make_err!(Code::Internal, "Expected version"))?;
 
@@ -830,7 +830,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
         // Try update with wrong version (should fail)
         data.content = "This should fail".to_string();
         data.version = version1; // Using old version
-        let result = helper.store.update_data(data.clone()).await;
+        let result = helper.store.update_data(data.clone(), None).await;
 
         assert!(result.is_err(), "Update with old version should fail");
         eprintln!("Correctly rejected update with stale version");
@@ -877,7 +877,7 @@ async fn test_scheduler_store_operations() -> Result<(), Error> {
                 version: 0,
             };
 
-            let version = helper.store.update_data(data).await?;
+            let version = helper.store.update_data(data, None).await?;
             assert_eq!(Some(1), version);
         }
 

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -23,8 +23,8 @@ use nativelink_config::stores::{RedisMode, RedisSpec};
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_redis_tester::{
-    ReadOnlyRedis, add_lua_script, fake_redis_sentinel_master_stream, fake_redis_sentinel_stream,
-    fake_redis_stream, make_fake_redis_with_responses,
+    ReadOnlyRedis, add_lua_script, add_to_response, fake_redis_sentinel_master_stream,
+    fake_redis_sentinel_stream, fake_redis_stream, make_fake_redis_with_responses,
 };
 use nativelink_store::cas_utils::ZERO_BYTE_DIGESTS;
 use nativelink_store::redis_store::{
@@ -66,12 +66,10 @@ async fn make_mock_store(
     make_mock_store_with_prefix(commands, String::new()).await
 }
 
+const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
+
 fn add_lua_version_script(mut responses: HashMap<String, String>) -> HashMap<String, String> {
-    add_lua_script(
-        &mut responses,
-        LUA_VERSION_SET_SCRIPT,
-        "b22b9926cbce9dd9ba97fa7ba3626f89feea1ed5",
-    );
+    add_lua_script(&mut responses, LUA_VERSION_SET_SCRIPT, FAKE_SCRIPT_SHA);
     responses
 }
 
@@ -92,7 +90,7 @@ async fn make_mock_store_with_prefix(
         0,
         MockCmd::new(
             redis::cmd("SCRIPT").arg("LOAD").arg(LUA_VERSION_SET_SCRIPT),
-            Ok("b22b9926cbce9dd9ba97fa7ba3626f89feea1ed5"),
+            Ok(FAKE_SCRIPT_SHA),
         ),
     );
     let mock_connection = MockRedisConnection::new(commands);
@@ -798,7 +796,10 @@ async fn test_sentinel_connect_and_update_data_unversioned_readonly() {
         content: "Test scheduler data #1".to_string(),
         version: 0,
     };
-    store.update_data(data).await.expect("working update");
+    store
+        .update_data(data, Some(Duration::from_secs(60)))
+        .await
+        .expect("working update");
 }
 
 #[nativelink_test]
@@ -825,7 +826,7 @@ async fn test_sentinel_connect_and_update_data_versioned_readonly() {
         content: "Test scheduler data #1".to_string(),
         version: 0,
     };
-    store.update_data(data).await.expect("working update");
+    store.update_data(data, None).await.expect("working update");
 }
 
 #[nativelink_test]
@@ -1466,4 +1467,103 @@ async fn send_messages_to_subscription_channel() -> Result<(), Error> {
     drop(subscription_manager);
 
     Ok(())
+}
+
+async fn core_test_update_data_unversioned_with_expiry(expire_response: i64) {
+    let redis_span = info_span!("redis");
+    let mut responses = add_lua_version_script(fake_redis_stream());
+    add_to_response(
+        &mut responses,
+        redis::cmd("HMSET")
+            .arg("test:scheduler_key_1")
+            .arg("data")
+            .arg("Test scheduler data #1")
+            .arg("test_index")
+            .arg("test_value")
+            .arg("content_prefix")
+            .arg("Test sched"),
+        vec![Value::Okay],
+    );
+    add_to_response(
+        &mut responses,
+        redis::cmd("EXPIRE").arg("test:scheduler_key_1").arg(60),
+        vec![Value::Int(expire_response)],
+    );
+
+    let redis_port = make_fake_redis_with_responses(responses)
+        .instrument(redis_span)
+        .await;
+    let spec = RedisSpec {
+        addresses: vec![format!("redis://127.0.0.1:{redis_port}/")],
+        mode: RedisMode::Standard,
+        ..Default::default()
+    };
+    let mut raw_store =
+        Arc::into_inner(RedisStore::new_standard(spec).await.expect("Working spec")).unwrap();
+    raw_store.replace_temp_name_generator(mock_uuid_generator);
+    let store = Arc::new(raw_store);
+    let data = TestSchedulerDataUnversioned {
+        key: "test:scheduler_key_1".to_string(),
+        content: "Test scheduler data #1".to_string(),
+        version: 0,
+    };
+    store
+        .update_data(data, Some(Duration::from_secs(60)))
+        .await
+        .expect("working update");
+}
+
+#[nativelink_test]
+async fn test_update_data_unversioned_with_expiry() {
+    core_test_update_data_unversioned_with_expiry(1).await;
+    assert!(!logs_contain("Wasn't able to set expiry for Redis key"));
+}
+
+#[nativelink_test]
+async fn test_update_data_unversioned_with_expiry_failure() {
+    core_test_update_data_unversioned_with_expiry(0).await;
+    assert!(logs_contain(
+        "Wasn't able to set expiry for Redis key redis_key=test:scheduler_key_1 seconds=60"
+    ));
+}
+#[nativelink_test]
+async fn test_update_data_versioned_with_expiry() {
+    let redis_span = info_span!("redis");
+    let mut responses = add_lua_version_script(fake_redis_stream());
+    add_to_response(
+        &mut responses,
+        redis::cmd("EVALSHA")
+            .arg(FAKE_SCRIPT_SHA)
+            .arg("1")
+            .arg("test:scheduler_key_1")
+            .arg("0")
+            .arg("60")
+            .arg("Test scheduler data #1")
+            .arg("test_index")
+            .arg("test_value")
+            .arg("content_prefix")
+            .arg("Test sched"),
+        vec![Value::Array(vec![Value::Boolean(true), Value::Int(1)])],
+    );
+    let redis_port = make_fake_redis_with_responses(responses)
+        .instrument(redis_span)
+        .await;
+    let spec = RedisSpec {
+        addresses: vec![format!("redis://127.0.0.1:{redis_port}/")],
+        mode: RedisMode::Standard,
+        ..Default::default()
+    };
+    let mut raw_store =
+        Arc::into_inner(RedisStore::new_standard(spec).await.expect("Working spec")).unwrap();
+    raw_store.replace_temp_name_generator(mock_uuid_generator);
+    let store = Arc::new(raw_store);
+    let data = TestSchedulerDataVersioned {
+        key: "test:scheduler_key_1".to_string(),
+        content: "Test scheduler data #1".to_string(),
+        version: 0,
+    };
+    store
+        .update_data(data, Some(Duration::from_secs(60)))
+        .await
+        .expect("working update");
 }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -449,9 +449,7 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
-            let Some(entry) = state.lru.get_mut(key.borrow()) else {
-                return None;
-            };
+            let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
             // Mirrors the per-key reap path in `sizes_for_keys`.

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -20,6 +20,7 @@ use core::hash::{Hash, Hasher};
 use core::ops::{Bound, RangeBounds};
 use core::pin::Pin;
 use core::ptr::addr_eq;
+use core::time::Duration;
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher as StdHasher;
 use std::ffi::OsString;
@@ -903,7 +904,11 @@ pub trait SchedulerStore: Send + Sync + 'static {
     /// the version in the passed in data.
     /// No guarantees are made about when `Version` is `FalseValue`.
     /// Indexes are guaranteed to be updated atomically with the data.
-    fn update_data<T>(&self, data: T) -> impl Future<Output = Result<Option<i64>, Error>> + Send
+    fn update_data<T>(
+        &self,
+        data: T,
+        expiry: Option<Duration>,
+    ) -> impl Future<Output = Result<Option<i64>, Error>> + Send
     where
         T: SchedulerStoreDataProvider
             + SchedulerStoreKeyProvider
@@ -921,7 +926,8 @@ pub trait SchedulerStore: Send + Sync + 'static {
         >,
     > + Send
     where
-        K: SchedulerIndexProvider + SchedulerStoreDecodeTo + Send;
+        K: SchedulerIndexProvider + SchedulerStoreDecodeTo + Send,
+        <K as SchedulerStoreDecodeTo>::DecodeOutput: Send;
 
     /// Returns data for the provided key with the given version if
     /// `StoreKeyProvider::Versioned` is `TrueValue`.

--- a/src/bin/redis_store_tester.rs
+++ b/src/bin/redis_store_tester.rs
@@ -244,7 +244,7 @@ async fn run<S: StoreDriver + SchedulerStore>(
                                 version: 0,
                             };
 
-                            store_clone.update_data(data).await?;
+                            store_clone.update_data(data, None).await?;
                         }
                         let search_results: Vec<_> = store_clone
                             .search_by_index_prefix(search_provider)
@@ -265,7 +265,9 @@ async fn run<S: StoreDriver + SchedulerStore>(
                             data.version = existing_data.version + 1;
                         }
 
-                        store_clone.update_data(data).await?;
+                        store_clone
+                            .update_data(data, Some(Duration::from_mins(1)))
+                            .await?;
                     }
                 }
                 Ok(())


### PR DESCRIPTION
# Description

The scheduler has a config option `retain_completed_for_s` that the Redis scheduler store doesn't actually pay attention to, and so you can end up over time with many (we've observed millions) of old completed entries in Redis that then slow everything down.

This PR explicitly sets a TTL with `EXPIRE` for completed actions, using the config option value.

## Type of change

Please delete options that aren't relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)

This is a breaking change as there will be some cases where an action would have previously stuck around for longer and that would have been needed in some cases, but the user hadn't set the timeout to as high as they actually needed. In this case, they'll need to actually configure the timeout v.s. getting away without it.

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2315)
<!-- Reviewable:end -->
