### PR TITLE
ft_aggregate: pass explicit TIMEOUT to absorb RediSearch slow scans

### DIFF
--- a/nativelink-redis-tester/src/dynamic_fake_redis.rs
+++ b/nativelink-redis-tester/src/dynamic_fake_redis.rs
@@ -137,9 +137,21 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
                             panic!("Aggregate query should be a string: {args:?}");
                         };
                         let query = str::from_utf8(raw_query).unwrap();
+                        // The real ft_aggregate caller now passes an explicit
+                        // `TIMEOUT <ms>` clause before `LOAD`. Tolerate both
+                        // shapes here so this fake doesn't break older callers
+                        // and the LOAD-args check still validates the bit we
+                        // actually care about.
+                        let load_offset = if matches!(args.get(2), Some(OwnedFrame::BulkString(b)) if b == b"TIMEOUT")
+                        {
+                            // Skip "TIMEOUT" and its millisecond argument.
+                            4
+                        } else {
+                            2
+                        };
                         // Lazy implementation making assumptions.
                         assert_eq!(
-                            args[2..6],
+                            args[load_offset..load_offset + 4],
                             vec![
                                 OwnedFrame::BulkString(b"LOAD".to_vec()),
                                 OwnedFrame::BulkString(b"2".to_vec()),

--- a/nativelink-store/src/redis_utils/ft_aggregate.rs
+++ b/nativelink-store/src/redis_utils/ft_aggregate.rs
@@ -43,7 +43,7 @@ pub(crate) struct FtAggregateOptions {
 /// lookup fails. When dedup fails the scheduler creates a duplicate
 /// operation for an action that is already in flight — observed as
 /// "two same actions running on different PRs" with each running the
-/// full `maxActionExecutingTimeoutS` window before completing. Pass an
+/// full `max_action_executing_timeout_s` window before completing. Pass an
 /// explicit value generous enough to absorb 1M+ document scans on a
 /// busy `RediSearch` instance.
 const FT_AGGREGATE_TIMEOUT_MS: u64 = 10_000;

--- a/nativelink-store/src/redis_utils/ft_aggregate.rs
+++ b/nativelink-store/src/redis_utils/ft_aggregate.rs
@@ -35,6 +35,19 @@ pub(crate) struct FtAggregateOptions {
     pub sort_by: Vec<String>,
 }
 
+/// Per-query `FT.AGGREGATE` timeout in milliseconds.
+///
+/// `RediSearch`'s module default (≈500 ms) is far too tight for the
+/// scheduler's awaited-action index under any meaningful load: queries
+/// time out, `NativeLink` surfaces them as parse errors, and the dedup
+/// lookup fails. When dedup fails the scheduler creates a duplicate
+/// operation for an action that is already in flight — observed as
+/// "two same actions running on different PRs" with each running the
+/// full `maxActionExecutingTimeoutS` window before completing. Pass an
+/// explicit value generous enough to absorb 1M+ document scans on a
+/// busy `RediSearch` instance.
+const FT_AGGREGATE_TIMEOUT_MS: u64 = 10_000;
+
 /// Calls `FT.AGGREGATE` in redis. redis-rs does not properly support this command
 /// so we have to manually handle it.
 pub(crate) async fn ft_aggregate<C>(
@@ -56,6 +69,8 @@ where
     let mut ft_aggregate_cmd = cmd
         .arg(&index)
         .arg(&query)
+        .arg("TIMEOUT")
+        .arg(FT_AGGREGATE_TIMEOUT_MS)
         .arg("LOAD")
         .arg(options.load.len())
         .arg(&options.load)

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -1042,6 +1042,8 @@ fn test_search_by_index() -> Result<(), Error> {
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")
@@ -1132,7 +1134,7 @@ fn test_search_by_index_failure() -> Result<(), Error> {
         "Client: TEST - Client: unexpected command", "Error with ft_create in RedisStore::search_by_index_prefix(test:_content_prefix_sort_key_3e762c15)", "---", "Client: TEST - Client: unexpected command", "Error with second ft_aggregate in RedisStore::search_by_index_prefix(test:_content_prefix_sort_key_3e762c15)"].iter().map(ToString::to_string).collect()));
 
     assert!(logs_contain(
-        "Error calling ft.aggregate e=TEST - Client: unexpected command index=\"test:_content_prefix_sort_key_3e762c15\" query=\"*\" options=FtAggregateOptions { load: [\"data\", \"version\"], cursor: FtAggregateCursor { count: 1500, max_idle: 30000 }, sort_by: [\"@sort_key\"] } all_args=[\"FT.AGGREGATE\", \"test:_content_prefix_sort_key_3e762c15\", \"*\", \"LOAD\", \"2\", \"data\", \"version\", \"WITHCURSOR\", \"COUNT\", \"1500\", \"MAXIDLE\", \"30000\", \"SORTBY\", \"2\", \"@sort_key\", \"ASC\"]"
+        "Error calling ft.aggregate e=TEST - Client: unexpected command index=\"test:_content_prefix_sort_key_3e762c15\" query=\"*\" options=FtAggregateOptions { load: [\"data\", \"version\"], cursor: FtAggregateCursor { count: 1500, max_idle: 30000 }, sort_by: [\"@sort_key\"] } all_args=[\"FT.AGGREGATE\", \"test:_content_prefix_sort_key_3e762c15\", \"*\", \"TIMEOUT\", \"10000\", \"LOAD\", \"2\", \"data\", \"version\", \"WITHCURSOR\", \"COUNT\", \"1500\", \"MAXIDLE\", \"30000\", \"SORTBY\", \"2\", \"@sort_key\", \"ASC\"]"
     ));
 
     Ok(())
@@ -1150,6 +1152,8 @@ fn test_search_by_index_swallows_already_exists_from_ft_create() -> Result<(), E
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")
@@ -1231,6 +1235,8 @@ fn test_search_by_index_preserves_other_ft_create_errors() -> Result<(), Error> 
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")
@@ -1309,6 +1315,8 @@ fn test_search_by_index_with_sort_key() -> Result<(), Error> {
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")
@@ -1392,6 +1400,8 @@ fn test_search_by_index_resp3() -> Result<(), Error> {
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")
@@ -1498,6 +1508,8 @@ fn test_search_by_index_skips_int_from_cursor_read() -> Result<(), Error> {
             redis::cmd("FT.AGGREGATE")
                 .arg("test:_content_prefix_sort_key_3e762c15")
                 .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
                 .arg("LOAD")
                 .arg(2)
                 .arg("data")


### PR DESCRIPTION
# Description

RediSearch's module default (~500 ms) is far too tight for the scheduler's awaited-action index under any meaningful load: queries time out, NativeLink surfaces them as parse errors, and the dedup lookup fails. When dedup fails the scheduler creates a duplicate operation for an action that is already in flight -- observed as "two same actions running on different PRs" with each running the full maxActionExecutingTimeoutS window before completing. Pass an explicit value generous enough to absorb 1M+ document scans on a busy RediSearch instance.

FakeRedisBackend's FT.AGGREGATE handler learns to tolerate the new explicit TIMEOUT clause (skipping it before validating the LOAD args), so the fake keeps working for both the new caller shape and any older one.

Test coverage, all in the existing separate test suites:

  * nativelink-store/tests/redis_store_test.rs pins the exact FT.AGGREGATE argument list (now including TIMEOUT 10000) in test_search_by_index, test_search_by_index_with_sort_key, test_search_by_index_resp3, test_search_by_index_skips_int_from_cursor_read, and the error-path log assertion in test_search_by_index_failure.

  * nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs exercises the fake's TIMEOUT-skipping path end to end through the real ft_aggregate caller; it fails without the FakeRedisBackend change.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2393)
<!-- Reviewable:end -->
