### PR TITLE
fix(scheduler): publish resource-usage origin event from ApiWorkerScheduler

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -26,13 +26,19 @@ use nativelink_metric::{
     MetricFieldData, MetricKind, MetricPublishKnownKindData, MetricsComponent,
     RootMetricsComponent, group,
 };
+use nativelink_proto::com::github::trace_machina::nativelink::events::{
+    Event, OriginEvent, ResponseEvent, event, response_event,
+};
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::ActionResourceUsage;
 use nativelink_util::action_messages::{OperationId, WorkerId};
 use nativelink_util::operation_state_manager::{UpdateOperationType, WorkerStateManager};
+use nativelink_util::origin_event::get_node_id;
 use nativelink_util::platform_properties::PlatformProperties;
 use nativelink_util::shutdown_guard::ShutdownGuard;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc};
 use tonic::async_trait;
 use tracing::{error, info, trace, warn};
+use uuid::Uuid;
 
 /// Metrics for tracking scheduler performance.
 #[derive(Debug, Default)]
@@ -491,6 +497,10 @@ pub struct ApiWorkerScheduler {
 
     /// Performance metrics for observability.
     metrics: Arc<SchedulerMetrics>,
+
+    /// Channel for publishing origin events such as worker-observed action
+    /// resource usage. `None` when origin events are disabled.
+    maybe_origin_event_tx: Option<mpsc::Sender<OriginEvent>>,
 }
 
 impl ApiWorkerScheduler {
@@ -501,6 +511,7 @@ impl ApiWorkerScheduler {
         worker_change_notify: Arc<Notify>,
         worker_timeout_s: u64,
         worker_registry: SharedWorkerRegistry,
+        maybe_origin_event_tx: Option<mpsc::Sender<OriginEvent>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(ApiWorkerSchedulerImpl {
@@ -516,6 +527,7 @@ impl ApiWorkerScheduler {
             worker_timeout_s,
             worker_registry,
             metrics: Arc::new(SchedulerMetrics::default()),
+            maybe_origin_event_tx,
         })
     }
 
@@ -622,6 +634,56 @@ impl ApiWorkerScheduler {
 impl WorkerScheduler for ApiWorkerScheduler {
     fn get_platform_property_manager(&self) -> &PlatformPropertyManager {
         self.platform_property_manager.as_ref()
+    }
+
+    async fn record_action_resource_usage(
+        &self,
+        worker_id: &WorkerId,
+        operation_id: &OperationId,
+        mut resource_usage: ActionResourceUsage,
+    ) -> Result<(), Error> {
+        // The worker API talks to this `ApiWorkerScheduler` (it is the
+        // `WorkerScheduler` returned by `SimpleScheduler::new`), so the
+        // resource-usage origin event must be published here. Previously the
+        // only override lived on `SimpleScheduler`, which this path never
+        // reaches, so the event was silently dropped by the trait's no-op
+        // default and `observed_worker_peak_memory_mib` was never recorded.
+        let Some(origin_event_tx) = self.maybe_origin_event_tx.as_ref() else {
+            return Ok(());
+        };
+        let Some(action_info) = self.running_action_info(worker_id, operation_id).await else {
+            return Ok(());
+        };
+
+        if resource_usage.operation_id.is_empty() {
+            resource_usage.operation_id = operation_id.to_string();
+        }
+        if resource_usage.worker_id.is_empty() {
+            resource_usage.worker_id = worker_id.to_string();
+        }
+
+        let event = Event {
+            event: Some(event::Event::Response(ResponseEvent {
+                event: Some(response_event::Event::ActionResourceUsage(resource_usage)),
+            })),
+        };
+        let origin_event = OriginEvent {
+            version: 0,
+            event_id: Uuid::now_v6(&get_node_id(Some(&event)))
+                .hyphenated()
+                .to_string(),
+            parent_event_id: action_info
+                .scheduler_start_execute_event_id
+                .clone()
+                .unwrap_or_default(),
+            bazel_request_metadata: action_info.origin_metadata.bazel_metadata.clone(),
+            identity: action_info.origin_metadata.identity,
+            event: Some(event),
+        };
+        if let Err(err) = origin_event_tx.try_send(origin_event) {
+            warn!(?err, "Failed to publish action resource usage origin event");
+        }
+        Ok(())
     }
 
     async fn add_worker(&self, worker: Worker) -> Result<(), Error> {

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -22,11 +22,9 @@ use nativelink_config::schedulers::SimpleSpec;
 use nativelink_error::{Code, Error, ResultExt};
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_proto::com::github::trace_machina::nativelink::events::{
-    Event, OriginEvent, RequestEvent, ResponseEvent, event, request_event, response_event,
+    Event, OriginEvent, RequestEvent, event, request_event,
 };
-use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::{
-    ActionResourceUsage, StartExecute,
-};
+use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_util::action_messages::{ActionInfo, ActionState, OperationId, WorkerId};
 use nativelink_util::instant_wrapper::InstantWrapper;
 use nativelink_util::known_platform_property_provider::KnownPlatformPropertyProvider;
@@ -218,35 +216,6 @@ impl SimpleScheduler {
                 ?err,
                 "Failed to publish scheduler start execute origin event"
             );
-        }
-    }
-
-    fn publish_action_resource_usage(
-        maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
-        origin_metadata: &OriginMetadata,
-        parent_event_id: Option<&str>,
-        resource_usage: ActionResourceUsage,
-    ) {
-        let Some(origin_event_tx) = maybe_origin_event_tx else {
-            return;
-        };
-
-        let event = Event {
-            event: Some(event::Event::Response(ResponseEvent {
-                event: Some(response_event::Event::ActionResourceUsage(resource_usage)),
-            })),
-        };
-        let origin_event = OriginEvent {
-            version: 0,
-            event_id: Self::origin_event_id(&event),
-            parent_event_id: parent_event_id.unwrap_or_default().to_string(),
-            bazel_request_metadata: origin_metadata.bazel_metadata.clone(),
-            identity: origin_metadata.identity.clone(),
-            event: Some(event),
-        };
-
-        if let Err(err) = origin_event_tx.try_send(origin_event) {
-            warn!(?err, "Failed to publish action resource usage origin event");
         }
     }
 
@@ -554,6 +523,7 @@ impl SimpleScheduler {
             worker_change_notify.clone(),
             worker_timeout_s,
             worker_registry,
+            maybe_origin_event_tx.clone(),
         );
 
         let worker_scheduler_clone = worker_scheduler.clone();
@@ -761,36 +731,6 @@ impl WorkerScheduler for SimpleScheduler {
         self.worker_scheduler
             .update_action(worker_id, operation_id, update)
             .await
-    }
-
-    async fn record_action_resource_usage(
-        &self,
-        worker_id: &WorkerId,
-        operation_id: &OperationId,
-        mut resource_usage: ActionResourceUsage,
-    ) -> Result<(), Error> {
-        let Some(action_info) = self
-            .worker_scheduler
-            .running_action_info(worker_id, operation_id)
-            .await
-        else {
-            return Ok(());
-        };
-
-        if resource_usage.operation_id.is_empty() {
-            resource_usage.operation_id = operation_id.to_string();
-        }
-        if resource_usage.worker_id.is_empty() {
-            resource_usage.worker_id = worker_id.to_string();
-        }
-
-        Self::publish_action_resource_usage(
-            self.maybe_origin_event_tx.as_ref(),
-            &action_info.origin_metadata,
-            action_info.scheduler_start_execute_event_id.as_deref(),
-            resource_usage,
-        );
-        Ok(())
     }
 
     async fn worker_keep_alive_received(

--- a/nativelink-scheduler/tests/simple_scheduler_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_test.rs
@@ -194,7 +194,7 @@ async fn scheduler_start_execute_origin_event_includes_resource_hints() -> Resul
     let worker_id = WorkerId("worker_id".to_string());
     let task_change_notify = Arc::new(Notify::new());
     let (origin_event_tx, mut origin_event_rx) = mpsc::channel(8);
-    let (scheduler, _worker_scheduler) = SimpleScheduler::new_with_callback(
+    let (scheduler, worker_scheduler) = SimpleScheduler::new_with_callback(
         &SimpleSpec {
             supported_platform_properties: Some(HashMap::from([
                 ("cpu_count".to_string(), PropertyType::Minimum),
@@ -310,7 +310,7 @@ async fn scheduler_start_execute_origin_event_includes_resource_hints() -> Resul
         start_action_platform.properties
     );
 
-    scheduler
+    worker_scheduler
         .record_action_resource_usage(
             &worker_id,
             &OperationId::from(start_action.operation_id.as_str()),

--- a/nativelink-service/tests/worker_api_server_test.rs
+++ b/nativelink-service/tests/worker_api_server_test.rs
@@ -168,6 +168,7 @@ async fn setup_api_server_with_task_limit(
         tasks_or_worker_change_notify,
         worker_timeout,
         worker_registry,
+        None,
     );
 
     let mut schedulers: HashMap<String, Arc<dyn WorkerScheduler>> = HashMap::new();


### PR DESCRIPTION
# Description

The worker reports observed peak memory in ExecuteResult.resource_usage, which WorkerApiServer forwards via WorkerScheduler::record_action_resource_usage. That trait method has a no-op default; the only override lived on SimpleScheduler. But WorkerApiServer is handed the inner ApiWorkerScheduler (the worker_scheduler returned by SimpleScheduler::new), which did not override it — so every worker-reported resource usage hit the no-op and observed_worker_peak_memory_mib was never populated.

Give ApiWorkerScheduler the origin_event_tx and implement record_action_resource_usage there (it already owns running_action_info), publishing the ResponseEvent::ActionResourceUsage origin event that bep-etl ingests. Verified via debug build: worker samples peak, sends it, scheduler receives it — but record_action_resource_usage's publish was never reached.

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2413)
<!-- Reviewable:end -->
