### PR TITLE
worker: use Duration::from_mins() for timeout constants

### DIFF
--- a/nativelink-worker/src/persistent_worker/live_worker.rs
+++ b/nativelink-worker/src/persistent_worker/live_worker.rs
@@ -46,7 +46,7 @@ use super::protocol::{WireFormat, WorkRequest, WorkResponse};
 /// Default time we wait for a single `WorkResponse` after writing a request.
 /// Beyond this we kill the worker and surface a `DeadlineExceeded` error.
 /// Callers may override via `LiveWorker::dispatch_with_timeout`.
-const DEFAULT_DISPATCH_TIMEOUT: Duration = Duration::from_secs(60 * 10);
+const DEFAULT_DISPATCH_TIMEOUT: Duration = Duration::from_mins(10);
 
 /// One persistent-worker child process.
 #[derive(Debug)]

--- a/nativelink-worker/src/persistent_worker/pool.rs
+++ b/nativelink-worker/src/persistent_worker/pool.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_MAX_WORKERS_PER_KEY: usize = 4;
 
 /// Default idle timeout. A worker that has not handled a request for this
 /// duration is shut down by the background sweeper.
-pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 5);
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// Default per-worker request cap. After this many `dispatch` calls a worker is
 /// dropped on `release` (helps recycle accumulated JVM state).


### PR DESCRIPTION
# Description

Transition to `Duration::from_mins()` over `Duration::from_secs()` as the mins unit better fit the current intent.



## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2411)
<!-- Reviewable:end -->
