### PR TITLE
fix(redis_store): survive Redis failover across writes and reads

### DIFF
--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -79,6 +79,12 @@ const DEFAULT_CONNECTION_POOL_SIZE: usize = 3;
 /// Note: If this changes it should be updated in the config documentation.
 const DEFAULT_RETRY_DELAY: f32 = 0.1;
 
+/// Maximum attempts to verify a freshly written value (re-resolving the master
+/// each time) in `RedisStore::update`. Covers a Redis failover or brief replica
+/// lag between the chunk writes and the length check, so a transient topology
+/// change doesn't fail an otherwise healthy write.
+const MAX_UPDATE_VERIFY_ATTEMPTS: u32 = 5;
+
 /// The default connection timeout in milliseconds if not specified.
 /// Note: If this changes it should be updated in the config documentation.
 const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 3000;
@@ -946,29 +952,83 @@ where
             }
         }
 
-        let blob_len: usize = client
-            .connection_manager
-            .strlen(&temp_key)
-            .await
-            .err_tip(|| format!("In RedisStore::update strlen check for {temp_key}"))?;
-        // This is a safety check to ensure that in the event some kind of retry was to happen
-        // and the data was appended to the key twice, we reject the data.
-        if blob_len != usize::try_from(total_len).unwrap_or(usize::MAX) {
-            return Err(make_input_err!(
-                "Data length mismatch in RedisStore::update for {}({}) - expected {} bytes, got {} bytes",
-                key.borrow().as_str(),
-                temp_key,
-                total_len,
-                blob_len,
-            ));
-        }
+        let expected_len = usize::try_from(total_len).unwrap_or(usize::MAX);
+
+        // The chunk writes above reconnect on ReadOnly, so on a mid-write Redis
+        // failover the data lands on the *current* master. The length check and
+        // rename below must run against that same master: the connection
+        // captured before the writes may now point at a demoted replica, where
+        // strlen reads 0 and would fail an otherwise healthy write. Re-resolve
+        // the master and retry so a transient topology change (failover or brief
+        // replica lag) doesn't drop the value.
+        let mut attempt: u32 = 0;
+        let blob_len = loop {
+            attempt += 1;
+            let blob_len: usize = client
+                .connection_manager
+                .strlen(&temp_key)
+                .await
+                .err_tip(|| format!("In RedisStore::update strlen check for {temp_key}"))?;
+            // Safety check: reject if a retried append double-wrote the data.
+            if blob_len > expected_len {
+                return Err(make_input_err!(
+                    "Data length mismatch in RedisStore::update for {}({}) - expected {} bytes, got {} bytes",
+                    key.borrow().as_str(),
+                    temp_key,
+                    total_len,
+                    blob_len,
+                ));
+            }
+            if blob_len == expected_len {
+                break blob_len;
+            }
+            // blob_len < expected (typically 0): the temp key isn't visible on
+            // this connection yet — re-resolve the master and retry.
+            if attempt >= MAX_UPDATE_VERIFY_ATTEMPTS {
+                return Err(make_input_err!(
+                    "Data length mismatch in RedisStore::update for {}({}) - expected {} bytes, got {} bytes after {} attempts",
+                    key.borrow().as_str(),
+                    temp_key,
+                    total_len,
+                    blob_len,
+                    attempt,
+                ));
+            }
+            let (connection_manager, uuid) = self.connection_manager.reconnect(client.uuid).await?;
+            client.connection_manager = connection_manager;
+            client.uuid = uuid;
+            sleep(Duration::from_secs_f32(DEFAULT_RETRY_DELAY)).await;
+        };
 
         // Rename the temp key so that the data appears under the real key. Any data already present in the real key is lost.
-        client
+        // Reconnect once on ReadOnly in case the master moved between the verify and here.
+        match client
             .connection_manager
             .rename::<_, _, ()>(&temp_key, final_key.as_ref())
             .await
