### PR TITLE
listener: support `IP_FREEBIND` to bind not-yet-assigned addresses

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -536,6 +536,12 @@ pub struct HttpListener {
     #[serde(deserialize_with = "convert_string_with_shellexpand")]
     pub socket_address: String,
 
+    /// Allow binding `socket_address` before it is assigned locally.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub freebind: bool,
+
     /// Data transport compression configuration to use for this service.
     #[serde(default)]
     pub compression: HttpCompressionConfig,

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -16,7 +16,9 @@ use core::pin::Pin;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll};
 use std::fs::{Metadata, Permissions};
-use std::io::{IoSlice, Seek};
+use std::io::{self, IoSlice, Seek};
+#[cfg(target_os = "linux")]
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use nativelink_error::{Code, Error, ResultExt, make_err};
@@ -46,7 +48,6 @@ impl FileSlot {
     /// Only available on Linux;
     #[cfg(target_os = "linux")]
     pub fn advise_dontneed(&self) {
-        use std::os::unix::io::AsRawFd;
         let fd = self.inner.as_raw_fd();
         let ret = unsafe { libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED) };
         if ret != 0 {
@@ -62,6 +63,35 @@ impl FileSlot {
     pub const fn advise_dontneed(&self) {
         // No-op: posix_fadvise is not available on Mac or Windows.
     }
+}
+
+/// Enable [`IP_FREEBIND`](`libc::IP_FREEBIND`) before binding a socket.
+#[cfg(target_os = "linux")]
+pub fn set_freebind<F: AsRawFd>(socket: &F) -> Result<(), io::Error> {
+    let enable = 1;
+    let optlen = libc::socklen_t::try_from(size_of::<libc::c_int>())
+        .expect("size of c_int always fits in socklen_t");
+
+    // SAFETY: we pass in a valid fd, initialized optval, and matching optlen.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_FREEBIND,
+            core::ptr::addr_of!(enable).cast(),
+            optlen,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub const fn set_freebind<F>(_socket: &F) -> Result<(), io::Error> {
+    Ok(())
 }
 
 impl AsRef<tokio::fs::File> for FileSlot {

--- a/nativelink-util/tests/fs_test.rs
+++ b/nativelink-util/tests/fs_test.rs
@@ -37,3 +37,25 @@ async fn remove_files_with_bad_permissions() -> Result<(), Box<dyn core::error::
     assert!(!fs::exists(&bad_perms_directory)?);
     Ok(())
 }
+
+#[cfg(target_os = "linux")]
+#[nativelink_test]
+async fn freebind_allows_binding_unassigned_address() -> Result<(), Box<dyn core::error::Error>> {
+    use std::io::ErrorKind;
+
+    use nativelink_util::fs::set_freebind;
+    use tokio::net::TcpSocket;
+
+    let addr = "192.0.2.1:0".parse()?;
+
+    // Without `IP_FREEBIND` the kernel refuses to bind an unassigned address.
+    let err = TcpSocket::new_v4()?.bind(addr).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::AddrNotAvailable);
+
+    // With IP_FREEBIND the same bind succeeds.
+    let socket = TcpSocket::new_v4()?;
+    set_freebind(&socket)?;
+    socket.bind(addr)?;
+
+    Ok(())
+}

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -64,7 +64,7 @@ use nativelink_util::{background_spawn, fs, spawn};
 use nativelink_worker::local_worker::new_local_worker;
 use rustls_pki_types::pem::PemObject;
 use rustls_pki_types::{CertificateRevocationListDer, PrivateKeyDer};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpSocket};
 use tokio::select;
 #[cfg(target_family = "unix")]
 use tokio::signal::unix::{SignalKind, signal};
@@ -94,6 +94,17 @@ const DEFAULT_MAX_QUEUE_EVENTS: usize = 0x0001_0000;
 /// Broadcast Channel Capacity
 /// Note: The actual capacity may be greater than the provided capacity.
 const BROADCAST_CAPACITY: usize = 1;
+
+/// Bind a [`TcpListener`] with `IP_FREEBIND` set.
+fn bind_freebind(socket_addr: SocketAddr) -> Result<TcpListener, std::io::Error> {
+    let socket = match socket_addr {
+        SocketAddr::V4(_) => TcpSocket::new_v4(),
+        SocketAddr::V6(_) => TcpSocket::new_v6(),
+    }?;
+    fs::set_freebind(&socket)?;
+    socket.bind(socket_addr)?;
+    socket.listen(1024)
+}
 
 /// Backend for bazel remote execution / cache API.
 #[derive(Parser, Debug)]
@@ -511,25 +522,26 @@ async fn inner_main(
                 Error::from_std_err(Code::InvalidArgument, &e)
                     .append(format!("Invalid address '{}'", http_config.socket_address))
             })?;
-        let tcp_listener = TcpListener::bind(&socket_addr)
-            .await
-            .map_err(|e| match e.kind() {
-                ErrorKind::AddrInUse => make_err!(
-                    Code::AlreadyExists,
-                    "Address '{}' is already in use by another process.",
-                    socket_addr
-                ),
-                ErrorKind::PermissionDenied => make_err!(
-                    Code::PermissionDenied,
-                    "Permission denied. You may need root privileges to bind to address '{}'.",
-                    socket_addr
-                ),
-                ErrorKind::InvalidInput => {
-                    make_input_err!("The provided address '{}' is invalid.", socket_addr)
-                }
-                _ => Error::from_std_err(Code::Internal, &e)
-                    .append(format!("Failed to bind to socket address '{socket_addr}'")),
-            })?;
+        let tcp_listener = if http_config.freebind {
+            bind_freebind(socket_addr)
+        } else {
+            TcpListener::bind(&socket_addr).await
+        }
+        .map_err(|e| match e.kind() {
+            ErrorKind::AddrInUse => make_err!(
+                Code::AlreadyExists,
+                "Address '{socket_addr}' is already in use by another process.",
+            ),
+            ErrorKind::PermissionDenied => make_err!(
+                Code::PermissionDenied,
+                "Permission denied. You may need root privileges to bind to address '{socket_addr}'.",
+            ),
+            ErrorKind::InvalidInput => {
+                make_input_err!("The provided address '{socket_addr}' is invalid.")
+            }
+            _ => Error::from_std_err(Code::Internal, &e)
+                .append(format!("Failed to bind to socket address '{socket_addr}'")),
+        })?;
         let mut http = auto::Builder::new(TaskExecutor::default());
 
         let http_config = &http_config.advanced_http;

--- a/web/apps/docs/content/docs/reference/nativelink-config.mdx
+++ b/web/apps/docs/content/docs/reference/nativelink-config.mdx
@@ -92,6 +92,7 @@ services exposed:
   listener: {
     http: {
       socket_address: "0.0.0.0:50051",
+      freebind: false, // optional, Linux only
       tls: { /* optional */ },
       advanced_http: { http2_keep_alive_interval: 10 },
     },


### PR DESCRIPTION
# Description

Binding an address that another daemon brings up after start races interface
setup and fails with `EADDRNOTAVAIL`, crash-looping until it appears.

This commit adds an opt-in `freebind` flag on the HTTP listener that
sets `IP_FREEBIND` before bind, so an address brought up after start
(such as a tailscale IP) can be bound immediately.

Fixes # (issue)

n/a, but my use case is for hosting a nativelink instance over tailscale so any of my machines can pull from the cache. I noticed it crash looping before tailscale came online when rebooting the machine with the instance.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I've added a unit test, as well as tested this on my instance. It works as expected without crashing :)

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2399)
<!-- Reviewable:end -->
