### PR TITLE
Fix the directory we push to attic from

### DIFF
--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -13,13 +13,11 @@ runs:
       - name: Check attic push
         if: ${{ inputs.nativelink_attic_token != '' }}
         run: |
-          cd /tmp
-          cat attic-push.log
+          cat /tmp/attic-push.log
         shell: bash
 
       - name: Attic push
         if: ${{ inputs.nix_name != '' && inputs.nativelink_attic_token != '' }}
         run: |
-          cd /tmp
-          ./result/bin/attic push nativelink $(nix eval --raw ${{ inputs.nix_name }})
+          /tmp/result/bin/attic push nativelink $(nix eval --raw ${{ inputs.nix_name }})
         shell: bash


### PR DESCRIPTION
# Description

Right now, [we get](https://github.com/TraceMachina/nativelink/actions/runs/25742760942/job/75597517375)
```
path '/tmp' does not contain a 'flake.nix', searching up
error: could not find a flake.nix file
🤷 Nothing specified.
Hint: Pass --stdin to read the list of store paths from standard input.
```
This PR makes the attic push happen from the directory we're actually running stuff from.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2326)
<!-- Reviewable:end -->
