### PR TITLE
fast_slow_store: bypass leader/follower dedup for huge blobs

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -800,6 +800,16 @@ pub struct FastSlowSpec {
     /// and you wish to have an upstream read only store.
     #[serde(default)]
     pub slow_direction: StoreDirection,
+
+    /// Reads of blobs at or above this size skip the leader/follower dedup
+    /// map and stream straight from the slow store without populating the
+    /// fast tier. `0` (the default) disables the bypass: every read goes
+    /// through dedup, matching the prior behaviour. Enable it by setting a
+    /// threshold — 256 MiB is a reasonable starting point for backends where
+    /// large-blob dedup is a net loss (followers tend to time out anyway),
+    /// but the right value is workload-dependent.
+    #[serde(default, deserialize_with = "convert_data_size_with_shellexpand")]
+    pub bypass_dedup_threshold_bytes: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -59,6 +59,8 @@ pub struct FastSlowStore {
     #[metric(group = "slow_store")]
     slow_store: Store,
     slow_direction: StoreDirection,
+    /// See [`FastSlowSpec::bypass_dedup_threshold_bytes`].
+    bypass_dedup_threshold_bytes: u64,
     weak_self: Weak<Self>,
     #[metric]
     metrics: FastSlowStoreMetrics,
@@ -159,6 +161,8 @@ impl FastSlowStore {
             fast_direction: spec.fast_direction,
             slow_store,
             slow_direction: spec.slow_direction,
+            // 0 (default) disables the bypass entirely (always dedup).
+            bypass_dedup_threshold_bytes: spec.bypass_dedup_threshold_bytes,
             weak_self: weak_self.clone(),
             metrics: FastSlowStoreMetrics::default(),
             populating_digests: Mutex::new(HashMap::new()),
@@ -181,6 +185,22 @@ impl FastSlowStore {
             key: Some(owned),
             write_complete_guard,
         }
+    }
+
+    /// Digest size in bytes, or `None` for non-digest keys.
+    const fn digest_size_bytes(key: &StoreKey<'_>) -> Option<u64> {
+        match key {
+            StoreKey::Digest(d) => Some(d.size_bytes()),
+            StoreKey::Str(_) => None,
+        }
+    }
+
+    /// Whether a read should skip dedup and hit the slow store directly. A
+    /// threshold of 0 disables the bypass so every read goes through dedup.
+    fn should_bypass_dedup(&self, key: &StoreKey<'_>) -> bool {
+        self.bypass_dedup_threshold_bytes != 0
+            && Self::digest_size_bytes(key)
+                .is_some_and(|size| size >= self.bypass_dedup_threshold_bytes)
     }
 
     pub const fn fast_store(&self) -> &Store {
@@ -773,6 +793,26 @@ impl StoreDriver for FastSlowStore {
             return Ok(());
         }
 
+        // Huge blobs: dedup is a net loss (followers time out anyway and
+        // the fast tier is evicted), so read straight from the slow store.
+        if self.should_bypass_dedup(&key) {
+            self.metrics
+                .huge_blob_dedup_bypasses
+                .fetch_add(1, Ordering::Acquire);
+            self.metrics
+                .slow_store_hit_count
+                .fetch_add(1, Ordering::Acquire);
+            debug!(%key, threshold_bytes = self.bypass_dedup_threshold_bytes, "Bypassing dedup for huge blob");
+            self.slow_store
+                .get_part(key, writer.borrow_mut(), offset, length)
+                .await
+                .err_tip(|| "In FastSlowStore::get_part huge-blob bypass")?;
+            self.metrics
+                .slow_store_downloaded_bytes
+                .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
+            return Ok(());
+        }
+
         let mut writer = Some(writer);
 
         // Drive the dedup loader. Two distinct paths:
@@ -887,6 +927,8 @@ struct FastSlowStoreMetrics {
         help = "Number of times a follower bypassed the populating-digests dedup because the leader exceeded LEADER_WAIT_TIMEOUT"
     )]
     leader_wait_timeouts: AtomicU64,
+    #[metric(help = "get_part calls that bypassed dedup for huge blobs")]
+    huge_blob_dedup_bypasses: AtomicU64,
 }
 
 /// Maximum time a follower will wait on the leader-populator before

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use core::pin::Pin;
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use core::time::Duration;
 use std::sync::{Arc, Mutex};
 
@@ -53,6 +53,7 @@ fn make_stores_direction(
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction,
             slow_direction,
+            bypass_dedup_threshold_bytes: 0,
         },
         fast_store.clone(),
         slow_store.clone(),
@@ -356,6 +357,7 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast_store,
         slow_store,
@@ -399,6 +401,7 @@ async fn ignore_value_in_fast_store() -> Result<(), Error> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast_store.clone(),
         slow_store,
@@ -424,6 +427,7 @@ async fn has_checks_fast_store_when_noop() -> Result<(), Error> {
         slow: StoreSpec::Noop(NoopSpec::default()),
         fast_direction: StoreDirection::default(),
         slow_direction: StoreDirection::default(),
+        bypass_dedup_threshold_bytes: 0,
     };
     let fast_slow_store = Arc::new(FastSlowStore::new(
         &fast_slow_store_config,
@@ -660,6 +664,7 @@ fn make_stores_with_lazy_slow() -> (Store, Store, Store) {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast_store.clone(),
         slow_store.clone(),
@@ -791,6 +796,7 @@ fn make_fast_slow_with_instrumented_slow(
     digest: DigestInfo,
     data: Vec<u8>,
     gate: Option<tokio::sync::oneshot::Receiver<()>>,
+    bypass_dedup_threshold_bytes: u64,
 ) -> (Store, Arc<InstrumentedSlowStore>) {
     let slow = Arc::new(InstrumentedSlowStore {
         digest,
@@ -805,6 +811,7 @@ fn make_fast_slow_with_instrumented_slow(
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes,
         },
         fast,
         Store::new(slow.clone()),
@@ -822,7 +829,7 @@ async fn concurrent_reads_dedup_to_a_single_slow_store_call() -> Result<(), Erro
 
     let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
     let (fast_slow_store, slow) =
-        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx));
+        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx), 0);
 
     let mut handles = Vec::with_capacity(N_CONCURRENT);
     for _ in 0..N_CONCURRENT {
@@ -863,6 +870,51 @@ async fn concurrent_reads_dedup_to_a_single_slow_store_call() -> Result<(), Erro
     Ok(())
 }
 
+/// With an opt-in threshold set, reads of blobs at or above it skip the
+/// dedup map and hit the slow store on every concurrent read. This is the
+/// counterpart to `concurrent_reads_dedup_to_a_single_slow_store_call`,
+/// which leaves the threshold at 0 (disabled) and therefore dedups.
+#[nativelink_test]
+async fn concurrent_reads_bypass_dedup_above_threshold() -> Result<(), Error> {
+    const N_CONCURRENT: usize = 8;
+    let original_data = make_random_data(4096);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+    let blob_size = u64::try_from(original_data.len()).unwrap();
+
+    // Threshold == blob size, so every read is at-or-above and bypasses
+    // dedup. No gate: each reader hits the slow store directly.
+    let (fast_slow_store, slow) =
+        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), None, blob_size);
+
+    let mut handles = Vec::with_capacity(N_CONCURRENT);
+    for _ in 0..N_CONCURRENT {
+        let store = fast_slow_store.clone();
+        handles.push(tokio::spawn(async move {
+            store.get_part_unchunked(digest, 0, None).await
+        }));
+    }
+
+    let results = join_all(handles).await;
+    for r in results {
+        let bytes = r
+            .map_err(|e| make_err!(Code::Internal, "join error: {e:?}"))?
+            .err_tip(|| "Concurrent bypass get_part_unchunked failed")?;
+        assert_eq!(
+            bytes.as_ref(),
+            original_data.as_slice(),
+            "Every bypassed reader must still observe the full, correct payload"
+        );
+    }
+
+    let slow_calls = slow.get_part_count.load(Ordering::Acquire);
+    assert_eq!(
+        slow_calls, N_CONCURRENT as u64,
+        "With the bypass threshold set, each of {N_CONCURRENT} reads must hit the slow store directly (no dedup), got {slow_calls}",
+    );
+
+    Ok(())
+}
+
 /// Dropping a follower's outer future must not cancel the leader's
 /// populate.
 #[nativelink_test]
@@ -872,7 +924,7 @@ async fn dropping_a_follower_does_not_cancel_the_leader() -> Result<(), Error> {
 
     let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
     let (fast_slow_store, slow) =
-        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx));
+        make_fast_slow_with_instrumented_slow(digest, original_data.clone(), Some(gate_rx), 0);
 
     let store_for_a = fast_slow_store.clone();
     let leader_handle =
