### PR TITLE
Clarify NativeLink licensing docs

### DIFF
--- a/.github/styles/config/vocabularies/TraceMachina/accept.txt
+++ b/.github/styles/config/vocabularies/TraceMachina/accept.txt
@@ -16,6 +16,7 @@ ELB
 Eskandar
 FFI
 FFIs
+FSL
 GPUs
 Goma
 gzip

--- a/web/apps/docs/content/docs/contribute/guidelines.mdx
+++ b/web/apps/docs/content/docs/contribute/guidelines.mdx
@@ -3,9 +3,9 @@ title: Contribution guidelines
 description: How to land code in NativeLink — what we accept, how reviews work, what good PRs look like.
 ---
 
-NativeLink is open source, MIT-licensed, and accepts contributions
-from anyone willing to follow these guidelines. We try to make the
-process predictable.
+NativeLink is source-available, module-aware in its licensing, and
+accepts contributions from anyone willing to follow these guidelines.
+We try to make the process predictable.
 
 ## What we accept
 
@@ -69,8 +69,14 @@ process predictable.
 ## License
 
 By submitting a PR you agree your contribution is licensed under the
-project's MIT license. The DCO sign-off in your commit is the
-formal declaration.
+license that applies to the file or module you are changing. Most of
+the repository is `FSL-1.1-Apache-2.0`; metrics and remote persistent
+workers are Business Source License modules. The DCO sign-off in your
+commit is the formal declaration.
+
+Meaningful contributors may be eligible for license waivers for
+Business Source License modules. Open an issue or contact the
+maintainers before depending on a waiver.
 
 ## What's next
 

--- a/web/apps/docs/content/docs/contribute/guidelines.mdx
+++ b/web/apps/docs/content/docs/contribute/guidelines.mdx
@@ -71,8 +71,9 @@ We try to make the process predictable.
 By submitting a PR you agree your contribution is licensed under the
 license that applies to the file or module you are changing. Most of
 the repository is `FSL-1.1-Apache-2.0`; metrics and remote persistent
