### PR TITLE
Fix fast-slow store optimisation

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -564,6 +564,7 @@ impl ByteStreamServer {
                 // Bytestream always uses digest size as the actual byte size.
                 .update(digest, rx, UploadSizeInfo::ExactSize(digest.size_bytes()))
                 .await
+                .map(|_| ())
         });
         ActiveStreamGuard {
             stream_state: Some(StreamState {

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -697,9 +697,9 @@ impl StoreDriver for StallStore {
         _key: StoreKey<'_>,
         _reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         tokio::time::sleep(self.delay).await;
-        Ok(())
+        Ok(0)
     }
 
     async fn get_part(

--- a/nativelink-store/src/azure_blob_store.rs
+++ b/nativelink-store/src/azure_blob_store.rs
@@ -586,11 +586,11 @@ where
         digest: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let blob_path = self.make_blob_path(&digest);
         // Handling zero-sized content check
         if upload_size == UploadSizeInfo::ExactSize(0) {
-            return Ok(());
+            return Ok(0);
         }
 
         let max_size = match upload_size {
@@ -637,13 +637,15 @@ where
                             }
                         );
 
-                            upload_res
-                                .and(bind_res)
-                                .err_tip(|| "Failed to upload blob in single chunk")
+                            match (upload_res, bind_res) {
+                                (Ok(size), Ok(())) => Ok(size),
+                                (Err(e), _) | (_, Err(e)) => Err(e),
+                            }
+                            .err_tip(|| "Failed to upload blob in single chunk")
                         };
 
                         match result {
-                            Ok(()) => Some((RetryResult::Ok(()), reader)),
+                            Ok(()) => Some((RetryResult::Ok(reader.get_bytes_received()), reader)),
                             Err(mut err) => {
                                 err.code = Code::Aborted;
                                 let bytes_received = reader.get_bytes_received();
@@ -688,6 +690,7 @@ where
             let tx = tx.clone();
             let blob_path = blob_path.clone();
             async move {
+                let mut total_uploaded = 0;
                 for block_id in 0..MAX_BLOCKS {
                     let write_buf = reader
                         .consume(Some(
@@ -700,6 +703,8 @@ where
                     if write_buf.is_empty() {
                         break;
                     }
+
+                    total_uploaded += write_buf.len() as u64;
 
                     let block_id = format!("{block_id:032}");
                     let blob_path = blob_path.clone();
@@ -742,12 +747,13 @@ where
                             .append("Failed to send block to channel")
                     })?;
                 }
-                Ok::<_, Error>(())
+                Ok::<_, Error>(total_uploaded)
             }
             .fuse()
         };
 
         let mut upload_futures = FuturesUnordered::new();
+        let mut total_uploaded = 0;
 
         tokio::pin!(read_stream_fut);
 
@@ -756,7 +762,9 @@ where
                 break;
             }
             tokio::select! {
-                result = &mut read_stream_fut => result?,
+                result = &mut read_stream_fut => {
+                    total_uploaded = result?;
+                },
                 Some(block_id) = upload_futures.next() => block_ids.push(block_id?),
                 Some(fut) = rx.recv() => upload_futures.push(fut),
             }
@@ -792,7 +800,7 @@ where
                                             .append("Failed to commit block list in Azure store:"),
                                     )
                                 },
-                                |_| RetryResult::Ok(()),
+                                |_| RetryResult::Ok(total_uploaded),
                             ),
                         block_list,
                     ))

--- a/nativelink-store/src/cache_metrics_store.rs
+++ b/nativelink-store/src/cache_metrics_store.rs
@@ -108,33 +108,30 @@ impl StoreDriver for CacheMetricsStore {
     ) -> Result<(), Error> {
         let start = Instant::now();
         let result = self.backend.has_with_results(keys, results).await;
-        match &result {
-            Ok(()) => {
-                let hits = results.iter().filter(|result| result.is_some()).count();
-                let misses = results.len().saturating_sub(hits);
-                if hits > 0 {
-                    CACHE_METRICS
-                        .cache_operations
-                        .add(hits as u64, self.attrs.read_hit());
-                }
-                if misses > 0 {
-                    CACHE_METRICS
-                        .cache_operations
-                        .add(misses as u64, self.attrs.read_miss());
-                }
-                let duration_attrs = if hits > 0 {
-                    self.attrs.read_hit()
-                } else {
-                    self.attrs.read_miss()
-                };
-                self.record_duration(start, duration_attrs);
-            }
-            Err(_) => {
+        if result.is_ok() {
+            let hits = results.iter().filter(|result| result.is_some()).count();
+            let misses = results.len().saturating_sub(hits);
+            if hits > 0 {
                 CACHE_METRICS
                     .cache_operations
-                    .add(keys.len() as u64, self.attrs.read_error());
-                self.record_duration(start, self.attrs.read_error());
+                    .add(hits as u64, self.attrs.read_hit());
             }
+            if misses > 0 {
+                CACHE_METRICS
+                    .cache_operations
+                    .add(misses as u64, self.attrs.read_miss());
+            }
+            let duration_attrs = if hits > 0 {
+                self.attrs.read_hit()
+            } else {
+                self.attrs.read_miss()
+            };
+            self.record_duration(start, duration_attrs);
+        } else {
+            CACHE_METRICS
+                .cache_operations
+                .add(keys.len() as u64, self.attrs.read_error());
+            self.record_duration(start, self.attrs.read_error());
         }
         result
     }
@@ -152,24 +149,20 @@ impl StoreDriver for CacheMetricsStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let start = Instant::now();
-        let bytes = Self::size_info_bytes(upload_size);
         let result = self.backend.update(key, reader, upload_size).await;
-        match &result {
-            Ok(()) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_success());
-                self.record_write_io(bytes);
-                self.record_duration(start, self.attrs.write_success());
-            }
-            Err(_) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_error());
-                self.record_duration(start, self.attrs.write_error());
-            }
+        if let Ok(size) = &result {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_success());
+            self.record_write_io(Some(*size));
+            self.record_duration(start, self.attrs.write_success());
+        } else {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_error());
+            self.record_duration(start, self.attrs.write_error());
         }
         result
     }
@@ -184,27 +177,24 @@ impl StoreDriver for CacheMetricsStore {
         path: OsString,
         file: fs::FileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::FileSlot>, Error> {
+    ) -> Result<(u64, Option<fs::FileSlot>), Error> {
         let start = Instant::now();
         let bytes = Self::size_info_bytes(upload_size);
         let result = self
             .backend
             .update_with_whole_file(key, path, file, upload_size)
             .await;
-        match &result {
-            Ok(_) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_success());
-                self.record_write_io(bytes);
-                self.record_duration(start, self.attrs.write_success());
-            }
-            Err(_) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_error());
-                self.record_duration(start, self.attrs.write_error());
-            }
+        if result.is_ok() {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_success());
+            self.record_write_io(bytes);
+            self.record_duration(start, self.attrs.write_success());
+        } else {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_error());
+            self.record_duration(start, self.attrs.write_error());
         }
         result
     }
