### PR TITLE
ci: skip web deploy when CLOUDFLARE_API_TOKEN is unset

### DIFF
--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -57,7 +57,10 @@ jobs:
           "
 
       - name: Production deployment
-        if: matrix.os == 'ubuntu-24.04' && github.ref == 'refs/heads/main'
+        if: >-
+          matrix.os == 'ubuntu-24.04'
+          && github.ref == 'refs/heads/main'
+          && env.CLOUDFLARE_API_TOKEN != ''
         working-directory: web/platform
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The Production deployment step in web.yaml currently fires on every push to main and unconditionally calls `wrangler deploy`, which exits non-zero if CLOUDFLARE_API_TOKEN is empty. That fails the Deploy NativeLink Web workflow on any repo (upstream or fork) where the production environment secret isn't configured.

Add `env.CLOUDFLARE_API_TOKEN != ''` to the step's `if:` so the deploy is skipped (not failed) when the secret is missing. The build job above it continues to run on every push/PR and still fails on real build errors.

# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2365)
<!-- Reviewable:end -->
