### PR TITLE
store_awaited_action_db: retry try_subscribe once on miss

### DIFF
--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -680,8 +680,10 @@ where
         })
     }
 
+    // `pub` so integration tests in `tests/` can drive this directly;
+    // matches the precedent of `inner_update_awaited_action` below.
     #[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
-    async fn try_subscribe(
+    pub async fn try_subscribe(
         &self,
         client_operation_id: &ClientOperationId,
         unique_qualifier: &ActionUniqueQualifier,
@@ -691,20 +693,33 @@ where
         // we should add priority upgrades back in.
         _priority: i32,
     ) -> Result<Option<AwaitedAction>, Error> {
+        // Retry once on miss: closes the RediSearch index-visibility
+        // window where two concurrent `add_action` calls can both see
+        // empty and create duplicate scheduler operations.
+        const SUBSCRIBE_RACE_RETRY_DELAY: Duration = Duration::from_millis(20);
         match unique_qualifier {
             ActionUniqueQualifier::Cacheable(_) => {}
             ActionUniqueQualifier::Uncacheable(_) => return Ok(None),
         }
-        let stream = self
-            .store
-            .search_by_index_prefix(SearchUniqueQualifierToAwaitedAction(unique_qualifier))
-            .await
-            .err_tip(|| "In RedisAwaitedActionDb::try_subscribe")?;
-        tokio::pin!(stream);
-        let maybe_awaited_action = stream
-            .try_next()
-            .await
-            .err_tip(|| "In RedisAwaitedActionDb::try_subscribe")?;
+        let mut maybe_awaited_action: Option<AwaitedAction> = None;
+        for attempt in 0..2_u32 {
+            if attempt > 0 {
+                tokio::time::sleep(SUBSCRIBE_RACE_RETRY_DELAY).await;
+            }
+            let stream = self
+                .store
+                .search_by_index_prefix(SearchUniqueQualifierToAwaitedAction(unique_qualifier))
+                .await
+                .err_tip(|| "In RedisAwaitedActionDb::try_subscribe")?;
+            tokio::pin!(stream);
+            maybe_awaited_action = stream
+                .try_next()
+                .await
+                .err_tip(|| "In RedisAwaitedActionDb::try_subscribe")?;
+            if maybe_awaited_action.is_some() {
+                break;
+            }
+        }
         match maybe_awaited_action {
             Some(awaited_action) => {
                 // TODO(palfrey) We don't support joining completed jobs because we

--- a/nativelink-scheduler/tests/store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/store_awaited_action_db_test.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::todo)]
 
+use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -7,22 +8,26 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 use futures::{Stream, stream};
+use mock_instant::thread_local::SystemTime as MockSystemTime;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
 use nativelink_scheduler::awaited_action_db::AwaitedAction;
-use nativelink_scheduler::store_awaited_action_db::inner_update_awaited_action;
+use nativelink_scheduler::store_awaited_action_db::{
+    StoreAwaitedActionDb, inner_update_awaited_action,
+};
 use nativelink_util::action_messages::{
     ActionInfo, ActionUniqueKey, ActionUniqueQualifier, OperationId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
+use nativelink_util::instant_wrapper::MockInstantWrapped;
 use nativelink_util::store_trait::{
     SchedulerCurrentVersionProvider, SchedulerIndexProvider, SchedulerStore,
     SchedulerStoreDataProvider, SchedulerStoreDecodeTo, SchedulerStoreKeyProvider,
     SchedulerSubscription, SchedulerSubscriptionManager,
 };
 use pretty_assertions::assert_eq;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 const INSTANCE_NAME: &str = "foo";
 
@@ -145,5 +150,242 @@ async fn test_inner_update_awaited_action() -> Result<(), Error> {
         "{update:#?}"
     );
     assert_eq!(update.1, Some(Duration::from_mins(5)));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `try_subscribe` retry behavior.
+// ---------------------------------------------------------------------------
+
+fn make_cacheable_action_info() -> Arc<ActionInfo> {
+    Arc::new(ActionInfo {
+        command_digest: DigestInfo::zero_digest(),
+        input_root_digest: DigestInfo::zero_digest(),
+        timeout: Duration::from_secs(1),
+        platform_properties: HashMap::new(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionUniqueQualifier::Cacheable(ActionUniqueKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::zero_digest(),
+        }),
+    })
+}
+
+fn make_existing_awaited_action() -> AwaitedAction {
+    AwaitedAction::new(
+        OperationId::from("existing-operation"),
+        make_cacheable_action_info(),
+        MockSystemTime::now().into(),
+    )
+}
+
+struct PendingSubscription;
+impl SchedulerSubscription for PendingSubscription {
+    async fn changed(&mut self) -> Result<(), Error> {
+        futures::future::pending().await
+    }
+}
+
+struct PendingSubscriptionManager;
+impl SchedulerSubscriptionManager for PendingSubscriptionManager {
+    type Subscription = PendingSubscription;
+    fn subscribe<K>(&self, _key: K) -> Result<Self::Subscription, Error>
+    where
+        K: SchedulerStoreKeyProvider,
+    {
+        Ok(PendingSubscription)
+    }
+    fn is_reliable() -> bool {
+        true
+    }
+}
+
+/// Fake `SchedulerStore` whose `search_by_index_prefix` returns an empty
+/// stream for the first `empty_for` calls and a single-item decoded stream
+/// thereafter — simulates the `RediSearch` index-visibility lag the retry
+/// is meant to absorb.
+struct EventuallyVisibleStore {
+    search_calls: Arc<AtomicUsize>,
+    empty_for: usize,
+    encoded_action: Bytes,
+}
+
+impl EventuallyVisibleStore {
+    fn new(empty_for: usize, action: &AwaitedAction) -> Self {
+        let encoded = serde_json::to_vec(action).expect("serialize AwaitedAction for fake store");
+        Self {
+            search_calls: Arc::new(AtomicUsize::new(0)),
+            empty_for,
+            encoded_action: Bytes::from(encoded),
+        }
+    }
+}
+
+impl SchedulerStore for EventuallyVisibleStore {
+    type SubscriptionManager = PendingSubscriptionManager;
+
+    async fn subscription_manager(&self) -> Result<Arc<Self::SubscriptionManager>, Error> {
+        Ok(Arc::new(PendingSubscriptionManager))
+    }
+
+    async fn update_data<T>(
+        &self,
+        _data: T,
+        _expiry: Option<Duration>,
+    ) -> Result<Option<i64>, Error>
+    where
+        T: SchedulerStoreDataProvider
+            + SchedulerStoreKeyProvider
+            + SchedulerCurrentVersionProvider
+            + Send,
+    {
+        Ok(Some(1))
+    }
+
+    async fn search_by_index_prefix<K>(
+        &self,
+        _index: K,
+    ) -> Result<
+        impl Stream<Item = Result<<K as SchedulerStoreDecodeTo>::DecodeOutput, Error>> + Send,
+        Error,
+    >
+    where
+        K: SchedulerIndexProvider + SchedulerStoreDecodeTo + Send,
+        <K as SchedulerStoreDecodeTo>::DecodeOutput: Send,
+    {
+        let n = self.search_calls.fetch_add(1, Ordering::SeqCst);
+        let items: Vec<Result<<K as SchedulerStoreDecodeTo>::DecodeOutput, Error>> =
+            if n < self.empty_for {
+                Vec::new()
+            } else {
+                vec![K::decode(1, self.encoded_action.clone())]
+            };
+        Ok(stream::iter(items))
+    }
+
+    async fn get_and_decode<K>(
+        &self,
+        _key: K,
+    ) -> Result<Option<<K as SchedulerStoreDecodeTo>::DecodeOutput>, Error>
+    where
+        K: SchedulerStoreKeyProvider + SchedulerStoreDecodeTo + Send,
+    {
+        todo!("not exercised by try_subscribe")
+    }
+}
+
+async fn build_db(
+    store: Arc<EventuallyVisibleStore>,
+) -> StoreAwaitedActionDb<
+    EventuallyVisibleStore,
+    fn() -> OperationId,
+    MockInstantWrapped,
+    fn() -> MockInstantWrapped,
+> {
+    fn new_op_id() -> OperationId {
+        OperationId::from("new-operation")
+    }
+    let now_fn: fn() -> MockInstantWrapped = MockInstantWrapped::default;
+    let op_id_fn: fn() -> OperationId = new_op_id;
+    StoreAwaitedActionDb::new(store, Arc::new(Notify::new()), now_fn, op_id_fn, 60)
+        .await
+        .expect("construct test db")
+}
+
+#[nativelink_test]
+async fn try_subscribe_retries_once_on_miss_then_returns_existing() -> Result<(), Error> {
+    let action = make_existing_awaited_action();
+    let qualifier = action.action_info().unique_qualifier.clone();
+    let store = Arc::new(EventuallyVisibleStore::new(
+        /* empty_for = */ 1, &action,
+    ));
+    let counter = store.search_calls.clone();
+    let db = build_db(store).await;
+
+    let result = db
+        .try_subscribe(
+            &OperationId::from("client-1"),
+            &qualifier,
+            Duration::from_secs(60),
+            0,
+        )
+        .await?;
+
+    assert!(
+        result.is_some(),
+        "retry should surface the action that became visible on the second lookup",
+    );
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "search_by_index_prefix must run exactly twice (first miss, then hit)",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn try_subscribe_returns_none_after_two_consecutive_misses() -> Result<(), Error> {
+    let action = make_existing_awaited_action();
+    let qualifier = action.action_info().unique_qualifier.clone();
+    let store = Arc::new(EventuallyVisibleStore::new(
+        /* empty_for = */ usize::MAX,
+        &action,
+    ));
+    let counter = store.search_calls.clone();
+    let db = build_db(store).await;
+
+    let result = db
+        .try_subscribe(
+            &OperationId::from("client-2"),
+            &qualifier,
+            Duration::from_secs(60),
+            0,
+        )
+        .await?;
+
+    assert!(
+        result.is_none(),
+        "two consecutive misses must return None — no further retries",
+    );
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "retry bound must cap search_by_index_prefix calls at 2",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn try_subscribe_skips_lookup_for_uncacheable_qualifier() -> Result<(), Error> {
+    let action = make_existing_awaited_action();
+    let store = Arc::new(EventuallyVisibleStore::new(
+        /* empty_for = */ 0, &action,
+    ));
+    let counter = store.search_calls.clone();
+    let db = build_db(store).await;
+
+    let uncacheable = ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
+        instance_name: INSTANCE_NAME.to_string(),
+        digest_function: DigestHasherFunc::Sha256,
+        digest: DigestInfo::zero_digest(),
+    });
+    let result = db
+        .try_subscribe(
+            &OperationId::from("client-3"),
+            &uncacheable,
+            Duration::from_secs(60),
+            0,
+        )
+        .await?;
+
+    assert!(result.is_none());
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "uncacheable qualifier must short-circuit before any lookup",
+    );
     Ok(())
 }


### PR DESCRIPTION
# Description

Concurrent `add_action` calls for the same `unique_qualifier` can each observe an empty `search_by_index_prefix` result and proceed to create separate scheduler operations for the same action digest, because the RediSearch secondary index commits slightly after the underlying HSET becomes visible to point reads. In production this surfaces as "two identical actions running on different PRs" — duplicate work the dedup is supposed to prevent.

Add one short retry (~20ms) after a missed lookup. The retry closes the index-visibility window without introducing a heavyweight atomic-claim path: the common no-miss path still does exactly one lookup, and the retry only fires when the first attempt returns empty.

Uses real tokio time rather than the configurable `now_fn`: the scheduler test harness's `MockInstantWrapped::sleep` busy-yields until mock time is advanced, which this path's existing callers don't do; the retry is a physical-time wait and should not participate in test-controlled time.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests and tested on a real environment. In-source unit tests cover three properties: the retry actually surfaces a value that becomes visible on the second lookup, two consecutive misses bound the calls at 2 (no further retries), and the uncacheable qualifier short-circuits before any lookup.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2367)
<!-- Reviewable:end -->
