### PR TITLE
redis_store: raise check_health PING ceiling from 2s to 4s

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1390,6 +1390,12 @@ pub struct RedisSpec {
     #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub connection_timeout_ms: u64,
 
+    /// Per-call ceiling for the `check_health` PING in milliseconds.
+    ///
+    /// Default: 4000 (4 seconds)
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
+    pub health_check_timeout_ms: u64,
+
     /// The amount of data to read from the redis server at a time.
     /// This is used to limit the amount of memory used when reading
     /// large objects from the redis server as well as limiting the

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -87,6 +87,10 @@ const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 3000;
 /// Note: If this changes it should be updated in the config documentation.
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 10_000;
 
+/// The default `check_health` PING ceiling in milliseconds if not specified.
+/// Note: If this changes it should be updated in the config documentation.
+const DEFAULT_HEALTH_CHECK_TIMEOUT_MS: u64 = 4000;
+
 /// The default maximum number of chunk uploads per update.
 /// Note: If this changes it should be updated in the config documentation.
 pub const DEFAULT_MAX_CHUNK_UPLOADS_PER_UPDATE: usize = 10;
@@ -344,6 +348,9 @@ where
     /// limits the calls to `get_client()`, but the requests per client
     /// are small enough that it works well enough.
     client_permits: Arc<Semaphore>,
+
+    /// Per-call ceiling for `check_health` PING.
+    health_check_timeout: Duration,
 }
 
 impl<C, M> Debug for RedisStore<C, M>
@@ -409,6 +416,7 @@ where
         scan_count: usize,
         max_client_permits: usize,
         max_count_per_cursor: u64,
+        health_check_timeout: Duration,
         subscriber_channel: UnboundedReceiver<PushInfo>,
         connection_manager: M,
     ) -> Result<Self, Error> {
@@ -427,6 +435,7 @@ where
             subscriber_channel: Mutex::new(Some(subscriber_channel)),
             client_permits: Arc::new(Semaphore::new(max_client_permits)),
             max_count_per_cursor,
+            health_check_timeout,
         })
     }
 
@@ -497,6 +506,9 @@ where
         }
         if spec.command_timeout_ms == 0 {
             spec.command_timeout_ms = DEFAULT_COMMAND_TIMEOUT_MS;
+        }
+        if spec.health_check_timeout_ms == 0 {
+            spec.health_check_timeout_ms = DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
         }
         if spec.connection_pool_size == 0 {
             spec.connection_pool_size = DEFAULT_CONNECTION_POOL_SIZE;
@@ -579,6 +591,7 @@ impl RedisStore<ClusterConnection, ClusterRedisManager<ClusterConnection>> {
             spec.scan_count,
             spec.max_client_permits,
             spec.max_count_per_cursor,
+            Duration::from_millis(spec.health_check_timeout_ms),
             subscriber_channel,
             ClusterRedisManager::new(client.get_async_connection().await?).await?,
         )
@@ -705,6 +718,7 @@ impl RedisStore<ConnectionManager, StandardRedisManager<ConnectionManager>> {
             spec.scan_count,
             spec.max_client_permits,
             spec.max_count_per_cursor,
+            Duration::from_millis(spec.health_check_timeout_ms),
             subscriber_channel,
             StandardRedisManager::new(Box::new(move || {
                 Box::pin(Self::connect(spec.clone(), tx.clone()))
@@ -1114,12 +1128,6 @@ where
     /// is reachable and the master is accepting commands; that is
     /// the only invariant a kubelet probe needs.
     async fn check_health(&self, _namespace: Cow<'static, str>) -> HealthStatus {
-        /// Per-check physical ceiling. Tight enough to stay well
-        /// under `HealthServer`'s default per-indicator budget;
-        /// loose enough to absorb a normally-slow PING during a
-        /// `BGSAVE` fork or sentinel rebalance.
-        const PING_TIMEOUT: Duration = Duration::from_secs(2);
-
         let mut client = match self.get_client().await {
             Ok(c) => c,
             Err(e) => {
@@ -1138,7 +1146,7 @@ where
                 .query_async::<()>(&mut client.connection_manager)
                 .await
         };
-        match timeout(PING_TIMEOUT, ping).await {
+        match timeout(self.health_check_timeout, ping).await {
             Ok(Ok(())) => HealthStatus::new_ok(self, "RedisStore::check_health: PING ok".into()),
             Ok(Err(e)) => HealthStatus::new_failed(
                 self,
@@ -1147,8 +1155,8 @@ where
             Err(_) => HealthStatus::new_failed(
                 self,
                 format!(
-                    "RedisStore::check_health: PING exceeded {} s timeout",
-                    PING_TIMEOUT.as_secs()
+                    "RedisStore::check_health: PING exceeded {}ms timeout",
+                    self.health_check_timeout.as_millis()
                 )
                 .into(),
             ),

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -107,6 +107,7 @@ async fn make_mock_store_with_prefix(
         DEFAULT_SCAN_COUNT,
         DEFAULT_MAX_PERMITS,
         DEFAULT_MAX_COUNT_PER_CURSOR,
+        Duration::from_secs(4),
         rx,
         manager,
     )


### PR DESCRIPTION
# Description

The previous 2-second PING ceiling was tight enough that a routine Redis BGSAVE fork would push every RedisStore indicator over the line simultaneously: on an 11 GB production master under load we observe fork-induced pauses around 3 seconds, and with three RedisStore indicators (AC, CAS, scheduler) all PING-ing through the same connection pool, all three return Failed in lockstep — surfacing as a 503 on /status and a kubelet probe-failure event even though the Redis service is otherwise healthy.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in an actual working configuration

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2354)
<!-- Reviewable:end -->
