### PR TITLE
fix broken website buttons ('contact us' and 'start free')

### DIFF
--- a/web/platform/src/components/qwik/pages/product.tsx
+++ b/web/platform/src/components/qwik/pages/product.tsx
@@ -34,7 +34,7 @@ const ProductHero = component$(() => {
             Start in 10 minutes
           </a>
           <a
-            href="/contact"
+            href="mailto:contact@nativelink.com"
             class="w-full md:w-auto h-12 px-8 flex items-center bg-transparent justify-center border-black border-2 border-solid text-black transition-all duration-200 hover:bg-[rgb(248,247,244)] rounded-interactive font-medium no-underline"
           >
             Talk to us
@@ -302,13 +302,13 @@ const ProductCTA = component$(() => {
             Clone the repo
           </a>
           <a
-            href="https://nativelink.com/cloud"
+            href="https://dev.nativelink.com"
             class="w-full md:w-auto h-12 px-8 flex items-center bg-transparent justify-center border-black border-2 border-solid text-black transition-all duration-200 hover:bg-[rgb(248,247,244)] rounded-interactive font-medium no-underline"
           >
             Start free
           </a>
           <a
-            href="/contact"
+            href="mailto:contact@nativelink.com"
             class="w-full md:w-auto h-12 px-8 flex items-center bg-transparent justify-center border-black border-2 border-solid text-black transition-all duration-200 hover:bg-[rgb(248,247,244)] rounded-interactive font-medium no-underline"
           >
             Talk to us

--- a/web/platform/src/components/qwik/sections/cta.tsx
+++ b/web/platform/src/components/qwik/sections/cta.tsx
@@ -18,13 +18,13 @@ export const CTA = component$(() => {
             Clone the repo
           </a>
           <a
-            href="https://nativelink.com/cloud"
+            href="https://dev.nativelink.com"
             class="w-full md:w-auto h-12 px-8 flex items-center bg-transparent justify-center border-black border-2 border-solid text-black transition-all duration-200 hover:bg-[rgb(248,247,244)] rounded-interactive font-medium no-underline"
           >
             Start free
           </a>
           <a
-            href="/contact"
+            href="mailto:contact@nativelink.com"
             class="w-full md:w-auto h-12 px-8 flex items-center bg-transparent justify-center border-black border-2 border-solid text-black transition-all duration-200 hover:bg-[rgb(248,247,244)] rounded-interactive font-medium no-underline"
           >
             Talk to us

--- a/web/platform/src/components/qwik/sections/hero.tsx
+++ b/web/platform/src/components/qwik/sections/hero.tsx
@@ -36,7 +36,7 @@ export const Hero = component$(() => {
             Start free
           </a>
           <a
-            href="/contact"
+            href="mailto:contact@nativelink.com"
             class="w-full md:w-auto h-11 px-7 flex items-center bg-transparent justify-center text-[rgb(80,80,80)] transition-colors duration-200 hover:text-black rounded-lg font-medium text-sm underline-offset-4"
           >
             Talk to us


### PR DESCRIPTION
# Description

Fixes two broken links in the marketing site (Qwik components under `web/platform`):

1. **"Start free" CTA** pointed to `https://nativelink.com/cloud`, which is not a valid page. Updated to `https://dev.nativelink.com` (the dev portal). Affects 2 buttons.
2. **"Talk to us" CTA** pointed to `/contact`, which returns 404 on the deployed site (no `/contact` route exists). Updated to `mailto:contact@nativelink.com` so the button opens the user's mail client — matching the existing email flow already used by the cards on the `/company` page (`src/components/qwik/pages/company.tsx`). Affects 4 buttons.

Files changed:
- `web/platform/src/components/qwik/sections/hero.tsx` — 1 button (Talk to us)
- `web/platform/src/components/qwik/sections/cta.tsx` — 2 buttons (Start free, Talk to us)
- `web/platform/src/components/qwik/pages/product.tsx` — 3 buttons (Start free × 1, Talk to us × 2)

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not yet verified in a running dev server locally (bun is not installed on my workstation). The changes are pure string replacements in static `href` attributes — no logic, props, or imports were modified. Verified by re-grepping the tree:
- 0 remaining instances of `href="https://nativelink.com/cloud"`
- 0 remaining instances of `href="/contact"`
- 6 expected `mailto:contact@nativelink.com` / `https://dev.nativelink.com` replacements in place

Recommend a quick manual check on the preview deploy: click "Start free" and "Talk to us" on the homepage, `/product` page, and confirm the mailto opens a compose window and the dev portal URL loads.

## Checklist

- [ ] Updated documentation if needed *(N/A — no documented behavior changed)*
- [ ] Tests added/amended *(N/A — no test coverage exists for static `href` values in these components)*
- [ ] `bazel test //...` passes locally *(not run — change is isolated to `web/platform` TSX files; not exercised by Bazel test targets)*
- [x] PR is contained in a single commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2369)
<!-- Reviewable:end -->
