### PR TITLE
nix: migrate off deprecated crane `stdenv` arg to `stdenvSelector`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1772080396,
-        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
+        "lastModified": 1780029330,
+        "narHash": "sha256-fWFKEKB5CP+NO8/3uOaEZIVbd03mvDJ//VsnKkXty08=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
+        "rev": "6823b493a0bc2142082075576efa6633b537197e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -81,8 +81,19 @@
         lib,
         ...
       }: let
-        craneLibFor = p: (crane.mkLib p).overrideToolchain pkgs.lre.stableRustFor;
-        nightlyCraneLibFor = p: (crane.mkLib p).overrideToolchain pkgs.lre.nightlyRustFor;
+        # On Linux we build fully static musl binaries, elsewhere the default stdenv.
+        stdenvSelectorFor = q:
+          if q.stdenv.targetPlatform.isLinux
+          then q.pkgsMusl.stdenv
+          else q.stdenv;
+        craneLibFor = p:
+          ((crane.mkLib p).overrideToolchain pkgs.lre.stableRustFor).overrideScope (_: _: {
+            stdenvSelector = stdenvSelectorFor;
+          });
+        nightlyCraneLibFor = p:
+          ((crane.mkLib p).overrideToolchain pkgs.lre.nightlyRustFor).overrideScope (_: _: {
+            stdenvSelector = stdenvSelectorFor;
+          });
 
         src = pkgs.lib.cleanSourceWith {
           src = (craneLibFor pkgs).path ./.;
@@ -124,10 +135,6 @@
         in
           {
             inherit src;
-            stdenv = q:
-              if q.stdenv.targetPlatform.isLinux
-              then q.pkgsMusl.stdenv
-              else q.stdenv;
             strictDeps = true;
             buildInputs =
               [p.cacert]


### PR DESCRIPTION
# Description

[Crane](https://github.com/ipetkov/crane) deprecated passing `stdenv` into `mkCargoDerivation`, however, since the input of crane here is a bit behind, no warning is emitted yet. I use Nativelink between my own machines, but I set the crane input here to follow a more up-to-date crane, and as such, I get hit with the following warning:

```
evaluation warning: passing in an `stdenv` override into `mkCargoDerivation` is now deprecated.
                    Changing the default `stdenv` must be done at the `craneLib` level like so:

                      craneLib = (inputs.crane.mkLib pkgs).overrideScope (final: prev: {
                        # Set this to the chosen stdenv, e.g. `p.clangStdenv`
                        stdenvSelector = p: p.stdenv;
```

This PR's change is defensive in nature, but I went ahead and updated the crane input as well. If that's undesireable, please let me know and I can revert that, the fix works without bumping crane.

Thanks for the really cool project :)

Fixes # (issue)

(No issue, just something I ran into)

## Type of change

A defensive future-bug fix.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran this locally, overriding my input with the local path.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2379)
<!-- Reviewable:end -->
