### PR TITLE
fast_slow_store: fall through to slow on stale fast-tier map entries

### DIFF
--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -758,19 +758,36 @@ impl StoreDriver for FastSlowStore {
         offset: u64,
         length: Option<u64>,
     ) -> Result<(), Error> {
-        // TODO(palfrey) Investigate if we should maybe ignore errors here instead of
-        // forwarding them up.
+        // `has()` can report a stale map entry whose file is gone, so
+        // get_part may still return NotFound; fall through to the slow
+        // store unless we have already streamed bytes to the caller.
         if self.fast_store.has(key.borrow()).await?.is_some() {
-            self.metrics
-                .fast_store_hit_count
-                .fetch_add(1, Ordering::Acquire);
-            self.fast_store
-                .get_part(key, writer.borrow_mut(), offset, length)
-                .await?;
-            self.metrics
-                .fast_store_downloaded_bytes
-                .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
-            return Ok(());
+            let bytes_before = writer.get_bytes_written();
+            match self
+                .fast_store
+                .get_part(key.borrow(), writer.borrow_mut(), offset, length)
+                .await
+            {
+                Ok(()) => {
+                    self.metrics
+                        .fast_store_hit_count
+                        .fetch_add(1, Ordering::Acquire);
+                    self.metrics
+                        .fast_store_downloaded_bytes
+                        .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
+                    return Ok(());
+                }
+                Err(e)
+                    if e.code == Code::NotFound && writer.get_bytes_written() == bytes_before =>
+                {
+                    self.metrics
+                        .fast_store_stale_map_falls_through
+                        .fetch_add(1, Ordering::Acquire);
+                    warn!(%key, ?e, "Stale fast-store map entry; falling through to slow store");
+                    // fall through to populate path
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         // If the fast store is noop or read only or update only then bypass it.
@@ -929,6 +946,8 @@ struct FastSlowStoreMetrics {
     leader_wait_timeouts: AtomicU64,
     #[metric(help = "get_part calls that bypassed dedup for huge blobs")]
     huge_blob_dedup_bypasses: AtomicU64,
+    #[metric(help = "Stale fast-store map entries that fell through to the slow store")]
+    fast_store_stale_map_falls_through: AtomicU64,
 }
 
 /// Maximum time a follower will wait on the leader-populator before

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -1818,3 +1818,164 @@ async fn bypass_threshold_is_inclusive_at_exact_size() -> Result<(), Error> {
     );
     Ok(())
 }
+
+/// Fast store with a stale map entry: `has()` says present, `get_part`
+/// returns `NotFound` (after `bytes_before_error` bytes, if non-zero).
+#[derive(MetricsComponent)]
+struct StaleFastStore {
+    inner: Arc<MemoryStore>,
+    reported_size: u64,
+    bytes_before_error: u64,
+    get_part_calls: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl StoreDriver for StaleFastStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        _digests: &[StoreKey<'_>],
+        results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        // Stale entry: report present regardless of backing data.
+        for result in results.iter_mut() {
+            *result = Some(self.reported_size);
+        }
+        Ok(())
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        digest: StoreKey<'_>,
+        reader: DropCloserReadHalf,
+        size_info: UploadSizeInfo,
+    ) -> Result<u64, Error> {
+        // Accept the fall-through repopulate.
+        Pin::new(self.inner.as_ref())
+            .update(digest, reader, size_info)
+            .await
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        writer: &mut DropCloserWriteHalf,
+        _offset: u64,
+        _length: Option<u64>,
+    ) -> Result<(), Error> {
+        self.get_part_calls.fetch_add(1, Ordering::AcqRel);
+        if self.bytes_before_error > 0 {
+            let partial_len = usize::try_from(self.bytes_before_error)
+                .err_tip(|| "bytes_before_error exceeds usize")?;
+            writer.send(Bytes::from(vec![0u8; partial_len])).await?;
+        }
+        Err(make_err!(
+            Code::NotFound,
+            "stale eviction-map entry: file missing on disk"
+        ))
+    }
+
+    fn inner_store(&self, _digest: Option<StoreKey>) -> &'_ dyn StoreDriver {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+default_health_status_indicator!(StaleFastStore);
+
+fn make_stores_with_stale_fast(
+    reported_size: u64,
+    bytes_before_error: u64,
+) -> (Store, Store, Arc<AtomicU64>) {
+    let get_part_calls = Arc::new(AtomicU64::new(0));
+    let fast_store = Store::new(Arc::new(StaleFastStore {
+        inner: MemoryStore::new(&MemorySpec::default()),
+        reported_size,
+        bytes_before_error,
+        get_part_calls: get_part_calls.clone(),
+    }));
+    let slow_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let fast_slow_store = Store::new(FastSlowStore::new(
+        &FastSlowSpec {
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
+            fast_direction: StoreDirection::default(),
+            slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
+        },
+        fast_store,
+        slow_store.clone(),
+    ));
+    (fast_slow_store, slow_store, get_part_calls)
+}
+
+/// A stale fast-store map entry must fall through to the slow store.
+#[nativelink_test]
+async fn get_part_falls_through_to_slow_on_stale_fast_map_entry() -> Result<(), Error> {
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+    let (fast_slow_store, slow_store, fast_get_part_calls) =
+        make_stores_with_stale_fast(original_data.len() as u64, 0);
+
+    // Only the slow store holds the data.
+    slow_store
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+
+    let served = fast_slow_store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .err_tip(|| "fast_slow get_part should fall through to slow store")?;
+
+    // Fast store always errors, so bytes can only come from the slow store.
+    assert_eq!(served, original_data, "served data must match slow store");
+    assert_eq!(
+        fast_get_part_calls.load(Ordering::Acquire),
+        1,
+        "fast store get_part must be attempted exactly once before falling through"
+    );
+
+    Ok(())
+}
+
+/// `NotFound` after partial bytes must propagate, not retry (would corrupt).
+#[nativelink_test]
+async fn get_part_propagates_not_found_after_partial_fast_read() -> Result<(), Error> {
+    let original_data = make_random_data(MEGABYTE_SZ);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+    let (fast_slow_store, slow_store, fast_get_part_calls) =
+        make_stores_with_stale_fast(original_data.len() as u64, 16);
+
+    slow_store
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+
+    let result = fast_slow_store.get_part_unchunked(digest, 0, None).await;
+
+    let err = result.expect_err("partial fast read then NotFound must not fall through");
+    assert_eq!(
+        err.code,
+        Code::NotFound,
+        "original NotFound must propagate, got: {err:?}"
+    );
+    assert_eq!(
+        fast_get_part_calls.load(Ordering::Acquire),
+        1,
+        "fast store get_part must be attempted exactly once"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

The fast store's has() is a metadata lookup against its in-memory eviction map; the actual file may have already been evicted off disk between has() and the subsequent get_part (or -- observed in production -- added to the map by a write whose final rename failed, leaving a phantom entry). When that happens the filesystem store returns NotFound from get_part. Falling through to populate from the slow store recovers transparently; propagating the error would surface as "FAILED_PRECONDITION ... not found in either fast or slow store" to the worker and fail the action even though the slow store has the blob.

We only fall through when no bytes have been written to the caller's writer yet -- once partial bytes have been streamed we cannot honour a retry without producing a corrupt result, so the original NotFound propagates. A new fast_store_stale_map_falls_through metric counts the recoveries.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests (in the existing nativelink-store/tests/fast_slow_store_test.rs suite) add a StaleFastStore whose has() reports the blob present while get_part always returns NotFound:

- get_part_falls_through_to_slow_on_stale_fast_map_entry: the read transparently serves the blob from the slow store; fails against the old propagate-immediately behavior.
- get_part_propagates_not_found_after_partial_fast_read: when the fast store errors NotFound *after* streaming partial bytes, the error must propagate rather than silently retry, guarding the bytes-written invariant.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2414)
<!-- Reviewable:end -->
