### PR TITLE
Release NativeLink v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.2](https://github.com/TraceMachina/nativelink/compare/v1.5.1..v1.5.2) - 2026-06-17
+
+### 🐛 Bug Fixes
+
+- *(redis)* ride out a Sentinel failover on the write paths ([#2445](https://github.com/TraceMachina/nativelink/issues/2445)) by @amankrx - ([a776234](https://github.com/TraceMachina/nativelink/commit/a77623428757dc8d228aa4932edcfd4dac81cea8))
+- *(origin-events)* don't drop resource-usage events on transient failure ([#2442](https://github.com/TraceMachina/nativelink/issues/2442)) by @amankrx - ([78af03a](https://github.com/TraceMachina/nativelink/commit/78af03a7e5c96fb8553b903d87fe6943e34932ee))
+
+### 📚 Documentation
+
+- Makes various docs improvements ([#2444](https://github.com/TraceMachina/nativelink/issues/2444)) by @palfrey - ([2d7d6b3](https://github.com/TraceMachina/nativelink/commit/2d7d6b325008f5e1a15657eb2bee8f1a8da0e0db))
+
+### ⚙️ Miscellaneous
+
+- Adds latest tag with bun ([#2440](https://github.com/TraceMachina/nativelink/issues/2440)) by @MarcusSorealheis - ([3bca6f7](https://github.com/TraceMachina/nativelink/commit/3bca6f7ec75af659dd015e7c9df08a85cc163365))
+
 ## [1.5.1](https://github.com/TraceMachina/nativelink/compare/v1.5.0..v1.5.1) - 2026-06-16
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "axum",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "mongodb",
  "nativelink-metric",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-lock",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.5.1"
+version = "1.5.2"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.5.1",
+    version = "1.5.2",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.5.1"
+version = "1.5.2"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.5.1"
+version = "1.5.2"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.5.1"
+version = "1.5.2"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.5.1"
+version = "1.5.2"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.5.1"
+version = "1.5.2"
 
 [features]
 nix = []


### PR DESCRIPTION
# Description

Release NativeLink v1.5.2.

## Type of change

- [x] New release

(The PR diff itself is only version metadata + changelog; the release ships the already-merged fixes #2445 / #2442 plus #2444 / #2440.)

## How Has This Been Tested?

- The shipped failover fixes were verified end-to-end on a live deployment with a Redis Sentinel master failover injected mid-build: build EXIT 0, resource-sizing + BEP build records survived, no worker churn, no dropped events.
- No code changes in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2446)
<!-- Reviewable:end -->
