### PR TITLE
fix(origin-events): don't drop resource-usage origin events on transient failure

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -680,7 +680,10 @@ impl WorkerScheduler for ApiWorkerScheduler {
             identity: action_info.origin_metadata.identity,
             event: Some(event),
         };
-        if let Err(err) = origin_event_tx.try_send(origin_event) {
+        // Awaited send (not try_send): apply backpressure when the publisher
+        // queue is full instead of silently dropping the resource-usage event,
+        // which is what drives action-level resource sizing in the UI.
+        if let Err(err) = origin_event_tx.send(origin_event).await {
             warn!(?err, "Failed to publish action resource usage origin event");
         }
         Ok(())

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -192,7 +192,7 @@ impl SimpleScheduler {
         }
     }
 
-    fn publish_scheduler_start_execute(
+    async fn publish_scheduler_start_execute(
         maybe_origin_event_tx: Option<&mpsc::Sender<OriginEvent>>,
         origin_metadata: &OriginMetadata,
         event_id: String,
@@ -211,7 +211,10 @@ impl SimpleScheduler {
             event: Some(event),
         };
 
-        if let Err(err) = origin_event_tx.try_send(origin_event) {
+        // Awaited send (not try_send): backpressure rather than drop, so the
+        // start-execute event that later resource-usage events reference as
+        // their parent isn't silently lost when the queue is full.
+        if let Err(err) = origin_event_tx.send(origin_event).await {
             warn!(
                 ?err,
                 "Failed to publish scheduler start execute origin event"
@@ -367,7 +370,8 @@ impl SimpleScheduler {
                         &event_origin_metadata,
                         event_id,
                         event,
-                    );
+                    )
+                    .await;
                 }
 
                 Ok(())

--- a/nativelink-util/src/origin_event_publisher.rs
+++ b/nativelink-util/src/origin_event_publisher.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::time::Duration;
+
 use bytes::BytesMut;
 use futures::{FutureExt, future};
 use nativelink_proto::com::github::trace_machina::nativelink::events::{OriginEvent, OriginEvents};
 use prost::Message;
 use tokio::sync::{broadcast, mpsc};
-use tracing::error;
+use tokio::time::sleep;
+use tracing::{error, warn};
 use uuid::{Timestamp, Uuid};
 
 use crate::shutdown_guard::{Priority, ShutdownGuard};
@@ -92,6 +95,10 @@ impl OriginEventPublisher {
     }
 
     async fn handle_batch(&self, batch: &mut Vec<OriginEvent>) {
+        // Bounded so a sustained store outage can't block the publisher (and
+        // thus the schedulers feeding it) forever; enough to ride out a
+        // Sentinel failover.
+        const MAX_UPLOAD_ATTEMPTS: u32 = 5;
         // UUID v6 requires a timestamp and node ID
         // Create timestamp from current system time with nanosecond precision
         let now = std::time::SystemTime::now()
@@ -119,16 +126,39 @@ impl OriginEventPublisher {
             error!("Failed to encode origin events: {}", e);
             return;
         }
-        let update_result = self
-            .store
-            .as_store_driver_pin()
-            .update_oneshot(
-                format!("OriginEvents:{}", uuid.hyphenated()).into(),
-                data.freeze(),
-            )
-            .await;
-        if let Err(err) = update_result {
-            error!("Failed to upload origin events: {}", err);
+        // The batch has already been drained out of `batch`, so a failed store
+        // write would silently lose these events (the source of the recurring
+        // "No action-level resource sizing records" — origin events dropped
+        // during a transient Redis disruption such as a Sentinel failover).
+        // Retry the upload, re-resolving the master each time, so a transient
+        // failure doesn't drop the events.
+        let key = format!("OriginEvents:{}", uuid.hyphenated());
+        let data = data.freeze();
+        for attempt in 1..=MAX_UPLOAD_ATTEMPTS {
+            match self
+                .store
+                .as_store_driver_pin()
+                .update_oneshot(key.clone().into(), data.clone())
+                .await
+            {
+                Ok(()) => return,
+                Err(err) if attempt < MAX_UPLOAD_ATTEMPTS => {
+                    warn!(
+                        attempt,
+                        max = MAX_UPLOAD_ATTEMPTS,
+                        ?err,
+                        "Failed to upload origin events, retrying"
+                    );
+                    sleep(Duration::from_secs_f32(0.1 * attempt as f32)).await;
+                }
+                Err(err) => {
+                    error!(
+                        attempts = MAX_UPLOAD_ATTEMPTS,
+                        ?err,
+                        "Failed to upload origin events after retries"
+                    );
+                }
+            }
         }
     }
 }

--- a/nativelink-util/tests/origin_event_test.rs
+++ b/nativelink-util/tests/origin_event_test.rs
@@ -12,12 +12,139 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::time::Duration;
+use std::sync::Arc;
+
+use nativelink_error::{Code, Error, make_err};
 use nativelink_macro::nativelink_test;
+use nativelink_metric::MetricsComponent;
 use nativelink_proto::com::github::trace_machina::nativelink::events::{
-    Event, RequestEvent, ResponseEvent, StreamEvent, event, request_event, response_event,
-    stream_event,
+    Event, OriginEvent, RequestEvent, ResponseEvent, StreamEvent, event, request_event,
+    response_event, stream_event,
 };
+use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
+use nativelink_util::default_health_status_indicator;
+use nativelink_util::health_utils::HealthStatusIndicator;
 use nativelink_util::origin_event::get_id_for_event;
+use nativelink_util::origin_event_publisher::OriginEventPublisher;
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreDriver, StoreKey, UploadSizeInfo,
+};
+use tokio::sync::{broadcast, mpsc};
+use tokio::time::sleep;
+use tonic::async_trait;
+
+/// A store whose `update` fails the first `fail_until` calls, then succeeds —
+/// to verify the origin-event publisher retries a transient upload failure
+/// instead of dropping the events (the resource-sizing durability gap).
+#[derive(Debug, MetricsComponent)]
+struct FlakyStore {
+    fail_until: usize,
+    attempts: AtomicUsize,
+}
+
+#[async_trait]
+#[allow(clippy::todo)]
+impl StoreDriver for FlakyStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        _keys: &[StoreKey<'_>],
+        _results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        mut reader: DropCloserReadHalf,
+        _upload_size: UploadSizeInfo,
+    ) -> Result<u64, Error> {
+        // Drain so the writer side completes.
+        reader.consume(None).await?;
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt <= self.fail_until {
+            return Err(make_err!(
+                Code::Unavailable,
+                "flaky store failure {attempt}"
+            ));
+        }
+        Ok(0)
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        _writer: &mut DropCloserWriteHalf,
+        _offset: u64,
+        _length: Option<u64>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    fn inner_store(&self, _digest: Option<StoreKey>) -> &dyn StoreDriver {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+default_health_status_indicator!(FlakyStore);
+
+// Regression test for the action-level resource-sizing durability gap: a
+// transient store-upload failure (e.g. a Redis Sentinel failover) must NOT drop
+// origin events — the publisher retries until the upload succeeds.
+#[nativelink_test]
+async fn origin_event_publisher_retries_store_upload() {
+    let store = Arc::new(FlakyStore {
+        fail_until: 2,
+        attempts: AtomicUsize::new(0),
+    });
+    let (tx, rx) = mpsc::channel::<OriginEvent>(16);
+    let (shutdown_tx, _shutdown_rx) = broadcast::channel(1);
+    let publisher = OriginEventPublisher::new(Store::new(store.clone()), rx, shutdown_tx);
+    let task = tokio::spawn(publisher.run());
+
+    tx.send(OriginEvent {
+        version: 0,
+        event_id: "e1".to_string(),
+        parent_event_id: String::new(),
+        bazel_request_metadata: None,
+        identity: String::new(),
+        event: None,
+    })
+    .await
+    .unwrap();
+
+    // 2 transient failures + 1 success = 3 attempts.
+    for _ in 0..100 {
+        if store.attempts.load(Ordering::SeqCst) >= 3 {
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        store.attempts.load(Ordering::SeqCst),
+        3,
+        "publisher must retry the upload past transient failures instead of dropping events",
+    );
+    task.abort();
+}
 
 macro_rules! event_assert {
     ($event:ident, $val:expr) => {


### PR DESCRIPTION
## Problem

Action-level resource sizing (worker peak memory / requested cpu+mem) intermittently shows **"No action-level resource sizing records"** in the dashboard for builds that run while the CAS/scheduler is rolling (deploy) or under load. The data is delivered as **origin events** (`ActionResourceUsage`), and they were being dropped two ways:

1. **`OriginEventPublisher::handle_batch`** drains the batch out of the buffer *before* the store write, so when `update_oneshot` fails transiently — e.g. a Redis Sentinel failover ("Failed to upload origin events: DeadlineExceeded") — the events are **dropped with only a log**, no retry.
2. The schedulers publish via **`origin_event_tx.try_send`** (`simple_scheduler.rs`, `api_worker_scheduler.rs`), which **drops** events when the bounded queue is full.

The consumer side (bep-etl) is already durable (stores keys + scans them), so these events never reach Redis at all — confirmed 0 orphaned `OriginEvents:*` keys for affected builds.

## Fix

- **Retry the upload** in `handle_batch` (bounded: 5 attempts with backoff, re-resolving the master each time) so a transient store failure doesn't drop the batch. Bounded so a sustained outage can't block the publisher (and the schedulers feeding it) forever.
- **Awaited `send` instead of `try_send`** at both publish sites — backpressure when the queue is full rather than silently dropping. (`publish_scheduler_start_execute` is now `async`; its only caller already awaits.)

The existing shutdown-drain in `run()` now also benefits from the retry.

## Test

New `origin_event_publisher_retries_store_upload`: a store that fails the first 2 uploads then succeeds → asserts the publisher retries to **3 attempts** (doesn't drop). Existing origin-event tests (scheduler 26, util) still pass; clippy clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2442)
<!-- Reviewable:end -->
