### PR TITLE
Fix infinite loop when using --help flag on the integration test script

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -42,6 +42,7 @@ Usage:
 TEST_PATTERNS: Name of test you wish to execute. Wildcard (*) supported.
                Default: '*.sh'
 EOT
+        exit 1
         ;;
     -*)
         echo "Unknown option $1"


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Remove infinite loop when using the `--help` flag from the `run_integration_tests.sh` script.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```
./run_integration_tests.sh --help
```

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2395)
<!-- Reviewable:end -->
