### PR TITLE
fix(redis_store): recover from Sentinel master failover without freezing the store

### DIFF
--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -217,6 +217,14 @@ where
     /// for this connection in order to avoid multiple reconnection attempts.
     connection_manager: tokio::sync::RwLock<(C, Uuid)>,
 
+    /// Serializes reconnect attempts so a Sentinel master failover triggers a
+    /// single re-resolution instead of a thundering herd. Kept separate from
+    /// `connection_manager` on purpose: the (potentially multi-second) connect
+    /// runs while holding only this lock, so in-flight `get_connection` readers
+    /// keep using the existing handle and are never frozen behind a slow
+    /// reconnect. See [`Self::reconnect`].
+    reconnect_lock: tokio::sync::Mutex<()>,
+
     /// A list of subscription that should be performed on reconnect.
     subscriptions: Mutex<HashSet<String>>,
 }
@@ -254,6 +262,7 @@ where
             connect_func,
             update_if_version_matches_script,
             connection_manager: tokio::sync::RwLock::new((connection_manager, Uuid::new_v4())),
+            reconnect_lock: tokio::sync::Mutex::new(()),
             subscriptions: Mutex::new(HashSet::new()),
         };
         {
@@ -270,14 +279,30 @@ impl RedisManager<ConnectionManager> for StandardRedisManager<ConnectionManager>
     }
 
     async fn reconnect(&self, uuid: Uuid) -> Result<(ConnectionManager, Uuid), Error> {
-        let mut guard = self.connection_manager.write().await;
-        if guard.1 != uuid {
-            let connection = guard.clone();
-            drop(guard);
-            return Ok(connection);
+        // Fast path: another caller already reconnected past this generation,
+        // so the handle is fresh — hand it back without re-resolving.
+        {
+            let guard = self.connection_manager.read().await;
+            if guard.1 != uuid {
+                return Ok(guard.clone());
+            }
+        }
+        // Serialize reconnect attempts on a dedicated lock so a failover storm
+        // resolves the new master once. Critically this is NOT the
+        // `connection_manager` lock, so the slow connect below does not block
+        // the `get_connection` readers that every Redis op needs — they keep
+        // using the old (now-failing) handle and fail fast on their own
+        // command timeout instead of all freezing behind one reconnect.
+        let _reconnect_guard = self.reconnect_lock.lock().await;
+        // Re-check: a reconnect may have completed while we waited for the lock.
+        {
+            let guard = self.connection_manager.read().await;
+            if guard.1 != uuid {
+                return Ok(guard.clone());
+            }
         }
         let mut connection_manager = (self.connect_func)().await?;
-        let uuid = Uuid::new_v4();
+        let new_uuid = Uuid::new_v4();
         self.configure(&mut connection_manager).await?;
         let subscriptions = {
             let guard = self.subscriptions.lock();
@@ -286,8 +311,13 @@ impl RedisManager<ConnectionManager> for StandardRedisManager<ConnectionManager>
         for subscription in subscriptions {
             connection_manager.psubscribe(&subscription).await?;
         }
-        *guard = (connection_manager.clone(), uuid);
-        Ok((connection_manager, uuid))
+        // Publish the new handle under a brief exclusive lock.
+        {
+            let mut guard = self.connection_manager.write().await;
+            *guard = (connection_manager.clone(), new_uuid);
+        }
+        info!(old = %uuid, new = %new_uuid, "StandardRedisManager re-resolved the Redis master");
+        Ok((connection_manager, new_uuid))
     }
 
     fn update_script(&self, key: &str) -> redis::ScriptInvocation<'_> {
@@ -1312,16 +1342,55 @@ where
                 .query_async::<()>(&mut client.connection_manager)
                 .await
         };
+        let retry_reason = match timeout(self.health_check_timeout, ping).await {
+            Ok(Ok(())) => {
+                return HealthStatus::new_ok(self, "RedisStore::check_health: PING ok".into());
+            }
+            // A PING that errors connection-wise or times out means the handle
+            // points at a master that went away (a Sentinel failover). Without
+            // re-resolving here, a store with no other traffic stays wedged on
+            // the dead handle and reports unhealthy forever — shedding readiness
+            // traffic from an otherwise-recovered pod until it is restarted.
+            Ok(Err(e)) if is_retryable_redis_error(&e) => format!("PING errored: {e}"),
+            Ok(Err(e)) => {
+                return HealthStatus::new_failed(
+                    self,
+                    format!("RedisStore::check_health: PING errored: {e}").into(),
+                );
+            }
+            Err(_) => format!(
+                "PING exceeded {}ms timeout",
+                self.health_check_timeout.as_millis()
+            ),
+        };
+
+        // The reconnect (re-resolving the master via Sentinel) is logged by
+        // `StandardRedisManager::reconnect`; `retry_reason` is surfaced in the
+        // failure message below if the second PING still doesn't come back.
+        if let Err(e) = client.reconnect(&self.connection_manager).await {
+            return HealthStatus::new_failed(
+                self,
+                format!("RedisStore::check_health: {retry_reason}; reconnect failed: {e}").into(),
+            );
+        }
+        let ping = async {
+            redis::cmd("PING")
+                .query_async::<()>(&mut client.connection_manager)
+                .await
+        };
         match timeout(self.health_check_timeout, ping).await {
-            Ok(Ok(())) => HealthStatus::new_ok(self, "RedisStore::check_health: PING ok".into()),
+            Ok(Ok(())) => HealthStatus::new_ok(
+                self,
+                "RedisStore::check_health: PING ok after re-resolving master".into(),
+            ),
             Ok(Err(e)) => HealthStatus::new_failed(
                 self,
-                format!("RedisStore::check_health: PING errored: {e}").into(),
+                format!("RedisStore::check_health: PING still errored after reconnect: {e}").into(),
             ),
             Err(_) => HealthStatus::new_failed(
                 self,
                 format!(
-                    "RedisStore::check_health: PING exceeded {}ms timeout",
+                    "RedisStore::check_health: PING still exceeded {}ms timeout after reconnect",
                     self.health_check_timeout.as_millis()
                 )
                 .into(),
@@ -1960,9 +2029,13 @@ where
 
         let (connection_manager, connect_id) = self.connection_manager.get_connection().await?;
         let stream = match run_ft_aggregate(connection_manager.clone()).await {
-            Err(err)
-                if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
-            {
+            // A demoted master answers READONLY and a dead/old master drops the
+            // connection or times the command out. Both mean the master moved
+            // (Sentinel failover) — re-resolve it and retry rather than letting
+            // the scheduler's matching loop spin on a stale handle. (A missing
+            // index is not retryable here; it falls through to the create path
+            // below, which re-runs on the next matching cycle if needed.)
+            Err(err) if is_retryable_redis_error(&err) => {
                 let (connection_manager, _connect_id) =
                     self.connection_manager.reconnect(connect_id).await?;
                 run_ft_aggregate(connection_manager).await.err_tip(|| {

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -813,6 +813,38 @@ async fn test_health() {
     }
 }
 
+// After a Sentinel master failover the health PING hits a dead/old master and
+// fails. check_health must re-resolve the master and PING again so a store with
+// no other traffic self-heals — otherwise it reports unhealthy until restart and
+// the readiness probe sheds traffic from an otherwise-recovered pod.
+#[nativelink_test]
+async fn check_health_recovers_after_failed_ping() {
+    let commands = vec![
+        // First PING hits the dead/old master.
+        MockCmd::new(
+            redis::cmd("PING"),
+            Err::<Value, _>(RedisError::from(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset by peer",
+            ))),
+        ),
+        // After re-resolving the master, the PING succeeds.
+        MockCmd::new(redis::cmd("PING"), Ok(Value::Okay)),
+    ];
+    let store = make_mock_store(commands).await;
+    // The readiness probe uses the HealthStatusIndicator impl (a PING), not the
+    // StoreLike default (update_oneshot) that `store.check_health` resolves to.
+    let health = nativelink_util::health_utils::HealthStatusIndicator::check_health(
+        &store,
+        std::borrow::Cow::Borrowed("foo"),
+    )
+    .await;
+    assert!(
+        matches!(health, HealthStatus::Ok { .. }),
+        "expected Ok after re-resolving the master on a failed PING, got: {health:?}",
+    );
+}
+
 #[nativelink_test]
 async fn test_deprecated_broadcast_channel_capacity() {
     let port = make_fake_redis().await;
@@ -1232,6 +1264,78 @@ fn test_search_by_index() -> Result<(), Error> {
         "Content should match search pattern: '{}'",
         search_results[0].content
     );
+
+    Ok(())
+}
+
+// A Sentinel master failover surfaces on the scheduler's index query as a
+// dropped connection / command timeout against the old master. The matching
+// loop must re-resolve the master and retry rather than spinning on the dead
+// handle until the CAS is restarted.
+#[nativelink_test]
+fn test_search_by_index_retries_on_failover() -> Result<(), Error> {
+    fn make_ft_aggregate(result: Result<Value, RedisError>) -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.AGGREGATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
+                .arg("LOAD")
+                .arg(2)
+                .arg("data")
+                .arg("version")
+                .arg("WITHCURSOR")
+                .arg("COUNT")
+                .arg(1500)
+                .arg("MAXIDLE")
+                .arg(30000)
+                .arg("SORTBY")
+                .arg(2usize)
+                .arg("@sort_key")
+                .arg("ASC"),
+            result,
+        )
+    }
+
+    let commands = vec![
+        // First query hits the dead/old master mid-failover.
+        make_ft_aggregate(Err(RedisError::from(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset by peer",
+        )))),
+        // After re-resolving the master, the retry succeeds.
+        make_ft_aggregate(Ok(Value::Array(vec![
+            Value::Array(vec![
+                Value::Int(1),
+                Value::Array(vec![
+                    Value::BulkString(b"data".to_vec()),
+                    Value::BulkString(b"1234".to_vec()),
+                    Value::BulkString(b"version".to_vec()),
+                    Value::BulkString(b"1".to_vec()),
+                ]),
+            ]),
+            Value::Int(0),
+        ]))),
+    ];
+    let store = make_mock_store(commands).await;
+    let search_provider = SearchByContentPrefix {
+        prefix: "Searchable".to_string(),
+    };
+
+    let search_results: Vec<TestSchedulerDataUnversioned> = store
+        .search_by_index_prefix(search_provider)
+        .await
+        .err_tip(|| "search should re-resolve the master and retry past the failover")?
+        .try_collect()
+        .await?;
+
+    assert_eq!(
+        search_results.len(),
+        1,
+        "Should find the entry after retrying on the re-resolved master",
+    );
+    assert_eq!(search_results[0].content, "1234");
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

A Redis Sentinel master failover stalls the CAS hard enough that builds fail and (with a redis-coupled liveness probe) the pod restarts — and tuning the store timeouts never fixed it, because the stall isn't a timeout-value problem:

1. `reconnect()` re-resolves the master via Sentinel (seconds during a failover) **while holding the `connection_manager` write lock**. Every `get_connection()` is a reader on that lock, so the whole store freezes behind one slow reconnect.
2. The scheduler index path (`search_by_index_prefix`) only re-resolves on `READONLY`. A dead/old master that drops the connection or times the command out is **not** `READONLY`, so the matching loop spins on the stale handle and never follows the failover.
3. `HealthStatusIndicator::check_health` PINGs but never reconnects on failure. After a failover a store whose connection is wedged — especially an idle one with no other traffic — fails the PING forever, so `/status` returns 503 and readiness sheds traffic from an otherwise-recovered pod until it's restarted.

## Fix

- Move the slow connect off the `connection_manager` write lock onto a dedicated `reconnect_lock`. Readers keep using the old handle and fail fast on their own command timeout; only the brief handle swap takes the write lock. A generation re-check keeps a failover storm to a single re-resolution.
- `search_by_index_prefix` reconnects on any retryable error (dropped / refused / timed-out / `READONLY`). A missing index stays non-retryable and falls through to the existing create path.
- `check_health` re-resolves the master and PINGs again on a failed PING, so an idle store self-heals within one readiness-probe cycle.

Builds on `is_retryable_redis_error` from #2437 (merged). Paired with the chart-side fix (TCP liveness + faster Sentinel failover) in enterprise-nativelink.

## Verified

Live GKE master failover (kill master mid-build → Sentinel promotes a replica): build completes EXIT 0, CAS 0 restarts, readiness stays healthy, every store connection re-resolves within ~18s, `/metrics` back to 200 in ~5ms. Unit: `test_search_by_index_retries_on_failover`, `check_health_recovers_after_failed_ping`; full `redis_store` suite (42) passes, clippy clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2438)
<!-- Reviewable:end -->
