### PR TITLE
Release NativeLink v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2](https://github.com/TraceMachina/nativelink/compare/v1.3.1..v1.3.2) - 2026-05-29
+
+
+
+### 📚 Documentation
+
+- remove base path URL in docs ([#2375](https://github.com/TraceMachina/nativelink/issues/2375)) - ([9bd088e](https://github.com/TraceMachina/nativelink/commit/9bd088eff672c4cf95164e475bab155b5c99b0db))
+- Bugfix/copy regressions ([#2371](https://github.com/TraceMachina/nativelink/issues/2371)) - ([2c54961](https://github.com/TraceMachina/nativelink/commit/2c5496173036773d205c5a39e75d0b7fc1a08c8a))
+
+### 🧪 Testing & CI
+
+- Fix fast-slow store optimisation ([#2373](https://github.com/TraceMachina/nativelink/issues/2373)) - ([2169fde](https://github.com/TraceMachina/nativelink/commit/2169fde722960fcc9aba44575dc8846c883b640f))
+
+### ⚙️ Miscellaneous
+
+- add CSS ambient declarations to work with TS6 ([#2374](https://github.com/TraceMachina/nativelink/issues/2374)) - ([84a7b07](https://github.com/TraceMachina/nativelink/commit/84a7b0750636254a836e8375b331d844f72d89d6))
+- fixing broken contact us button and start free buttons ([#2369](https://github.com/TraceMachina/nativelink/issues/2369)) - ([b157f0c](https://github.com/TraceMachina/nativelink/commit/b157f0c412184584d8326d0d7cedb17d315e4d5b))
+
+### ⬆️ Bumps & Version Updates
+
+- Add cache metrics ([#2344](https://github.com/TraceMachina/nativelink/issues/2344)) - ([9b016e5](https://github.com/TraceMachina/nativelink/commit/9b016e5b2a27f3d5c96993febfa27a5fe8b75b97))
+
 ## [1.3.1](https://github.com/TraceMachina/nativelink/compare/v1.3.0..v1.3.1) - 2026-05-23
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "axum",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "mongodb",
  "nativelink-metric",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "either",
  "nativelink-util",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-lock",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.3.1"
+version = "1.3.2"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.3.1",
+    version = "1.3.2",
     compatibility_level = 0,
 )
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ for how to build the images yourself.
 
 ```bash
 curl -O \
-    https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.0/nativelink-config/examples/basic_cas.json5
+    https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.2/nativelink-config/examples/basic_cas.json5
 
 # See https://github.com/TraceMachina/nativelink/pkgs/container/nativelink
 # to find the latest tag
 docker run \
     -v $(pwd)/basic_cas.json5:/config \
     -p 50051:50051 \
-    ghcr.io/tracemachina/nativelink:v1.3.0 \
+    ghcr.io/tracemachina/nativelink:v1.3.2 \
     config
 ```
 
@@ -88,7 +88,7 @@ docker run \
 ```powershell
 # Download the configuration file
 Invoke-WebRequest `
-    -Uri "https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.0/nativelink-config/examples/basic_cas.json5" `
+    -Uri "https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.2/nativelink-config/examples/basic_cas.json5" `
     -OutFile "basic_cas.json5"
 
 # Run the Docker container
@@ -96,7 +96,7 @@ Invoke-WebRequest `
 docker run `
     -v ${PWD}/basic_cas.json5:/config `
     -p 50051:50051 `
-    ghcr.io/tracemachina/nativelink:v1.3.0 `
+    ghcr.io/tracemachina/nativelink:v1.3.2 `
     config
 ```
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -7,7 +7,7 @@ autobins = false
 autoexamples = false
 edition = "2024"
 name = "nativelink-error"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.3.1"
+version = "1.3.2"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.3.1"
+version = "1.3.2"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.3.1"
+version = "1.3.2"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.3.1"
+version = "1.3.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.3.1"
+version = "1.3.2"
 
 [features]
 nix = []

--- a/web/apps/docs/content/docs/deployment/kubernetes.mdx
+++ b/web/apps/docs/content/docs/deployment/kubernetes.mdx
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: nativelink
-          image: ghcr.io/tracemachina/nativelink:v1.3.0
+          image: ghcr.io/tracemachina/nativelink:v1.3.2
           args: ["/config/cas.json5"]
           ports:
             - containerPort: 50051
@@ -104,7 +104,7 @@ spec:
     spec:
       containers:
         - name: nativelink
-          image: ghcr.io/tracemachina/nativelink:v1.3.0
+          image: ghcr.io/tracemachina/nativelink:v1.3.2
           args: ["/config/worker.json5"]
           resources:
             requests: { cpu: 4, memory: 8Gi }

--- a/web/apps/docs/content/docs/getting-started/on-prem.mdx
+++ b/web/apps/docs/content/docs/getting-started/on-prem.mdx
@@ -92,7 +92,7 @@ specific version your config references — `latest` works but pinning
 avoids surprises.
 
 ```bash
-docker pull ghcr.io/tracemachina/nativelink:v1.3.0
+docker pull ghcr.io/tracemachina/nativelink:v1.3.2
 ```
 
 The [`/pkgs/container/nativelink`](https://github.com/TraceMachina/nativelink/pkgs/container/nativelink)

--- a/web/apps/docs/content/docs/getting-started/setup.mdx
+++ b/web/apps/docs/content/docs/getting-started/setup.mdx
@@ -24,13 +24,13 @@ runs and ships with a tested configuration.
 
 ```bash
 # Grab a known-good basic configuration
-curl -O https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.0/nativelink-config/examples/basic_cas.json5
+curl -O https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.2/nativelink-config/examples/basic_cas.json5
 
 # Run the official image
 docker run \
   -v $(pwd)/basic_cas.json5:/config \
   -p 50051:50051 \
-  ghcr.io/tracemachina/nativelink:v1.3.0 config
+  ghcr.io/tracemachina/nativelink:v1.3.2 config
 ```
 
 The server is now listening on `localhost:50051`.
@@ -62,13 +62,13 @@ that supports Apple Silicon natively at the moment.
 
 ```powershell
 Invoke-WebRequest `
-  -Uri "https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.0/nativelink-config/examples/basic_cas.json5" `
+  -Uri "https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.2/nativelink-config/examples/basic_cas.json5" `
   -OutFile "basic_cas.json5"
 
 docker run `
   -v ${PWD}/basic_cas.json5:/config `
   -p 50051:50051 `
-  ghcr.io/tracemachina/nativelink:v1.3.0 config
+  ghcr.io/tracemachina/nativelink:v1.3.2 config
 ```
 
 Native Windows support is x86_64 only. ARM64 Windows users should use

--- a/web/apps/web/components/terminal-data.ts
+++ b/web/apps/web/components/terminal-data.ts
@@ -14,7 +14,7 @@ export const terminalTabs: TerminalTab[] = [
     name: "Quick Start",
     lines: [
       {
-        text: "curl -O https://raw.githubusercontent.com/TraceMachina/nativelink/v1.0.0/nativelink-config/examples/basic_cas.json5",
+        text: "curl -O https://raw.githubusercontent.com/TraceMachina/nativelink/v1.3.2/nativelink-config/examples/basic_cas.json5",
         delay: 0,
         instant: true,
       },
@@ -22,13 +22,13 @@ export const terminalTabs: TerminalTab[] = [
       { text: "100  2841  100  2841    0:00:01", delay: 50, instant: true },
       { text: "", delay: 300 },
       {
-        text: "docker run -v $(pwd)/basic_cas.json5:/config -p 50051:50051 ghcr.io/tracemachina/nativelink:v1.0.0 config",
+        text: "docker run -v $(pwd)/basic_cas.json5:/config -p 50051:50051 ghcr.io/tracemachina/nativelink:v1.3.2 config",
         delay: 200,
         instant: true,
       },
       { text: "", delay: 400 },
       { text: "Unable to find image locally", delay: 200, instant: true },
-      { text: "v1.0.0: Pulling from tracemachina/nativelink", delay: 100, instant: true },
+      { text: "v1.3.2: Pulling from tracemachina/nativelink", delay: 100, instant: true },
       { text: "a1d0c7532777: Downloading [=>              ] 15%", delay: 120, instant: true },
       { text: "a1d0c7532777: Downloading [=======>        ] 45%", delay: 120, instant: true },
       { text: "a1d0c7532777: Downloading [==============> ] 75%", delay: 120, instant: true },


### PR DESCRIPTION
## Summary
- Bump NativeLink package and module versions to 1.3.2
- Update Cargo.lock workspace package versions
- Prepend the 1.3.2 changelog section from git-cliff

## Verification
- git diff --check
- cargo metadata --locked --no-deps
- pre-commit hooks from git commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2377)
<!-- Reviewable:end -->
