### PR TITLE
Make bash shell scripts actually fall over

### DIFF
--- a/.github/actions/end-nix/action.yaml
+++ b/.github/actions/end-nix/action.yaml
@@ -14,7 +14,7 @@ runs:
         if: ${{ inputs.nativelink_attic_token != '' }}
         run: |
           cat /tmp/attic-push.log
-        shell: bash
+        shell: bash -euo pipefail {0}
 
       - name: Attic push
         if: ${{ inputs.nix_name != '' && inputs.nativelink_attic_token != '' }}
@@ -24,5 +24,6 @@ runs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
+            set -euo pipefail
             /tmp/result/bin/attic push nativelink $(nix eval --raw ${{ inputs.nix_name }})
           shell: bash

--- a/.github/actions/free-disk/action.yaml
+++ b/.github/actions/free-disk/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Check disk space
       run: df -h /
-      shell: bash
+      shell: bash -euo pipefail {0}
     - if: runner.os == 'Linux' # Only works on Linux
       name: Free disk space
       uses: >- # v3.2.2
@@ -29,7 +29,7 @@ runs:
     # using hints from https://github.com/actions/runner-images/issues/10511#issuecomment-3984466720
     - if: runner.os == 'macOS'
       name: Free Disk space
-      shell: bash
+      shell: bash -euo pipefail {0}
       run: |
         # Remove unnecessary pre-installed tools (saves 5-10GB)
         sudo rm -rf /usr/local/share/powershell
@@ -41,4 +41,4 @@ runs:
         xcrun simctl runtime list
     - name: Check disk space
       run: df -h /
-      shell: bash
+      shell: bash -euo pipefail {0}

--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -23,6 +23,7 @@ runs:
         timeout_minutes: 30
         max_attempts: 3
         command: |
+          set -euo pipefail
           cd /tmp
           nix build nixpkgs#attic-client
           # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -63,7 +63,6 @@ jobs:
             echo "Unknown runner OS: $RUNNER_OS"
             exit 1
           fi
-        shell: bash
 
   redis-store-tester:
     name: Redis store tester
@@ -96,7 +95,6 @@ jobs:
           RUST_LOG: trace
           REDIS_HOST: localhost
           MAX_LOOPS: 10 # running sequentially just to test all the actions work
-        shell: bash
 
       - name: Run Store tester with standard
         run: |
@@ -108,7 +106,6 @@ jobs:
           RUST_LOG: trace
           REDIS_HOST: localhost
           MAX_LOOPS: 10 # running sequentially just to test all the actions work
-        shell: bash
 
       - name: Run Store tester with cluster
         run: |
@@ -120,4 +117,3 @@ jobs:
           RUST_LOG: trace
           REDIS_HOST: localhost
           MAX_LOOPS: 10 # running sequentially just to test all the actions work
-        shell: bash

--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -45,7 +45,6 @@ jobs:
 
       - name: Set up Rust toolchain
         run: rustup update && rustup default ${{ matrix.toolchain }}
-        shell: bash
 
       - name: Rust cache
         # https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -62,7 +62,6 @@ jobs:
           done
           echo "::error::Bazel still failing after 3 attempts."
           exit 1
-        shell: bash
 
       - name: Teardown Worker
         uses: ./.github/actions/end-nix

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -46,4 +46,3 @@ jobs:
 
       - name: Run Bazel tests
         run: bazel test --config=${{ matrix.sanitizer }} --lockfile_mode=error --verbose_failures //...
-        shell: bash


### PR DESCRIPTION
# Description

This was mostly manifesting as attic failing to setup, but not doing a non-zero exit code, but various bash scripts weren't setup for exit properly on first command failure.

This PR removes all instances of `shell: bash` in workflows, because the [default shell in actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell) is already `bash -e` so it'll get the exit codes fine already. In actions, where we need to set an explicit shell, set it with failure flags already set. The exception to this is the usage of [`nick-fields/retry`](https://github.com/nick-fields/retry) where we need to do an explicit `set` command as it doesn't support bash with args.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2428)
<!-- Reviewable:end -->
