### PR TITLE
fix(redis): ride out a Sentinel failover on the store write paths + BEP retry

### DIFF
--- a/nativelink-service/src/bep_server.rs
+++ b/nativelink-service/src/bep_server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::pin::Pin;
+use core::time::Duration;
 use std::borrow::Cow;
 
 use bytes::BytesMut;
@@ -33,8 +34,14 @@ use opentelemetry::baggage::BaggageExt;
 use opentelemetry::context::Context;
 use opentelemetry_semantic_conventions::attribute::ENDUSER_ID;
 use prost::Message;
+use tokio::time::sleep;
 use tonic::{Request, Response, Result, Status, Streaming};
-use tracing::{Level, instrument};
+use tracing::{Level, instrument, warn};
+
+/// Bounded retries for persisting a BEP event so a transient store failure
+/// (e.g. a Redis Sentinel failover) doesn't drop it — BEP events are the
+/// authoritative build record, the same durability class as origin events.
+const MAX_BEP_UPLOAD_ATTEMPTS: u32 = 5;
 
 /// Current version of the BEP event. This might be used in the future if
 /// there is a breaking change in the BEP event format.
@@ -100,10 +107,33 @@ impl BepServer {
             .encode(&mut buf)
             .err_tip(|| "Could not encode PublishLifecycleEventRequest proto")?;
 
-        self.store
-            .update_oneshot(store_key.clone(), buf.freeze())
-            .await
-            .err_tip(|| format!("Failed to store PublishLifecycleEventRequest for {store_key}",))?;
+        let data = buf.freeze();
+        for attempt in 1..=MAX_BEP_UPLOAD_ATTEMPTS {
+            match self
+                .store
+                .update_oneshot(store_key.borrow(), data.clone())
+                .await
+            {
+                Ok(()) => break,
+                Err(err) if attempt < MAX_BEP_UPLOAD_ATTEMPTS => {
+                    warn!(
+                        attempt,
+                        max = MAX_BEP_UPLOAD_ATTEMPTS,
+                        ?err,
+                        %store_key,
+                        "Failed to store BEP lifecycle event, retrying"
+                    );
+                    sleep(Duration::from_secs_f32(0.1 * attempt as f32)).await;
+                }
+                Err(err) => {
+                    return Err(err).err_tip(|| {
+                        format!(
+                            "Failed to store PublishLifecycleEventRequest for {store_key} after retries"
+                        )
+                    });
+                }
+            }
+        }
 
         Ok(Response::new(()))
     }
