### PR TITLE
filesystem_store: make unref ENOENT idempotent and demote map/disk divergence to warn

### DIFF
--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -152,13 +152,15 @@ impl Drop for EncodedFilePath {
             "Spawned a filesystem_delete_file"
         );
         background_spawn!("filesystem_delete_file", async move {
-            let result = fs::remove_file(&file_path)
-                .await
-                .err_tip(|| format!("Failed to remove file {}", file_path.display()));
-            if let Err(err) = result {
-                error!(?file_path, ?err, "Failed to delete file",);
-            } else {
-                debug!(?file_path, "File deleted",);
+            match fs::remove_file(&file_path).await {
+                Ok(()) => debug!(?file_path, "File deleted"),
+                // The file already being gone is the desired end state of a
+                // delete, not a failure — e.g. an entry marked Temp after an
+                // already-gone unref points at a path that was never created.
+                Err(err) if err.code == Code::NotFound => {
+                    debug!(?file_path, "File already gone, nothing to delete");
+                }
+                Err(err) => error!(?file_path, ?err, "Failed to delete file"),
             }
             // .fetch_sub returns previous value, so we subtract one to get approximate current value
             let current_active_drop_spawns = shared_context
@@ -406,28 +408,34 @@ impl LenEntry for FileEntryImpl {
         let to_path = to_full_path_from_key(&encoded_file_path.shared_context.temp_path, &new_key);
 
         if let Err(err) = fs::rename(&from_path, &to_path).await {
-            // ENOENT here means the file we expected at `from_path`
-            // was already gone — typically because another thread's
-            // eviction beat us to the unref, or because the entry
-            // ended up in our map without its file ever landing on
-            // disk (the "phantom-map" case the runtime recovers from
-            // via `FastSlowStore::get_part`'s slow-store fallback).
-            // It is benign at this site — there is no file to move
-            // — and historically dominates the log volume of this
-            // store under heavy write+evict concurrency, fast enough
-            // to drown the runtime under sustained pressure. Demote
-            // to `debug` and drop the per-emission path fields so it
-            // stops costing serialization in the hot path.
-            //
-            // Other rename failures (EACCES, EXDEV, EBUSY, …) are
-            // genuinely unexpected and stay at `warn` with full
-            // context.
-            if err.code == Code::NotFound {
+            // ENOENT from rename is ambiguous: the source may be gone, or
+            // a directory component of the destination (the temp dir) may
+            // be missing. Confirm the source is genuinely gone before
+            // treating it as benign — otherwise a removed temp dir would
+            // flip an intact content file to Temp and orphan it on disk.
+            let source_gone = err.code == Code::NotFound
+                && matches!(
+                    fs::metadata(&from_path).await,
+                    Err(meta_err) if meta_err.code == Code::NotFound
+                );
+            if source_gone {
+                // The file is already gone — typically another thread's
+                // eviction beat us, or the entry never got its file on
+                // disk. Benign here, and it dominates log volume under
+                // heavy write+evict concurrency, so keep it at `debug`.
+                // Mark the entry Temp (as a successful rename would) so a
+                // repeat unref is a no-op and drop stops claiming the
+                // content path.
                 debug!(
                     key = ?encoded_file_path.key,
                     "Failed to rename file (already gone, treating as benign)",
                 );
+                encoded_file_path.path_type = PathType::Temp;
+                encoded_file_path.key = new_key;
             } else {
+                // Either a non-ENOENT failure (EACCES, EXDEV, EBUSY, …) or
+                // ENOENT with the source still present (missing temp dir).
+                // The content file is intact; leave the entry as Content.
                 warn!(
                     key = ?encoded_file_path.key,
                     ?from_path,
@@ -1441,10 +1449,14 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         let mut temp_file = entry.read_file_part(offset, read_limit).or_else(|err| async move {
             // If the file is not found, we need to remove it from the eviction map.
             if err.code == Code::NotFound {
-                error!(
+                // Map said the file was present but `open()` hit ENOENT.
+                // Self-heals: we remove the stale entry below and a
+                // fast/slow caller re-populates from the slow store, so
+                // this is a recoverable warn, not a fatal error.
+                warn!(
                     ?err,
                     key = ?owned_key,
-                    "Entry was in our map, but not found on disk. Removing from map as a precaution, but process probably need restarted."
+                    "Filesystem store map/disk divergence: removing entry; reader will fall through to slow store",
                 );
                 self.evicting_map.remove(&owned_key).await;
             }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -1798,3 +1798,131 @@ async fn detect_same_key_different_contents() -> Result<(), Error> {
     assert!(logs_contain("Files are different, so non-duplicate"));
     Ok(())
 }
+
+/// Map/disk divergence (map says present, file is gone) must surface as a
+/// recoverable warn and remove the stale entry — not a fatal error.
+#[nativelink_test]
+async fn get_part_on_map_disk_divergence_warns_and_removes_entry() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: content_path.clone(),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest, VALUE1.into()).await?;
+
+    // Delete the backing file out from under the still-present map entry.
+    let content_file = OsString::from(format!("{content_path}/{DIGEST_FOLDER}/{digest}"));
+    fs::remove_file(&content_file).await?;
+
+    let err = store
+        .get_part_unchunked(digest, 0, None)
+        .await
+        .expect_err("divergent read must fail");
+    assert_eq!(
+        err.code,
+        Code::NotFound,
+        "divergent read must surface NotFound"
+    );
+
+    assert!(
+        logs_contain("Filesystem store map/disk divergence"),
+        "divergence must be logged as a recoverable warn"
+    );
+    assert!(
+        !logs_contain("process probably need restarted"),
+        "stale fatal-sounding message must be gone"
+    );
+    assert_eq!(
+        store.has(digest).await?,
+        None,
+        "stale entry must be removed from the map"
+    );
+
+    Ok(())
+}
+
+/// unref must be idempotent when the file is already gone: the entry is
+/// marked Temp so a second unref early-returns instead of racing the
+/// vanished path again.
+#[nativelink_test]
+async fn unref_is_idempotent_when_file_already_gone() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: content_path.clone(),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest, VALUE1.into()).await?;
+    let file_entry = store.get_file_entry_for_digest(&digest).await?;
+
+    let content_file = OsString::from(format!("{content_path}/{DIGEST_FOLDER}/{digest}"));
+    fs::remove_file(&content_file).await?;
+
+    // First unref: rename hits ENOENT (benign) and flips the entry to Temp.
+    file_entry.unref().await;
+    // Second unref: must hit the Temp early-return, proving the flip stuck.
+    file_entry.unref().await;
+
+    assert!(
+        logs_contain("File is already a temp file"),
+        "second unref should early-return as a Temp file (idempotent)"
+    );
+
+    Ok(())
+}
+
+/// rename ENOENT is ambiguous: a missing temp directory must not be mistaken
+/// for a vanished source. With the source still present, unref must warn and
+/// leave the content file intact rather than flip to Temp and orphan it.
+#[nativelink_test]
+async fn unref_does_not_orphan_content_file_when_temp_dir_missing() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: content_path.clone(),
+            temp_path: temp_path.clone(),
+            eviction_policy: None,
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest, VALUE1.into()).await?;
+    let file_entry = store.get_file_entry_for_digest(&digest).await?;
+
+    // Remove the temp dir so rename's destination parent is gone (ENOENT)
+    // while the source content file is perfectly intact.
+    fs::remove_dir_all(format!("{temp_path}/{DIGEST_FOLDER}")).await?;
+
+    file_entry.unref().await;
+
+    assert!(
+        logs_contain("Failed to rename file"),
+        "missing temp dir (source present) must warn, not be treated as benign"
+    );
+    assert!(
+        !logs_contain("treating as benign"),
+        "an intact content file must not take the benign vanished-source path"
+    );
+    // The content file must still exist — not orphaned by a wrong Temp flip.
+    let content_file = OsString::from(format!("{content_path}/{DIGEST_FOLDER}/{digest}"));
+    assert_eq!(
+        read_file_contents(&content_file).await?,
+        VALUE1.as_bytes(),
+        "content file must remain intact after a failed unref rename"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

Two robustness fixes for the eviction map vs on-disk divergence that shows up under heavy write+evict concurrency:

  * unref: when the content file is already gone (rename returns ENOENT), mark the entry Temp and adopt the temp key, exactly as a successful rename would. A repeat unref then hits the `path_type == Temp` early-return instead of racing the vanished path again, and EncodedFilePath::drop stops re-claiming the content path.

  * get_part: a map entry whose file is missing on disk is recoverable (the entry is removed and a fast/slow caller re-populates from the slow store), not catastrophic. Demote the log from error! to warn! and drop the stale "process probably need restarted" wording.

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests (in the existing nativelink-store/tests/filesystem_store_test.rs suite):

- unref_is_idempotent_when_file_already_gone: deletes the backing file, calls unref twice, and asserts the second call hits the Temp early-return. Fails on the pre-fix path (no path_type flip).

- get_part_on_map_disk_divergence_warns_and_removes_entry: deletes the backing file, reads, and asserts NotFound surfaces, the warn fires (not the old error), and the stale entry is removed from the map.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2424)
<!-- Reviewable:end -->