@@ -213,20 +203,17 @@ impl StoreDriver for CacheMetricsStore {
         let start = Instant::now();
         let bytes = data.len() as u64;
         let result = self.backend.update_oneshot(key, data).await;
-        match &result {
-            Ok(()) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_success());
-                self.record_write_io(Some(bytes));
-                self.record_duration(start, self.attrs.write_success());
-            }
-            Err(_) => {
-                CACHE_METRICS
-                    .cache_operations
-                    .add(1, self.attrs.write_error());
-                self.record_duration(start, self.attrs.write_error());
-            }
+        if result.is_ok() {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_success());
+            self.record_write_io(Some(bytes));
+            self.record_duration(start, self.attrs.write_success());
+        } else {
+            CACHE_METRICS
+                .cache_operations
+                .add(1, self.attrs.write_error());
+            self.record_duration(start, self.attrs.write_error());
         }
         result
     }

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -354,7 +354,7 @@ impl StoreDriver for CompletenessCheckingStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         self.ac_store.update(key, reader, size_info).await
     }
 

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -291,7 +291,7 @@ impl StoreDriver for CompressionStore {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let mut output_state = UploadState::new(&self, upload_size)?;
 
         let (mut tx, rx) = make_buf_channel_pair();
@@ -417,10 +417,13 @@ impl StoreDriver for CompressionStore {
                     .err_tip(|| "Failed writing EOF in compression store update")?;
             }
 
-            Result::<(), Error>::Ok(())
+            Result::<u64, Error>::Ok(received_amt)
         };
         let (write_result, update_result) = tokio::join!(write_fut, update_fut);
