### PR TITLE
Web home page fix: update text "10 B+" to "10B+"

### DIFF
--- a/web/apps/web/app/page.tsx
+++ b/web/apps/web/app/page.tsx
@@ -37,7 +37,7 @@ const stats = [
     body: "Demonstrated on LLVM, one of the world's largest C++ codebases.",
   },
   {
-    value: "10 B+",
+    value: "10B+",
     label: "build requests per month",
     body: "served in production.",
   },


### PR DESCRIPTION
# Description

Removes the stray space in the homepage hero stat so it reads **`10B+`** instead of **`10 B+`**, matching the unspaced formatting used elsewhere on the site (e.g. the `1B+` figures on the product page and OpenGraph image). Purely a copy/formatting fix to the marketing site homepage — no logic change.

- **File:** `web/apps/web/app/page.tsx` — the `stats` array entry for "build requests per month"
- **Before:** `value: "10 B+"` → **After:** `value: "10B+"`

Fixes # (no associated issue — minor homepage copy fix)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified the one-line diff (`git diff web/apps/web/app/page.tsx`). The value is a static display string in the `stats` array, so behavior is unaffected beyond the rendered text. To confirm visually, run the web app and view the homepage hero stats:

```bash
cd web && bun install && bun run dev
```

## Checklist

- [ ] Updated documentation if needed — *n/a, no docs affected*
- [ ] Tests added/amended — *n/a, static copy change with no test surface*
- [ ] `bazel test //...` passes locally — *not run; web-app copy change outside Bazel-tested code*
- [x] PR is contained in a single commit, using `git amend`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2376)
<!-- Reviewable:end -->
