### PR TITLE
Add --fallback to all remaining nix CI commands

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -36,7 +36,7 @@ runs:
             # * https://github.com/zhaofengli/attic/issues/226
             # * https://github.com/zhaofengli/attic/pull/317
             # We use the original one first to get caching of this
-            nix build github:TraceMachina/attic
+            nix build --fallback github:TraceMachina/attic
             RUST_BACKTRACE=full RUST_LOG=debug,hyper_util=info,rustls=info ./result/bin/attic watch-store nativelink &> attic-push.log &
 
             # For the cases where we don't have a cache of it, push it

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Generate coverage
         run: |
-          nix build -L .#nativelinkCoverageForHost
+          nix build --fallback -L .#nativelinkCoverageForHost
 
       - name: Upload coverage artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/custom-image.yaml
+++ b/.github/workflows/custom-image.yaml
@@ -114,7 +114,7 @@ jobs:
         id: upload
         run: |
           GIT_HASH=$(git rev-parse --short HEAD)
-          nix run .#publish-ghcr ${{ needs.check-trigger.outputs.image }} "$GIT_HASH"
+          nix run --fallback .#publish-ghcr ${{ needs.check-trigger.outputs.image }} "$GIT_HASH"
 
           IMAGE_NAME=$(nix eval .#${{ needs.check-trigger.outputs.image }}.imageName --raw)
           echo "image_tag=ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${GIT_HASH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Test image
         run: |
-          nix run .#local-image-test ${{ matrix.image }}
+          nix run --fallback .#local-image-test ${{ matrix.image }}
 
       - name: Upload image
         run: |
-          nix run .#publish-ghcr ${{ matrix.image }}
+          nix run --fallback .#publish-ghcr ${{ matrix.image }}
         env:
           GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
           GHCR_USERNAME: ${{ github.actor }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Test nix run
         run: |
-          nix run -L .#nativelink-is-executable-test
+          nix run --fallback -L .#nativelink-is-executable-test
 
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
@@ -137,7 +137,7 @@ jobs:
 
       - name: Test ${{ matrix.test-name }} run
         run: |
-          nix run -L .#${{ matrix.test-name }}-with-nativelink-test
+          nix run --fallback -L .#${{ matrix.test-name }}-with-nativelink-test
 
       - name: Teardown Worker
         uses: ./.github/actions/end-nix
@@ -163,7 +163,7 @@ jobs:
 
       - name: Get commands list
         run: |
-          COMMANDS=$(nix run .#rbe-toolchain-with-nativelink-test list)
+          COMMANDS=$(nix run --fallback .#rbe-toolchain-with-nativelink-test list)
           echo "matrix={\"command\":${COMMANDS}}" >> $GITHUB_OUTPUT
         id: set-matrix
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: Test ${{ matrix.command }} with rbe
         run: |
-          nix run -L .#rbe-toolchain-with-nativelink-test ${{ matrix.command }}
+          nix run --fallback -L .#rbe-toolchain-with-nativelink-test ${{ matrix.command }}
 
       - name: Teardown Worker
         uses: ./.github/actions/end-nix

--- a/.github/workflows/tagged_image.yaml
+++ b/.github/workflows/tagged_image.yaml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Test image
         run: |
-          nix run .#local-image-test ${{ matrix.image }}
+          nix run --fallback .#local-image-test ${{ matrix.image }}
 
       - name: Upload image
         run: |
-          nix run .#publish-ghcr ${{ matrix.image }} ${{github.ref_name}}
+          nix run --fallback .#publish-ghcr ${{ matrix.image }} ${{github.ref_name}}
         env:
           GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
           GHCR_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
# Description

https://github.com/TraceMachina/nativelink/pull/2308 added `--fallback` to the `nix develop` commands, but we also need it for `nix run`/`nix build` as https://github.com/TraceMachina/nativelink/actions/runs/26250652654/job/77260563563 demonstrated

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2360)
<!-- Reviewable:end -->
