### PR TITLE
Link from main nativelink site to enterprise site

### DIFF
--- a/web/apps/web/app/compliance/page.tsx
+++ b/web/apps/web/app/compliance/page.tsx
@@ -173,6 +173,19 @@ export default function CompliancePage() {
                 </h3>
                 <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
                   {c.body}
+                  {c.title === "Data residency" && (
+                    <>
+                      {" "}
+                      <a
+                        href="https://enterprise.nativelink.com"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-medium text-brand underline-offset-4 hover:underline"
+                      >
+                        Deploy on-prem with our Helm charts →
+                      </a>
+                    </>
+                  )}
                 </p>
               </div>
             </Reveal>

--- a/web/apps/web/app/pricing/page.tsx
+++ b/web/apps/web/app/pricing/page.tsx
@@ -49,7 +49,7 @@ const tiers = [
       "Procurement support",
       "Priority feature requests",
     ],
-    cta: { label: "Request quote", href: "mailto:hello@nativelink.com" },
+    cta: { label: "Subscribe now", href: "https://enterprise.nativelink.com" },
     variant: "ghost" as const,
   },
 ];
@@ -298,7 +298,18 @@ export default function PricingPage() {
                           <Cell value={row.cloud} />
                         </td>
                         <td className="px-6 py-4">
-                          <Cell value={row.ent} />
+                          {row.label === "Hosting" ? (
+                            <a
+                              href="https://enterprise.nativelink.com"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="font-mono text-sm text-brand underline-offset-4 hover:underline"
+                            >
+                              {row.ent}
+                            </a>
+                          ) : (
+                            <Cell value={row.ent} />
+                          )}
                         </td>
                       </tr>
                     ))}

--- a/web/packages/ui/src/components/mobile-nav.tsx
+++ b/web/packages/ui/src/components/mobile-nav.tsx
@@ -16,7 +16,11 @@ interface MobileNavProps {
 }
 
 const opensInNewTab = (label: string, href: string) =>
-  label === "Docs" || label === "Get started" || label === "Start free" || href === "/docs";
+  label === "Docs" ||
+  label === "Get started" ||
+  label === "Start free" ||
+  href === "/docs" ||
+  href.startsWith("http");
 
 export function MobileNav({
   links,

--- a/web/packages/ui/src/components/site-footer.tsx
+++ b/web/packages/ui/src/components/site-footer.tsx
@@ -25,6 +25,7 @@ const defaultColumns: FooterColumn[] = [
       { label: "Product", href: "/product" },
       { label: "Pricing", href: "/pricing" },
       { label: "Docs", href: "/docs" },
+      { label: "Enterprise", href: "https://enterprise.nativelink.com" },
       { label: "Status", href: "/status" },
     ],
   },
@@ -112,6 +113,8 @@ export function SiteFooter({
                 <li key={link.href}>
                   <a
                     href={link.href}
+                    target={link.href.startsWith("http") ? "_blank" : undefined}
+                    rel={link.href.startsWith("http") ? "noreferrer" : undefined}
                     className="inline-flex min-h-[36px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
                   >
                     {link.label}

--- a/web/packages/ui/src/components/site-header.tsx
+++ b/web/packages/ui/src/components/site-header.tsx
@@ -10,7 +10,11 @@ export interface NavLink {
 }
 
 const opensInNewTab = (label: string, href: string) =>
-  label === "Docs" || label === "Get started" || label === "Start free" || href === "/docs";
+  label === "Docs" ||
+  label === "Get started" ||
+  label === "Start free" ||
+  href === "/docs" ||
+  href.startsWith("http");
 
 interface SiteHeaderProps {
   links?: NavLink[];
@@ -26,6 +30,7 @@ const defaultLinks: NavLink[] = [
   { label: "Company", href: "/company" },
   { label: "Resources", href: "/resources" },
   { label: "Docs", href: "/docs" },
+  { label: "Enterprise", href: "https://enterprise.nativelink.com" },
 ];
 
 export function SiteHeader({


### PR DESCRIPTION
Replaces the "Request quote" mailto with a self-serve link to the enterprise
Helm-chart license site so customers can sign up and pay directly.

## Description

Adds links from nativelink.com to the new enterprise Helm-chart license site
(enterprise.nativelink.com) so customers can self-serve sign-up and payment
instead of going through a sales email.

- **Header nav:** new "Enterprise" link to the right of Docs (desktop + mobile).
- **Footer:** "Enterprise" link in the Product column, after Docs.
- **Pricing — Enterprise tier:** CTA changed from "Request quote" (mailto) to
  "Subscribe now", linking to enterprise.nativelink.com.
- **Pricing — comparison table:** the Hosting row's "On-prem or managed" cell
  links to the enterprise site.
- **Compliance:** the air-gapped / data-residency control links to the
  enterprise site ("Deploy on-prem with our Helm charts").

External links open in a new tab. Copy/links only — no functional or backend
changes.

Fixes # (n/a)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Static copy/link change with no logic. Verified the rendered links and hrefs
in the affected files (header, footer, pricing, compliance). Lint/typecheck to
be confirmed via CI (`bun run typecheck` / `biome`); no behavior to unit-test.

Manual check: load `/pricing` and `/compliance`, confirm the Enterprise nav +
footer links and the "Subscribe now" button all resolve to
https://enterprise.nativelink.com.

## Checklist

- [ ] Updated documentation if needed (n/a — no docs affected)
- [ ] Tests added/amended (n/a — copy/link-only change)
- [ ] `bazel test //...` passes locally (not run — no Rust/build changes)
- [x] PR is contained in a single commit, using git amend

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2407)
<!-- Reviewable:end -->
