### PR TITLE
simple_scheduler_state_manager: count worker disconnects toward max_job_retries

### DIFF
--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -785,7 +785,30 @@ where
                         ActionStage::Queued
                     }
                 }
-                UpdateOperationType::UpdateWithDisconnect => ActionStage::Queued,
+                UpdateOperationType::UpdateWithDisconnect => {
+                    awaited_action.attempts += 1;
+                    if awaited_action.attempts > self.max_job_retries {
+                        ActionStage::Completed(ActionResult {
+                            execution_metadata: ExecutionMetadata {
+                                worker: maybe_worker_id
+                                    .map_or_else(String::default, ToString::to_string),
+                                ..ExecutionMetadata::default()
+                            },
+                            error: Some(make_err!(
+                                Code::Aborted,
+                                "Worker disconnected {} times (>{} max_job_retries) before \
+                                 completing this action; suspect worker crash loop, e.g. OOM \
+                                 from action working set exceeding pod memory limit. \
+                                 operation_id={operation_id} last_worker={maybe_worker_id:?}",
+                                awaited_action.attempts,
+                                self.max_job_retries,
+                            )),
+                            ..ActionResult::default()
+                        })
+                    } else {
+                        ActionStage::Queued
+                    }
+                }
                 // We shouldn't get here, but we just ignore it if we do.
                 UpdateOperationType::ExecutionComplete => {
                     warn!("inner_update_operation got an ExecutionComplete, that's unexpected.");

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -2116,6 +2116,126 @@ async fn worker_retries_on_internal_error_and_fails_test() -> Result<(), Error> 
     Ok(())
 }
 
+/// Regression test for the worker-OOM redispatch loop.
+#[nativelink_test]
+async fn worker_retries_on_disconnect_and_fails_test() -> Result<(), Error> {
+    let worker_id = WorkerId("worker_id".to_string());
+
+    let task_change_notify = Arc::new(Notify::new());
+    let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
+        &SimpleSpec {
+            max_job_retries: 1,
+            ..Default::default()
+        },
+        memory_awaited_action_db_factory(
+            0,
+            &task_change_notify.clone(),
+            MockInstantWrapped::default,
+        ),
+        || async move {},
+        task_change_notify,
+        MockInstantWrapped::default,
+        None,
+    );
+    let action_digest = DigestInfo::new([42u8; 32], 512);
+
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, worker_id.clone(), PlatformProperties::default()).await?;
+    let insert_timestamp = make_system_time(1);
+    let mut action_listener =
+        setup_action(&scheduler, action_digest, HashMap::new(), insert_timestamp).await?;
+
+    let operation_id = {
+        let operation_id = match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(exec)) => exec.operation_id,
+            v => panic!("Expected StartAction, got : {v:?}"),
+        };
+        assert_eq!(
+            action_listener.changed().await.unwrap().0.stage,
+            ActionStage::Executing
+        );
+        OperationId::from(operation_id.as_str())
+    };
+
+    // First disconnect: attempts becomes 1, still <= max_job_retries=1,
+    // so the action must re-queue (not yet fail).
+    drop(
+        scheduler
+            .update_action(
+                &worker_id,
+                &operation_id,
+                UpdateOperationType::UpdateWithDisconnect,
+            )
+            .await,
+    );
+
+    {
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
+        assert_eq!(
+            action_state.stage,
+            ActionStage::Queued,
+            "first disconnect must re-queue (attempts=1, max_retries=1)"
+        );
+    }
+
+    // Second worker picks the action up.
+    let mut rx_from_worker =
+        setup_new_worker(&scheduler, worker_id.clone(), PlatformProperties::default()).await?;
+    {
+        match rx_from_worker.recv().await.unwrap().update {
+            Some(update_for_worker::Update::StartAction(_)) => {}
+            v => panic!("Expected StartAction, got : {v:?}"),
+        }
+        assert_eq!(
+            action_listener.changed().await.unwrap().0.stage,
+            ActionStage::Executing
+        );
+    }
+
+    // Second disconnect: attempts becomes 2, > max_job_retries=1, so
+    // the action must transition to Completed with an error that
+    // names the worker-disconnect failure mode explicitly. Pre-fix
+    // this branch would have just re-queued the action a second time
+    // (no attempts increment), and the loop would continue forever.
+    drop(
+        scheduler
+            .update_action(
+                &worker_id,
+                &operation_id,
+                UpdateOperationType::UpdateWithDisconnect,
+            )
+            .await,
+    );
+
+    {
+        let (action_state, _maybe_origin_metadata) = action_listener.changed().await.unwrap();
+        let ActionStage::Completed(result) = &action_state.stage else {
+            panic!(
+                "Expected Completed after exceeding max_job_retries on disconnects, \
+                 got: {:?}",
+                action_state.stage
+            );
+        };
+        let err = result
+            .error
+            .as_ref()
+            .expect("disconnect-induced Completed must carry an error");
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("Worker disconnected"),
+            "error should name the worker-disconnect failure mode for grep-ability; \
+             got: {err_str}",
+        );
+        assert!(
+            err_str.contains("max_job_retries") || err_str.contains("crash loop"),
+            "error should explain the cause (crash loop / max retries exceeded) so \
+             operators don't mistake it for TIMEOUT/NO STATUS; got: {err_str}",
+        );
+    }
+
+    Ok(())
+}
+
 #[nativelink_test]
 async fn ensure_scheduler_drops_inner_spawn() -> Result<(), Error> {
     struct DropChecker {


### PR DESCRIPTION
# Description

Avoid worker disconnects that keeps on running the build forever. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added tests and tested it in a working build environment. 

Please also list any relevant details for your test configuration

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2352)
<!-- Reviewable:end -->