@@ -1003,6 +1055,7 @@ async fn has_sees_in_flight_slow_writes() -> Result<(), Error> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast,
         Store::new(slow.clone()),
@@ -1158,6 +1211,7 @@ async fn has_does_not_consult_fast_store_when_slow_store_hits() -> Result<(), Er
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast,
         slow.clone(),
@@ -1275,6 +1329,7 @@ async fn dropping_update_future_cleans_up_in_flight_entry() -> Result<(), Error>
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::ReadOnly,
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast,
         Store::new(slow.clone()),
@@ -1440,6 +1495,7 @@ async fn has_with_results_handles_mixed_key_sources() -> Result<(), Error> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::ReadOnly,
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         fast.clone(),
         Store::new(slow.clone()),
@@ -1511,5 +1567,254 @@ async fn has_with_results_handles_mixed_key_sources() -> Result<(), Error> {
     );
     assert_eq!(results[3], None, "missing key must stay None");
 
+    Ok(())
+}
+
+// Huge-blob dedup bypass: a `CountingSlowStore` counts get_part calls.
+// Under dedup all readers collapse to one call; under bypass each reader
+// drives its own and the fast tier stays empty.
+
+/// `MemoryStore` wrapper that counts `get_part` invocations.
+#[derive(MetricsComponent)]
+struct CountingSlowStore {
+    inner: Arc<MemoryStore>,
+    get_part_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl StoreDriver for CountingSlowStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        keys: &[StoreKey<'_>],
+        results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        Pin::new(self.inner.as_ref())
+            .has_with_results(keys, results)
+            .await
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        key: StoreKey<'_>,
+        reader: DropCloserReadHalf,
+        size_info: UploadSizeInfo,
+    ) -> Result<u64, Error> {
+        Pin::new(self.inner.as_ref())
+            .update(key, reader, size_info)
+            .await
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        key: StoreKey<'_>,
+        writer: &mut DropCloserWriteHalf,
+        offset: u64,
+        length: Option<u64>,
+    ) -> Result<(), Error> {
+        self.get_part_calls.fetch_add(1, Ordering::AcqRel);
+        Pin::new(self.inner.as_ref())
+            .get_part(key, writer, offset, length)
+            .await
+    }
+
+    fn inner_store(&self, _digest: Option<StoreKey>) -> &dyn StoreDriver {
+        self
+    }
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+default_health_status_indicator!(CountingSlowStore);
+
+#[nativelink_test]
+async fn huge_blob_bypasses_dedup_and_skips_populate() -> Result<(), Error> {
+    // 1 KiB threshold so a 2 KiB blob trips the bypass.
+    const THRESHOLD: u64 = 1024;
+    const BLOB_SIZE: usize = 2 * 1024;
+    const READERS: usize = 8;
+
+    let original_data = make_random_data(BLOB_SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+
+    // Seed the slow tier directly so the fast tier starts empty.
+    let inner_slow = MemoryStore::new(&MemorySpec::default());
+    inner_slow
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counting = Arc::new(CountingSlowStore {
+        inner: inner_slow,
+        get_part_calls: calls.clone(),
+    });
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let slow_store = Store::new(counting);
+    let fast_slow_store = Store::new(FastSlowStore::new(
+        &FastSlowSpec {
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
+            fast_direction: StoreDirection::default(),
+            slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: THRESHOLD,
+        },
+        fast_store.clone(),
+        slow_store,
+    ));
+
+    // Fan out READERS concurrent get_part calls.
+    let mut joins = Vec::with_capacity(READERS);
+    for _ in 0..READERS {
+        let store = fast_slow_store.clone();
+        let expected = original_data.clone();
+        joins.push(tokio::spawn(async move {
+            let got = store.get_part_unchunked(digest, 0, None).await?;
+            assert_eq!(got.as_ref(), expected.as_slice(), "data mismatch");
+            Ok::<_, Error>(())
+        }));
+    }
+    for j in joins {
+        j.await
+            .map_err(|e| make_err!(Code::Internal, "join failed: {e}"))??;
+    }
+
+    // Bypass: one slow-store call per reader.
+    assert_eq!(
+        calls.load(Ordering::Acquire),
+        READERS,
+        "expected {READERS} slow-store get_part calls under bypass, observed dedup"
+    );
+
+    // Fast tier must stay empty.
+    assert!(
+        fast_store.has(digest).await?.is_none(),
+        "huge-blob bypass populated the fast tier; that defeats the point of the bypass"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn small_blob_still_dedups_and_populates() -> Result<(), Error> {
+    // 64-byte blob sits below the 1 MiB threshold, so dedup runs.
+    const THRESHOLD: u64 = 1024 * 1024;
+    const BLOB_SIZE: usize = 64;
+    const READERS: usize = 8;
+
+    let original_data = make_random_data(BLOB_SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+
+    let inner_slow = MemoryStore::new(&MemorySpec::default());
+    inner_slow
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counting = Arc::new(CountingSlowStore {
+        inner: inner_slow,
+        get_part_calls: calls.clone(),
+    });
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let slow_store = Store::new(counting);
+    let fast_slow_store = Store::new(FastSlowStore::new(
+        &FastSlowSpec {
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
+            fast_direction: StoreDirection::default(),
+            slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: THRESHOLD,
+        },
+        fast_store.clone(),
+        slow_store,
+    ));
+
+    let mut joins = Vec::with_capacity(READERS);
+    for _ in 0..READERS {
+        let store = fast_slow_store.clone();
+        let expected = original_data.clone();
+        joins.push(tokio::spawn(async move {
+            let got = store.get_part_unchunked(digest, 0, None).await?;
+            assert_eq!(got.as_ref(), expected.as_slice(), "data mismatch");
+            Ok::<_, Error>(())
+        }));
+    }
+    for j in joins {
+        j.await
+            .map_err(|e| make_err!(Code::Internal, "join failed: {e}"))??;
+    }
+
+    // Dedup: all readers collapse to one slow-store call.
+    assert_eq!(
+        calls.load(Ordering::Acquire),
+        1,
+        "small-blob path lost dedup; observed >1 slow-store call"
+    );
+
+    // Fast tier should be populated.
+    assert!(
+        fast_store.has(digest).await?.is_some(),
+        "small-blob path failed to populate the fast tier"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn bypass_threshold_is_inclusive_at_exact_size() -> Result<(), Error> {
+    // Bypass is `size >= threshold`, so size == threshold must bypass.
+    const SIZE: usize = 4096;
+    const READERS: usize = 4;
+
+    let original_data = make_random_data(SIZE);
+    let digest = DigestInfo::try_new(VALID_HASH, original_data.len()).unwrap();
+
+    let inner_slow = MemoryStore::new(&MemorySpec::default());
+    inner_slow
+        .update_oneshot(digest, original_data.clone().into())
+        .await?;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counting = Arc::new(CountingSlowStore {
+        inner: inner_slow,
+        get_part_calls: calls.clone(),
+    });
+    let fast_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    let slow_store = Store::new(counting);
+    let fast_slow_store = Store::new(FastSlowStore::new(
+        &FastSlowSpec {
+            fast: StoreSpec::Memory(MemorySpec::default()),
+            slow: StoreSpec::Memory(MemorySpec::default()),
+            fast_direction: StoreDirection::default(),
+            slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: SIZE as u64,
+        },
+        fast_store.clone(),
+        slow_store,
+    ));
+
+    let mut joins = Vec::with_capacity(READERS);
+    for _ in 0..READERS {
+        let store = fast_slow_store.clone();
+        joins.push(tokio::spawn(async move {
+            let _ignored = store.get_part_unchunked(digest, 0, None).await?;
+            Ok::<_, Error>(())
+        }));
+    }
+    for j in joins {
+        j.await
+            .map_err(|e| make_err!(Code::Internal, "join failed: {e}"))??;
+    }
+
+    assert_eq!(
+        calls.load(Ordering::Acquire),
+        READERS,
+        "size == threshold should bypass dedup but observed dedup",
+    );
     Ok(())
 }

--- a/nativelink-worker/src/directory_cache.rs
+++ b/nativelink-worker/src/directory_cache.rs
@@ -793,6 +793,7 @@ mod tests {
                 slow: StoreSpec::Memory(slow_spec),
                 fast_direction: StoreDirection::default(),
                 slow_direction: StoreDirection::default(),
+                bypass_dedup_threshold_bytes: 0,
             },
             Store::new(fast_store),
             Store::new(slow_store.clone()),

--- a/nativelink-worker/tests/directory_cache_test.rs
+++ b/nativelink-worker/tests/directory_cache_test.rs
@@ -52,6 +52,7 @@ async fn make_cas_store(slow_store: Arc<MemoryStore>) -> Arc<FastSlowStore> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         Store::new(fast_store),
         Store::new(slow_store),

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -424,6 +424,7 @@ async fn new_local_worker_creates_work_directory_test() -> Result<(), Error> {
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         Store::new(
             <FilesystemStore>::new(&FilesystemSpec {
@@ -465,6 +466,7 @@ async fn new_local_worker_removes_work_directory_before_start_test() -> Result<(
             slow: StoreSpec::Memory(MemorySpec::default()),
             fast_direction: StoreDirection::default(),
             slow_direction: StoreDirection::default(),
+            bypass_dedup_threshold_bytes: 0,
         },
         Store::new(
             <FilesystemStore>::new(&FilesystemSpec {

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -117,6 +117,7 @@ mod tests {
                 slow: StoreSpec::Memory(slow_config),
                 fast_direction: StoreDirection::default(),
                 slow_direction: StoreDirection::default(),
+                bypass_dedup_threshold_bytes: 0,
             },
             Store::new(fast_store.clone()),
             Store::new(slow_store.clone()),


### PR DESCRIPTION
# Description

The populating-digests dedup is a net loss for multi-GB blobs: the leader's pull from the slow store reliably exceeds LEADER_WAIT_TIMEOUT, every concurrent follower falls through to its own slow-store read anyway, and populating the fast tier with the huge blob evicts a large number of smaller, more-useful entries.

Add a configurable size threshold (FastSlowSpec::bypass_dedup_threshold_bytes, default 256 MiB when unset) at and above which get_part streams straight from the slow store and skips the populate. Below the threshold the existing leader/follower path is unchanged. A huge_blob_dedup_bypasses metric counts the bypasses.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests (in the existing nativelink-store/tests/fast_slow_store_test.rs suite, via a CountingSlowStore that counts get_part calls):

- huge_blob_bypasses_dedup_and_skips_populate: a blob above the threshold drives one slow-store call per concurrent reader and leaves the fast tier empty.
- small_blob_still_dedups_and_populates: a blob below the threshold collapses to a single slow-store call and populates the fast tier.
- bypass_threshold_is_inclusive_at_exact_size: size == threshold takes the bypass path (the condition is >=).

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2415)
<!-- Reviewable:end -->
