### PR TITLE
fix(web): Add www to apex domain redirect

### DIFF
--- a/web/apps/web/next.config.mjs
+++ b/web/apps/web/next.config.mjs
@@ -19,14 +19,28 @@ const nextConfig = {
         ? process.env.DOCS_URL
         : (process.env.DOCS_DEV_URL ?? "http://localhost:3001");
 
-    // If we're in production and DOCS_URL isn't set, skip the redirect
-    // entirely — better to 404 cleanly than to redirect to nothing.
-    if (!target) return [];
+    const redirects = [];
 
-    return [
-      { source: "/docs", destination: target, permanent: false },
-      { source: "/docs/:path*", destination: `${target}/:path*`, permanent: false },
-    ];
+    // Redirect www to apex domain
+    if (process.env.NODE_ENV === "production") {
+      redirects.push({
+        source: "/:path*",
+        has: [{ type: "host", value: "www.nativelink.com" }],
+        destination: "https://nativelink.com/:path*",
+        permanent: true,
+      });
+    }
+
+    // If we're in production and DOCS_URL isn't set, skip the docs redirect
+    // entirely — better to 404 cleanly than to redirect to nothing.
+    if (target) {
+      redirects.push(
+        { source: "/docs", destination: target, permanent: false },
+        { source: "/docs/:path*", destination: `${target}/:path*`, permanent: false }
+      );
+    }
+
+    return redirects;
   },
 };
 


### PR DESCRIPTION
## Problem

Currently `www.nativelink.com` serves the old Astro site while `nativelink.com` serves the new Next.js site. This creates an inconsistent user experience.

## Solution

Add a permanent redirect in `next.config.mjs` that redirects all `www.nativelink.com` traffic to `nativelink.com` in production.

### Changes
- Added host-based redirect: `www.nativelink.com/*` → `https://nativelink.com/*` (301 permanent)
- Refactored `redirects()` to build array conditionally for cleaner logic
- Redirect only active in production (won't affect local dev)

## Vercel Configuration Required

**Action needed by maintainers with Vercel access:**

1. Go to the **marketing project** (`apps/web`) on Vercel
2. Navigate to **Settings → Domains**
3. Verify `www.nativelink.com` is added as a domain to this project
4. If `www.nativelink.com` is assigned to an old/deprecated Vercel project, remove it from there
5. Ensure DNS points correctly:
   ```
   www.nativelink.com  CNAME  cname.vercel-dns.com
   ```

This code fix ensures the redirect works, but proper Vercel domain configuration is the root solution.

## Testing

Once deployed, verify:
- `https://www.nativelink.com` → redirects to `https://nativelink.com`
- `https://www.nativelink.com/docs` → redirects to `https://nativelink.com/docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2431)
<!-- Reviewable:end -->
