### PR TITLE
nix: replace deprecated `pkgs.system` with `stdenv.hostPlatform.system`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,9 +174,9 @@
             });
 
         nativeTargetPkgs =
-          if pkgs.system == "x86_64-linux"
+          if pkgs.stdenv.hostPlatform.system == "x86_64-linux"
           then pkgs.pkgsCross.musl64
-          else if pkgs.system == "aarch64-linux"
+          else if pkgs.stdenv.hostPlatform.system == "aarch64-linux"
           then pkgs.pkgsCross.aarch64-multiplatform-musl
           else pkgs;
 

--- a/flake.nix
+++ b/flake.nix
@@ -256,7 +256,7 @@
               pkgs.unzip
               pkgs.zstd
               pkgs.cargo-bloat
-              pkgs.mold-wrapped
+              pkgs.mold
               pkgs.reindeer
               pkgs.lld_22
               pkgs.clang_22

--- a/local-remote-execution/flake-module.nix
+++ b/local-remote-execution/flake-module.nix
@@ -179,8 +179,8 @@
               # platforms corresponding to the host. When using remote executors that
               # differ from the platform corresponding to the host this should be extended
               # via manual `--extra_toolchains` arguments.
-              "--extra_toolchains=@local-remote-execution//rust:rust-${pkgs.system}"
-              "--extra_toolchains=@local-remote-execution//rust:rustfmt-${pkgs.system}"
+              "--extra_toolchains=@local-remote-execution//rust:rust-${pkgs.stdenv.hostPlatform.system}"
+              "--extra_toolchains=@local-remote-execution//rust:rustfmt-${pkgs.stdenv.hostPlatform.system}"
 
               # Defaults for rust target platforms. This is a convenience setting that
               # may be overridden by manual `--platforms` arguments.

--- a/local-remote-execution/overlays/default.nix
+++ b/local-remote-execution/overlays/default.nix
@@ -1,5 +1,5 @@
 {nix2container}: final: _prev: {
-  inherit (nix2container.packages.${final.system}) nix2container;
+  inherit (nix2container.packages.${final.stdenv.hostPlatform.system}) nix2container;
 
   rbe-configs-gen = final.callPackage ./rbe-configs-gen {};
 

--- a/tools/public/default.nix
+++ b/tools/public/default.nix
@@ -1,5 +1,5 @@
 {nix2container}: final: _prev: {
-  inherit (nix2container.packages.${final.system}) nix2container;
+  inherit (nix2container.packages.${final.stdenv.hostPlatform.system}) nix2container;
 
   # Note: Only put tools here that should be usable from external flakes.
   nativelink-tools = {


### PR DESCRIPTION
# Description

This pr fixes a deprecation warning that nix emits, as well as updating a package's name as it was renamed

Fixes # (issue)

N/A

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested and eval'd this locally and it still works

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2381)
<!-- Reviewable:end -->
