### PR TITLE
Remove extra Github icon

### DIFF
--- a/web/apps/docs/app/layout.config.tsx
+++ b/web/apps/docs/app/layout.config.tsx
@@ -7,21 +7,9 @@ export const baseOptions: BaseLayoutProps = {
     url: "/",
     transparentMode: "top",
   },
-  // Only the GitHub icon in the top-nav. Cross-app links back to marketing
+  // Only the GitHub icon in the top-nav (via githubUrl). Cross-app links back to marketing
   // (/product, /pricing, /resources) clutter a docs-focused nav.
   links: [
-    {
-      type: "icon",
-      icon: (
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.01c-3.2.7-3.87-1.36-3.87-1.36-.52-1.34-1.28-1.69-1.28-1.69-1.05-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.55-.29-5.23-1.28-5.23-5.68 0-1.25.45-2.28 1.19-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39s1.97.13 2.89.39c2.21-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.8 1.19 1.83 1.19 3.08 0 4.41-2.69 5.39-5.25 5.67.41.36.78 1.06.78 2.14v3.17c0 .31.21.68.8.56 4.57-1.52 7.86-5.83 7.86-10.91C23.5 5.65 18.35.5 12 .5Z" />
-        </svg>
-      ),
-      text: "GitHub",
-      url: "https://github.com/TraceMachina/nativelink",
-      external: true,
-      secondary: true,
-    },
   ],
   githubUrl: "https://github.com/TraceMachina/nativelink",
 };


### PR DESCRIPTION
# Description

docs.nativelink.com currently shows the following in the bottom left
<img width="280" height="94" alt="image" src="https://github.com/user-attachments/assets/a6d930ea-ed29-4979-90c4-d66418c9ab13" />
This PR removes the duplicate icon

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bun dev:docs`

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2387)
<!-- Reviewable:end -->