-            .err_tip(|| "While queueing key rename in RedisStore::update()")?;
+        {
+            Ok(()) => {}
+            Err(err)
+                if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
+            {
+                let (connection_manager, uuid) =
+                    self.connection_manager.reconnect(client.uuid).await?;
+                client.connection_manager = connection_manager;
+                client.uuid = uuid;
+                client
+                    .connection_manager
+                    .rename::<_, _, ()>(&temp_key, final_key.as_ref())
+                    .await
+                    .err_tip(
+                        || "While queueing key rename (after reconnect) in RedisStore::update()",
+                    )?;
+            }
+            Err(err) => {
+                return Err(
+                    Error::from(err).append("While queueing key rename in RedisStore::update()")
+                );
+            }
+        }
 
         // If we have a publish channel configured, send a notice that the key has been set.
         if let Some(pub_sub_channel) = &self.pub_sub_channel {

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -186,6 +186,82 @@ async fn upload_and_get_data() -> Result<(), Error> {
     Ok(())
 }
 
+// Regression test for Redis-replica/failover handling in RedisStore::update.
+// If the post-write STRLEN reads 0 (the connection points at a node that doesn't
+// yet have the freshly written temp key — e.g. a failover moved the master, or
+// brief replica lag), update must re-resolve the master and retry rather than
+// failing the write with a "Data length mismatch" error.
+#[nativelink_test]
+async fn update_retries_after_transient_zero_length() -> Result<(), Error> {
+    let data = Bytes::from_static(b"14");
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{digest}");
+    let temp_key = make_temp_key(&packed_hash_hex);
+    let real_key = packed_hash_hex;
+
+    let commands = vec![
+        MockCmd::new(
+            redis::cmd("SETRANGE")
+                .arg(temp_key.clone())
+                .arg(0)
+                .arg(data.to_vec()),
+            Ok(Value::Int(0)),
+        ),
+        // First verify hits a stale/replica connection that can't see the temp key.
+        MockCmd::new(
+            redis::cmd("STRLEN").arg(temp_key.clone()),
+            Ok(Value::Int(0)),
+        ),
+        // After re-resolving the master, the retry sees the real length.
+        MockCmd::new(
+            redis::cmd("STRLEN").arg(temp_key.clone()),
+            Ok(Value::Int(data.len() as i64)),
+        ),
+        MockCmd::new(
+            redis::cmd("RENAME").arg(temp_key).arg(real_key),
+            Ok(Value::Nil),
+        ),
+    ];
+
+    let store = make_mock_store(commands).await;
+    // Must succeed despite the transient zero-length read.
+    store.update_oneshot(digest, data).await?;
+    Ok(())
+}
+
+// If the value never becomes visible (genuine loss / persistent failure), update
+// still errors after exhausting its retries rather than hanging.
+#[nativelink_test]
+async fn update_errors_when_length_never_matches() -> Result<(), Error> {
+    let data = Bytes::from_static(b"14");
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{digest}");
+    let temp_key = make_temp_key(&packed_hash_hex);
+
+    let mut commands = vec![MockCmd::new(
+        redis::cmd("SETRANGE")
+            .arg(temp_key.clone())
+            .arg(0)
+            .arg(data.to_vec()),
+        Ok(Value::Int(0)),
+    )];
+    // MAX_UPDATE_VERIFY_ATTEMPTS (5) STRLEN reads that all return 0.
+    for _ in 0..5 {
+        commands.push(MockCmd::new(
+            redis::cmd("STRLEN").arg(temp_key.clone()),
+            Ok(Value::Int(0)),
+        ));
+    }
+
+    let store = make_mock_store(commands).await;
+    let result = store.update_oneshot(digest, data).await;
+    assert!(
+        result.is_err(),
+        "expected a Data length mismatch error after exhausting retries",
+    );
+    Ok(())
+}
+
 #[nativelink_test]
 async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
     let data = Bytes::from_static(b"14");


### PR DESCRIPTION
## Problem
With Redis replication, a failover *during* an operation surfaced transient errors. The write path failed hard (`Data length mismatch … got 0 bytes` → lost BEP events on a live cluster); the read paths (`has`/`get_part`/`list`) leaned only on the driver's single retry and could surface a transient error on a slow failover.

## Cause
Operations that span a master change ran their verify/read on a connection that became a demoted replica:
- `update`: chunk `SETRANGE` reconnects on `ReadOnly` (data lands on the new master), but the `STRLEN` verify + `RENAME` used the pre-write connection → `STRLEN` reads 0 → whole write rejected.
- `has_with_results` / `get_part` / `list`: no app-level re-resolve+retry (the `has` pipeline even had a `TODO(palfrey)` about it).

## Fix
A shared retryable-error check (`is_retryable_redis_error`: dropped/refused connection, IO error, or `ReadOnly`) plus, on a transient error, re-resolve the master (`reconnect`) and retry up to `MAX_REDIS_RETRY_ATTEMPTS`:
- `update`: retry the `STRLEN` verify; reconnect once on `ReadOnly` for `RENAME`. Genuine double-append still errors; a value that never appears still errors after retries.
- `has_with_results`, `get_part` (getrange + exists): retry the idempotent read.
- `list`: restart the SCAN from scratch (SCAN already may re-emit keys, so callers tolerate duplicates).
(`update_data` already reconnects; pub/sub re-subscribes on reconnect.)

## Verification
- Unit tests (MockRedisConnection): update retry-succeeds + give-up; `has` retry-after-transient-error. Full `redis_store` suite **40 passed**; `cargo check`/`rustfmt` clean.
- Live: an image built from this branch ran **8 builds through a forced master kill — all EXIT 0, 0 `Data length mismatch`, complete BEP data** (the old image failed the same scenario).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2435)
<!-- Reviewable:end -->
