### PR TITLE
Only push attic client when we've got the token

### DIFF
--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -5,17 +5,20 @@ description: "Common teardown for all runs using Nix."
 inputs:
   nix_name:
     default: ""
+  nativelink_attic_token:
+    required: true
 runs:
   using: "composite"
   steps:
       - name: Check attic push
+        if: ${{ inputs.nativelink_attic_token != '' }}
         run: |
           cd /tmp
           cat attic-push.log
         shell: bash
 
       - name: Attic push
-        if: ${{ inputs.nix_name != '' }}
+        if: ${{ inputs.nix_name != '' && inputs.nativelink_attic_token != '' }}
         run: |
           cd /tmp
           ./result/bin/attic push nativelink $(nix eval --raw ${{ inputs.nix_name }})

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -29,13 +29,17 @@ runs:
           ./result/bin/attic login uc1-dev https://attic.uc1.scdev.nativelink.net/ ${{ inputs.nativelink_attic_token }}
           ./result/bin/attic use nativelink
 
-          # Replace with more reliable attic for working around
-          # * https://github.com/zhaofengli/attic/issues/226
-          # * https://github.com/zhaofengli/attic/pull/317
-          # We use the original one first to get caching of this
-          nix build github:TraceMachina/attic
-          RUST_BACKTRACE=full RUST_LOG=debug,hyper_util=info,rustls=info ./result/bin/attic watch-store nativelink &> attic-push.log &
+          if [ -n "${{ inputs.nativelink_attic_token }}" ]; then
+            # If we don't have a token, we can't push!
 
-          # For the cases where we don't have a cache of it, push anyways
-          ./result/bin/attic push nativelink $(nix eval --raw github:TraceMachina/attic)
+            # Replace with more reliable attic for working around
+            # * https://github.com/zhaofengli/attic/issues/226
+            # * https://github.com/zhaofengli/attic/pull/317
+            # We use the original one first to get caching of this
+            nix build github:TraceMachina/attic
+            RUST_BACKTRACE=full RUST_LOG=debug,hyper_util=info,rustls=info ./result/bin/attic watch-store nativelink &> attic-push.log &
+
+            # For the cases where we don't have a cache of it, push it
+            ./result/bin/attic push nativelink $(nix eval --raw github:TraceMachina/attic)
+          fi
         shell: bash

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -55,6 +55,7 @@ jobs:
         if: always()
         with:
           nix_name: .#nativelinkCoverageForHost
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/custom-image.yaml
+++ b/.github/workflows/custom-image.yaml
@@ -148,3 +148,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -63,3 +63,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -55,6 +55,8 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
 #   remote:
 #     strategy:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -55,6 +55,8 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
   nix-cargo:
     strategy:
@@ -82,6 +84,8 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
   installation:
     strategy:
@@ -112,6 +116,7 @@ jobs:
         if: always()
         with:
           nix_name: .#nativelink-is-executable-test
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
   integration:
     name: ${{ matrix.test-name }}
@@ -138,4 +143,5 @@ jobs:
         uses: ./.github/actions/end-nix
         if: always()
         with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
           nix_name: .#${{ matrix.test-name }}-with-nativelink-test

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -34,3 +34,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -48,4 +48,5 @@ jobs:
         uses: ./.github/actions/end-nix
         if: always()
         with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
           nix_name: .#${{ matrix.image }}

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -70,3 +70,5 @@ jobs:
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
         if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}


### PR DESCRIPTION
# Description

https://github.com/TraceMachina/nativelink/pull/2310 broke things because it assumed everyone could push contents, which isn't true on PRs that aren't off the main repo i.e. forks because they don't have the secret token.

This PR only pushes on runs with tokens.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2316)
<!-- Reviewable:end -->
