### PR TITLE
Release NativeLink v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.1](https://github.com/TraceMachina/nativelink/compare/v1.5.0..v1.5.1) - 2026-06-16
+
+### ⛰️  Features
+
+- Introduce load-balanced channel for OpenTelemetry exporters ([#2175](https://github.com/TraceMachina/nativelink/issues/2175)) - ([82fe6e4](https://github.com/TraceMachina/nativelink/commit/82fe6e4864ac303766d97565542b6a0bc44338c2))
+
+### 🐛 Bug Fixes
+
+- *(redis_store)* recover connections through a Sentinel master failover ([#2438](https://github.com/TraceMachina/nativelink/issues/2438)) - ([06e0caf](https://github.com/TraceMachina/nativelink/commit/06e0caff19bd827ba63080a6f1663356393e1850))
+- *(redis_store)* retry has/get_part/list on failover too ([#2437](https://github.com/TraceMachina/nativelink/issues/2437)) - ([d4565e6](https://github.com/TraceMachina/nativelink/commit/d4565e655a844a0983b39d0831d999ee9df78246))
+- *(redis_store)* re-resolve master on update verify/rename for failover safety ([#2435](https://github.com/TraceMachina/nativelink/issues/2435)) - ([54918b6](https://github.com/TraceMachina/nativelink/commit/54918b629f5394fa2eac6b68278869e1671aa3bc))
+
+### 📚 Documentation
+
+- Autogenerate docs again ([#2433](https://github.com/TraceMachina/nativelink/issues/2433)) - ([dc3702c](https://github.com/TraceMachina/nativelink/commit/dc3702c25e229fc5a20146d4b9c8e6d6f4c0a499))
+
+### 🧪 Testing & CI
+
+- Dump coverage in text form during CI ([#2432](https://github.com/TraceMachina/nativelink/issues/2432)) - ([04c2f49](https://github.com/TraceMachina/nativelink/commit/04c2f4976e8aadec587f64bb9fe65cfcb90973ad))
+- Make bash shell scripts actually fall over ([#2428](https://github.com/TraceMachina/nativelink/issues/2428)) - ([d537003](https://github.com/TraceMachina/nativelink/commit/d537003b2eb7ccae69bd126fbec4ea4a9e73aa03))
+- worker_utils test coverage to 100% ([#2427](https://github.com/TraceMachina/nativelink/issues/2427)) - ([729c88d](https://github.com/TraceMachina/nativelink/commit/729c88dcf65dd40da4736ddf328fb6a2dbbecd63))
+
+### ⚙️ Miscellaneous
+
+- wtf did this come from ([#2434](https://github.com/TraceMachina/nativelink/issues/2434)) - ([6abc5d8](https://github.com/TraceMachina/nativelink/commit/6abc5d87e3127ec8eaf7b8a802c47e2aa3a4f7e2))
+
 ## [1.5.0](https://github.com/TraceMachina/nativelink/compare/v1.4.0..v1.5.0) - 2026-06-12
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "axum",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "mongodb",
  "nativelink-metric",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-lock",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.5.0"
+version = "1.5.1"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.5.0",
+    version = "1.5.1",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.5.0"
+version = "1.5.1"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.5.0"
+version = "1.5.1"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.5.0"
+version = "1.5.1"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.5.0"
+version = "1.5.1"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.5.0"
+version = "1.5.1"
 
 [features]
 nix = []


### PR DESCRIPTION
# Description

Release NativeLink v1.5.1.

Cuts a release from main — 9 commits since v1.5.0. Per CONTRIBUTING "Creating
releases": bumps the version in `MODULE.bazel`, `Cargo.toml`, and all
`nativelink-*/Cargo.toml` (plus the matching `nativelink-*` entries in
`Cargo.lock`), and regenerates `CHANGELOG.md` with `git cliff --tag=v1.5.1`
(entries then regrouped into the correct sections, matching what was done for
the v1.5.0 entry).

Release highlights — Redis Sentinel master-failover hardening:
- redis_store: re-resolve master on update verify/rename for failover safety (#2435)
- redis_store: retry has/get_part/list on failover too (#2437)
- redis_store: recover connections through a Sentinel master failover (#2438)
- Introduce load-balanced channel for OpenTelemetry exporters (#2175)

No breaking changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

(The PR diff itself is only version metadata + changelog; the release ships the
already-merged Redis failover fixes #2435/#2437/#2438.)

## How Has This Been Tested?

- Verified no `1.5.0` package references remain in `MODULE.bazel`, `Cargo.toml`,
  or any `nativelink-*/Cargo.toml` (the unrelated `byteorder` 1.5.0 dependency is
  left untouched); all 13 `nativelink-*` entries in `Cargo.lock` bumped to 1.5.1
  via `cargo update --workspace`. `cargo verify-project` passes.
- `CHANGELOG.md` entry checked against `git log v1.5.0..main` — all 9 commits
  accounted for, none duplicated.
- No code changes in this PR; relying on CI for `bazel test //...` (not run
  locally on this machine).

## Checklist

- [x] Updated documentation if needed (CHANGELOG.md)
- [ ] Tests added/amended — N/A, no code changes
- [ ] `bazel test //...` passes locally — not run locally; CI will run it
- [x] PR is contained in a single commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2439)
<!-- Reviewable:end -->