-workers are Business Source License modules. The DCO sign-off in your
-commit is the formal declaration.
+workers are Business Source License modules. See the
+[license page](https://nativelink.com/license) for the practical
+summary. The DCO sign-off in your commit is the formal declaration.
 
 Meaningful contributors may be eligible for license waivers for
 Business Source License modules. Open an issue or contact the

--- a/web/apps/docs/content/docs/deployment/metrics.mdx
+++ b/web/apps/docs/content/docs/deployment/metrics.mdx
@@ -7,6 +7,13 @@ NativeLink emits remote execution metrics through OpenTelemetry. Cache operation
 metrics are available when the store is explicitly wrapped with the opt-in
 `cache_metrics` store wrapper.
 
+<Callout type="info" title="License note">
+  NativeLink metrics are licensed under the Business Source License.
+  Use them through NativeLink Cloud, Enterprise, or a separate license
+  agreement. Meaningful contributors may be eligible for license
+  waivers; contact the maintainers before depending on one.
+</Callout>
+
 ## Overview
 
 NativeLink does not expose a Prometheus scrape endpoint directly. It emits OTLP

--- a/web/apps/docs/content/docs/deployment/metrics.mdx
+++ b/web/apps/docs/content/docs/deployment/metrics.mdx
@@ -9,9 +9,11 @@ metrics are available when the store is explicitly wrapped with the opt-in
 
 <Callout type="info" title="License note">
   NativeLink metrics are licensed under the Business Source License.
-  Use them through NativeLink Cloud, Enterprise, or a separate license
-  agreement. Meaningful contributors may be eligible for license
-  waivers; contact the maintainers before depending on one.
+  Individual developer cache use does not need a commercial license.
+  Teams using metrics in shared, production, or commercial settings
+can use NativeLink Cloud, Enterprise, or an intentionally
+very inexpensive separate license. See the
+  [license page](https://nativelink.com/license).
 </Callout>
 
 ## Overview

--- a/web/apps/docs/content/docs/deployment/persistent-workers.mdx
+++ b/web/apps/docs/content/docs/deployment/persistent-workers.mdx
@@ -11,6 +11,14 @@ Persistent workers solve this by keeping a pool of long-lived worker
 processes running and routing matching actions to them. The startup
 cost is paid once; subsequent actions reuse the same process.
 
+<Callout type="info" title="License note">
+  Remote persistent workers are licensed under the Business Source
+  License. Use them through NativeLink Cloud, Enterprise, or a
+  separate license agreement. Meaningful contributors may be eligible
+  for license waivers; contact the maintainers before depending on
+  one.
+</Callout>
+
 ## When this matters
 
 | Toolchain          | Startup cost | Persistent worker win |

--- a/web/apps/docs/content/docs/deployment/persistent-workers.mdx
+++ b/web/apps/docs/content/docs/deployment/persistent-workers.mdx
@@ -13,10 +13,11 @@ cost is paid once; subsequent actions reuse the same process.
 
 <Callout type="info" title="License note">
   Remote persistent workers are licensed under the Business Source
-  License. Use them through NativeLink Cloud, Enterprise, or a
-  separate license agreement. Meaningful contributors may be eligible
-  for license waivers; contact the maintainers before depending on
-  one.
+  License. Individual developer cache use does not need a commercial
+  license. Teams using persistent workers in shared, production, or
+commercial settings can use NativeLink Cloud, Enterprise, or an
+intentionally very inexpensive separate license. See the
+  [license page](https://nativelink.com/license).
 </Callout>
 
 ## When this matters

--- a/web/apps/docs/content/docs/explanations/history.mdx
+++ b/web/apps/docs/content/docs/explanations/history.mdx
@@ -42,7 +42,8 @@ The most important shifts:
   line that runs your builds. Most of the monorepo is
   `FSL-1.1-Apache-2.0`; a small set of commercial modules, including
   metrics and remote persistent workers, is licensed under the
-  Business Source License.
+  Business Source License. See the
+  [license page](https://nativelink.com/license).
 
 ## Adoption
 

--- a/web/apps/docs/content/docs/explanations/history.mdx
+++ b/web/apps/docs/content/docs/explanations/history.mdx
@@ -38,8 +38,11 @@ The most important shifts:
   logic, no eviction races, no "is this artifact stale?" checks.
 - **A single binary for every role.** CAS, AC, scheduler, worker —
   the same executable, different config flags. Deployment is plain.
-- **Open source, MIT-licensed.** You can read every line that runs
-  your builds.
+- **Source-available, module-aware licensing.** You can read every
+  line that runs your builds. Most of the monorepo is
+  `FSL-1.1-Apache-2.0`; a small set of commercial modules, including
+  metrics and remote persistent workers, is licensed under the
+  Business Source License.
 
 ## Adoption
 

--- a/web/apps/docs/content/docs/faq/cost.mdx
+++ b/web/apps/docs/content/docs/faq/cost.mdx
@@ -9,11 +9,16 @@ self-hosted use.** Most of the monorepo is licensed under
 redistribution for non-competing purposes, then grants an Apache 2.0
 future license on the schedule described in the repository
 [`LICENSE`](https://github.com/TraceMachina/nativelink/blob/main/LICENSE).
+The customer-facing summary lives on the
+[NativeLink license page](https://nativelink.com/license).
 
 NativeLink is not a single-license monorepo. Some feature modules
 carry their own source headers. In particular, metrics and remote
-persistent workers are licensed under the Business Source License and
-require a Cloud, Enterprise, or separate license agreement for use.
+persistent workers are licensed under the Business Source License.
+Developers using NativeLink for an individual cache do not need a
+commercial license. Teams using those modules in shared, production,
+or commercial settings can use NativeLink Cloud, Enterprise, or a
+separate commercial license, which is intentionally very inexpensive.
 Meaningful contributors may be eligible for license waivers; contact
 the maintainers before relying on one.
 

--- a/web/apps/docs/content/docs/faq/cost.mdx
+++ b/web/apps/docs/content/docs/faq/cost.mdx
@@ -1,15 +1,25 @@
 ---
 title: Is NativeLink free?
-description: Yes — the open-source core is MIT-licensed and free forever. Cloud and Enterprise are paid offerings.
+description: Yes — NativeLink is source-available and free for permitted self-hosted use. Cloud and Enterprise are paid offerings.
 ---
 
-**Yes — the open-source release is MIT-licensed and free forever.**
-You can self-host it on any infrastructure you control, modify it,
-redistribute it, run it for as many users as you want.
+**Yes — NativeLink is source-available and free for permitted
+self-hosted use.** Most of the monorepo is licensed under
+`FSL-1.1-Apache-2.0`, which allows internal use, modification, and
+redistribution for non-competing purposes, then grants an Apache 2.0
+future license on the schedule described in the repository
+[`LICENSE`](https://github.com/TraceMachina/nativelink/blob/main/LICENSE).
+
+NativeLink is not a single-license monorepo. Some feature modules
+carry their own source headers. In particular, metrics and remote
+persistent workers are licensed under the Business Source License and
+require a Cloud, Enterprise, or separate license agreement for use.
+Meaningful contributors may be eligible for license waivers; contact
+the maintainers before relying on one.
 
 If you'd rather pay someone to run it for you, two paid tiers exist:
 
-- **Cloud** — managed multi-tenant cluster, flat $1,000/month. Full
+- **Cloud** — managed multi-tenant cluster, flat $999+/month. Full
   SLA, autoscaling, dashboard.
 - **Enterprise** — single-tenant deployment, dedicated solutions
   engineer, on-prem or managed. Custom contracts.
@@ -26,9 +36,10 @@ comparison.
 - The CLI tooling and Helm chart.
 
 No artificial limits on cache size, action count, worker count, or
-team size. The open-source build is the same build we run in
-production — minus the operational tooling and dedicated support that
-Cloud and Enterprise add.
+team size. The self-hosted build is the same codebase we run in
+production, subject to the license that applies to each module, minus
+the operational tooling and dedicated support that Cloud and
+Enterprise add.
 
 ## What you'd pay for instead
 

--- a/web/apps/docs/content/docs/getting-started/on-prem.mdx
+++ b/web/apps/docs/content/docs/getting-started/on-prem.mdx
@@ -3,8 +3,8 @@ title: NativeLink on-prem
 description: Self-host NativeLink on hardware you control, with the operational checklist a team rollout actually needs.
 ---
 
-The open-source release of NativeLink is designed to run on your own
-infrastructure. This page covers what changes between the
+The source-available release of NativeLink is designed to run on your
+own infrastructure. This page covers what changes between the
 [10-minute setup](/getting-started/setup) and a deployment that
 serves your team without 3 AM pages.
 

--- a/web/apps/docs/content/docs/reference/changelog.mdx
+++ b/web/apps/docs/content/docs/reference/changelog.mdx
@@ -40,7 +40,8 @@ release.
 - **GA release.** Production-stable APIs, semver from this point on.
 - **FSL-Apache licensing.** The repository moved to
   `FSL-1.1-Apache-2.0` for most modules, with feature-specific
-  Business Source License modules called out in source headers.
+  Business Source License modules called out in source headers. See
+  the [license page](https://nativelink.com/license).
 - **Helm chart** for Kubernetes deployment promoted to stable.
 
 ## v0.x — pre-GA

--- a/web/apps/docs/content/docs/reference/changelog.mdx
+++ b/web/apps/docs/content/docs/reference/changelog.mdx
@@ -38,7 +38,9 @@ release.
 ## v1.0 — November 2025
 
 - **GA release.** Production-stable APIs, semver from this point on.
-- **MIT license.** Re-licensed from FSL.
+- **FSL-Apache licensing.** The repository moved to
+  `FSL-1.1-Apache-2.0` for most modules, with feature-specific
+  Business Source License modules called out in source headers.
 - **Helm chart** for Kubernetes deployment promoted to stable.
 
 ## v0.x — pre-GA

--- a/web/apps/web/app/community/page.tsx
+++ b/web/apps/web/app/community/page.tsx
@@ -36,7 +36,7 @@ const channels = [
   },
   {
     title: "Clone the repo",
-    body: "MIT-licensed. File issues, send PRs, or just star us. Every contribution gets a review.",
+    body: "Public source, with module-aware licensing. File issues, send PRs, or just star us. Every contribution gets a review.",
     href: "https://github.com/tracemachina/nativelink",
     label: "View on GitHub",
     accent: "default" as const,

--- a/web/apps/web/app/company/page.tsx
+++ b/web/apps/web/app/company/page.tsx
@@ -19,7 +19,7 @@ const values = [
   },
   {
     title: "Default to open.",
-    body: "Our core is MIT-licensed and stays that way. We sell support and operations, not access to the code that runs builds.",
+    body: "Most of the monorepo is FSL-1.1-Apache-2.0. We keep the code visible, and we sell support, operations, and commercial terms for selected modules.",
   },
   {
     title: "Speed is a feature.",

--- a/web/apps/web/app/license/page.tsx
+++ b/web/apps/web/app/license/page.tsx
@@ -1,0 +1,132 @@
+import { Eyebrow, Reveal, Section } from "@nativelink/ui";
+
+export const metadata = {
+  title: "License",
+  description:
+    "How NativeLink's source-available, FSL-Apache, and Business Source License modules fit together.",
+};
+
+const toc = [
+  { id: "overview", label: "Overview" },
+  { id: "individual-cache", label: "Individual cache use" },
+  { id: "commercial-modules", label: "Commercial modules" },
+  { id: "contributors", label: "Contributor waivers" },
+  { id: "source", label: "Source of truth" },
+];
+
+export default function LicensePage() {
+  return (
+    <>
+      <section className="relative overflow-hidden">
+        <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[400px] bg-[radial-gradient(ellipse_800px_400px_at_50%_-20%,rgb(var(--nl-color-brand)/0.10),transparent_70%)]" />
+        <Section width="default" className="pt-24 pb-12 md:pt-32">
+          <Reveal>
+            <div className="mx-auto max-w-[820px] text-center">
+              <Eyebrow className="mb-5">License</Eyebrow>
+              <h1 className="text-balance text-[44px] font-semibold leading-[1.05] tracking-[-0.035em] md:text-[60px]">
+                NativeLink Licensing
+              </h1>
+              <p className="mx-auto mt-5 max-w-[650px] text-base leading-relaxed text-muted-foreground md:text-lg">
+                NativeLink is a monorepo with module-aware licensing. Most code is
+                FSL-Apache; selected commercial modules use the Business Source
+                License.
+              </p>
+            </div>
+          </Reveal>
+        </Section>
+      </section>
+
+      <Section width="default" className="pb-24">
+        <div className="grid gap-12 lg:grid-cols-[220px_1fr]">
+          <aside className="hidden lg:block">
+            <div className="sticky top-24">
+              <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.18em] text-muted">
+                On this page
+              </p>
+              <ul className="space-y-2 text-sm">
+                {toc.map((item) => (
+                  <li key={item.id}>
+                    <a
+                      href={`#${item.id}`}
+                      className="block text-muted-foreground transition-colors hover:text-brand"
+                    >
+                      {item.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+
+          <article className="prose-styles max-w-[68ch]">
+            <Reveal>
+              <h2 id="overview" className="scroll-mt-24 text-3xl font-semibold tracking-tight text-foreground">
+                Overview
+              </h2>
+              <p className="mt-4 text-[15px] leading-relaxed text-muted-foreground">
+                Most NativeLink modules are licensed under
+                FSL-1.1-Apache-2.0. That license allows internal use,
+                modification, and redistribution for non-competing purposes, then
+                grants an Apache 2.0 future license on the schedule described in
+                the repository license.
+              </p>
+              <p className="mt-4 text-[15px] leading-relaxed text-muted-foreground">
+                NativeLink is not a single-license repository. Some files and
+                modules carry their own source headers, and those headers control
+                the license for that code.
+              </p>
+
+              <h3 id="individual-cache" className="mt-10 scroll-mt-24 text-xl font-semibold tracking-tight text-foreground">
+                Individual Cache Use
+              </h3>
+              <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+                Developers using NativeLink for an individual cache do not need a
+                commercial license. That path is meant to stay simple: run the
+                cache locally or on infrastructure you control, point your build
+                tool at it, and keep your loop fast.
+              </p>
+
+              <h3 id="commercial-modules" className="mt-10 scroll-mt-24 text-xl font-semibold tracking-tight text-foreground">
+                Commercial Modules
+              </h3>
+              <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+                Metrics and remote persistent workers are licensed under the
+                Business Source License. Teams using those modules in shared,
+                production, or commercial settings should use NativeLink Cloud,
+                Enterprise, or a separate commercial license.
+              </p>
+              <p className="mt-4 text-[15px] leading-relaxed text-muted-foreground">
+                The separate commercial license is intentionally very inexpensive.
+                It is there to keep the project sustainable without putting
+                friction in front of individual developers.
+              </p>
+
+              <h3 id="contributors" className="mt-10 scroll-mt-24 text-xl font-semibold tracking-tight text-foreground">
+                Contributor Waivers
+              </h3>
+              <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+                Meaningful contributors may be eligible for license waivers for
+                Business Source License modules. Open an issue or contact the
+                maintainers before depending on a waiver.
+              </p>
+
+              <h3 id="source" className="mt-10 scroll-mt-24 text-xl font-semibold tracking-tight text-foreground">
+                Source of Truth
+              </h3>
+              <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+                The repository
+                {" "}
+                <a href="https://github.com/TraceMachina/nativelink/blob/main/LICENSE">LICENSE</a>
+                {" "}
+                file and source headers are the authoritative licensing text. For
+                commercial terms, contact
+                {" "}
+                <a href="mailto:contact@nativelink.com">contact@nativelink.com</a>.
+              </p>
+            </Reveal>
+          </article>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/web/apps/web/app/opengraph-image.tsx
+++ b/web/apps/web/app/opengraph-image.tsx
@@ -133,7 +133,7 @@ export default async function OpenGraphImage() {
             <span>1B+ build requests / month</span>
           </div>
           <span style={{ color: "#3C3A4E" }}>·</span>
-          <span>Rust · Open source · MIT</span>
+          <span>Rust · Source available · FSL-Apache</span>
         </div>
       </div>
     </div>,

--- a/web/apps/web/app/product/page.tsx
+++ b/web/apps/web/app/product/page.tsx
@@ -35,7 +35,7 @@ const pillars = [
   {
     eyebrow: "Cloud & self-host",
     title: "Hosted by us. Or run by you.",
-    body: "Start free on NativeLink Cloud in ten minutes. Move to dedicated infrastructure when your scale demands it. Or self-host the open-source release with one Docker command. Same code path. Same performance.",
+    body: "Start free on NativeLink Cloud in ten minutes. Move to dedicated infrastructure when your scale demands it. Or self-host the source-available release with one Docker command. Same code path. Same performance.",
     metric: "<10m",
     metricLabel: "time to first hit",
     icon: (
@@ -93,7 +93,7 @@ const faqItems: FAQItem[] = [
   },
   {
     q: "Is NativeLink free?",
-    a: "The open-source core is MIT-licensed and free forever. You only pay if you want our managed Cloud or an Enterprise contract.",
+    a: "Most of the monorepo is FSL-1.1-Apache-2.0. Metrics and remote persistent workers are Business Source License modules; managed Cloud and Enterprise include the commercial terms.",
   },
   {
     q: "Why Rust?",

--- a/web/apps/web/app/product/page.tsx
+++ b/web/apps/web/app/product/page.tsx
@@ -93,7 +93,7 @@ const faqItems: FAQItem[] = [
   },
   {
     q: "Is NativeLink free?",
-    a: "Most of the monorepo is FSL-1.1-Apache-2.0. Metrics and remote persistent workers are Business Source License modules; managed Cloud and Enterprise include the commercial terms.",
+    a: "Most of the monorepo is FSL-1.1-Apache-2.0. Individual cache use does not need a commercial license. Metrics and remote persistent workers are Business Source License modules; Cloud, Enterprise, or a very inexpensive separate license covers shared production use.",
   },
   {
     q: "Why Rust?",

--- a/web/apps/web/app/sitemap.ts
+++ b/web/apps/web/app/sitemap.ts
@@ -10,6 +10,7 @@ const routes: { path: string; changeFrequency: MetadataRoute.Sitemap[number]["ch
   { path: "/community", changeFrequency: "daily", priority: 0.7 },
   { path: "/resources", changeFrequency: "weekly", priority: 0.8 },
   { path: "/contact", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/license", changeFrequency: "yearly", priority: 0.4 },
   { path: "/status", changeFrequency: "daily", priority: 0.5 },
   { path: "/terms", changeFrequency: "yearly", priority: 0.3 },
   { path: "/compliance", changeFrequency: "yearly", priority: 0.4 },

--- a/web/apps/web/app/terms/page.tsx
+++ b/web/apps/web/app/terms/page.tsx
@@ -96,6 +96,10 @@ export default function TermsPage() {
                 licensing. Most modules are licensed under FSL-1.1-Apache-2.0,
                 while some commercial modules, including metrics and remote
                 persistent workers, are licensed under the Business Source License.
+                Developers using NativeLink for an individual cache do not need a
+                commercial license; team and production usage of commercial modules
+                can be covered by an intentionally very inexpensive separate license.
+                See the <a href="/license">license page</a> for details.
                 NativeLink Cloud and Enterprise offerings are provided under the
                 separate agreement you accept when you sign up for those services.
               </p>

--- a/web/apps/web/app/terms/page.tsx
+++ b/web/apps/web/app/terms/page.tsx
@@ -92,11 +92,12 @@ export default function TermsPage() {
                 2. License & Use
               </h3>
               <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
-                The NativeLink open-source core is distributed under the MIT
-                License. You are free to use, modify, and distribute the open-source
-                release subject to that license. NativeLink Cloud and Enterprise
-                offerings are provided under the separate agreement you accept when
-                you sign up for those services.
+                NativeLink is distributed from a monorepo with module-aware
+                licensing. Most modules are licensed under FSL-1.1-Apache-2.0,
+                while some commercial modules, including metrics and remote
+                persistent workers, are licensed under the Business Source License.
+                NativeLink Cloud and Enterprise offerings are provided under the
+                separate agreement you accept when you sign up for those services.
               </p>
 
               <h3 id="accounts" className="mt-10 scroll-mt-24 text-xl font-semibold tracking-tight text-foreground">
@@ -142,8 +143,8 @@ export default function TermsPage() {
                   themselves are content-addressed and never inspected by us.
                 </li>
                 <li>
-                  Anonymous usage telemetry from the open-source release, which can
-                  be disabled with a single flag.
+                  Anonymous usage telemetry from the source-available release,
+                  which can be disabled with a single flag.
                 </li>
                 <li>
                   Standard server logs (IP addresses, user agents) retained for 30


### PR DESCRIPTION
## Summary
- Add a main /license page for customer-facing license guidance
- Replace stale MIT/open-source-release wording with module-aware FSL-Apache and Business Source License language
- Clarify that individual developer cache use does not need a commercial license, and that shared/production commercial-module use can be covered by Cloud, Enterprise, or a very inexpensive separate license
- Link metrics, persistent workers, contribution, history, changelog, terms, and product references to the main license page where relevant

## Verification
- git diff --check
- bun --filter @nativelink/docs typecheck
- bun --filter @nativelink/web typecheck
- nix develop -c pre-commit run vale --files web/apps/docs/content/docs/explanations/history.mdx web/apps/docs/content/docs/reference/changelog.mdx web/apps/docs/content/docs/faq/cost.mdx web/apps/docs/content/docs/contribute/guidelines.mdx web/apps/docs/content/docs/deployment/metrics.mdx web/apps/docs/content/docs/deployment/persistent-workers.mdx
- bun --filter @nativelink/web build
- bun --filter @nativelink/docs build

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2380)
<!-- Reviewable:end -->