-        write_result.merge(update_result)
+        match (write_result, update_result) {
+            (Ok(size), Ok(_)) => Ok(size),
+            (Err(e), _) | (_, Err(e)) => Err(e),
+        }
     }
 
     async fn get_part(

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -208,10 +208,10 @@ impl StoreDriver for DedupStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let mut bytes_reader = StreamReader::new(reader);
         let frame_reader = FramedRead::new(&mut bytes_reader, self.fast_cdc_decoder.clone());
-        let index_entries = frame_reader
+        let index_entries: Vec<_> = frame_reader
             .map(|r| r.err_tip(|| "Failed to decode frame from fast_cdc"))
             .map_ok(|frame| async move {
                 let hash = blake3::hash(&frame[..]).into();
@@ -236,6 +236,8 @@ impl StoreDriver for DedupStore {
             .try_collect()
             .await?;
 
+        let total_size = index_entries.iter().map(DigestInfo::size_bytes).sum();
+
         let serialized_index = wincode::config::serialize(
             &DedupIndex {
                 entries: index_entries,
@@ -255,7 +257,7 @@ impl StoreDriver for DedupStore {
             .await
             .err_tip(|| "Failed to insert our index entry to index_store in dedup_store")?;
 
-        Ok(())
+        Ok(total_size)
     }
 
     async fn get_part(

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -231,7 +231,7 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let digest = key.into_digest();
         let mut exists = [None];
         self.inner_has_with_results(&[digest], &mut exists)
@@ -240,11 +240,11 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         if exists[0].is_some() {
             // We need to drain the reader to avoid the writer complaining that we dropped
             // the connection prematurely.
-            reader
+            let size = reader
                 .drain()
                 .await
                 .err_tip(|| "In ExistenceCacheStore::update")?;
-            return Ok(());
+            return Ok(size);
         }
         {
             let mut locked_callbacks = self.pause_remove_callbacks.lock();
@@ -254,14 +254,12 @@ impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
         }
         trace!(?digest, "Inserting into inner cache");
         let result = self.inner_store.update(digest, reader, size_info).await;
-        if result.is_ok() {
+        if let Ok(size) = &result {
             trace!(?digest, "Inserting into existence cache");
-            if let UploadSizeInfo::ExactSize(size) = size_info {
-                let _ = self
-                    .existence_cache
-                    .insert(digest, ExistenceItem(size))
-                    .await;
-            }
+            let _ = self
+                .existence_cache
+                .insert(digest, ExistenceItem(*size))
+                .await;
         }
         {
             let maybe_keys = self.pause_remove_callbacks.lock().take();

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
+use futures::stream::{FuturesUnordered, StreamExt};
 use futures::{FutureExt, join};
 use nativelink_config::stores::{FastSlowSpec, StoreDirection};
 use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
@@ -44,6 +45,7 @@ use tracing::{debug, info, trace, warn};
 // there are many copies happening internally.
 
 type Loader = Arc<OnceCell<()>>;
+type MaybeSize = Option<u64>;
 
 // TODO(palfrey) We should consider copying the data in the background to allow the
 // client to hang up while the data is buffered. An alternative is to possibly make a
@@ -70,7 +72,7 @@ pub struct FastSlowStore {
     // concurrent writer that has not yet finished pushing to the slow store
     // is still visible to a concurrent existence check, preventing redundant
     // duplicate uploads of the same blob.
-    in_flight_slow_writes: Mutex<HashMap<StoreKey<'static>, u64>>,
+    in_flight_slow_writes: Mutex<HashMap<StoreKey<'static>, Arc<tokio::sync::Mutex<MaybeSize>>>>,
 }
 
 // This guard ensures that the populating_digests is cleared even if the future
@@ -104,6 +106,13 @@ impl LoaderGuard<'_> {
 struct InFlightSlowWriteGuard {
     weak_store: Weak<FastSlowStore>,
     key: Option<StoreKey<'static>>,
+    write_complete_guard: tokio::sync::OwnedMutexGuard<MaybeSize>,
+}
+
+impl InFlightSlowWriteGuard {
+    fn complete(mut self, size: MaybeSize) {
+        *self.write_complete_guard = size;
+    }
 }
 
 impl Drop for InFlightSlowWriteGuard {
@@ -157,33 +166,20 @@ impl FastSlowStore {
         })
     }
 
-    /// Best-effort size for tracking in-flight slow writes. Falls back to 0
-    /// when neither the upload size nor the key carries an exact size
-    /// (e.g. `MaxSize` for a string key). Callers of `has_with_results` only
-    /// rely on `Some(_)` vs `None`, so a size of 0 still correctly signals
-    /// "this blob exists".
-    const fn track_size(key: &StoreKey<'_>, size_info: UploadSizeInfo) -> u64 {
-        match size_info {
-            UploadSizeInfo::ExactSize(s) => s,
-            UploadSizeInfo::MaxSize(_) => match key {
-                StoreKey::Digest(d) => d.size_bytes(),
-                StoreKey::Str(_) => 0,
-            },
-        }
-    }
-
-    fn register_in_flight_slow_write(
-        &self,
-        key: StoreKey<'_>,
-        size: u64,
-    ) -> InFlightSlowWriteGuard {
+    fn register_in_flight_slow_write(&self, key: StoreKey<'_>) -> InFlightSlowWriteGuard {
         let owned = key.into_owned();
+        let write_complete = Arc::new(tokio::sync::Mutex::new(None));
+        let write_complete_guard = write_complete
+            .clone()
+            .try_lock_owned()
+            .expect("Newly created mutex is locked");
         self.in_flight_slow_writes
             .lock()
-            .insert(owned.borrow().into_owned(), size);
+            .insert(owned.borrow().into_owned(), write_complete);
         InFlightSlowWriteGuard {
             weak_store: self.weak_self.clone(),
             key: Some(owned),
+            write_complete_guard,
         }
     }
 
@@ -423,54 +419,37 @@ impl StoreDriver for FastSlowStore {
         if slow_store.optimized_for(StoreOptimizations::NoopDownloads) {
             return self.fast_store.has_with_results(key, results).await;
         }
-        // Primary lookup is the slow store because that's authoritative for
-        // downstream consumers that fetch from there. But the slow store
-        // alone can miss two important cases:
-        //   1. A concurrent writer's slow-store write is still in flight.
-        //   2. The blob is present in the fast (local) store — either
-        //      fast-only by configuration, or because the slow write has
-        //      not yet started/completed.
-        // Reporting NotFound in those cases causes redundant duplicate
-        // uploads or unnecessary slow-store fetches.
+
+        // Check with the slow store first.
         self.slow_store.has_with_results(key, results).await?;
 
-        // Fill in any blobs whose slow-store write is currently in flight.
-        // Cheap when the map is empty (the common case).
+        // Check for any in-flight requests to the slow store next.
+        let mut in_flight_futs = FuturesUnordered::new();
         {
             let in_flight = self.in_flight_slow_writes.lock();
             if !in_flight.is_empty() {
-                for (k, result) in key.iter().zip(results.iter_mut()) {
+                for (i, (k, result)) in key.iter().zip(results.iter_mut()).enumerate() {
                     if result.is_none() {
                         let owned = k.borrow().into_owned();
-                        if let Some(size) = in_flight.get(&owned) {
-                            *result = Some(*size);
+                        if let Some(maybe_size) = in_flight.get(&owned) {
+                            let maybe_size = maybe_size.clone();
+                            in_flight_futs.push(async move { (i, *maybe_size.lock().await) });
                         }
                     }
                 }
             }
         }
-
-        // Fall back to the fast store for anything still missing. This
-        // covers fast-only writes and the brief window between fast-store
-        // insertion and slow-store write start.
-        let missing_indices: Vec<usize> = results
-            .iter()
-            .enumerate()
-            .filter_map(|(i, r)| if r.is_none() { Some(i) } else { None })
-            .collect();
-        if !missing_indices.is_empty() {
-            let missing_keys: Vec<StoreKey<'_>> =
-                missing_indices.iter().map(|&i| key[i].borrow()).collect();
-            let mut fast_results = vec![None; missing_keys.len()];
-            self.fast_store
-                .has_with_results(&missing_keys, &mut fast_results)
-                .await?;
-            for (j, &orig_idx) in missing_indices.iter().enumerate() {
-                if fast_results[j].is_some() {
-                    results[orig_idx] = fast_results[j];
-                }
-            }
+        while let Some((i, size)) = in_flight_futs.next().await {
+            results[i] = size;
         }
+
+        // NOTE: We intentionally *NEVER* check the fast store, this is to
+        // ensure that we re-upload data to the slow store if it only exists
+        // in the fast store.  This does not affect workers as they do not
+        // check existence through `has` and instead go direct to loading the
+        // data which bypasses the check and will load from the fast store if
+        // it does not exist in the slow store.
+
         Ok(())
     }
 
@@ -479,7 +458,7 @@ impl StoreDriver for FastSlowStore {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // If either one of our stores is a noop store, bypass the multiplexing
         // and just use the store that is not a noop store.
         let ignore_slow = self
@@ -497,23 +476,22 @@ impl StoreDriver for FastSlowStore {
         if ignore_slow && ignore_fast {
             // We need to drain the reader to avoid the writer complaining that we dropped
             // the connection prematurely.
-            reader
-                .drain()
-                .await
-                .err_tip(|| "In FastFlowStore::update")?;
-            return Ok(());
+            return reader.drain().await.err_tip(|| "In FastFlowStore::update");
         }
         if ignore_slow {
             return self.fast_store.update(key, reader, size_info).await;
         }
+        let slow_in_flight_guard = self.register_in_flight_slow_write(key.borrow());
         if ignore_fast {
-            let _guard =
-                self.register_in_flight_slow_write(key.borrow(), Self::track_size(&key, size_info));
-            return self.slow_store.update(key, reader, size_info).await;
+            let result = self
+                .slow_store
+                .update(key.borrow(), reader, size_info)
+                .await;
+            if let Ok(size) = &result {
+                slow_in_flight_guard.complete(Some(*size));
+            }
+            return result;
         }
-
-        let _slow_in_flight_guard =
-            self.register_in_flight_slow_write(key.borrow(), Self::track_size(&key, size_info));
 
         let (mut fast_tx, fast_rx) = make_buf_channel_pair();
         let (mut slow_tx, slow_rx) = make_buf_channel_pair();
@@ -524,9 +502,9 @@ impl StoreDriver for FastSlowStore {
             "FastSlowStore::update: starting dual-store upload",
         );
         let update_start = std::time::Instant::now();
-        let mut bytes_sent: u64 = 0;
 
         let data_stream_fut = async move {
+            let mut bytes_sent: u64 = 0;
             loop {
                 let buffer = reader
                     .recv()
@@ -544,7 +522,7 @@ impl StoreDriver for FastSlowStore {
                         total_bytes = bytes_sent,
                         "FastSlowStore::update: data_stream sent EOF to both stores",
                     );
-                    return Result::<(), Error>::Ok(());
+                    return Result::<u64, Error>::Ok(bytes_sent);
                 }
 
                 let chunk_len = buffer.len();
@@ -585,12 +563,18 @@ impl StoreDriver for FastSlowStore {
         let (data_stream_res, fast_res, slow_res) =
             join!(data_stream_fut, fast_store_fut, slow_store_fut);
 
+        if let Ok(size) = slow_res {
+            slow_in_flight_guard.complete(Some(size));
+        } else {
+            drop(slow_in_flight_guard);
+        }
+
         let total_elapsed = update_start.elapsed();
         if data_stream_res.is_err() || fast_res.is_err() || slow_res.is_err() {
             let all_not_found = [&data_stream_res, &fast_res, &slow_res]
                 .iter()
                 .all(|r| match r {
-                    Ok(()) => true,
+                    Ok(_size) => true,
                     Err(e) => e.code == Code::NotFound,
                 });
             if all_not_found {
@@ -619,8 +603,7 @@ impl StoreDriver for FastSlowStore {
                 "FastSlowStore::update: completed successfully",
             );
         }
-        data_stream_res.merge(fast_res).merge(slow_res)?;
-        Ok(())
+        data_stream_res.merge(fast_res).merge(slow_res)
     }
 
     /// `FastSlowStore` has optimizations for dealing with files.
@@ -637,7 +620,7 @@ impl StoreDriver for FastSlowStore {
         path: OsString,
         mut file: fs::FileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::FileSlot>, Error> {
+    ) -> Result<(u64, Option<fs::FileSlot>), Error> {
         trace!(
             key = ?key,
             ?upload_size,
@@ -656,11 +639,8 @@ impl StoreDriver for FastSlowStore {
             {
                 trace!("FastSlowStore::update_with_whole_file: uploading to slow_store");
                 let slow_start = std::time::Instant::now();
-                let _guard = self.register_in_flight_slow_write(
-                    key.borrow(),
-                    Self::track_size(&key, upload_size),
-                );
-                slow_update_store_with_file(
+                let slow_in_flight_guard = self.register_in_flight_slow_write(key.borrow());
+                let size = slow_update_store_with_file(
                     self.slow_store.as_store_driver_pin(),
                     key.borrow(),
                     &mut file,
@@ -668,6 +648,7 @@ impl StoreDriver for FastSlowStore {
                 )
                 .await
                 .err_tip(|| "In FastSlowStore::update_with_whole_file slow_store")?;
+                slow_in_flight_guard.complete(Some(size));
                 trace!(
                     elapsed_ms = slow_start.elapsed().as_millis(),
                     "FastSlowStore::update_with_whole_file: slow_store upload completed",
@@ -676,7 +657,16 @@ impl StoreDriver for FastSlowStore {
             if self.fast_direction == StoreDirection::ReadOnly
                 || self.fast_direction == StoreDirection::Get
             {
-                return Ok(Some(file));
+                let file_size = match upload_size {
+                    UploadSizeInfo::ExactSize(size) => size,
+                    UploadSizeInfo::MaxSize(_) => file
+                        .as_ref()
+                        .metadata()
+                        .await
+                        .err_tip(|| format!("While reading metadata for {}", path.display()))?
+                        .len(),
+                };
+                return Ok((file_size, Some(file)));
             }
             return self
                 .fast_store
@@ -694,33 +684,51 @@ impl StoreDriver for FastSlowStore {
                 .optimized_for(StoreOptimizations::NoopUpdates)
                 || self.fast_direction == StoreDirection::ReadOnly
                 || self.fast_direction == StoreDirection::Get;
-            if !ignore_fast {
-                slow_update_store_with_file(
-                    self.fast_store.as_store_driver_pin(),
-                    key.borrow(),
-                    &mut file,
-                    upload_size,
+            let maybe_size = if ignore_fast {
+                None
+            } else {
+                Some(
+                    slow_update_store_with_file(
+                        self.fast_store.as_store_driver_pin(),
+                        key.borrow(),
+                        &mut file,
+                        upload_size,
+                    )
+                    .await
+                    .err_tip(|| "In FastSlowStore::update_with_whole_file fast_store")?,
                 )
-                .await
-                .err_tip(|| "In FastSlowStore::update_with_whole_file fast_store")?;
-            }
+            };
             let ignore_slow = self.slow_direction == StoreDirection::ReadOnly
                 || self.slow_direction == StoreDirection::Get;
             if ignore_slow {
-                return Ok(Some(file));
+                let size = match maybe_size {
+                    Some(size) => size,
+                    None => match upload_size {
+                        UploadSizeInfo::ExactSize(size) => size,
+                        UploadSizeInfo::MaxSize(_) => file
+                            .as_ref()
+                            .metadata()
+                            .await
+                            .err_tip(|| format!("While reading metadata for {}", path.display()))?
+                            .len(),
+                    },
+                };
+                return Ok((size, Some(file)));
             }
-            let _guard = self
-                .register_in_flight_slow_write(key.borrow(), Self::track_size(&key, upload_size));
-            return self
+            let slow_in_flight_guard: InFlightSlowWriteGuard =
+                self.register_in_flight_slow_write(key.borrow());
+            let (size, maybe_file_slot) = self
                 .slow_store
-                .update_with_whole_file(key, path, file, upload_size)
-                .await;
+                .update_with_whole_file(key.borrow(), path, file, upload_size)
+                .await?;
+            slow_in_flight_guard.complete(Some(size));
+            return Ok((size, maybe_file_slot));
         }
 
-        slow_update_store_with_file(self, key, &mut file, upload_size)
+        let size = slow_update_store_with_file(self, key, &mut file, upload_size)
             .await
             .err_tip(|| "In FastSlowStore::update_with_whole_file")?;
-        Ok(Some(file))
+        Ok((size, Some(file)))
     }
 
     async fn get_part(
@@ -888,6 +896,6 @@ struct FastSlowStoreMetrics {
 /// concurrent reader of the same digest until each one's own `gRPC`
 /// deadline fired (e.g. Bazel's `--remote_timeout`), turning a
 /// single slow read into a fan-out of `DEADLINE_EXCEEDED` errors.
-const LEADER_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+const LEADER_WAIT_TIMEOUT: Duration = Duration::from_mins(1);
 
 default_health_status_indicator!(FastSlowStore);

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -958,7 +958,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         mut temp_file: fs::FileSlot,
         final_key: StoreKey<'static>,
         mut reader: DropCloserReadHalf,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let mut data_size = 0;
         loop {
             let mut data = reader
@@ -997,7 +997,8 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         drop(temp_file);
 
         *entry.data_size_mut() = data_size;
-        self.emplace_file(final_key, Arc::new(entry)).await
+        self.emplace_file(final_key, Arc::new(entry)).await?;
+        Ok(data_size)
     }
 
     async fn emplace_file(&self, key: StoreKey<'static>, entry: Arc<Fe>) -> Result<(), Error> {
@@ -1144,10 +1145,10 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         if is_zero_digest(key.borrow()) {
-            // don't need to add, because zero length files are just assumed to exist
-            return Ok(());
+            // don't need to add, because zero length files are just assumed to exist.
+            return Ok(0);
         }
 
         let temp_key = make_temp_key(&key);
@@ -1241,7 +1242,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         path: OsString,
         file: fs::FileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::FileSlot>, Error> {
+    ) -> Result<(u64, Option<fs::FileSlot>), Error> {
         let file_size = match upload_size {
             UploadSizeInfo::ExactSize(size) => size,
             UploadSizeInfo::MaxSize(_) => file
@@ -1253,7 +1254,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         };
         if file_size == 0 {
             // don't need to add, because zero length files are just assumed to exist
-            return Ok(None);
+            return Ok((0, None));
         }
         let entry = Fe::create(
             file_size,
@@ -1272,7 +1273,7 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         self.emplace_file(key.into_owned(), Arc::new(entry))
             .await
             .err_tip(|| "Could not move file into store in upload_file_to_store, maybe dest is on different volume?")?;
-        return Ok(None);
+        return Ok((file_size, None));
     }
 
     async fn get_part(

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -233,13 +233,14 @@ where
         digest: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         if is_zero_digest(digest.borrow()) {
             return reader.recv().await.and_then(|should_be_empty| {
-                should_be_empty
-                    .is_empty()
-                    .then_some(())
-                    .ok_or_else(|| make_err!(Code::Internal, "Zero byte hash not empty"))
+                if should_be_empty.is_empty() {
+                    Ok(0)
+                } else {
+                    Err(make_err!(Code::Internal, "Zero byte hash not empty"))
+                }
             });
         }
 
@@ -255,13 +256,14 @@ where
             && size < MIN_MULTIPART_SIZE
         {
             let content = reader.consume(Some(usize::try_from(size)?)).await?;
+            let content_len = content.len() as u64;
             let client = &self.client;
 
             return self
                 .retrier
                 .retry(unfold(content, |content| async {
                     match client.write_object(&object_path, content.to_vec()).await {
-                        Ok(()) => Some((RetryResult::Ok(()), content)),
+                        Ok(()) => Some((RetryResult::Ok(content_len), content)),
                         Err(e) => Some((RetryResult::Retry(e), content)),
                     }
                 }))
@@ -356,7 +358,7 @@ where
                             )
                             .await
                         {
-                            Ok(()) => Some((RetryResult::Ok(()), ())),
+                            Ok(()) => Some((RetryResult::Ok(offset), ())),
                             Err(e) => Some((RetryResult::Retry(e), ())),
                         }
                     }))
@@ -368,7 +370,7 @@ where
                 .retrier
                 .retry(unfold((), |()| async {
                     match client.write_object(&object_path, Vec::new()).await {
-                        Ok(()) => Some((RetryResult::Ok(()), ())),
+                        Ok(()) => Some((RetryResult::Ok(0), ())),
                         Err(e) => Some((RetryResult::Retry(e), ())),
                     }
                 }))
@@ -392,7 +394,7 @@ where
             }))
             .await?;
 
-        Ok(())
+        Ok(offset)
     }
 
     async fn get_part(

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -679,8 +679,10 @@ impl GrpcStore {
         &self,
         digest: DigestInfo,
         mut reader: DropCloserReadHalf,
-    ) -> Result<(), Error> {
-        let action_result = ActionResult::decode(reader.consume(None).await?)
+    ) -> Result<u64, Error> {
+        let bytes = reader.consume(None).await?;
+        let len = bytes.len() as u64;
+        let action_result = ActionResult::decode(bytes)
             .err_tip(|| "Failed to decode ActionResult in update_action_result_from_bytes")?;
         let update_action_request = UpdateActionResultRequest {
             instance_name: self.instance_name.clone(),
@@ -695,7 +697,7 @@ impl GrpcStore {
         };
         self.update_action_result(Request::new(update_action_request))
             .await
-            .map(|_| ())
+            .map(|_| len)
     }
 }
 
@@ -773,7 +775,7 @@ impl StoreDriver for GrpcStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         struct LocalState {
             resource_name: String,
             reader: DropCloserReadHalf,
@@ -864,7 +866,7 @@ impl StoreDriver for GrpcStore {
         .await
         .err_tip(|| "in GrpcStore::update()")?;
 
-        Ok(())
+        Ok(digest.size_bytes())
     }
 
     async fn get_part(

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -135,7 +135,7 @@ impl StoreDriver for MemoryStore {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // Internally Bytes might hold a reference to more data than just our data. To prevent
         // this potential case, we make a full copy of our data for long-term storage.
         let final_buffer = {
@@ -148,10 +148,11 @@ impl StoreDriver for MemoryStore {
             new_buffer.freeze()
         };
 
+        let len = final_buffer.len().try_into().unwrap_or(0);
         self.evicting_map
             .insert(key.into_owned().into(), BytesWrapper(final_buffer))
             .await;
-        Ok(())
+        Ok(len)
     }
 
     fn optimized_for(&self, optimization: StoreOptimizations) -> bool {

--- a/nativelink-store/src/mongo_store.rs
+++ b/nativelink-store/src/mongo_store.rs
@@ -440,7 +440,7 @@ impl StoreDriver for ExperimentalMongoStore {
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let encoded_key = self.encode_key(&key);
 
         // Handle zero digest
@@ -458,7 +458,7 @@ impl StoreDriver for ExperimentalMongoStore {
                         "Failed to drain in ExperimentalMongoStore::update: {e}"
                     )
                 })?;
-                return Ok(());
+                return Ok(0);
             }
         }
 
@@ -515,7 +515,7 @@ impl StoreDriver for ExperimentalMongoStore {
 
         drop(semaphore);
 
-        Ok(())
+        Ok(size.try_into().unwrap_or(0))
     }
 
     async fn get_part(

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -63,11 +63,11 @@ impl StoreDriver for NoopStore {
         _key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // We need to drain the reader to avoid the writer complaining that we dropped
         // the connection prematurely.
-        reader.drain().await.err_tip(|| "In NoopStore::update")?;
-        Ok(())
+        let size = reader.drain().await.err_tip(|| "In NoopStore::update")?;
+        Ok(size)
     }
 
     fn optimized_for(&self, optimization: StoreOptimizations) -> bool {

--- a/nativelink-store/src/ontap_s3_existence_cache_store.rs
+++ b/nativelink-store/src/ontap_s3_existence_cache_store.rs
@@ -510,7 +510,7 @@ where
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let key_owned = key.into_owned();
         let result = self
             .inner_store

--- a/nativelink-store/src/ontap_s3_store.rs
+++ b/nativelink-store/src/ontap_s3_store.rs
@@ -338,7 +338,7 @@ where
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let s3_path = &self.make_s3_path(&key);
 
         let max_size = match size_info {
@@ -360,7 +360,7 @@ where
 
                     let result = {
                         let reader_ref = &mut reader;
-                        let (upload_res, bind_res): (Result<(), Error>, Result<(), Error>) = tokio::join!(async move {
+                        let (upload_res, bind_res): (Result<u64, Error>, Result<(), Error>) = tokio::join!(async move {
                             let raw_body_bytes = {
                                 let mut raw_body_chunks = BytesMut::new();
                                 loop {
@@ -380,6 +380,7 @@ where
                             let internal_res = match raw_body_bytes {
                                 Ok(body_bytes) => {
                                     let hash = Sha256::digest(&body_bytes);
+                                    let body_len: u64 = body_bytes.len().try_into().unwrap_or(0);
                                     let send_res = self.s3_client
                                         .put_object()
                                         .bucket(&self.bucket)
@@ -394,10 +395,10 @@ where
                                         .mutate_request(|req| {req.headers_mut().insert("x-amz-content-sha256", "UNSIGNED-PAYLOAD");})
                                         .send();
                                     Either::Left(send_res.map_ok_or_else(|e| Err(
-                                        Error::from_std_err(Code::Aborted, &e)), |_| Ok(())))
+                                        Error::from_std_err(Code::Aborted, &e)), move |_| Ok(body_len)))
                                     }
                                 Err(collect_err) => {
-                                    async fn make_collect_err(collect_err: Error) -> Result<(), Error> {
+                                    async fn make_collect_err(collect_err: Error) -> Result<u64, Error> {
                                         Err(collect_err)
                                     }
 
@@ -412,9 +413,11 @@ where
                         },
                             tx.bind_buffered(reader_ref)
                         );
-                        upload_res
-                            .merge(bind_res)
-                            .err_tip(|| "Failed to upload file to ONTAP S3 in single chunk")
+                        match (upload_res, bind_res) {
+                            (Ok(size), Ok(())) => Ok(size),
+                            (Err(e), _) | (_, Err(e)) => Err(e),
+                        }
+                        .err_tip(|| "Failed to upload file to ONTAP S3 in single chunk")
                     };
 
                     let retry_result = result.map_or_else(
@@ -446,7 +449,7 @@ where
                             event!(Level::INFO, ?err, ?bytes_received, "Retryable ONTAP S3 error");
                             RetryResult::Retry(err)
                         },
-                        |()| RetryResult::Ok(())
+                        RetryResult::Ok
                     );
                     Some((retry_result, reader))
                 })
@@ -496,6 +499,7 @@ where
             let read_stream_fut = (
                 async move {
                     let retrier = &Pin::get_ref(self).retrier;
+                    let mut total_uploaded = 0;
                     for part_number in 1..i32::MAX {
                         let write_buf = reader
                             .consume(
@@ -511,6 +515,8 @@ where
                         if write_buf.is_empty() {
                             break;
                         }
+
+                        total_uploaded += write_buf.len() as u64;
 
                         tx
                             .send(
@@ -550,11 +556,12 @@ where
                                 Error::from_std_err(Code::Internal, &err).append("Failed to send part to channel in ontap_s3_store")
                             })?;
                     }
-                    Result::<_, Error>::Ok(())
+                    Result::<_, Error>::Ok(total_uploaded)
                 }
             ).fuse();
 
             let mut upload_futures = FuturesUnordered::new();
+            let mut total_uploaded = 0;
             let mut completed_parts = Vec::with_capacity(
                 usize::try_from(cmp::min(
                     MAX_UPLOAD_PARTS as u64,
@@ -569,7 +576,9 @@ where
                     break;
                 }
                 tokio::select! {
-                    result = &mut read_stream_fut => result?,
+                    result = &mut read_stream_fut => {
+                        total_uploaded = result?;
+                    },
                     Some(upload_result) = upload_futures.next() => completed_parts.push(upload_result?),
                     Some(fut) = rx.recv() => upload_futures.push(fut),
                 }
@@ -600,7 +609,7 @@ where
                                         ),
                                     )
                                 },
-                                |_| RetryResult::Ok(()),
+                                |_| RetryResult::Ok(total_uploaded),
                             ),
                         completed_parts,
                     ))
@@ -609,25 +618,22 @@ where
         };
 
         upload_parts()
-            .or_else(move |e| async move {
-                Result::<(), _>::Err(e).merge(
-                    self.s3_client
-                        .abort_multipart_upload()
-                        .bucket(&self.bucket)
-                        .key(s3_path)
-                        .upload_id(upload_id)
-                        .send()
-                        .await
-                        .map_or_else(
-                            |e| {
-                                let err = Error::from_std_err(Code::Aborted, &e)
-                                    .append("Failed to abort multipart upload in ONTAP S3 store");
-                                event!(Level::INFO, ?err, "Multipart upload error");
-                                Err(err)
-                            },
-                            |_| Ok(()),
-                        ),
-                )
+            .or_else(move |mut e| async move {
+                let abort_res = self
+                    .s3_client
+                    .abort_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(s3_path)
+                    .upload_id(upload_id)
+                    .send()
+                    .await;
+                if let Err(abort_err) = abort_res {
+                    let err = Error::from_std_err(Code::Aborted, &abort_err)
+                        .append("Failed to abort multipart upload in ONTAP S3 store");
+                    event!(Level::INFO, ?err, "Multipart upload error");
+                    e = e.merge(err);
+                }
+                Err(e)
             })
             .await
     }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -854,7 +854,7 @@ where
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let final_key = self.encode_key(&key);
 
         // While the name generation function can be supplied by the user, we need to have the curly
@@ -882,7 +882,7 @@ where
                     .await
                     .err_tip(|| "Failed to drain in RedisStore::update")?;
                 // Zero-digest keys are special -- we don't need to do anything with it.
-                return Ok(());
+                return Ok(0);
             }
         }
 
@@ -972,13 +972,13 @@ where
 
         // If we have a publish channel configured, send a notice that the key has been set.
         if let Some(pub_sub_channel) = &self.pub_sub_channel {
-            return Ok(client
+            client
                 .connection_manager
-                .publish(pub_sub_channel, final_key.as_ref())
-                .await?);
+                .publish::<_, _, ()>(pub_sub_channel, final_key.as_ref())
+                .await?;
         }
 
-        Ok(())
+        Ok(blob_len.try_into().unwrap_or(0))
     }
 
     async fn get_part(

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -118,7 +118,7 @@ impl StoreDriver for RefStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         self.get_store()?.update(key, reader, size_info).await
     }
 

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -268,7 +268,7 @@ where
         digest: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let s3_path = &self.make_s3_path(&digest);
 
         let max_size = match upload_size {
@@ -312,13 +312,15 @@ where
                                     size: sz,
                                 }))
                                 .send()
-                                .map_ok_or_else(|e| Err(Error::from_std_err(Code::Aborted, &e)), |_| Ok(())),
+                                .map_ok_or_else(|e| Err(Error::from_std_err(Code::Aborted, &e)), |_| Ok(sz)),
                             // Stream all data from the reader channel to the writer channel.
                             tx.bind_buffered(reader_ref)
                         );
-                        upload_res
-                            .merge(bind_res)
-                            .err_tip(|| "Failed to upload file to s3 in single chunk")
+                        match (upload_res, bind_res) {
+                            (Ok(size), Ok(())) => Ok(size),
+                            (Err(e), _) | (_, Err(e)) => Err(e),
+                        }
+                        .err_tip(|| "Failed to upload file to s3 in single chunk")
                     };
 
                     // If we failed to upload the file, check to see if we can retry.
@@ -343,7 +345,7 @@ where
                             "Retryable S3 error"
                         );
                         RetryResult::Retry(err)
-                    }, |()| RetryResult::Ok(()));
+                    }, |size| RetryResult::Ok(size));
                     Some((retry_result, reader))
                 }))
                 .await;
@@ -394,6 +396,7 @@ where
 
             let read_stream_fut = async move {
                 let retrier = &Pin::get_ref(self).retrier;
+                let mut total_uploaded = 0;
                 // Note: Our break condition is when we reach EOF.
                 for part_number in 1..i32::MAX {
                     let write_buf = reader
@@ -405,6 +408,8 @@ where
                     if write_buf.is_empty() {
                         break; // Reached EOF.
                     }
+
+                    total_uploaded += write_buf.len() as u64;
 
                     tx.send(retrier.retry(unfold(write_buf, move |write_buf| {
                         async move {
@@ -447,11 +452,12 @@ where
                             .append("Failed to send part to channel in s3_store")
                     })?;
                 }
-                Result::<_, Error>::Ok(())
+                Result::<_, Error>::Ok(total_uploaded)
             }
             .fuse();
 
             let mut upload_futures = FuturesUnordered::new();
+            let mut total_uploaded = 0;
 
             let mut completed_parts = Vec::with_capacity(
                 usize::try_from(cmp::min(
@@ -466,7 +472,9 @@ where
                     break; // No more data to process.
                 }
                 tokio::select! {
-                    result = &mut read_stream_fut => result?, // Return error or wait for other futures.
+                    result = &mut read_stream_fut => {
+                        total_uploaded = result?;
+                    }, // Return error or wait for other futures.
                     Some(upload_result) = upload_futures.next() => completed_parts.push(upload_result?),
                     Some(fut) = rx.recv() => upload_futures.push(fut),
                 }
@@ -499,7 +507,7 @@ where
                                         ),
                                     )
                                 },
-                                |_| RetryResult::Ok(()),
+                                |_| RetryResult::Ok(total_uploaded),
                             ),
                         completed_parts,
                     ))
@@ -509,26 +517,22 @@ where
         // Upload our parts and complete the multipart upload.
         // If we fail attempt to abort the multipart upload (cleanup).
         upload_parts()
-            .or_else(move |e| async move {
-                Result::<(), _>::Err(e).merge(
-                    // Note: We don't retry here because this is just a best attempt.
-                    self.s3_client
-                        .abort_multipart_upload()
-                        .bucket(&self.bucket)
-                        .key(s3_path)
-                        .upload_id(upload_id)
-                        .send()
-                        .await
-                        .map_or_else(
-                            |e| {
-                                let err = Error::from_std_err(Code::Aborted, &e)
-                                    .append("Failed to abort multipart upload in S3 store");
-                                info!(?err, "Multipart upload error");
-                                Err(err)
-                            },
-                            |_| Ok(()),
-                        ),
-                )
+            .or_else(move |mut e| async move {
+                let abort_res = self
+                    .s3_client
+                    .abort_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(s3_path)
+                    .upload_id(upload_id)
+                    .send()
+                    .await;
+                if let Err(abort_err) = abort_res {
+                    let err = Error::from_std_err(Code::Aborted, &abort_err)
+                        .append("Failed to abort multipart upload in S3 store");
+                    info!(?err, "Multipart upload error");
+                    e = e.merge(err);
+                }
+                Err(e)
             })
             .await
     }

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -206,7 +206,7 @@ impl StoreDriver for ShardStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let store = self.get_store(&key);
         store
             .update(key, reader, size_info)

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -100,7 +100,7 @@ impl StoreDriver for SizePartitioningStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let digest = match key {
             StoreKey::Digest(digest) => digest,
             other @ StoreKey::Str(_) => {

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -65,7 +65,7 @@ impl VerifyStore {
         maybe_expected_digest_size: Option<u64>,
         original_hash: &PackedHash,
         mut maybe_hasher: Option<&mut D>,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let mut sum_size: u64 = 0;
         loop {
             let chunk = rx
@@ -140,7 +140,7 @@ impl VerifyStore {
                 .await
                 .err_tip(|| "Failed to write chunk to inner store in verify store")?;
         }
-        Ok(())
+        Ok(sum_size)
     }
 }
 
@@ -159,7 +159,7 @@ impl StoreDriver for VerifyStore {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let StoreKey::Digest(digest) = key else {
             return Err(make_input_err!(
                 "Only digests are supported in VerifyStore. Got {key:?}"
@@ -207,7 +207,11 @@ impl StoreDriver for VerifyStore {
 
         let (update_res, check_res) = tokio::join!(update_fut, check_fut);
 
-        update_res.merge(check_res)
+        match (update_res, check_res) {
+            // Prioritize the check future's error, as it's more specific.
+            (_, Err(e)) | (Err(e), Ok(_)) => Err(e),
+            (Ok(size), Ok(_)) => Ok(size),
+        }
     }
 
     async fn get_part(

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -273,10 +273,10 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             _digest: StoreKey<'_>,
             mut reader: DropCloserReadHalf,
             _size_info: UploadSizeInfo,
-        ) -> Result<(), Error> {
+        ) -> Result<u64, Error> {
             // Gets called in the fast store and we don't need to do
             // anything.  Should only complete when drain has finished.
-            reader.drain().await?;
+            let size = reader.drain().await?;
             let eof_tx = self.eof_tx.lock().unwrap().take();
             if let Some(tx) = eof_tx {
                 tx.send(())
@@ -286,7 +286,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             if let Some(rx) = read_rx {
                 rx.await.map_err(|e| make_err!(Code::Internal, "{:?}", e))?;
             }
-            Ok(())
+            Ok(size)
         }
 
         async fn get_part(
@@ -367,7 +367,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             // Drop get_part as soon as rx.drain() completes
             tokio::select!(
                 res = rx.drain() => res,
-                res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes())) => res,
+                res = fast_slow_store.get_part(digest, tx, 0, Some(digest.size_bytes())) => res.map(|()| digest.size_bytes()),
             )
         },
         async move {
@@ -389,14 +389,8 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
     get_res.merge(read_res)
 }
 
-// Previously `has()` returned `None` for a blob that was present only in the
-// fast store. That behavior caused redundant work: a worker that had already
-// cached a blob locally would still get NotFound from `has()` and re-fetch
-// (or re-upload) the same data. `has_with_results` now falls back to the
-// fast store when the slow store reports nothing, so a fast-only hit
-// correctly returns the blob's size.
 #[nativelink_test]
-async fn fast_store_only_value_is_reported_by_has() -> Result<(), Error> {
+async fn ignore_value_in_fast_store() -> Result<(), Error> {
     let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
     let fast_slow_store = Arc::new(FastSlowStore::new(
@@ -413,10 +407,9 @@ async fn fast_store_only_value_is_reported_by_has() -> Result<(), Error> {
     fast_store
         .update_oneshot(digest, make_random_data(100).into())
         .await?;
-    assert_eq!(
-        fast_slow_store.has(digest).await?,
-        Some(100),
-        "Expected fast-store-only blob to be reported as present",
+    assert!(
+        fast_slow_store.has(digest).await?.is_none(),
+        "Expected data to not exist in store"
     );
     Ok(())
 }
@@ -607,7 +600,7 @@ fn make_stores_with_lazy_slow() -> (Store, Store, Store) {
             digest: StoreKey<'_>,
             reader: DropCloserReadHalf,
             size_info: UploadSizeInfo,
-        ) -> Result<(), Error> {
+        ) -> Result<u64, Error> {
             Pin::new(self.inner.as_ref())
                 .update(digest, reader, size_info)
                 .await
@@ -748,7 +741,7 @@ impl StoreDriver for InstrumentedSlowStore {
         _key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // Drain anything sent so the writer side does not deadlock.
         reader.drain().await
     }
@@ -953,7 +946,7 @@ async fn has_sees_in_flight_slow_writes() -> Result<(), Error> {
             _key: StoreKey<'_>,
             mut reader: DropCloserReadHalf,
             _size_info: UploadSizeInfo,
-        ) -> Result<(), Error> {
+        ) -> Result<u64, Error> {
             let started_tx = self.started_tx.lock().unwrap().take();
             if let Some(tx) = started_tx {
                 let _ = tx.send(());
@@ -1042,12 +1035,16 @@ async fn has_sees_in_flight_slow_writes() -> Result<(), Error> {
 
     // Concurrent observer: the slow store will return None (its
     // has_with_results above), so the only way this can be Some is via
-    // the in-flight map.
-    assert_eq!(
-        fast_slow.has(digest).await?,
-        Some(data.len() as u64),
-        "Concurrent has() must see in-flight slow write",
-    );
+    // the in-flight map wait.
+    let observer_store = fast_slow.clone();
+    let mut observer = tokio::spawn(async move { observer_store.has(digest).await });
+
+    // Prove that the observer is blocked waiting for the in-flight write.
+    // It should not resolve before the gate is released.
+    tokio::select! {
+        _ = &mut observer => panic!("Observer resolved before writer completed"),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
 
     // Release the writer and confirm the in-flight tracker is cleaned up.
     gate_tx
@@ -1057,13 +1054,22 @@ async fn has_sees_in_flight_slow_writes() -> Result<(), Error> {
         .await
         .map_err(|e| make_err!(Code::Internal, "writer join error: {e:?}"))??;
 
-    // After completion the fast store still has the blob, so has() should
-    // remain Some via the fast-store fallback (the GatedSlowStore still
-    // reports None).
+    let has_result = observer
+        .await
+        .map_err(|e| make_err!(Code::Internal, "observer join error: {e:?}"))??;
+
+    assert_eq!(
+        has_result,
+        Some(data.len() as u64),
+        "Concurrent has() must wait for and see in-flight slow write",
+    );
+
+    // After completion the fast store still has the blob, but has() should
+    // return None since we never fallback to checking the fast store.
     assert_eq!(
         fast_slow.has(digest).await?,
-        Some(data.len() as u64),
-        "Post-write has() should see the blob via fast-store fallback",
+        None,
+        "Post-write has() should not see the blob via fast-store fallback",
     );
 
     Ok(())
@@ -1099,7 +1105,7 @@ async fn has_does_not_consult_fast_store_when_slow_store_hits() -> Result<(), Er
             key: StoreKey<'_>,
             reader: DropCloserReadHalf,
             size_info: UploadSizeInfo,
-        ) -> Result<(), Error> {
+        ) -> Result<u64, Error> {
             Pin::new(self.inner.as_ref())
                 .update(key, reader, size_info)
                 .await
@@ -1201,7 +1207,7 @@ impl StoreDriver for GatedSlowStore2 {
         _key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let started_tx = self.started_tx.lock().unwrap().take();
         if let Some(tx) = started_tx {
             let _ = tx.send(());
@@ -1290,11 +1296,16 @@ async fn dropping_update_future_cleans_up_in_flight_entry() -> Result<(), Error>
     started_rx
         .await
         .map_err(|e| make_err!(Code::Internal, "started signal lost: {e:?}"))?;
-    assert_eq!(
-        fast_slow.has(digest).await?,
-        Some(data.len() as u64),
-        "Pre-cancel: in-flight slow write must be visible via has()",
-    );
+
+    let observer_store = fast_slow.clone();
+    let mut observer = tokio::spawn(async move { observer_store.has(digest).await });
+
+    // Prove that the observer is blocked waiting for the in-flight write.
+    // It should not resolve before the gate is released.
+    tokio::select! {
+        _ = &mut observer => panic!("Observer resolved before writer completed"),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
 
     // Cancel the writer. The guard's Drop should remove the entry.
     writer.abort();
@@ -1304,6 +1315,15 @@ async fn dropping_update_future_cleans_up_in_flight_entry() -> Result<(), Error>
     // The gate is now stale (writer is gone) — drop the receiver explicitly
     // by releasing the sender to avoid any hang in unrelated code paths.
     drop(gate_tx);
+
+    let has_result = observer
+        .await
+        .map_err(|e| make_err!(Code::Internal, "observer join error: {e:?}"))??;
+
+    assert_eq!(
+        has_result, None,
+        "Pre-cancel: in-flight slow write must be aborted and return None",
+    );
 
     assert_eq!(
         fast_slow.has(digest).await?,
@@ -1349,7 +1369,7 @@ impl StoreDriver for MapBackedSlow {
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // Delegate to the gated inner so timing is controllable.
         Pin::new(self.inner.as_ref())
             .update(key, reader, size_info)
@@ -1453,16 +1473,23 @@ async fn has_with_results_handles_mixed_key_sources() -> Result<(), Error> {
         StoreKey::Digest(fast_only_digest),
         StoreKey::Digest(missing_digest),
     ];
-    let mut results: [Option<u64>; 4] = [None; 4];
-    fast_slow
-        .as_store_driver_pin()
-        .has_with_results(&keys, &mut results)
-        .await?;
 
-    assert_eq!(results[0], Some(slow_only_size), "slow-only key");
-    assert_eq!(results[1], Some(in_flight_size), "in-flight key");
-    assert_eq!(results[2], Some(fast_only_size), "fast-only key");
-    assert_eq!(results[3], None, "missing key must stay None");
+    let observer_store = fast_slow.clone();
+    let mut observer = tokio::spawn(async move {
+        let mut results: [Option<u64>; 4] = [None; 4];
+        observer_store
+            .as_store_driver_pin()
+            .has_with_results(&keys, &mut results)
+            .await?;
+        Ok::<_, Error>(results)
+    });
+
+    // Prove that the observer is blocked waiting for the in-flight write.
+    // It should not resolve before the gate is released.
+    tokio::select! {
+        _ = &mut observer => panic!("Observer resolved before writer completed"),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
 
     // Cleanup: release the gated writer.
     gate_tx
@@ -1471,6 +1498,18 @@ async fn has_with_results_handles_mixed_key_sources() -> Result<(), Error> {
     writer
         .await
         .map_err(|e| make_err!(Code::Internal, "writer join error: {e:?}"))??;
+
+    let results = observer
+        .await
+        .map_err(|e| make_err!(Code::Internal, "observer join error: {e:?}"))??;
+
+    assert_eq!(results[0], Some(slow_only_size), "slow-only key");
+    assert_eq!(results[1], Some(in_flight_size), "in-flight key");
+    assert_eq!(
+        results[2], None,
+        "fast-only key should be None because we do not check fast store"
+    );
+    assert_eq!(results[3], None, "missing key must stay None");
 
     Ok(())
 }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -999,6 +999,7 @@ async fn update_with_zero_digest() -> Result<(), Error> {
         store
             .update(digest, reader, UploadSizeInfo::ExactSize(0))
             .await
+            .map(|_| ())
     })
     .await
 }
@@ -1304,7 +1305,7 @@ async fn update_with_whole_file_uses_same_inode() -> Result<(), Error> {
             )
             .await?;
         assert!(
-            result.is_none(),
+            result.1.is_none(),
             "Expected filesystem store to consume the file"
         );
         original_inode

--- a/nativelink-store/tests/verify_store_test.rs
+++ b/nativelink-store/tests/verify_store_test.rs
@@ -153,7 +153,7 @@ async fn verify_size_true_succeeds_on_multi_chunk_stream_update() -> Result<(), 
     tx.send("bar".into()).await?;
     tx.send_eof()?;
     let result = future.await.err_tip(|| "Failed to join spawn future")?;
-    assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
+    assert_eq!(result, Ok(6), "Expected success, got: {:?}", result);
     assert_eq!(
         inner_store.has(digest).await,
         Ok(Some(6)),

--- a/nativelink-util/src/buf_channel.rs
+++ b/nativelink-util/src/buf_channel.rs
@@ -303,18 +303,19 @@ impl DropCloserReadHalf {
     }
 
     /// Drains the reader until an EOF is received, but sends data to the void.
-    pub async fn drain(&mut self) -> Result<(), Error> {
+    pub async fn drain(&mut self) -> Result<u64, Error> {
+        let mut total_bytes: u64 = 0;
         loop {
-            if self
+            let bytes = self
                 .recv()
                 .await
-                .err_tip(|| "Failed to drain in buf_channel::drain")?
-                .is_empty()
-            {
+                .err_tip(|| "Failed to drain in buf_channel::drain")?;
+            if bytes.is_empty() {
                 break; // EOF.
             }
+            total_bytes += bytes.len().try_into().unwrap_or(0);
         }
-        Ok(())
+        Ok(total_bytes)
     }
 
     /// Peek the next set of bytes in the stream without consuming them.

--- a/nativelink-util/src/connection_manager.rs
+++ b/nativelink-util/src/connection_manager.rs
@@ -335,7 +335,7 @@ impl ConnectionManagerWorker {
     }
 
     fn provide_channel(
-        &mut self,
+        &self,
         channel: EstablishedChannel,
         tx: oneshot::Sender<Connection>,
         permit: OwnedSemaphorePermit,

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -95,7 +95,7 @@ pub async fn slow_update_store_with_file<S: StoreDriver + ?Sized>(
     digest: impl Into<StoreKey<'_>>,
     file: &mut fs::FileSlot,
     upload_size: UploadSizeInfo,
-) -> Result<(), Error> {
+) -> Result<u64, Error> {
     file.rewind()
         .await
         .err_tip(|| "Failed to rewind in upload_file_to_store")?;
@@ -123,7 +123,7 @@ pub async fn slow_update_store_with_file<S: StoreDriver + ?Sized>(
     };
     tokio::pin!(read_data_fut);
     let (update_res, read_res) = tokio::join!(update_fut, read_data_fut);
-    update_res.merge(read_res)
+    read_res.merge(update_res)
 }
 
 /// Optimizations that stores may want to expose to the callers.
@@ -525,7 +525,7 @@ pub trait StoreLike: Send + Sync + Sized + Unpin + 'static {
         digest: impl Into<StoreKey<'a>>,
         reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> impl Future<Output = Result<(), Error>> + Send + 'a {
+    ) -> impl Future<Output = Result<u64, Error>> + Send + 'a {
         self.as_store_driver_pin()
             .update(digest.into(), reader, upload_size)
     }
@@ -547,7 +547,7 @@ pub trait StoreLike: Send + Sync + Sized + Unpin + 'static {
         path: OsString,
         file: fs::FileSlot,
         upload_size: UploadSizeInfo,
-    ) -> impl Future<Output = Result<Option<fs::FileSlot>, Error>> + Send + 'a {
+    ) -> impl Future<Output = Result<(u64, Option<fs::FileSlot>), Error>> + Send + 'a {
         self.as_store_driver_pin()
             .update_with_whole_file(digest.into(), path, file, upload_size)
     }
@@ -667,7 +667,7 @@ pub trait StoreDriver:
         key: StoreKey<'_>,
         reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
-    ) -> Result<(), Error>;
+    ) -> Result<u64, Error>;
 
     /// See: [`StoreLike::optimized_for`] for details.
     fn optimized_for(&self, _optimization: StoreOptimizations) -> bool {
@@ -681,7 +681,7 @@ pub trait StoreDriver:
         path: OsString,
         mut file: fs::FileSlot,
         upload_size: UploadSizeInfo,
-    ) -> Result<Option<fs::FileSlot>, Error> {
+    ) -> Result<(u64, Option<fs::FileSlot>), Error> {
         let inner_store = self.inner_store(Some(key.borrow()));
         if inner_store.optimized_for(StoreOptimizations::FileUpdates) {
             error_if!(
@@ -692,8 +692,8 @@ pub trait StoreDriver:
                 .update_with_whole_file(key, path, file, upload_size)
                 .await;
         }
-        slow_update_store_with_file(self, key, &mut file, upload_size).await?;
-        Ok(Some(file))
+        let size = slow_update_store_with_file(self, key, &mut file, upload_size).await?;
+        Ok((size, Some(file)))
     }
 
     /// See: [`StoreLike::update_oneshot`] for details.

--- a/nativelink-util/tests/store_trait_test.rs
+++ b/nativelink-util/tests/store_trait_test.rs
@@ -31,7 +31,7 @@ impl StoreDriver for FakeStore {
         _key: StoreKey<'_>,
         _reader: DropCloserReadHalf,
         _size_info: UploadSizeInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         todo!();
     }
 


### PR DESCRIPTION
# Description

The PR #2343 updated the fast-slow store such that it ignored files missing in the slow store for the `has` calls and also said that a file was in the slow store while it was still being uploaded to it.

This causes significant regressions to the function of the fast-slow store such that files missing in the slow store do not get re-uploaded when they have been purged from an upstream cache and also starts actions downloading files from the slow store before they've been committed.

Here we fix both of those by reverting the logic and putting back the regression test for the former issue and also adding in a async Mutex which only reports the slow store upload after it's completed.  In order to perform this correctly the store trait is updated to return the uploaded size in the successful state.

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Updated the tests.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2373)
<!-- Reviewable:end -->
