### PR TITLE
Fix broken reid link at the bottom of cmake-recc

### DIFF
--- a/web/apps/docs/content/docs/rbe/cmake-recc.mdx
+++ b/web/apps/docs/content/docs/rbe/cmake-recc.mdx
@@ -6,11 +6,13 @@ pagefind: true
 
 <Callout title="Inspired by Reid Kleckner" type="idea">
 This tutorial follows the approach Reid Kleckner laid out in
-[Distributed builds of LLVM with CMake, recc, and NativeLink](https://reidkleckner.dev/posts/llvm-recc-nativelink/).
+[Distributed builds of LLVM with CMake, recc, and NativeLink](reid).
 Read his post for the LLVM-scale walkthrough and the reasoning behind
 each piece. This page is the short, hands-on version for your own
 projects.
 </Callout>
+
+[reid]: https://reidkleckner.dev/posts/llvm-recc-nativelink/
 
 *Read time: ~5 minutes. Hands-on time: another ~5 if you have Docker and a
 package manager handy; longer on Linux if you build `recc` from source.*
@@ -201,4 +203,4 @@ docker stop nativelink && docker rm nativelink
   actually offload compile work. See the
   [deployment examples](/docs/deployment-examples/kubernetes).
 - For PCH, LTO, and other gnarly C++ build features at scale, read
-  [Reid Kleckner's writeup][reid].
+  [Reid Kleckner's writeup](reid).


### PR DESCRIPTION
# Description

https://docs.nativelink.com/rbe/cmake-recc has a broken link at the bottom of the page which this PR fixes
<img width="424" height="98" alt="image" src="https://github.com/user-attachments/assets/3cfae174-781b-4be9-9730-d57308328603" />

I've spent a while trying to find a good linter for this, but haven't seen anything obvious (remark has a few bits, but not seeing anything obvious that would have caught this).

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bun run dev:docs`

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2426)
<!-- Reviewable:end -->
