### PR TITLE
Split rbe-toolchain into multiple tests

### DIFF
--- a/.github/actions/free-disk/action.yaml
+++ b/.github/actions/free-disk/action.yaml
@@ -4,6 +4,9 @@ description: "Free up disk space on workers"
 runs:
   using: "composite"
   steps:
+    - name: Check disk space
+      run: df -h /
+      shell: bash
     - if: runner.os == 'Linux' # Only works on Linux
       name: Free disk space
       uses: >- # v3.2.2
@@ -15,17 +18,6 @@ runs:
         remove_haskell: true
         remove_tool_cache: false # TODO(palfrey): Do we really need this?
         # Note: Not deleting google-cloud-cli because it takes too long.
-        remove_packages: >
-          azure-cli
-          microsoft-edge-stable
-          google-chrome-stable
-          firefox
-          postgresql*
-          temurin-*
-          *llvm*
-          mysql*
-          dotnet-sdk-*
-        remove_packages_one_command: true
         remove_folders: >
           /usr/share/swift
           /usr/share/miniconda
@@ -39,8 +31,6 @@ runs:
       name: Free Disk space
       shell: bash
       run: |
-        df -h /
-
         # Remove unnecessary pre-installed tools (saves 5-10GB)
         sudo rm -rf /usr/local/share/powershell
         sudo rm -rf /usr/local/lib/node_modules
@@ -49,5 +39,6 @@ runs:
         # Remove unused Xcode simulators (can save 2-5GB each)
         xcrun simctl delete unavailable
         xcrun simctl runtime list
-
-        df -h /
+    - name: Check disk space
+      run: df -h /
+      shell: bash

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -122,7 +122,7 @@ jobs:
     name: ${{ matrix.test-name }}
     strategy:
       matrix:
-          test-name: [buildstream, buck2, rbe-toolchain, mongo]
+          test-name: [buildstream, buck2, mongo]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -145,3 +145,52 @@ jobs:
         with:
           nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
           nix_name: .#${{ matrix.test-name }}-with-nativelink-test
+
+  # rbe-toolchain is slow because it has many subcommands, so split it out
+  generate-rbe-commands:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: >- # v6.0.2
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
+
+      - name: Get commands list
+        run: |
+          COMMANDS=$(nix run .#rbe-toolchain-with-nativelink-test list)
+          echo "matrix={\"command\":${COMMANDS}}" >> $GITHUB_OUTPUT
+        id: set-matrix
+
+  rbe-toolchain:
+    name: rbe ${{ matrix.command}}
+    needs: [generate-rbe-commands]
+    strategy:
+        matrix: ${{fromJson(needs.generate-rbe-commands.outputs.matrix)}}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: >- # v6.0.2
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Prepare Worker
+        uses: ./.github/actions/prepare-nix
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
+
+      - name: Test ${{ matrix.command }} with rbe
+        run: |
+          nix run -L .#rbe-toolchain-with-nativelink-test ${{ matrix.command }}
+
+      - name: Teardown Worker
+        uses: ./.github/actions/end-nix
+        if: always()
+        with:
+          nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
+          nix_name: .#rbe-toolchain-with-nativelink-test

--- a/toolchain-examples/rbe-toolchain-test.nix
+++ b/toolchain-examples/rbe-toolchain-test.nix
@@ -2,19 +2,10 @@
   nativelink,
   writeShellScriptBin,
   bazelisk,
+  jo,
 }:
 writeShellScriptBin "rbe-toolchain-test" ''
   set -uo pipefail
-
-  cleanup() {
-    local pids=$(jobs -pr)
-    [ -n "$pids" ] && kill $pids
-  }
-  trap "cleanup" INT QUIT TERM EXIT
-
-  NO_COLOR=true ${nativelink}/bin/nativelink -- toolchain-examples/nativelink-config.json5 | tee -i toolchain-examples/nativelink.log &
-
-  CORE_BAZEL_ARGS="--check_direct_dependencies=error --remote_cache=grpc://localhost:50051 --remote_executor=grpc://localhost:50051"
 
   CPU_TYPE=$(uname -m)
 
