### PR TITLE
Clarify error when TCP Listener binding fails

### DIFF
--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -15,6 +15,7 @@
 use core::net::SocketAddr;
 use core::time::Duration;
 use std::collections::{HashMap, HashSet};
+use std::io::ErrorKind;
 use std::sync::Arc;
 
 use async_lock::Mutex as AsyncMutex;
@@ -510,7 +511,25 @@ async fn inner_main(
                 Error::from_std_err(Code::InvalidArgument, &e)
                     .append(format!("Invalid address '{}'", http_config.socket_address))
             })?;
-        let tcp_listener = TcpListener::bind(&socket_addr).await?;
+        let tcp_listener = TcpListener::bind(&socket_addr)
+            .await
+            .map_err(|e| match e.kind() {
+                ErrorKind::AddrInUse => make_err!(
+                    Code::AlreadyExists,
+                    "Address '{}' is already in use by another process.",
+                    socket_addr
+                ),
+                ErrorKind::PermissionDenied => make_err!(
+                    Code::PermissionDenied,
+                    "Permission denied. You may need root privileges to bind to address '{}'.",
+                    socket_addr
+                ),
+                ErrorKind::InvalidInput => {
+                    make_input_err!("The provided address '{}' is invalid.", socket_addr)
+                }
+                _ => Error::from_std_err(Code::Internal, &e)
+                    .append(format!("Failed to bind to socket address '{socket_addr}'")),
+            })?;
         let mut http = auto::Builder::new(TaskExecutor::default());
 
         let http_config = &http_config.advanced_http;


### PR DESCRIPTION
# Description

When `TcpListener::bind` failed, the resulting error was opaque—the raw IO error was simply bubbled up via `?`. This left users with no clear indication of which port or address was in conflict, whether they lacked permissions, or if the address itself was invalid.

This change maps common `std::io::ErrorKind` variants to specific gRPC-style error codes and provides descriptive, human-readable messages:

| Condition | gRPC Code | Message |
| :--- | :--- | :--- |
| **AddrInUse** | AlreadyExists | "Address '{addr}' is already in use by another process." |
| **PermissionDenied** | PermissionDenied | "Permission denied. You may need root privileges to bind to address '{addr}'." |
| **InvalidInput** | InvalidArgument | "The provided address '{addr}' is invalid." |
| **Other** | Internal | "Failed to bind to socket address '{addr}'" (appended to original error) |

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```bash
cargo run --bin nativelink -- path/to/config.json5
```
**Note**: To verify the fix, ensure the target config.json5 explicitly uses an address or port that is already in use.

## Checklist
- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] bazel test //... passes locally
- [ ] PR is contained in a single commit using git amend (see [docs](https://www.atlassian.com/git/tutorials/rewriting-history))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2394)
<!-- Reviewable:end -->
