### PR TITLE
store_awaited_action_db: bound cid_* lifetime to stop orphan accumulation

### DIFF
--- a/nativelink-redis-tester/src/dynamic_fake_redis.rs
+++ b/nativelink-redis-tester/src/dynamic_fake_redis.rs
@@ -34,6 +34,9 @@ pub trait SubscriptionManagerNotify {
 pub struct FakeRedisBackend<S: SubscriptionManagerNotify> {
     /// Contains a list of all of the Redis keys -> fields.
     pub table: Arc<Mutex<HashMap<String, HashMap<String, Value>>>>,
+    /// TTL (seconds) attached to each key via `EXPIRE`, so tests can
+    /// assert a key was given a bounded lifetime.
+    pub expiries: Arc<Mutex<HashMap<String, i64>>>,
     subscription_manager: Arc<Mutex<Option<Arc<S>>>>,
 }
 
@@ -55,6 +58,7 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
     pub fn new() -> Self {
         Self {
             table: Arc::new(Mutex::new(HashMap::new())),
+            expiries: Arc::new(Mutex::new(HashMap::new())),
             subscription_manager: Arc::new(Mutex::new(None)),
         }
     }
@@ -332,6 +336,28 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
                         debug!(%key, ?values, "Inserting with HMSET");
                         self.table.lock().unwrap().insert(key, values);
                         Value::Okay
+                    }
+
+                    "EXPIRE" => {
+                        // `EXPIRE key seconds`: record the TTL; return 1
+                        // if the key existed, else 0 (as real Redis does).
+                        let key_name =
+                            str::from_utf8(args[0].as_bytes().expect("Key argument is not bytes"))
+                                .expect("Unable to parse key name")
+                                .to_string();
+                        let seconds = str::from_utf8(
+                            args[1].as_bytes().expect("EXPIRE seconds is not bytes"),
+                        )
+                        .expect("EXPIRE seconds is not utf8")
+                        .parse::<i64>()
+                        .expect("EXPIRE seconds is not an integer");
+                        let exists = self.table.lock().unwrap().contains_key(&key_name);
+                        if exists {
+                            self.expiries.lock().unwrap().insert(key_name, seconds);
+                            Value::Int(1)
+                        } else {
+                            Value::Int(0)
+                        }
                     }
 
                     "HMGET" => {

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -380,6 +380,10 @@ fn awaited_action_decode(version: i64, data: &Bytes) -> Result<AwaitedAction, Er
 
 const OPERATION_ID_TO_AWAITED_ACTION_KEY_PREFIX: &str = "aa_";
 const CLIENT_ID_TO_OPERATION_ID_KEY_PREFIX: &str = "cid_";
+/// TTL bounding the cid_* mapping's lifetime so it cannot outlive its
+/// aa_* key and accumulate as a permanent orphan (24h safely exceeds
+/// any real action lifetime).
+const CLIENT_ID_MAPPING_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 /// Phase 2: Separate key prefix for client keepalives (non-versioned).
 const CLIENT_KEEPALIVE_KEY_PREFIX: &str = "ck_";
 
@@ -926,14 +930,14 @@ where
                 continue;
             }
 
-            // Add the client_operation_id to operation_id mapping
+            // Bound the cid_* mapping's lifetime (see CLIENT_ID_MAPPING_TTL).
             self.store
                 .update_data(
                     UpdateClientIdToOperationId {
                         client_operation_id: client_operation_id.clone(),
                         operation_id: operation_id.clone(),
                     },
-                    None,
+                    Some(CLIENT_ID_MAPPING_TTL),
                 )
                 .await
                 .err_tip(|| "In RedisAwaitedActionDb::add_action while adding client mapping")?;

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -512,3 +512,74 @@ async fn test_orphaned_client_operation_id_returns_none() -> Result<(), Error> {
 
     Ok(())
 }