@@ -29,22 +20,49 @@ writeShellScriptBin "rbe-toolchain-test" ''
   RUST_ZIG_PLATFORM="--config=zig-cc --platforms=//platforms:linux_''${PLATFORM}_gnu_2_28 --host_platform=@rules_rs//:local_gnu_platform --extra_execution_platforms=@rules_rs//:local_gnu_platform"
 
   # As per https://nativelink.com/docs/rbe/remote-execution-examples#minimal-example-targets
-  COMMANDS=("test //cpp $ZIG_PLATFORM"
-            "test //cpp $LLVM_PLATFORM"
-            "test //python"
-            "test //go $ZIG_PLATFORM"
-            "test //rust $RUST_ZIG_PLATFORM"
-            "test //java:HelloWorld --config=java"
-            "build @curl//... $ZIG_PLATFORM"
-            "build @zstd//... $ZIG_PLATFORM"
-            # "test @abseil-cpp//... $ZIG_PLATFORM" # Buggy build due to google_benchmark errors
-            "test @abseil-py//..."
-            "test @circl//... $ZIG_PLATFORM"
-            )
+  declare -A COMMANDS
+  COMMANDS=(
+    [cpp-zig]="test //cpp $ZIG_PLATFORM"
+    [cpp-llvm]="test //cpp $LLVM_PLATFORM"
+    [python]="test //python"
+    [go]="test //go $ZIG_PLATFORM"
+    [rust]="test //rust $RUST_ZIG_PLATFORM"
+    [java]="test //java:HelloWorld --config=java"
+    [curl]="build @curl//... $ZIG_PLATFORM"
+    [zstd]="build @zstd//... $ZIG_PLATFORM"
+    [abseil-py]="test @abseil-py//..."
+    [circl]="test @circl//... $ZIG_PLATFORM"
+  )
+  # "test @abseil-cpp//... $ZIG_PLATFORM" # Buggy build due to google_benchmark errors
+
+  if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied"
+    keys=$(echo ''${!COMMANDS[@]} | xargs -n1 | sort | tr '\n' ' ')
+    echo "Need list, all, or one of $keys"
+    exit 1
+  fi
+
+  if [ $1 == "list" ]
+  then
+    ${jo}/bin/jo -a "''${!COMMANDS[@]}"
+    exit 0
+  fi
+
+  cleanup() {
+    local pids=$(jobs -pr)
+    [ -n "$pids" ] && kill $pids
+  }
+  trap "cleanup" INT QUIT TERM EXIT
+
+  NO_COLOR=true ${nativelink}/bin/nativelink -- toolchain-examples/nativelink-config.json5 | tee -i toolchain-examples/nativelink.log &
+
+  CORE_BAZEL_ARGS="--check_direct_dependencies=error --remote_cache=grpc://localhost:50051 --remote_executor=grpc://localhost:50051"
 
   echo "" > toolchain-examples/cmd.log
-  for cmd in "''${COMMANDS[@]}"
-  do
+
+  run_cmd() {
+    cmd=$1
     FULL_CMD="${bazelisk}/bin/bazelisk $cmd $CORE_BAZEL_ARGS"
     echo $FULL_CMD
     echo -e \\n$FULL_CMD\\n >> toolchain-examples/cmd.log
@@ -60,7 +78,23 @@ writeShellScriptBin "rbe-toolchain-test" ''
         exit 1
       ;;
     esac
-  done
+  }
+
+  if [ $1 == "all" ]
+  then
+    for cmd in "''${COMMANDS[@]}"
+    do
+      run_cmd "$cmd"
+    done
+  else
+    cmd=''${COMMANDS[$1]:-}
+    if [ -z "$cmd" ]
+    then
+      echo "Invalid command: $1"
+      exit 1
+    fi
+    run_cmd "$cmd"
+  fi
 
   nativelink_output=$(cat toolchain-examples/nativelink.log)
 


### PR DESCRIPTION
# Description

It's the slowest test by about a factor of 2-3x now, mostly because it's got a lot of subtests. This PR gives the command a `list` subcommand as well as the ability to run individual subcommands. The overall end-to-end time for a RBE test goes from ~24m to ~6m max, even though there's a lot more of them. This does increase our needed test runner count a bunch, but only on Ubuntu machines which we have a lot of headroom for and tend to get allocated very fast.

It also removes the "remove package" step of the free disk action, as that wasn't freeing up much space, but it was very unreliable in terms of runtime, and especially with more separate jobs it was radically increasing the runtime sometimes.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2330)
<!-- Reviewable:end -->