@@ -141,16 +171,31 @@ impl BepServer {
                 .encode(&mut buf)
                 .err_tip(|| "Could not encode PublishBuildToolEventStreamRequest proto")?;
 
-            store
-                .update_oneshot(
-                    StoreKey::Str(Cow::Owned(format!(
-                        "BepEvent:be:{}:{}:{}",
-                        &stream_id.build_id, &stream_id.invocation_id, sequence_number,
-                    ))),
-                    buf.freeze(),
-                )
-                .await
-                .err_tip(|| "Failed to store PublishBuildToolEventStreamRequest")?;
+            let store_key = StoreKey::Str(Cow::Owned(format!(
+                "BepEvent:be:{}:{}:{}",
+                &stream_id.build_id, &stream_id.invocation_id, sequence_number,
+            )));
+            let data = buf.freeze();
+            for attempt in 1..=MAX_BEP_UPLOAD_ATTEMPTS {
+                match store.update_oneshot(store_key.borrow(), data.clone()).await {
+                    Ok(()) => break,
+                    Err(err) if attempt < MAX_BEP_UPLOAD_ATTEMPTS => {
+                        warn!(
+                            attempt,
+                            max = MAX_BEP_UPLOAD_ATTEMPTS,
+                            ?err,
+                            %store_key,
+                            "Failed to store BEP build-tool event, retrying"
+                        );
+                        sleep(Duration::from_secs_f32(0.1 * attempt as f32)).await;
+                    }
+                    Err(err) => {
+                        return Err(err).err_tip(
+                            || "Failed to store PublishBuildToolEventStreamRequest after retries",
+                        )?;
+                    }
+                }
+            }
 
             Ok(PublishBuildToolEventStreamResponse {
                 stream_id: Some(stream_id.clone()),

--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::pin::Pin;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use std::borrow::Cow;
 use std::sync::Arc;
 
@@ -19,8 +21,9 @@ use futures::StreamExt;
 use hyper::body::Frame;
 use nativelink_config::cas_server::BepConfig;
 use nativelink_config::stores::{MemorySpec, StoreSpec};
-use nativelink_error::{Error, ResultExt};
+use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
+use nativelink_metric::MetricsComponent;
 use nativelink_proto::com::github::trace_machina::nativelink::events::{BepEvent, bep_event};
 use nativelink_proto::google::devtools::build::v1::build_event::console_output::Output;
 use nativelink_proto::google::devtools::build::v1::build_event::{
@@ -37,15 +40,21 @@ use nativelink_proto::google::devtools::build::v1::{
 use nativelink_service::bep_server::BepServer;
 use nativelink_store::default_store_factory::store_factory;
 use nativelink_store::store_manager::StoreManager;
-use nativelink_util::buf_channel::make_buf_channel_pair;
+use nativelink_util::buf_channel::{
+    DropCloserReadHalf, DropCloserWriteHalf, make_buf_channel_pair,
+};
 use nativelink_util::channel_body_for_tests::ChannelBody;
 use nativelink_util::common::encode_stream_proto;
-use nativelink_util::store_trait::{Store, StoreKey, StoreLike};
+use nativelink_util::default_health_status_indicator;
+use nativelink_util::health_utils::HealthStatusIndicator;
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo,
+};
 use pretty_assertions::assert_eq;
 use prost::Message;
 use prost_types::Timestamp;
 use tonic::codec::{Codec, ProstCodec};
-use tonic::{Request, Streaming};
+use tonic::{Request, Streaming, async_trait};
 
 const BEP_STORE_NAME: &str = "main_bep";
 
@@ -78,6 +87,120 @@ fn get_bep_store(store_manager: &StoreManager) -> Result<Store, Error> {
     store_manager
         .get_store(BEP_STORE_NAME)
         .err_tip(|| format!("While retrieving bep_store {BEP_STORE_NAME}"))
+}
+
+/// A store whose `update` fails the first `fail_until` calls, then succeeds —
+/// to verify the BEP server retries a transient upload failure (e.g. a Redis
+/// Sentinel failover) instead of dropping the event.
+#[derive(Debug, MetricsComponent)]
+struct FlakyStore {
+    fail_until: usize,
+    attempts: AtomicUsize,
+}
+
+#[async_trait]
+#[allow(clippy::todo)]
+impl StoreDriver for FlakyStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        _keys: &[StoreKey<'_>],
+        _results: &mut [Option<u64>],
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        mut reader: DropCloserReadHalf,
+        _upload_size: UploadSizeInfo,
+    ) -> Result<u64, Error> {
+        // Drain so the writer side completes.
+        reader.consume(None).await?;
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt <= self.fail_until {
+            return Err(make_err!(
+                Code::Unavailable,
+                "flaky store failure {attempt}"
+            ));
+        }
+        Ok(0)
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        _key: StoreKey<'_>,
+        _writer: &mut DropCloserWriteHalf,
+        _offset: u64,
+        _length: Option<u64>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    fn inner_store(&self, _digest: Option<StoreKey>) -> &dyn StoreDriver {
+        self
+    }
+
+    fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+        self
+    }
+
+    fn register_remove_callback(
+        self: Arc<Self>,
+        _callback: Arc<dyn RemoveItemCallback>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+default_health_status_indicator!(FlakyStore);
+
+/// A transient store-upload failure (e.g. a Redis Sentinel failover) must NOT
+/// drop a BEP lifecycle event — the server retries the upload until it lands.
+#[nativelink_test]
+async fn publish_lifecycle_event_retries_transient_store_failure()
+-> Result<(), Box<dyn core::error::Error>> {
+    let flaky = Arc::new(FlakyStore {
+        fail_until: 2,
+        attempts: AtomicUsize::new(0),
+    });
+    let store_manager = Arc::new(StoreManager::new());
+    store_manager.add_store(BEP_STORE_NAME, Store::new(flaky.clone()));
+    let bep_server = make_bep_server(&store_manager)?;
+
+    let request = PublishLifecycleEventRequest {
+        service_level: ServiceLevel::Interactive as i32,
+        build_event: Some(OrderedBuildEvent {
+            stream_id: Some(StreamId {
+                build_id: "some-build-id".to_string(),
+                invocation_id: "some-invocation-id".to_string(),
+                component: BuildComponent::Controller as i32,
+            }),
+            sequence_number: 1,
+            event: None,
+        }),
+        stream_timeout: None,
+        notification_keywords: vec![],
+        project_id: "some-project-id".to_string(),
+        check_preceding_lifecycle_events_present: false,
+    };
+
+    // Must succeed despite the first two transient failures.
+    bep_server
+        .publish_lifecycle_event(Request::new(request))
+        .await
+        .err_tip(|| "publish_lifecycle_event should succeed after retrying")?;
+
+    assert_eq!(
+        flaky.attempts.load(Ordering::SeqCst),
+        3,
+        "the BEP publish must retry past transient store failures (2 failures + 1 success)",
+    );
+    Ok(())
 }
 
 /// Asserts that a gRPC request for a [`PublishLifecycleEventRequest`] is correctly dumped into a [`Store`]

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1019,7 +1019,7 @@ where
                         .await {
                         Ok(_) => {},
                         Err(err)
-                            if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
+                            if is_retryable_redis_error(&err) =>
                         {
                             let (mut connection_manager, _connect_id) = self.connection_manager.reconnect(connect_id).await?;
                             connection_manager
@@ -1051,7 +1051,7 @@ where
 
         let expected_len = usize::try_from(total_len).unwrap_or(usize::MAX);
 
-        // The chunk writes above reconnect on ReadOnly, so on a mid-write Redis
+        // The chunk writes above reconnect on any transient failover error, so on a mid-write Redis
         // failover the data lands on the *current* master. The length check and
         // rename below must run against that same master: the connection
         // captured before the writes may now point at a demoted replica, where
@@ -1098,16 +1098,14 @@ where
         };
 
         // Rename the temp key so that the data appears under the real key. Any data already present in the real key is lost.
-        // Reconnect once on ReadOnly in case the master moved between the verify and here.
+        // Reconnect once on a transient failover error in case the master moved between the verify and here.
         match client
             .connection_manager
             .rename::<_, _, ()>(&temp_key, final_key.as_ref())
             .await
         {
             Ok(()) => {}
-            Err(err)
-                if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
-            {
+            Err(err) if is_retryable_redis_error(&err) => {
                 let (connection_manager, uuid) =
                     self.connection_manager.reconnect(client.uuid).await?;
                 client.connection_manager = connection_manager;
@@ -1835,9 +1833,7 @@ where
                 .await
             {
                 Ok(v) => v,
-                Err(err)
-                    if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
-                {
+                Err(err) if is_retryable_redis_error(&err) => {
                     client.reconnect(&self.connection_manager).await?;
                     script_invocation
                         .invoke_async(&mut client.connection_manager)
@@ -1922,9 +1918,7 @@ where
                         }
                     }
                 }
-                Err(err)
-                    if err.kind() == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
-                {
+                Err(err) if is_retryable_redis_error(&err) => {
                     client.reconnect(&self.connection_manager).await?;
                     client
                         .connection_manager
@@ -2048,10 +2042,7 @@ where
             Err(_) => {
                 let (connection_manager, result) =
                     match run_ft_create(connection_manager.clone()).await {
-                        Err(err)
-                            if err.kind()
-                                == redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly) =>
-                        {
+                        Err(err) if is_retryable_redis_error(&err) => {
                             let (connection_manager, _connect_id) =
                                 self.connection_manager.reconnect(connect_id).await?;
                             (
@@ -2194,14 +2185,36 @@ where
         let key = key.get_key();
         let key = self.encode_key(&key);
         let mut client = self.get_client().await?;
-        let results: Vec<Value> = client
-            .connection_manager
-            .hmget::<_, Vec<String>, Vec<Value>>(
-                key.as_ref(),
-                vec![VERSION_FIELD_NAME.into(), DATA_FIELD_NAME.into()],
-            )
-            .await
-            .err_tip(|| format!("In RedisStore::get_without_version::notversioned {key}"))?;
+        // hmget is idempotent, so re-resolve the master and retry on a transient
+        // failover (matching the read paths in get_part/list) instead of failing
+        // a scheduler-state read while the master is moving.
+        let results: Vec<Value> = {
+            let mut attempt: u32 = 0;
+            loop {
+                attempt += 1;
+                match client
+                    .connection_manager
+                    .hmget::<_, Vec<String>, Vec<Value>>(
+                        key.as_ref(),
+                        vec![VERSION_FIELD_NAME.into(), DATA_FIELD_NAME.into()],
+                    )
+                    .await
+                {
+                    Ok(v) => break v,
+                    Err(err)
+                        if attempt < MAX_REDIS_RETRY_ATTEMPTS && is_retryable_redis_error(&err) =>
+                    {
+                        client.reconnect(&self.connection_manager).await?;
+                        sleep(Duration::from_secs_f32(DEFAULT_RETRY_DELAY)).await;
+                    }
+                    Err(err) => {
+                        return Err(Error::from(err).append(format!(
+                            "In RedisStore::get_without_version::notversioned {key}"
+                        )));
+                    }
+                }
+            }
+        };
         let Some(Value::BulkString(data)) = results.get(1) else {
             return Ok(None);
         };

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -304,6 +304,55 @@ async fn has_retries_after_transient_error() -> Result<(), Error> {
     Ok(())
 }
 
+// The write path must also ride out a transient Redis error (e.g. a connection
+// dropped by a Sentinel failover) by re-resolving the master and retrying the
+// chunk write, rather than hard-failing the upload. Previously the chunk write
+// only retried a ReadOnly reply (a demoted replica), so a dropped connection —
+// the more common failover symptom — failed the upload and dropped the data.
+#[nativelink_test]
+async fn update_retries_after_transient_write_error() -> Result<(), Error> {
+    let data = Bytes::from_static(b"14");
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{digest}");
+    let temp_key = make_temp_key(&packed_hash_hex);
+    let real_key = packed_hash_hex;
+
+    let commands = vec![
+        // First chunk write fails with a retryable connection error.
+        MockCmd::new(
+            redis::cmd("SETRANGE")
+                .arg(temp_key.clone())
+                .arg(0)
+                .arg(data.to_vec()),
+            Err::<Value, _>(RedisError::from(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "transient",
+            ))),
+        ),
+        // After re-resolving the master, the retried chunk write succeeds.
+        MockCmd::new(
+            redis::cmd("SETRANGE")
+                .arg(temp_key.clone())
+                .arg(0)
+                .arg(data.to_vec()),
+            Ok(Value::Int(0)),
+        ),
+        MockCmd::new(
+            redis::cmd("STRLEN").arg(temp_key.clone()),
+            Ok(Value::Int(data.len() as i64)),
+        ),
+        MockCmd::new(
+            redis::cmd("RENAME").arg(temp_key).arg(real_key),
+            Ok(Value::Nil),
+        ),
+    ];
+
+    let store = make_mock_store(commands).await;
+    // Must succeed despite the transient write error.
+    store.update_oneshot(digest, data).await?;
+    Ok(())
+}
+
 #[nativelink_test]
 async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
     let data = Bytes::from_static(b"14");
@@ -794,13 +843,16 @@ async fn test_health() {
                 struct_name,
                 "nativelink_store::redis_store::RedisStore<redis::aio::connection_manager::ConnectionManager, nativelink_store::redis_store::StandardRedisManager<redis::aio::connection_manager::ConnectionManager>>"
             );
+            // The write path treats a timeout as retryable (a failover symptom),
+            // so it re-resolves the master and retries the chunk write once before
+            // surfacing the error — hence the "(after reconnect)" prefix.
             assert!(
-                message.starts_with("Store.update_oneshot() failed: Error { code: DeadlineExceeded, messages: [\"Io: timed out\", \"While appending to temp key ("),
+                message.starts_with("Store.update_oneshot() failed: Error { code: DeadlineExceeded, messages: [\"Io: timed out\", \"(after reconnect) while appending to temp key ("),
                 "message: '{message}'"
             );
             logs_assert(|logs| {
                 for log in logs {
-                    if log.contains("check_health Store.update_oneshot() failed e=Error { code: DeadlineExceeded, messages: [\"Io: timed out\", \"While appending to temp key (") {
+                    if log.contains("check_health Store.update_oneshot() failed e=Error { code: DeadlineExceeded, messages: [\"Io: timed out\", \"(after reconnect) while appending to temp key (") {
                         return Ok(())
                     }
                 }


### PR DESCRIPTION
Follow-up to #2442. Verifying that fix against a live deployment, a Redis Sentinel failover **during a build** still lost the build's BEP records and churned workers.

**Cause:** the store's read paths retry on any transient error (`is_retryable_redis_error`), but the write paths only retried `ReadOnly` — so a dropped connection (the usual failover symptom) failed the write. `BepServer` had no retry, and `get_and_decode` (scheduler-state read) had none either.

**Change:**
- `redis_store`: `setrange`, `rename`, `update_data`, `ft_create`, `get_and_decode` now retry on `is_retryable_redis_error`, matching the read paths.
- `bep_server`: bounded retry (with backoff) around `update_oneshot` — parity with the origin-event publisher.

**Tests:** write-path retry, BEP publish retry, and `test_health` updated for the new reconnect-retry message. Full `redis_store_test`/`bep_server_test` suites pass; clippy clean.

Consumer-side half: TraceMachina/cloud-platform#1067 — both are needed end-to-end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2445)
<!-- Reviewable:end -->