+
+/// `add_action` must attach a TTL to the cid_* mapping; without one it
+/// outlives its aa_* key and accumulates as a permanent orphan.
+#[nativelink_test]
+async fn add_action_attaches_ttl_to_cid_mapping() -> Result<(), Error> {
+    const CLIENT_OPERATION_ID: &str = "cid_ttl_test_client";
+    const WORKER_OPERATION_ID: &str = "cid_ttl_test_worker";
+    const SUB_CHANNEL: &str = "sub_channel";
+
+    let action_info = Arc::new(ActionInfo {
+        command_digest: DigestInfo::zero_digest(),
+        input_root_digest: DigestInfo::zero_digest(),
+        timeout: Duration::from_secs(1),
+        platform_properties: HashMap::new(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionUniqueQualifier::Cacheable(ActionUniqueKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::zero_digest(),
+        }),
+    });
+
+    let fake_redis_backend: FakeRedisBackend<RedisSubscriptionManager> = FakeRedisBackend::new();
+    let fake_redis_port = fake_redis_backend.clone().run().await;
+    let spec = RedisSpec {
+        addresses: vec![format!("redis://127.0.0.1:{fake_redis_port}")],
+        experimental_pub_sub_channel: Some(SUB_CHANNEL.to_string()),
+        ..Default::default()
+    };
+    let store = RedisStore::new_standard(spec).await.expect("Working spec");
+    fake_redis_backend.set_subscription_manager(store.subscription_manager().await.unwrap());
+
+    let notifier = Arc::new(Notify::new());
+    let awaited_action_db = StoreAwaitedActionDb::new(
+        store.clone(),
+        notifier.clone(),
+        MockInstantWrapped::default,
+        move || WORKER_OPERATION_ID.into(),
+        60,
+    )
+    .await
+    .unwrap();
+
+    let _subscription = awaited_action_db
+        .add_action(
+            CLIENT_OPERATION_ID.into(),
+            action_info.clone(),
+            Duration::from_mins(1),
+        )
+        .await
+        .unwrap();
+
+    // The cid_* key must have an EXPIRE attached.
+    let expiries = fake_redis_backend.expiries.lock().unwrap().clone();
+    let cid_key = format!("cid_{CLIENT_OPERATION_ID}");
+    let ttl = expiries.get(&cid_key).copied().unwrap_or_else(|| {
+        panic!(
+            "expected an EXPIRE on {cid_key} after add_action, but none was set. \
+             All recorded expiries: {expiries:?}"
+        )
+    });
+    assert!(
+        ttl > 0,
+        "cid_* TTL must be positive (got {ttl}); a 0 or negative TTL would \
+         immediately evict the mapping and break in-flight WaitExecution calls"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

add_action wrote the cid_<client_operation_id> -> operation_id pointer with expiry=None. PR #2315 ("Add expiry to completed redis actions") then started attaching retain_completed_for_s TTL onto the matching aa_* key on completion. The TTL mismatch produced permanent orphans: aa_* expired after retain_completed_for_s, cid_* lingered forever. A subsequent WaitExecution resolving the stale cid_* hit the orphan path, returned NotFound, and the client (Bazel) restarted Execute -- which created another unbounded cid_*. In production the cid_* count reached 3.8M with ~4.5% already orphaned and intermittent "lost-action" symptoms in long builds.

The action's full lifetime is unknown at insert time (queue + execute
+ retain), so attach a generous 24h fixed ceiling: it comfortably exceeds the longest production client_action_timeout_s + max_action_executing_timeout_s + retain_completed_for_s combinations observed (~1500s) and bounds orphan accumulation to a single day's worth of builds.



Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test infra: dynamic_fake_redis::FakeRedisBackend previously panicked on EXPIRE. Add an EXPIRE handler + expiries HashMap so the new add_action_attaches_ttl_to_cid_mapping regression test can assert TTL attachment without standing up real Redis; it fails on the pre-fix path (no EXPIRE recorded) and passes after.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2417)
<!-- Reviewable:end -->
