### PR TITLE
execution_server: pre-validate CAS blobs and return PreconditionFailure

### DIFF
--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -51,11 +51,57 @@ macro_rules! error_if {
     }};
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+/// Typed metadata that travels with an [`Error`].
+///
+/// Used in place of string-parsing error messages when the producer
+/// has structured information the consumer needs to act on. The
+/// motivating case is missing-blob errors from `fast_slow_store` —
+/// `to_execute_response` reads [`ErrorContext::MissingDigest`] and
+/// surfaces a `FAILED_PRECONDITION` with a `PreconditionFailure`
+/// detail naming the digest, which Bazel auto-retries on.
+///
+/// Default is [`ErrorContext::None`]; existing call sites that
+/// construct [`Error`] via `make_err!` / `Error::new` do not need to
+/// be updated.
+#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub enum ErrorContext {
+    #[default]
+    None,
+    /// The error refers to a specific CAS blob that could not be
+    /// located. `hash` and `size` together form the digest the client
+    /// should re-upload (REv2 `blobs/{hash}/{size}`).
+    MissingDigest { hash: String, size: i64 },
+}
+
+#[derive(Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Error {
     #[serde(with = "CodeDef")]
     pub code: Code,
     pub messages: Vec<String>,
+    #[serde(default, skip_serializing_if = "ErrorContext::is_none")]
+    pub context: ErrorContext,
+}
+
+impl core::fmt::Debug for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut builder = f.debug_struct("Error");
+        builder.field("code", &self.code);
+        if !self.messages.is_empty() {
+            builder.field("messages", &self.messages);
+        }
+        if !self.context.is_none() {
+            builder.field("context", &self.context);
+        }
+        builder.finish()
+    }
+}
+
+impl ErrorContext {
+    #[inline]
+    #[must_use]
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
 }
 
 impl MetricsComponent for Error {
@@ -71,7 +117,11 @@ impl MetricsComponent for Error {
 impl Error {
     #[must_use]
     pub const fn new_with_messages(code: Code, messages: Vec<String>) -> Self {
-        Self { code, messages }
+        Self {
+            code,
+            messages,
+            context: ErrorContext::None,
+        }
     }
 
     #[must_use]
@@ -98,6 +148,13 @@ impl Error {
     #[must_use]
     pub fn append<S: Into<String>>(mut self, msg: S) -> Self {
         self.messages.push(msg.into());
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn with_context(mut self, context: ErrorContext) -> Self {
+        self.context = context;
         self
     }
 
@@ -152,6 +209,7 @@ impl From<nativelink_proto::google::rpc::Status> for Error {
         Self {
             code: val.code.into(),
             messages: vec![val.message],
+            context: ErrorContext::None,
         }
     }
 }
@@ -263,6 +321,7 @@ impl From<std::io::Error> for Error {
         Self {
             code: err.kind().into_code(),
             messages: vec![err.to_string()],
+            context: ErrorContext::None,
         }
     }
 }
@@ -440,6 +499,7 @@ impl<T> ResultExt<T> for Option<T> {
             let mut error = Error {
                 code: Code::Internal,
                 messages: vec![],
+                context: ErrorContext::None,
             };
             let (code, message) = tip_fn(&error);
             error.code = code;

--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -69,7 +69,7 @@ pub enum ErrorContext {
     None,
     /// The error refers to a specific CAS blob that could not be
     /// located. `hash` and `size` together form the digest the client
-    /// should re-upload (REv2 `blobs/{hash}/{size}`).
+    /// should re-upload (`REv2` `blobs/{hash}/{size}`).
     MissingDigest { hash: String, size: i64 },
 }
 

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -47,43 +47,39 @@ use nativelink_util::digest_hasher::{DigestHasherFunc, make_ctx_for_hash_func};
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ClientStateManager, OperationFilter,
 };
+use nativelink_util::precondition_failure;
 use nativelink_util::store_trait::{Store, StoreLike};
 use opentelemetry::context::FutureExt;
 use prost::Message as _;
 use tonic::{Code, Request, Response, Status};
 use tracing::{Instrument, Level, debug, error, error_span, instrument, warn};
 
-/// Inline definition of `google.rpc.PreconditionFailure`. Bazel's
-/// `RemoteSpawnRunner` inspects this proto in the gRPC `Status.details`
-/// of a `FAILED_PRECONDITION` response and, when violations of type
-/// `MISSING` are present, automatically re-uploads the named blobs and
-/// retries the Execute call. Without this detail Bazel surfaces the
-/// failure as a hard build error — exactly the symptom triggered by an
-/// interrupted previous build leaving partial CAS uploads.
-mod precondition_failure {
-    /// `google.rpc.PreconditionFailure`.
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct PreconditionFailure {
-        #[prost(message, repeated, tag = "1")]
-        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
-    }
-    /// `google.rpc.PreconditionFailure.Violation`.
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct Violation {
-        #[prost(string, tag = "1")]
-        pub(super) r#type: ::prost::alloc::string::String,
-        #[prost(string, tag = "2")]
-        pub(super) subject: ::prost::alloc::string::String,
-        #[prost(string, tag = "3")]
-        pub(super) description: ::prost::alloc::string::String,
-    }
-    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
-    pub(super) const VIOLATION_TYPE_MISSING: &str = "MISSING";
+/// Result of a synchronous `Execute` decision before the async
+/// scheduling stream begins. Stream is the happy path; Reject is a
+/// client-facing gRPC `Status` returned without going through NL's
+/// internal Error/instrumentation pipeline.
+enum ExecuteOutcome<S> {
+    Stream(S),
+    Reject(Status),
 }
 
 /// Build a tonic [`Status`] of code `FAILED_PRECONDITION` whose details
 /// carry a `google.rpc.PreconditionFailure` listing the missing CAS
 /// blobs.
+///
+/// The pre-check that calls this is intentionally shallow: it only
+/// validates the top-level Action proto, `command_digest`, and
+/// `input_root_digest`. Nested Directory protos and file contents
+/// under the input root are not walked here — the worker path fetches
+/// those lazily and reports them via the same mechanism (see
+/// `action_messages::to_execute_response`, which dispatches on
+/// `Error::context`).
+///
+/// Race note: the pre-check uses `has_many` then the action is
+/// scheduled; a blob present at check time may be evicted before the
+/// worker fetches it. That case is intentionally not addressed here —
+/// the worker path covers it with the same `FAILED_PRECONDITION`
+/// surfacing, so Bazel retries either way.
 fn missing_blobs_failed_precondition(
     missing: &[(DigestInfo, &'static str)],
     summary: &str,
@@ -320,7 +316,7 @@ impl ExecutionServer {
     async fn inner_execute(
         &self,
         request: ExecuteRequest,
-    ) -> Result<Result<impl Stream<Item = Result<Operation, Status>> + Send + use<>, Status>, Error>
+    ) -> Result<ExecuteOutcome<impl Stream<Item = Result<Operation, Status>> + Send + use<>>, Error>
     {
         let instance_name = request.instance_name;
 
@@ -353,7 +349,7 @@ impl ExecutionServer {
                 let summary = format!(
                     "Action {digest} is missing from CAS; client should re-upload it and retry"
                 );
-                return Ok(Err(missing_blobs_failed_precondition(
+                return Ok(ExecuteOutcome::Reject(missing_blobs_failed_precondition(
                     &[(digest, "Action")],
                     &summary,
                 )));
@@ -408,7 +404,9 @@ impl ExecutionServer {
                     missing.len(),
                     digest,
                 );
-                return Ok(Err(missing_blobs_failed_precondition(&missing, &summary)));
+                return Ok(ExecuteOutcome::Reject(missing_blobs_failed_precondition(
+                    &missing, &summary,
+                )));
             }
         }
 
@@ -432,7 +430,7 @@ impl ExecutionServer {
             .await
             .err_tip(|| "Failed to schedule task")?;
 
-        Ok(Ok(Self::to_execute_stream(
+        Ok(ExecuteOutcome::Stream(Self::to_execute_stream(
             &NativelinkOperationId::new(
                 instance_name,
                 action_listener
@@ -505,8 +503,8 @@ impl Execution for ExecutionServer {
             .err_tip(|| "Failed on execute() command")?;
 
         match result {
-            Ok(stream) => Ok(Response::new(Box::pin(stream))),
-            Err(status) => Err(status),
+            ExecuteOutcome::Stream(stream) => Ok(Response::new(Box::pin(stream))),
+            ExecuteOutcome::Reject(status) => Err(status),
         }
     }
 

--- a/nativelink-service/src/execution_server.rs
+++ b/nativelink-service/src/execution_server.rs
@@ -20,6 +20,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use futures::stream::unfold;
 use futures::{Stream, StreamExt};
 use nativelink_config::cas_server::{ExecutionConfig, InstanceName, WithInstanceName};
@@ -35,6 +36,7 @@ use nativelink_proto::google::longrunning::{
     CancelOperationRequest, DeleteOperationRequest, GetOperationRequest, ListOperationsRequest,
     ListOperationsResponse, Operation, WaitOperationRequest,
 };
+use nativelink_proto::google::rpc::Status as GrpcStatusProto;
 use nativelink_store::ac_utils::get_and_decode_digest;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::action_messages::{
@@ -45,10 +47,86 @@ use nativelink_util::digest_hasher::{DigestHasherFunc, make_ctx_for_hash_func};
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ClientStateManager, OperationFilter,
 };
-use nativelink_util::store_trait::Store;
+use nativelink_util::store_trait::{Store, StoreLike};
 use opentelemetry::context::FutureExt;
-use tonic::{Request, Response, Status};
-use tracing::{Instrument, Level, debug, error, error_span, instrument};
+use prost::Message as _;
+use tonic::{Code, Request, Response, Status};
+use tracing::{Instrument, Level, debug, error, error_span, instrument, warn};
+
+/// Inline definition of `google.rpc.PreconditionFailure`. Bazel's
+/// `RemoteSpawnRunner` inspects this proto in the gRPC `Status.details`
+/// of a `FAILED_PRECONDITION` response and, when violations of type
+/// `MISSING` are present, automatically re-uploads the named blobs and
+/// retries the Execute call. Without this detail Bazel surfaces the
+/// failure as a hard build error — exactly the symptom triggered by an
+/// interrupted previous build leaving partial CAS uploads.
+mod precondition_failure {
+    /// `google.rpc.PreconditionFailure`.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct PreconditionFailure {
+        #[prost(message, repeated, tag = "1")]
+        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
+    }
+    /// `google.rpc.PreconditionFailure.Violation`.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct Violation {
+        #[prost(string, tag = "1")]
+        pub(super) r#type: ::prost::alloc::string::String,
+        #[prost(string, tag = "2")]
+        pub(super) subject: ::prost::alloc::string::String,
+        #[prost(string, tag = "3")]
+        pub(super) description: ::prost::alloc::string::String,
+    }
+    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
+    pub(super) const VIOLATION_TYPE_MISSING: &str = "MISSING";
+}
+
+/// Build a tonic [`Status`] of code `FAILED_PRECONDITION` whose details
+/// carry a `google.rpc.PreconditionFailure` listing the missing CAS
+/// blobs.
+fn missing_blobs_failed_precondition(
+    missing: &[(DigestInfo, &'static str)],
+    summary: &str,
+) -> Status {
+    let pf = precondition_failure::PreconditionFailure {
+        violations: missing
+            .iter()
+            .map(|(d, ctx)| precondition_failure::Violation {
+                r#type: precondition_failure::VIOLATION_TYPE_MISSING.to_string(),
+                // Per REv2, the subject for a missing-blob violation is
+                // `blobs/<hash>/<size>` so the client knows exactly
+                // which digest to re-upload.
+                subject: format!("blobs/{}/{}", d.packed_hash(), d.size_bytes()),
+                description: (*ctx).to_string(),
+            })
+            .collect(),
+    };
+
+    // Wrap PreconditionFailure into a google.protobuf.Any.
+    let mut pf_buf: Vec<u8> = Vec::with_capacity(pf.encoded_len());
+    pf.encode(&mut pf_buf)
+        .expect("encoding prost message into Vec<u8> cannot fail");
+    let any = prost_types::Any {
+        type_url: precondition_failure::TYPE_URL.to_string(),
+        value: pf_buf,
+    };
+
+    let status_proto = GrpcStatusProto {
+        code: Code::FailedPrecondition as i32,
+        message: summary.to_string(),
+        details: vec![any],
+    };
+    let mut status_buf: Vec<u8> = Vec::with_capacity(status_proto.encoded_len());
+    status_proto
+        .encode(&mut status_buf)
+        .expect("encoding prost message into Vec<u8> cannot fail");
+
+    Status::with_details(
+        Code::FailedPrecondition,
+        summary.to_string(),
+        Bytes::from(status_buf),
+    )
+}
 
 type InstanceInfoName = String;
 
@@ -242,7 +320,8 @@ impl ExecutionServer {
     async fn inner_execute(
         &self,
         request: ExecuteRequest,
-    ) -> Result<impl Stream<Item = Result<Operation, Status>> + Send + use<>, Error> {
+    ) -> Result<Result<impl Stream<Item = Result<Operation, Status>> + Send + use<>, Status>, Error>
+    {
         let instance_name = request.instance_name;
 
         let instance_info = self
@@ -261,8 +340,78 @@ impl ExecutionServer {
             .execution_policy
             .map_or(DEFAULT_EXECUTION_PRIORITY, |p| p.priority);
 
-        let action =
-            get_and_decode_digest::<Action>(&instance_info.cas_store, digest.into()).await?;
+        let action = match get_and_decode_digest::<Action>(&instance_info.cas_store, digest.into())
+            .await
+        {
+            Ok(a) => a,
+            Err(e) if e.code == Code::NotFound => {
+                warn!(
+                    %digest,
+                    %e,
+                    "Execute: Action proto missing from CAS; returning FAILED_PRECONDITION with PreconditionFailure detail so Bazel can re-upload"
+                );
+                let summary = format!(
+                    "Action {digest} is missing from CAS; client should re-upload it and retry"
+                );
+                return Ok(Err(missing_blobs_failed_precondition(
+                    &[(digest, "Action")],
+                    &summary,
+                )));
+            }
+            Err(e) => return Err(e).err_tip(|| "Decoding Action proto in Execute")?,
+        };
+
+        let action_command_digest = action
+            .command_digest
+            .as_ref()
+            .map(|d| DigestInfo::try_from(d.clone()))
+            .transpose()
+            .err_tip(|| "Failed to parse command_digest from Action")?;
+        let action_input_root_digest = action
+            .input_root_digest
+            .as_ref()
+            .map(|d| DigestInfo::try_from(d.clone()))
+            .transpose()
+            .err_tip(|| "Failed to parse input_root_digest from Action")?;
+        let mut blobs_to_check: Vec<DigestInfo> = Vec::with_capacity(2);
+        if let Some(d) = action_command_digest {
+            blobs_to_check.push(d);
+        }
+        if let Some(d) = action_input_root_digest {
+            blobs_to_check.push(d);
+        }
+        if !blobs_to_check.is_empty() {
+            let store_keys: Vec<_> = blobs_to_check.iter().map(|d| (*d).into()).collect();
+            let sizes = instance_info
+                .cas_store
+                .has_many(&store_keys)
+                .await
+                .err_tip(|| "Validating Action input blobs in CAS")?;
+            let mut missing: Vec<(DigestInfo, &'static str)> = Vec::new();
+            for ((digest, present), label) in blobs_to_check
+                .iter()
+                .zip(sizes.iter())
+                .zip(["Action.command_digest", "Action.input_root_digest"].iter())
+            {
+                if present.is_none() {
+                    missing.push((*digest, label));
+                }
+            }
+            if !missing.is_empty() {
+                warn!(
+                    ?missing,
+                    %digest,
+                    "Execute pre-check found missing CAS blobs; returning FAILED_PRECONDITION with PreconditionFailure detail so Bazel can re-upload"
+                );
+                let summary = format!(
+                    "{} CAS blob(s) referenced by action {} are missing; client should re-upload them and retry",
+                    missing.len(),
+                    digest,
+                );
+                return Ok(Err(missing_blobs_failed_precondition(&missing, &summary)));
+            }
+        }
+
         let action_info = instance_info
             .build_action_info(
                 instance_name.clone(),
@@ -283,7 +432,7 @@ impl ExecutionServer {
             .await
             .err_tip(|| "Failed to schedule task")?;
 
-        Ok(Box::pin(Self::to_execute_stream(
+        Ok(Ok(Self::to_execute_stream(
             &NativelinkOperationId::new(
                 instance_name,
                 action_listener
@@ -355,7 +504,10 @@ impl Execution for ExecutionServer {
             .await
             .err_tip(|| "Failed on execute() command")?;
 
-        Ok(Response::new(Box::pin(result)))
+        match result {
+            Ok(stream) => Ok(Response::new(Box::pin(stream))),
+            Err(status) => Err(status),
+        }
     }
 
     #[instrument(

--- a/nativelink-service/tests/execution_server_test.rs
+++ b/nativelink-service/tests/execution_server_test.rs
@@ -23,25 +23,54 @@ use nativelink_config::stores::{MemorySpec, StoreSpec};
 use nativelink_error::{Code, Error, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::execution_server::Execution;
-use nativelink_proto::build::bazel::remote::execution::v2::{ExecuteRequest, digest_function};
+use nativelink_proto::build::bazel::remote::execution::v2::{
+    Action, ExecuteRequest, digest_function,
+};
 use nativelink_proto::google::longrunning::operations_server::Operations;
 use nativelink_proto::google::longrunning::{
     CancelOperationRequest, DeleteOperationRequest, GetOperationRequest, ListOperationsRequest,
     WaitOperationRequest,
 };
+use nativelink_proto::google::rpc::Status as GrpcStatusProto;
 use nativelink_scheduler::mock_scheduler::MockActionScheduler;
 use nativelink_service::execution_server::ExecutionServer;
+use nativelink_store::ac_utils::serialize_and_upload_message;
 use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
 use nativelink_util::action_messages::{
     ActionInfo, ActionResult, ActionStage, ActionState, OperationId,
 };
 use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager,
 };
 use nativelink_util::origin_event::OriginMetadata;
-use tonic::Request;
+use nativelink_util::store_trait::StoreLike;
+use prost::Message as _;
+use tonic::{Code as TonicCode, Request};
+
+/// Local mirror of `google.rpc.PreconditionFailure`, kept here so this
+/// integration test can decode the detail bytes that `ExecutionServer`
+/// places in `grpc-status-details-bin` without depending on the inline
+/// definition inside `execution_server.rs` (which is mod-private).
+mod precondition_failure {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct PreconditionFailure {
+        #[prost(message, repeated, tag = "1")]
+        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct Violation {
+        #[prost(string, tag = "1")]
+        pub(super) r#type: ::prost::alloc::string::String,
+        #[prost(string, tag = "2")]
+        pub(super) subject: ::prost::alloc::string::String,
+        #[prost(string, tag = "3")]
+        pub(super) description: ::prost::alloc::string::String,
+    }
+    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
+}
 
 const INSTANCE_NAME: &str = "instance_name";
 
@@ -327,6 +356,193 @@ impl ActionStateResult for TimeoutActionStateResult {
             "as_action_info not implemented"
         ))
     }
+}
+
+/// Encodes a digest into the `REv2` missing-blob subject format.
+fn blob_subject(d: &DigestInfo) -> String {
+    format!("blobs/{}/{}", d.packed_hash(), d.size_bytes())
+}
+
+/// Decode the `FAILED_PRECONDITION` detail bytes that the server placed
+/// in `grpc-status-details-bin`. Returns the inner `PreconditionFailure`.
+fn decode_precondition_failure(
+    status: &tonic::Status,
+) -> Result<precondition_failure::PreconditionFailure, Box<dyn core::error::Error>> {
+    let outer = GrpcStatusProto::decode(status.details())?;
+    assert_eq!(
+        outer.code,
+        TonicCode::FailedPrecondition as i32,
+        "inner google.rpc.Status code should match the tonic FAILED_PRECONDITION",
+    );
+    assert_eq!(outer.details.len(), 1, "expected exactly one detail");
+    assert_eq!(
+        outer.details[0].type_url,
+        precondition_failure::TYPE_URL,
+        "detail type_url must match PreconditionFailure",
+    );
+    Ok(precondition_failure::PreconditionFailure::decode(
+        &*outer.details[0].value,
+    )?)
+}
+
+async fn upload_action(
+    cas_store: &nativelink_util::store_trait::Store,
+    action: &Action,
+) -> Result<DigestInfo, Error> {
+    serialize_and_upload_message(
+        action,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await
+}
+
+const fn make_fake_digest(byte: u8, size: u64) -> DigestInfo {
+    DigestInfo::new([byte; 32], size)
+}
+
+fn make_execute_request(action_digest: DigestInfo) -> ExecuteRequest {
+    ExecuteRequest {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: digest_function::Value::Sha256.into(),
+        skip_cache_lookup: false,
+        action_digest: Some(action_digest.into()),
+        execution_policy: None,
+        results_cache_policy: None,
+    }
+}
+
+#[nativelink_test]
+async fn execute_missing_action_returns_precondition_failure()
+-> Result<(), Box<dyn core::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let (execution_server, _) = make_execution_server(&store_manager)?;
+
+    let action_digest = make_fake_digest(0xaa, 16);
+
+    let Err(status) = execution_server
+        .execute(Request::new(make_execute_request(action_digest)))
+        .await
+    else {
+        panic!("execute should fail when the Action is missing");
+    };
+
+    assert_eq!(status.code(), TonicCode::FailedPrecondition);
+    let pf = decode_precondition_failure(&status)?;
+    assert_eq!(pf.violations.len(), 1);
+    let v = &pf.violations[0];
+    assert_eq!(v.r#type, "MISSING");
+    assert_eq!(v.subject, blob_subject(&action_digest));
+    assert_eq!(v.description, "Action");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn execute_missing_command_returns_precondition_failure()
+-> Result<(), Box<dyn core::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let (execution_server, _) = make_execution_server(&store_manager)?;
+    let cas_store = store_manager.get_store("main_cas").unwrap();
+
+    let command_digest = make_fake_digest(0xc1, 8);
+    let input_root = Action::default();
+    let input_root_digest = upload_action(&cas_store, &input_root).await?;
+
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = upload_action(&cas_store, &action).await?;
+
+    let Err(status) = execution_server
+        .execute(Request::new(make_execute_request(action_digest)))
+        .await
+    else {
+        panic!("execute should fail when command_digest is missing");
+    };
+
+    assert_eq!(status.code(), TonicCode::FailedPrecondition);
+    let pf = decode_precondition_failure(&status)?;
+    assert_eq!(pf.violations.len(), 1);
+    assert_eq!(pf.violations[0].r#type, "MISSING");
+    assert_eq!(pf.violations[0].subject, blob_subject(&command_digest));
+    assert_eq!(pf.violations[0].description, "Action.command_digest");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn execute_missing_input_root_returns_precondition_failure()
+-> Result<(), Box<dyn core::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let (execution_server, _) = make_execution_server(&store_manager)?;
+    let cas_store = store_manager.get_store("main_cas").unwrap();
+
+    // Upload command, omit input_root.
+    let command_proto = nativelink_proto::build::bazel::remote::execution::v2::Command::default();
+    let command_digest = serialize_and_upload_message(
+        &command_proto,
+        cas_store.as_pin(),
+        &mut DigestHasherFunc::Sha256.hasher(),
+    )
+    .await?;
+    let input_root_digest = make_fake_digest(0xd2, 16);
+
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = upload_action(&cas_store, &action).await?;
+
+    let Err(status) = execution_server
+        .execute(Request::new(make_execute_request(action_digest)))
+        .await
+    else {
+        panic!("execute should fail when input_root_digest is missing");
+    };
+
+    assert_eq!(status.code(), TonicCode::FailedPrecondition);
+    let pf = decode_precondition_failure(&status)?;
+    assert_eq!(pf.violations.len(), 1);
+    assert_eq!(pf.violations[0].r#type, "MISSING");
+    assert_eq!(pf.violations[0].subject, blob_subject(&input_root_digest));
+    assert_eq!(pf.violations[0].description, "Action.input_root_digest");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn execute_missing_command_and_input_root_returns_both_violations()
+-> Result<(), Box<dyn core::error::Error>> {
+    let store_manager = make_store_manager().await?;
+    let (execution_server, _) = make_execution_server(&store_manager)?;
+    let cas_store = store_manager.get_store("main_cas").unwrap();
+
+    let command_digest = make_fake_digest(0xe3, 8);
+    let input_root_digest = make_fake_digest(0xf4, 16);
+
+    let action = Action {
+        command_digest: Some(command_digest.into()),
+        input_root_digest: Some(input_root_digest.into()),
+        ..Default::default()
+    };
+    let action_digest = upload_action(&cas_store, &action).await?;
+
+    let Err(status) = execution_server
+        .execute(Request::new(make_execute_request(action_digest)))
+        .await
+    else {
+        panic!("execute should fail when both blobs are missing");
+    };
+
+    assert_eq!(status.code(), TonicCode::FailedPrecondition);
+    let pf = decode_precondition_failure(&status)?;
+    assert_eq!(pf.violations.len(), 2);
+    assert_eq!(pf.violations[0].subject, blob_subject(&command_digest));
+    assert_eq!(pf.violations[0].description, "Action.command_digest");
+    assert_eq!(pf.violations[1].subject, blob_subject(&input_root_digest));
+    assert_eq!(pf.violations[1].description, "Action.input_root_digest");
+    Ok(())
 }
 
 #[nativelink_test]

--- a/nativelink-service/tests/execution_server_test.rs
+++ b/nativelink-service/tests/execution_server_test.rs
@@ -46,31 +46,10 @@ use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager,
 };
 use nativelink_util::origin_event::OriginMetadata;
+use nativelink_util::precondition_failure;
 use nativelink_util::store_trait::StoreLike;
 use prost::Message as _;
 use tonic::{Code as TonicCode, Request};
-
-/// Local mirror of `google.rpc.PreconditionFailure`, kept here so this
-/// integration test can decode the detail bytes that `ExecutionServer`
-/// places in `grpc-status-details-bin` without depending on the inline
-/// definition inside `execution_server.rs` (which is mod-private).
-mod precondition_failure {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct PreconditionFailure {
-        #[prost(message, repeated, tag = "1")]
-        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
-    }
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct Violation {
-        #[prost(string, tag = "1")]
-        pub(super) r#type: ::prost::alloc::string::String,
-        #[prost(string, tag = "2")]
-        pub(super) subject: ::prost::alloc::string::String,
-        #[prost(string, tag = "3")]
-        pub(super) description: ::prost::alloc::string::String,
-    }
-    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
-}
 
 const INSTANCE_NAME: &str = "instance_name";
 

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, Weak};
 use async_trait::async_trait;
 use futures::{FutureExt, join};
 use nativelink_config::stores::{FastSlowSpec, StoreDirection};
-use nativelink_error::{Code, Error, ResultExt, make_err};
+use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
 use nativelink_metric::MetricsComponent;
 use nativelink_util::buf_channel::{
     DropCloserReadHalf, DropCloserWriteHalf, make_buf_channel_pair,
@@ -191,12 +191,20 @@ impl FastSlowStore {
                     .await
                     .err_tip(|| "Failed to run has() on slow store")?
                     .ok_or_else(|| {
-                        make_err!(
+                        let err = make_err!(
                             Code::NotFound,
                             "Object {} not found in either fast or slow store. \
                                 If using multiple workers, ensure all workers share the same CAS storage path.",
                             key.as_str()
-                        )
+                        );
+                        if let StoreKey::Digest(d) = key.borrow() {
+                            err.with_context(ErrorContext::MissingDigest {
+                                hash: d.packed_hash().to_string(),
+                                size: d.size_bytes() as i64,
+                            })
+                        } else {
+                            err
+                        }
                     })?
             )
         };

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1813,22 +1813,25 @@ where
                         result => (connection_manager, result),
                     };
 
-                let create_result = match result {
-                    Ok(()) => Ok(()),
-                    Err(ref e)
-                        if e.kind() == redis::ErrorKind::Extension
-                            && e.code() == Some("Index")
-                            && e.detail() == Some("already exists") =>
-                    {
+                // RediSearch returns ErrorKind::Extension with code "Index"
+                // and detail along the lines of "Index already exists" when
+                // FT.CREATE races with another node.
+                let create_result = result.or_else(|e| {
+                    let is_already_exists = e.kind() == redis::ErrorKind::Extension
+                        && e.code() == Some("Index")
+                        && e.detail()
+                            .is_some_and(|d| d.to_ascii_lowercase().contains("already exists"));
+                    if is_already_exists {
                         Ok(())
+                    } else {
+                        Err(e).err_tip(|| {
+                            format!(
+                                "Error with ft_create in RedisStore::search_by_index_prefix({})",
+                                get_index_name!(K::KEY_PREFIX, K::INDEX_NAME, K::MAYBE_SORT_KEY),
+                            )
+                        })
                     }
-                    Err(_) => result.err_tip(|| {
-                        format!(
-                            "Error with ft_create in RedisStore::search_by_index_prefix({})",
-                            get_index_name!(K::KEY_PREFIX, K::INDEX_NAME, K::MAYBE_SORT_KEY),
-                        )
-                    }),
-                };
+                });
 
                 let run_result = run_ft_aggregate(connection_manager).await.err_tip(|| {
                     format!(

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1812,12 +1812,23 @@ where
                         }
                         result => (connection_manager, result),
                     };
-                let create_result = result.err_tip(|| {
-                    format!(
-                        "Error with ft_create in RedisStore::search_by_index_prefix({})",
-                        get_index_name!(K::KEY_PREFIX, K::INDEX_NAME, K::MAYBE_SORT_KEY),
-                    )
-                });
+
+                let create_result = match result {
+                    Ok(()) => Ok(()),
+                    Err(ref e)
+                        if e.kind() == redis::ErrorKind::Extension
+                            && e.code() == Some("Index")
+                            && e.detail() == Some("already exists") =>
+                    {
+                        Ok(())
+                    }
+                    Err(_) => result.err_tip(|| {
+                        format!(
+                            "Error with ft_create in RedisStore::search_by_index_prefix({})",
+                            get_index_name!(K::KEY_PREFIX, K::INDEX_NAME, K::MAYBE_SORT_KEY),
+                        )
+                    }),
+                };
 
                 let run_result = run_ft_aggregate(connection_manager).await.err_tip(|| {
                     format!(

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -28,7 +28,7 @@ use futures::executor::block_on;
 use futures::task::Poll;
 use futures::{Future, FutureExt, poll};
 use nativelink_config::stores::{EvictionPolicy, FilesystemSpec};
-use nativelink_error::{Code, Error, ResultExt, make_err};
+use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_store::filesystem_store::{
     DIGEST_FOLDER, EncodedFilePath, FileEntry, FileEntryImpl, FileType, FilesystemStore,
@@ -1458,6 +1458,7 @@ async fn safe_small_safe_eviction() -> Result<(), Error> {
             messages: vec![format!(
                 "{VALID_HASH}-{bytes} not found in filesystem store here"
             )],
+            context: ErrorContext::None,
         }),
         "Expected data to not exist in store, because eviction"
     );

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -40,7 +40,7 @@ use nativelink_util::store_trait::{
     StoreLike, TrueValue, UploadSizeInfo,
 };
 use pretty_assertions::assert_eq;
-use redis::{PushInfo, RedisError, Value};
+use redis::{PushInfo, RedisError, Value, make_extension_error};
 use redis_test::{MockCmd, MockRedisConnection};
 use tokio::time::{sleep, timeout};
 use tracing::{Instrument, info, info_span};
@@ -1128,6 +1128,170 @@ fn test_search_by_index_failure() -> Result<(), Error> {
     assert!(logs_contain(
         "Error calling ft.aggregate e=TEST - Client: unexpected command index=\"test:_content_prefix_sort_key_3e762c15\" query=\"*\" options=FtAggregateOptions { load: [\"data\", \"version\"], cursor: FtAggregateCursor { count: 1500, max_idle: 30000 }, sort_by: [\"@sort_key\"] } all_args=[\"FT.AGGREGATE\", \"test:_content_prefix_sort_key_3e762c15\", \"*\", \"LOAD\", \"2\", \"data\", \"version\", \"WITHCURSOR\", \"COUNT\", \"1500\", \"MAXIDLE\", \"30000\", \"SORTBY\", \"2\", \"@sort_key\", \"ASC\"]"
     ));
+
+    Ok(())
+}
+
+/// When `ft_create` races a parallel caller, `RediSearch` returns an
+/// Extension-kind error with code="Index" and detail="already exists".
+/// That outcome is benign — the index is in place, which is the only
+/// postcondition we care about. The race-loser's error must not pollute
+/// the merged error surfaced when the second `ft_aggregate` also fails.
+#[nativelink_test]
+fn test_search_by_index_swallows_already_exists_from_ft_create() -> Result<(), Error> {
+    fn make_ft_aggregate() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.AGGREGATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("@content_prefix:{ Searchable }")
+                .arg("LOAD")
+                .arg(2)
+                .arg("data")
+                .arg("version")
+                .arg("WITHCURSOR")
+                .arg("COUNT")
+                .arg(1500)
+                .arg("MAXIDLE")
+                .arg(30000)
+                .arg("SORTBY")
+                .arg(2usize)
+                .arg("@sort_key")
+                .arg("ASC"),
+            Err::<Value, _>(make_extension_error(
+                "BUSY".to_string(),
+                Some("Redis is busy running a script".to_string()),
+            )),
+        )
+    }
+    fn make_ft_create_already_exists() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.CREATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("ON")
+                .arg("HASH")
+                .arg("NOHL")
+                .arg("NOFIELDS")
+                .arg("NOFREQS")
+                .arg("NOOFFSETS")
+                .arg("TEMPORARY")
+                .arg(86400)
+                .arg("PREFIX")
+                .arg(1)
+                .arg("test:")
+                .arg("SCHEMA")
+                .arg("content_prefix")
+                .arg("TAG")
+                .arg("sort_key")
+                .arg("TAG")
+                .arg("SORTABLE"),
+            Err::<Value, _>(make_extension_error(
+                "Index".to_string(),
+                Some("already exists".to_string()),
+            )),
+        )
+    }
+
+    let commands = vec![
+        make_ft_aggregate(),
+        make_ft_create_already_exists(),
+        make_ft_aggregate(),
+    ];
+    let store = make_mock_store(commands).await;
+    let search_provider = SearchByContentPrefix {
+        prefix: "Searchable".to_string(),
+    };
+
+    let Err(error) = store.search_by_index_prefix(search_provider).await else {
+        panic!("Expected error from the second ft_aggregate");
+    };
+
+    let formatted = format!("{error}");
+    assert!(
+        !formatted.contains("already exists"),
+        "merged error must not carry the swallowed ft_create noise; got: {formatted}",
+    );
+    assert!(
+        formatted.contains("second ft_aggregate"),
+        "merged error must carry the second ft_aggregate failure context; got: {formatted}",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+fn test_search_by_index_preserves_other_ft_create_errors() -> Result<(), Error> {
+    fn make_ft_aggregate() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.AGGREGATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("@content_prefix:{ Searchable }")
+                .arg("LOAD")
+                .arg(2)
+                .arg("data")
+                .arg("version")
+                .arg("WITHCURSOR")
+                .arg("COUNT")
+                .arg(1500)
+                .arg("MAXIDLE")
+                .arg(30000)
+                .arg("SORTBY")
+                .arg(2usize)
+                .arg("@sort_key")
+                .arg("ASC"),
+            Err::<Value, _>(make_extension_error(
+                "BUSY".to_string(),
+                Some("Redis is busy running a script".to_string()),
+            )),
+        )
+    }
+    fn make_ft_create_other_error() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.CREATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("ON")
+                .arg("HASH")
+                .arg("NOHL")
+                .arg("NOFIELDS")
+                .arg("NOFREQS")
+                .arg("NOOFFSETS")
+                .arg("TEMPORARY")
+                .arg(86400)
+                .arg("PREFIX")
+                .arg(1)
+                .arg("test:")
+                .arg("SCHEMA")
+                .arg("content_prefix")
+                .arg("TAG")
+                .arg("sort_key")
+                .arg("TAG")
+                .arg("SORTABLE"),
+            // A genuinely surprising ft_create failure that must not be
+            // swallowed by the new typed match.
+            Err::<Value, _>(make_extension_error(
+                "PERM".to_string(),
+                Some("no permission".to_string()),
+            )),
+        )
+    }
+
+    let commands = vec![
+        make_ft_aggregate(),
+        make_ft_create_other_error(),
+        make_ft_aggregate(),
+    ];
+    let store = make_mock_store(commands).await;
+    let search_provider = SearchByContentPrefix {
+        prefix: "Searchable".to_string(),
+    };
+
+    let Err(error) = store.search_by_index_prefix(search_provider).await else {
+        panic!("Expected error");
+    };
+    let formatted = format!("{error}");
+    assert!(
+        formatted.contains("PERM") || formatted.contains("no permission"),
+        "merged error must include the real ft_create failure context; got: {formatted}",
+    );
 
     Ok(())
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use bytes::{Bytes, BytesMut};
 use futures::TryStreamExt;
 use nativelink_config::stores::{RedisMode, RedisSpec};
-use nativelink_error::{Code, Error, ResultExt, make_err};
+use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_redis_tester::{
     ReadOnlyRedis, add_lua_script, add_to_response, fake_redis_sentinel_master_stream,
@@ -642,7 +642,8 @@ fn test_connection_errors() {
             messages: vec![
                 "Io: timed out".into(),
                 format!("While connecting to redis with url: redis://nativelink.com:6379/")
-            ]
+            ],
+            context: ErrorContext::None,
         },
         err
     );
@@ -741,7 +742,8 @@ async fn test_sentinel_connect_with_bad_master() {
             messages: vec![
                 "MasterNameNotFoundBySentinel: Master with given name not found in sentinel - MasterNameNotFoundBySentinel".into(),
                 format!("While connecting to redis with url: redis+sentinel://127.0.0.1:{port}/")
-            ]
+            ],
+            context: ErrorContext::None,
         },
         RedisStore::new_standard(spec).await.unwrap_err()
     );
@@ -863,7 +865,8 @@ async fn test_redis_connect_timeout() {
             messages: vec![
                 "Io: timed out".into(),
                 format!("While connecting to redis with url: redis://127.0.0.1:{port}/")
-            ]
+            ],
+            context: ErrorContext::None,
         },
         RedisStore::new_standard(spec).await.unwrap_err()
     );

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -31,6 +31,7 @@ rust_library(
         "src/origin_event.rs",
         "src/origin_event_publisher.rs",
         "src/platform_properties.rs",
+        "src/precondition_failure.rs",
         "src/proto_stream_utils.rs",
         "src/resource_info.rs",
         "src/retry.rs",

--- a/nativelink-util/BUILD.bazel
+++ b/nativelink-util/BUILD.bazel
@@ -137,6 +137,8 @@ rust_test_suite(
         "@crates//:opentelemetry-http",
         "@crates//:parking_lot",
         "@crates//:pretty_assertions",
+        "@crates//:prost",
+        "@crates//:prost-types",
         "@crates//:rand",
         "@crates//:serde_json",
         "@crates//:sha2",

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use humantime::format_duration;
-use nativelink_error::{Error, ResultExt, error_if, make_input_err};
+use nativelink_error::{Error, ErrorContext, ResultExt, error_if, make_input_err};
 use nativelink_metric::{
     MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent, publish,
 };
@@ -843,48 +843,14 @@ impl From<&ActionStage> for execution_stage::Value {
     }
 }
 
-/// `google.rpc.PreconditionFailure` (defined inline to avoid pulling
-/// `tonic-types` and the additional proto-generated module). Bazel's
-/// `RemoteExecutionService` reads this proto out of
-/// `ExecuteResponse.status.details` for `FAILED_PRECONDITION` results
-/// and, for `MISSING` violations, automatically re-uploads the named
-/// blobs and retries the Execute call. Mirrors the schema in
-/// `google/rpc/error_details.proto`.
-mod precondition_failure {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct PreconditionFailure {
-        #[prost(message, repeated, tag = "1")]
-        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
-    }
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct Violation {
-        #[prost(string, tag = "1")]
-        pub(super) r#type: ::prost::alloc::string::String,
-        #[prost(string, tag = "2")]
-        pub(super) subject: ::prost::alloc::string::String,
-        #[prost(string, tag = "3")]
-        pub(super) description: ::prost::alloc::string::String,
-    }
-    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
-    pub(super) const VIOLATION_TYPE_MISSING: &str = "MISSING";
-}
+use crate::precondition_failure;
 
-const MISSING_BLOB_MARKER: &str = "not found in either fast or slow store";
-
-fn extract_missing_blob_digest(err: &Error) -> Option<(String, i64)> {
-    for msg in &err.messages {
-        if !msg.contains(MISSING_BLOB_MARKER) {
-            continue;
-        }
-        let after_object = msg.find("Object ").map(|i| &msg[i + "Object ".len()..])?;
-        let digest_str = after_object.split(" not found").next()?;
-        let (hash, size) = digest_str.rsplit_once('-')?;
-        let size: i64 = size.parse().ok()?;
-        return Some((hash.to_string(), size));
-    }
-    None
-}
-
+/// Build a `google.rpc.Status` of code `FAILED_PRECONDITION` whose
+/// details carry a `PreconditionFailure` naming the missing blob.
+///
+/// This is the worker-side counterpart to `execution_server`'s
+/// `missing_blobs_failed_precondition` — both produce the REv2
+/// subject format `blobs/{hash}/{size}` that Bazel auto-retries on.
 fn missing_blob_failed_precondition_status(err: &Error, hash: &str, size: i64) -> Status {
     let pf = precondition_failure::PreconditionFailure {
         violations: vec![precondition_failure::Violation {
@@ -931,16 +897,21 @@ pub fn to_execute_response(action_result: ActionResult) -> ExecuteResponse {
     // `PreconditionFailure` detail naming the digest. Bazel sees the
     // detail, re-uploads the missing blob, and retries automatically;
     // without the detail it gives up and the build fails.
+    //
+    // The dispatch is on `Error::context` (typed metadata attached at
+    // the production site in `fast_slow_store`), not the message text.
+    // String-matching across crate boundaries silently regresses when
+    // the producing crate reformats its error — see commit history.
     let status = Some(
         action_result
             .error
             .clone()
-            .map(|err| {
-                if let Some((hash, size)) = extract_missing_blob_digest(&err) {
+            .map(|err| match &err.context {
+                ErrorContext::MissingDigest { hash, size } => {
+                    let (hash, size) = (hash.clone(), *size);
                     missing_blob_failed_precondition_status(&err, &hash, size)
-                } else {
-                    err.into()
                 }
+                ErrorContext::None => err.into(),
             })
             .unwrap_or_default(),
     );

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -849,7 +849,7 @@ use crate::precondition_failure;
 /// details carry a `PreconditionFailure` naming the missing blob.
 ///
 /// This is the worker-side counterpart to `execution_server`'s
-/// `missing_blobs_failed_precondition` — both produce the REv2
+/// `missing_blobs_failed_precondition` — both produce the `REv2`
 /// subject format `blobs/{hash}/{size}` that Bazel auto-retries on.
 fn missing_blob_failed_precondition_status(err: &Error, hash: &str, size: i64) -> Status {
     let pf = precondition_failure::PreconditionFailure {

--- a/nativelink-util/src/action_messages.rs
+++ b/nativelink-util/src/action_messages.rs
@@ -843,6 +843,71 @@ impl From<&ActionStage> for execution_stage::Value {
     }
 }
 
+/// `google.rpc.PreconditionFailure` (defined inline to avoid pulling
+/// `tonic-types` and the additional proto-generated module). Bazel's
+/// `RemoteExecutionService` reads this proto out of
+/// `ExecuteResponse.status.details` for `FAILED_PRECONDITION` results
+/// and, for `MISSING` violations, automatically re-uploads the named
+/// blobs and retries the Execute call. Mirrors the schema in
+/// `google/rpc/error_details.proto`.
+mod precondition_failure {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct PreconditionFailure {
+        #[prost(message, repeated, tag = "1")]
+        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct Violation {
+        #[prost(string, tag = "1")]
+        pub(super) r#type: ::prost::alloc::string::String,
+        #[prost(string, tag = "2")]
+        pub(super) subject: ::prost::alloc::string::String,
+        #[prost(string, tag = "3")]
+        pub(super) description: ::prost::alloc::string::String,
+    }
+    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
+    pub(super) const VIOLATION_TYPE_MISSING: &str = "MISSING";
+}
+
+const MISSING_BLOB_MARKER: &str = "not found in either fast or slow store";
+
+fn extract_missing_blob_digest(err: &Error) -> Option<(String, i64)> {
+    for msg in &err.messages {
+        if !msg.contains(MISSING_BLOB_MARKER) {
+            continue;
+        }
+        let after_object = msg.find("Object ").map(|i| &msg[i + "Object ".len()..])?;
+        let digest_str = after_object.split(" not found").next()?;
+        let (hash, size) = digest_str.rsplit_once('-')?;
+        let size: i64 = size.parse().ok()?;
+        return Some((hash.to_string(), size));
+    }
+    None
+}
+
+fn missing_blob_failed_precondition_status(err: &Error, hash: &str, size: i64) -> Status {
+    let pf = precondition_failure::PreconditionFailure {
+        violations: vec![precondition_failure::Violation {
+            r#type: precondition_failure::VIOLATION_TYPE_MISSING.to_string(),
+            // REv2-mandated subject format for missing-blob violations.
+            subject: format!("blobs/{hash}/{size}"),
+            description: err.message_string(),
+        }],
+    };
+    let mut buf: Vec<u8> = Vec::with_capacity(pf.encoded_len());
+    pf.encode(&mut buf)
+        .expect("encoding prost message into Vec<u8> cannot fail");
+    let any = Any {
+        type_url: precondition_failure::TYPE_URL.to_string(),
+        value: buf,
+    };
+    Status {
+        code: Code::FailedPrecondition as i32,
+        message: err.message_string(),
+        details: vec![any],
+    }
+}
+
 pub fn to_execute_response(action_result: ActionResult) -> ExecuteResponse {
     fn logs_from(server_logs: HashMap<String, DigestInfo>) -> HashMap<String, LogFile> {
         let mut logs = HashMap::with_capacity(server_logs.len());
@@ -858,11 +923,26 @@ pub fn to_execute_response(action_result: ActionResult) -> ExecuteResponse {
         logs
     }
 
+    // If the action failed because a CAS blob is missing — most often a
+    // `Directory` proto in the input tree (the Execute pre-check only
+    // validates the top-level Action, command_digest, and
+    // input_root_digest; nested Directories are fetched lazily by the
+    // worker) — surface the failure as `FAILED_PRECONDITION` with a
+    // `PreconditionFailure` detail naming the digest. Bazel sees the
+    // detail, re-uploads the missing blob, and retries automatically;
+    // without the detail it gives up and the build fails.
     let status = Some(
         action_result
             .error
             .clone()
-            .map_or_else(Status::default, Into::into),
+            .map(|err| {
+                if let Some((hash, size)) = extract_missing_blob_digest(&err) {
+                    missing_blob_failed_precondition_status(&err, &hash, size)
+                } else {
+                    err.into()
+                }
+            })
+            .unwrap_or_default(),
     );
     let message = action_result.message.clone();
     ExecuteResponse {

--- a/nativelink-util/src/lib.rs
+++ b/nativelink-util/src/lib.rs
@@ -32,6 +32,7 @@ pub mod operation_state_manager;
 pub mod origin_event;
 pub mod origin_event_publisher;
 pub mod platform_properties;
+pub mod precondition_failure;
 pub mod proto_stream_utils;
 pub mod resource_info;
 pub mod retry;

--- a/nativelink-util/src/precondition_failure.rs
+++ b/nativelink-util/src/precondition_failure.rs
@@ -30,7 +30,7 @@ pub struct PreconditionFailure {
 }
 
 /// `google.rpc.PreconditionFailure.Violation`.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Eq, PartialEq, ::prost::Message)]
 pub struct Violation {
     #[prost(string, tag = "1")]
     pub r#type: ::prost::alloc::string::String,

--- a/nativelink-util/src/precondition_failure.rs
+++ b/nativelink-util/src/precondition_failure.rs
@@ -1,0 +1,44 @@
+// Copyright 2024 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    See LICENSE file for details
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Inline definition of `google.rpc.PreconditionFailure`.
+//!
+//! Bazel's `RemoteSpawnRunner` reads this proto out of an
+//! `ExecuteResponse.status.details` (or, for synchronous Execute
+//! errors, the gRPC `Status.details` carried via
+//! `grpc-status-details-bin`) of a `FAILED_PRECONDITION` response
+//! and, for violations of type `MISSING`, automatically re-uploads
+//! the named blobs and retries the Execute call. Without this detail
+//! Bazel surfaces the failure as a hard build error.
+
+/// `google.rpc.PreconditionFailure`.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreconditionFailure {
+    #[prost(message, repeated, tag = "1")]
+    pub violations: ::prost::alloc::vec::Vec<Violation>,
+}
+
+/// `google.rpc.PreconditionFailure.Violation`.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Violation {
+    #[prost(string, tag = "1")]
+    pub r#type: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub subject: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub description: ::prost::alloc::string::String,
+}
+
+pub const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
+pub const VIOLATION_TYPE_MISSING: &str = "MISSING";

--- a/nativelink-util/tests/action_messages_test.rs
+++ b/nativelink-util/tests/action_messages_test.rs
@@ -1,8 +1,39 @@
+use std::collections::HashMap;
+use std::time::SystemTime;
+
 use hex::FromHex;
+use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
-use nativelink_util::action_messages::{ActionInfo, ActionUniqueKey, ActionUniqueQualifier};
+use nativelink_util::action_messages::{
+    ActionInfo, ActionResult, ActionUniqueKey, ActionUniqueQualifier, ExecutionMetadata,
+    INTERNAL_ERROR_EXIT_CODE, to_execute_response,
+};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
+use prost::Message as _;
+
+/// Local mirror of `google.rpc.PreconditionFailure`, kept here so this
+/// integration test can decode the `details[0].value` bytes that
+/// `to_execute_response` places in the `ExecuteResponse.status` without
+/// depending on the mod-private inline definition inside
+/// `action_messages.rs`.
+mod precondition_failure {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct PreconditionFailure {
+        #[prost(message, repeated, tag = "1")]
+        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub(super) struct Violation {
+        #[prost(string, tag = "1")]
+        pub(super) r#type: ::prost::alloc::string::String,
+        #[prost(string, tag = "2")]
+        pub(super) subject: ::prost::alloc::string::String,
+        #[prost(string, tag = "3")]
+        pub(super) description: ::prost::alloc::string::String,
+    }
+    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
+}
 
 fn make_key() -> ActionUniqueKey {
     ActionUniqueKey {
@@ -36,4 +67,135 @@ fn old_unique_qualifier_uncachable_works() {
         action_info.unique_qualifier,
         ActionUniqueQualifier::Uncacheable(make_key())
     );
+}
+
+const MISSING_DIGEST_HEX: &str = "38fc5a8a97c1217160b0b658751979b9a1171286381489c8b98c993ec40b1546";
+const MISSING_DIGEST_SIZE: u64 = 210;
+
+fn missing_digest() -> DigestInfo {
+    DigestInfo::new(
+        <[u8; 32]>::from_hex(MISSING_DIGEST_HEX).unwrap(),
+        MISSING_DIGEST_SIZE,
+    )
+}
+
+fn make_missing_blob_error(digest: &DigestInfo) -> Error {
+    make_err!(
+        Code::NotFound,
+        "Object {} not found in either fast or slow store. \
+            If using multiple workers, ensure all workers share the same CAS storage path.",
+        digest,
+    )
+}
+
+fn action_result_with_error(error: Option<Error>) -> ActionResult {
+    ActionResult {
+        output_files: Vec::new(),
+        output_folders: Vec::new(),
+        output_directory_symlinks: Vec::new(),
+        output_file_symlinks: Vec::new(),
+        exit_code: INTERNAL_ERROR_EXIT_CODE,
+        stdout_digest: DigestInfo::new([0u8; 32], 0),
+        stderr_digest: DigestInfo::new([0u8; 32], 0),
+        execution_metadata: ExecutionMetadata {
+            worker: String::new(),
+            queued_timestamp: SystemTime::UNIX_EPOCH,
+            worker_start_timestamp: SystemTime::UNIX_EPOCH,
+            worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+            input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+            execution_start_timestamp: SystemTime::UNIX_EPOCH,
+            execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+            output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+        },
+        server_logs: HashMap::new(),
+        error,
+        message: String::new(),
+    }
+}
+
+fn assert_missing_blob_status(status: &nativelink_proto::google::rpc::Status, digest: &DigestInfo) {
+    use tonic::Code as TonicCode;
+    assert_eq!(
+        status.code,
+        TonicCode::FailedPrecondition as i32,
+        "missing-blob errors should be surfaced as FAILED_PRECONDITION",
+    );
+    assert_eq!(status.details.len(), 1, "expected exactly one detail Any");
+    assert_eq!(status.details[0].type_url, precondition_failure::TYPE_URL);
+    let pf = precondition_failure::PreconditionFailure::decode(&*status.details[0].value)
+        .expect("decoding PreconditionFailure must succeed");
+    assert_eq!(pf.violations.len(), 1, "expected one MISSING violation");
+    assert_eq!(pf.violations[0].r#type, "MISSING");
+    assert_eq!(
+        pf.violations[0].subject,
+        format!("blobs/{}/{}", digest.packed_hash(), digest.size_bytes()),
+        "subject must follow REv2 `blobs/<hash>/<size>` format",
+    );
+    assert!(
+        !pf.violations[0].description.is_empty(),
+        "description should carry the underlying error message",
+    );
+}
+
+#[nativelink_test]
+fn to_execute_response_surfaces_missing_blob_as_precondition_failure() {
+    let digest = missing_digest();
+    let action_result = action_result_with_error(Some(make_missing_blob_error(&digest)));
+    let resp = to_execute_response(action_result);
+    let status = resp.status.expect("status must be set");
+    assert_missing_blob_status(&status, &digest);
+}
+
+#[nativelink_test]
+fn to_execute_response_detects_missing_blob_through_err_tip_wrapping() {
+    let digest = missing_digest();
+    let wrapped: Error = Err::<(), _>(make_missing_blob_error(&digest))
+        .err_tip(|| "While running the action")
+        .err_tip(|| "In worker output upload")
+        .unwrap_err();
+    let action_result = action_result_with_error(Some(wrapped));
+    let resp = to_execute_response(action_result);
+    let status = resp.status.expect("status must be set");
+    assert_missing_blob_status(&status, &digest);
+}
+
+#[nativelink_test]
+fn to_execute_response_leaves_non_missing_blob_errors_unchanged() {
+    let action_result = action_result_with_error(Some(make_err!(
+        Code::NotFound,
+        "Some other not-found error that doesn't mention CAS",
+    )));
+    let resp = to_execute_response(action_result);
+    let status = resp.status.expect("status must be set");
+    assert_eq!(status.code, Code::NotFound as i32);
+    assert!(
+        status.details.is_empty(),
+        "non-missing-blob errors must not carry a PreconditionFailure detail",
+    );
+}
+
+#[nativelink_test]
+fn to_execute_response_falls_back_when_digest_cannot_be_parsed() {
+    let action_result = action_result_with_error(Some(make_err!(
+        Code::NotFound,
+        // Marker present, but no `Object <hash>-<size>` prefix.
+        "the cache returned: not found in either fast or slow store",
+    )));
+    let resp = to_execute_response(action_result);
+    let status = resp.status.expect("status must be set");
+    assert!(
+        status.details.is_empty(),
+        "missing-blob messages that cannot be parsed must not produce a violation",
+    );
+}
+
+#[nativelink_test]
+fn to_execute_response_emits_default_status_when_no_error() {
+    let resp = to_execute_response(action_result_with_error(None));
+    let status = resp.status.expect("status must be set");
+    assert_eq!(status.code, 0);
+    assert!(status.details.is_empty());
+    assert!(status.message.is_empty());
 }

--- a/nativelink-util/tests/action_messages_test.rs
+++ b/nativelink-util/tests/action_messages_test.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use hex::FromHex;
-use nativelink_error::{Code, Error, ResultExt, make_err};
+use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_util::action_messages::{
     ActionInfo, ActionResult, ActionUniqueKey, ActionUniqueQualifier, ExecutionMetadata,
@@ -10,30 +10,8 @@ use nativelink_util::action_messages::{
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::precondition_failure;
 use prost::Message as _;
-
-/// Local mirror of `google.rpc.PreconditionFailure`, kept here so this
-/// integration test can decode the `details[0].value` bytes that
-/// `to_execute_response` places in the `ExecuteResponse.status` without
-/// depending on the mod-private inline definition inside
-/// `action_messages.rs`.
-mod precondition_failure {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct PreconditionFailure {
-        #[prost(message, repeated, tag = "1")]
-        pub(super) violations: ::prost::alloc::vec::Vec<Violation>,
-    }
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub(super) struct Violation {
-        #[prost(string, tag = "1")]
-        pub(super) r#type: ::prost::alloc::string::String,
-        #[prost(string, tag = "2")]
-        pub(super) subject: ::prost::alloc::string::String,
-        #[prost(string, tag = "3")]
-        pub(super) description: ::prost::alloc::string::String,
-    }
-    pub(super) const TYPE_URL: &str = "type.googleapis.com/google.rpc.PreconditionFailure";
-}
 
 fn make_key() -> ActionUniqueKey {
     ActionUniqueKey {
@@ -86,6 +64,10 @@ fn make_missing_blob_error(digest: &DigestInfo) -> Error {
             If using multiple workers, ensure all workers share the same CAS storage path.",
         digest,
     )
+    .with_context(ErrorContext::MissingDigest {
+        hash: digest.packed_hash().to_string(),
+        size: digest.size_bytes() as i64,
+    })
 }
 
 fn action_result_with_error(error: Option<Error>) -> ActionResult {
@@ -177,17 +159,18 @@ fn to_execute_response_leaves_non_missing_blob_errors_unchanged() {
 }
 
 #[nativelink_test]
-fn to_execute_response_falls_back_when_digest_cannot_be_parsed() {
+fn to_execute_response_does_not_misclassify_error_without_context() {
+    // Pre-typed-context behavior matched on substrings ("Object … not
+    // found").
     let action_result = action_result_with_error(Some(make_err!(
         Code::NotFound,
-        // Marker present, but no `Object <hash>-<size>` prefix.
-        "the cache returned: not found in either fast or slow store",
+        "Object xyz not found in either fast or slow store",
     )));
     let resp = to_execute_response(action_result);
     let status = resp.status.expect("status must be set");
     assert!(
         status.details.is_empty(),
-        "missing-blob messages that cannot be parsed must not produce a violation",
+        "errors without ErrorContext::MissingDigest must not produce a PreconditionFailure detail",
     );
 }
 


### PR DESCRIPTION
# Description

Inline definition of `google.rpc.PreconditionFailure`. Bazel's `RemoteSpawnRunner` inspects this proto in the gRPC `Status.details` of a `FAILED_PRECONDITION` response and, when violations of type `MISSING` are present, automatically re-uploads the named blobs and retries the Execute call. Without this detail Bazel surfaces the failure as a hard build error — exactly the symptom triggered by an interrupted previous build leaving partial CAS uploads.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2322)
<!-- Reviewable:end -->
