### PR TITLE
bytestream_server: single-acquire active_uploads in create_or_join_upload_stream

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -494,8 +494,9 @@ impl ByteStreamServer {
         // Parse UUID string to u128 key for efficient HashMap operations
         let uuid_key = parse_uuid_to_key(uuid_str);
 
-        let (uuid, bytes_received, is_collision) =
-            match instance.active_uploads.lock().entry(uuid_key) {
+        let (uuid, bytes_received, is_collision) = {
+            let mut active_uploads = instance.active_uploads.lock();
+            match active_uploads.entry(uuid_key) {
                 Entry::Occupied(mut entry) => {
                     let maybe_idle_stream = entry.get_mut();
                     if let Some(idle_stream) = maybe_idle_stream.1.take() {
@@ -512,8 +513,8 @@ impl ByteStreamServer {
                             .fetch_add(1, Ordering::Relaxed);
                         return idle_stream.into_active_stream(bytes_received, instance);
                     }
-                    // Case 3: Stream is active - generate a unique UUID to avoid collision
-                    // Using nanosecond timestamp makes collision probability essentially zero
+                    // Case 3: Stream is active - generate a unique UUID to avoid collision.
+                    // Using nanosecond timestamp makes collision probability essentially zero.
                     let original_key = *entry.key();
                     let unique_key = Self::generate_unique_uuid_key(original_key);
                     warn!(
@@ -521,11 +522,9 @@ impl ByteStreamServer {
                         original_uuid = format!("{:032x}", original_key),
                         unique_uuid = format!("{:032x}", unique_key)
                     );
-                    // Entry goes out of scope here, releasing the lock
-
+                    // Release the Occupied entry's borrow so we can insert on the same guard.
+                    drop(entry);
                     let bytes_received = Arc::new(AtomicU64::new(0));
-                    let mut active_uploads = instance.active_uploads.lock();
-                    // Insert with the unique UUID - this should never collide due to nanosecond precision
                     active_uploads.insert(unique_key, (bytes_received.clone(), None));
                     (unique_key, bytes_received, true)
                 }
@@ -537,7 +536,8 @@ impl ByteStreamServer {
                     entry.insert((bytes_received.clone(), None));
                     (uuid, bytes_received, false)
                 }
-            };
+            }
+        };
 
         // Track metrics for new upload
         instance

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -1077,3 +1077,71 @@ async fn write_too_many_bytes_fails() -> Result<(), Box<dyn core::error::Error>>
 // in production with large C++ builds using Bazel.
 // Manual testing shows the warning: "UUID collision detected, generating unique UUID"
 // and both uploads complete successfully.
+
+#[nativelink_test]
+async fn uuid_collision_does_not_deadlock() -> Result<(), Box<dyn core::error::Error>> {
+    // Two Write RPCs share a UUID while the first is mid-stream
+    // (Entry::Occupied + idle_stream == None — Case 3 in
+    // create_or_join_upload_stream). The server must release the
+    // active_uploads lock before re-acquiring it for the unique-key insert,
+    // otherwise it self-deadlocks on parking_lot's non-reentrant Mutex.
+    //
+    // A std::thread watchdog hard-exits at 5 s: tokio::time::timeout does
+    // not reliably fire when a runtime worker is parked on a sync mutex.
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    struct WatchdogGuard(Arc<AtomicBool>);
+    impl Drop for WatchdogGuard {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    const DATA: &[u8] = &[0u8; 10];
+    let resource_name = make_resource_name(DATA.len());
+
+    let done = Arc::new(AtomicBool::new(false));
+    let _wd = WatchdogGuard(done.clone());
+    std::thread::spawn({
+        let done = done.clone();
+        move || {
+            std::thread::sleep(core::time::Duration::from_secs(5));
+            if !done.load(Ordering::SeqCst) {
+                eprintln!("watchdog: timed out — UUID collision deadlock still present");
+                std::process::exit(2);
+            }
+        }
+    });
+
+    let bs_server = Arc::new(
+        make_bytestream_server(make_store_manager().await?.as_ref(), None)
+            .expect("Failed to make server"),
+    );
+
+    // Write 1: keep the stream open with partial data so the UUID lands in
+    // active_uploads with idle_stream == None.
+    let (tx1, _join1) = make_stream_and_writer_spawn(bs_server.clone(), None);
+    tx1.send(Frame::data(encode_stream_proto(&WriteRequest {
+        resource_name: resource_name.clone(),
+        write_offset: 0,
+        finish_write: false,
+        data: DATA[..5].into(),
+    })?))
+    .await?;
+    tokio::time::sleep(core::time::Duration::from_millis(50)).await;
+
+    // Write 2: same UUID while write 1 is active — triggers Case 3.
+    let (tx2, join2) = make_stream_and_writer_spawn(bs_server.clone(), None);
+    tx2.send(Frame::data(encode_stream_proto(&WriteRequest {
+        resource_name: resource_name.clone(),
+        write_offset: 0,
+        finish_write: true,
+        data: DATA.into(),
+    })?))
+    .await?;
+    drop(tx2);
+
+    join2.await.expect("task panicked")?;
+    drop(tx1);
+    Ok(())
+}


### PR DESCRIPTION
# Description

The Entry::Occupied (UUID-collision) arm acquires
`instance.active_uploads.lock()` twice in the same `let` statement: once as the match scrutinee
(`match instance.active_uploads.lock().entry(uuid_key)`) and once inside the arm
(`let mut active_uploads = instance.active_uploads.lock()`). The inline comment claims "Entry goes out of scope here, releasing the lock" between the two, but Rust's temporary-lifetime rules keep the scrutinee's `MutexGuard` alive until the enclosing `let` statement ends.
`parking_lot::Mutex` is non-reentrant, so the second `.lock()` call parks the calling thread on the same mutex it still holds.

Reproduction: Bazel CI cohort against a single-tier `filesystem` CAS topology (no memory or slow store), single in-cluster runner issuing ~120 concurrent local upload actions, many of them 100 MiB+ blobs. Under that load CAS emits a burst of `Unexpected EOF`, `Stream error at byte …`, and
`Expected WriteRequest (got None)` errors interleaved with the `UUID collision detected` warn from this function, then the process goes silent for several minutes — CPU drops to single- digit milli-cores while the gRPC listener keeps accepting and the pod stays alive. The HTTP `/metrics` endpoint hangs (default `StoreDriver::check_health` writes a probe blob through the same store path) and Bazel clients hit `DEADLINE_EXCEEDED`. The wedge sometimes self-recovers after ~5-10 min and sometimes persists, consistent with a contention-bound async-runtime stall on a hot synchronous mutex rather than a clean every-time deadlock; either way the restructure removes the pattern.

Note: for debugging the liveness probe in the helm chart was changed to that the hanging /metrics endpoint is not restarting CAS.

The collision path has no automated test; the manual-verification note in `bytestream_server_test.rs` exercised it at trivial concurrency, which is why the bug slipped through.

Restructure: bind `active_uploads` once at the top of the block, match on `active_uploads.entry(uuid_key)`, drop the `Entry::Occupied` entry's borrow explicitly before calling `insert` under the unique key, and let the guard drop on scope exit.

Empirical impact under the reproduction config:
- Unpatched: ~18 ByteStream error bursts in <30 s, in-flight upload buffer climbs to ~11 GiB, test wall regression / failure.
- Patched (same config): 0 ByteStream errors, in-flight buffer stays <1 MiB, faster CI wall (CAS CPU shifts from parking on the lock to real work).

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- NativeLink Bazel tests (added a new test case)
- Tested the built image in our installation and it fixed the deadlock/contention scenario

## Checklist

- [X] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2408)
<!-- Reviewable:end -->
