### PR TITLE
ref_store now resolves on boot, not first query

### DIFF
--- a/nativelink-service/tests/bep_server_test.rs
+++ b/nativelink-service/tests/bep_server_test.rs
@@ -101,6 +101,10 @@ struct FlakyStore {
 #[async_trait]
 #[allow(clippy::todo)]
 impl StoreDriver for FlakyStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],

--- a/nativelink-service/tests/cas_server_test.rs
+++ b/nativelink-service/tests/cas_server_test.rs
@@ -681,6 +681,10 @@ struct StallStore {
 
 #[async_trait]
 impl StoreDriver for StallStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _digests: &[StoreKey<'_>],

--- a/nativelink-store/src/azure_blob_store.rs
+++ b/nativelink-store/src/azure_blob_store.rs
@@ -557,6 +557,10 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/cache_metrics_store.rs
+++ b/nativelink-store/src/cache_metrics_store.rs
@@ -101,6 +101,11 @@ impl MetricsComponent for CacheMetricsStore {
 
 #[async_trait]
 impl StoreDriver for CacheMetricsStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        self.backend.clone().into_inner().post_init().await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/completeness_checking_store.rs
+++ b/nativelink-store/src/completeness_checking_store.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::{FuturesUnordered, StreamExt};
-use futures::{FutureExt, TryFutureExt, select};
+use futures::{FutureExt, TryFutureExt, select, try_join};
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_metric::MetricsComponent;
 use nativelink_proto::build::bazel::remote::execution::v2::{
@@ -341,6 +341,14 @@ impl CompletenessCheckingStore {
 
 #[async_trait]
 impl StoreDriver for CompletenessCheckingStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        try_join!(
+            self.cas_store.clone().into_inner().post_init(),
+            self.ac_store.clone().into_inner().post_init()
+        )?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -278,6 +278,11 @@ impl CompressionStore {
 
 #[async_trait]
 impl StoreDriver for CompressionStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        self.inner_store.clone().into_inner().post_init().await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],

--- a/nativelink-store/src/dedup_store.rs
+++ b/nativelink-store/src/dedup_store.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::{self, FuturesOrdered, StreamExt, TryStreamExt};
+use futures::try_join;
 use nativelink_config::stores::DedupSpec;
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_metric::MetricsComponent;
@@ -176,6 +177,14 @@ impl DedupStore {
 
 #[async_trait]
 impl StoreDriver for DedupStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        try_join!(
+            self.index_store.clone().into_inner().post_init(),
+            self.content_store.clone().into_inner().post_init(),
+        )?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],

--- a/nativelink-store/src/existence_cache_store.rs
+++ b/nativelink-store/src/existence_cache_store.rs
@@ -210,6 +210,11 @@ impl<I: InstantWrapper> ExistenceCacheStore<I> {
 
 #[async_trait]
 impl<I: InstantWrapper> StoreDriver for ExistenceCacheStore<I> {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        self.inner_store.clone().into_inner().post_init().await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use futures::stream::{FuturesUnordered, StreamExt};
-use futures::{FutureExt, join};
+use futures::{FutureExt, join, try_join};
 use nativelink_config::stores::{FastSlowSpec, StoreDirection};
 use nativelink_error::{Code, Error, ErrorContext, ResultExt, make_err};
 use nativelink_metric::MetricsComponent;
@@ -428,6 +428,14 @@ impl FastSlowStore {
 
 #[async_trait]
 impl StoreDriver for FastSlowStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        try_join!(
+            self.fast_store.clone().into_inner().post_init(),
+            self.slow_store.clone().into_inner().post_init()
+        )?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         key: &[StoreKey<'_>],

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1260,6 +1260,10 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
 
 #[async_trait]
 impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -206,6 +206,10 @@ where
     Client: GcsOperations + 'static,
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -703,6 +703,10 @@ impl GrpcStore {
 
 #[async_trait]
 impl StoreDriver for GrpcStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     // NOTE: This function can only be safely used on CAS stores. AC stores may return a size that
     // is incorrect.
     async fn has_with_results(

--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -92,6 +92,10 @@ impl MemoryStore {
 
 #[async_trait]
 impl StoreDriver for MemoryStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/mongo_store.rs
+++ b/nativelink-store/src/mongo_store.rs
@@ -313,6 +313,10 @@ impl ExperimentalMongoStore {
 
 #[async_trait]
 impl StoreDriver for ExperimentalMongoStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/noop_store.rs
+++ b/nativelink-store/src/noop_store.rs
@@ -47,6 +47,10 @@ impl NoopStore {
 
 #[async_trait]
 impl StoreDriver for NoopStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],

--- a/nativelink-store/src/ontap_s3_existence_cache_store.rs
+++ b/nativelink-store/src/ontap_s3_existence_cache_store.rs
@@ -442,6 +442,11 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + Clone + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        self.inner_store.clone().into_inner().post_init().await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/ontap_s3_store.rs
+++ b/nativelink-store/src/ontap_s3_store.rs
@@ -292,6 +292,10 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -783,6 +783,10 @@ where
     C: ConnectionLike + Clone + Send + Sync + Unpin + 'static,
     M: RedisManager<C> + Unpin + Send + Sync + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/ref_store.rs
+++ b/nativelink-store/src/ref_store.rs
@@ -26,7 +26,7 @@ use nativelink_util::store_trait::{
     RemoveItemCallback, Store, StoreDriver, StoreKey, StoreLike, UploadSizeInfo,
 };
 use parking_lot::Mutex;
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::store_manager::StoreManager;
 
@@ -64,13 +64,6 @@ impl RefStore {
         })
     }
 
-    // This will get the store or populate it if needed. It is designed to be quite fast on the
-    // common path, but slow on the uncommon path. It does use some unsafe functions because we
-    // wanted it to be fast. It is technically possible on some platforms for this function to
-    // create a data race here is the reason I do not believe it is an issue:
-    // 1. It would only happen on the very first call of the function (after first call we are safe)
-    // 2. It should only happen on platforms that are < 64 bit address space
-    // 3. It is likely that the internals of how Option work protect us anyway.
     #[inline]
     fn get_store(&self) -> Result<&Store, Error> {
         let ref_store = self.inner.cell.0.get();
@@ -79,8 +72,23 @@ impl RefStore {
                 return Ok(store);
             }
         }
-        // This should protect us against multiple writers writing the same location at the same
-        // time.
+        Err(make_input_err!(
+            "ref_store cannot get store '{}', was post_init called?",
+            self.name
+        ))
+    }
+}
+
+#[async_trait]
+impl StoreDriver for RefStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        debug!("Running post_init to get store");
+        let ref_store = self.inner.cell.0.get();
+        unsafe {
+            if (*ref_store).is_some() {
+                return Err(make_input_err!("post_init already called for RefStore"));
+            }
+        }
         let _lock = self.inner.mux.lock();
         let store_manager = self
             .store_manager
@@ -89,22 +97,21 @@ impl RefStore {
         if let Some(store) = store_manager.get_store(&self.name) {
             let remove_callbacks = self.remove_callbacks.lock().clone();
             for callback in remove_callbacks {
+                debug!(?callback, ?store, "Added callback to store");
                 store.register_remove_callback(callback)?;
             }
             unsafe {
                 *ref_store = Some(store);
-                return Ok((*ref_store).as_ref().unwrap());
             }
+            Ok(())
+        } else {
+            Err(make_input_err!(
+                "Failed to find store '{}' in StoreManager in RefStore",
+                self.name
+            ))
         }
-        Err(make_input_err!(
-            "Failed to find store '{}' in StoreManager in RefStore",
-            self.name
-        ))
     }
-}
 
-#[async_trait]
-impl StoreDriver for RefStore {
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
@@ -138,7 +145,7 @@ impl StoreDriver for RefStore {
         match self.get_store() {
             Ok(store) => store.inner_store(key),
             Err(err) => {
-                error!(?key, ?err, "Failed to get store for key",);
+                error!(?key, ?err, "Failed to get store for key");
                 self
             }
         }
@@ -160,7 +167,10 @@ impl StoreDriver for RefStore {
         let ref_store = self.inner.cell.0.get();
         unsafe {
             if let Some(ref store) = *ref_store {
+                debug!(?callback, ?store, "New callback");
                 store.register_remove_callback(callback)?;
+            } else {
+                debug!(?callback, "New callback, no store yet");
             }
         }
         Ok(())

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -243,6 +243,10 @@ where
     I: InstantWrapper,
     NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/shard_store.rs
+++ b/nativelink-store/src/shard_store.rs
@@ -19,6 +19,7 @@ use std::hash::DefaultHasher;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::future::try_join_all;
 use futures::stream::{FuturesUnordered, TryStreamExt};
 use nativelink_config::stores::ShardSpec;
 use nativelink_error::{Error, ResultExt, error_if};
@@ -146,6 +147,15 @@ impl ShardStore {
 
 #[async_trait]
 impl StoreDriver for ShardStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        let mut futures = vec![];
+        for store_and_weight in &self.weights_and_stores {
+            futures.push(store_and_weight.store.clone().into_inner().post_init());
+        }
+        try_join_all(futures).await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/size_partitioning_store.rs
+++ b/nativelink-store/src/size_partitioning_store.rs
@@ -16,6 +16,7 @@ use core::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::try_join;
 use nativelink_config::stores::SizePartitioningSpec;
 use nativelink_error::{Error, ResultExt, make_input_err};
 use nativelink_metric::MetricsComponent;
@@ -48,6 +49,14 @@ impl SizePartitioningStore {
 
 #[async_trait]
 impl StoreDriver for SizePartitioningStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        try_join!(
+            self.upper_store.clone().into_inner().post_init(),
+            self.lower_store.clone().into_inner().post_init(),
+        )?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],

--- a/nativelink-store/src/store_manager.rs
+++ b/nativelink-store/src/store_manager.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use nativelink_error::Error;
 use nativelink_metric::{MetricsComponent, RootMetricsComponent};
 use nativelink_util::store_trait::Store;
 use parking_lot::RwLock;
@@ -42,6 +43,17 @@ impl StoreManager {
             return Some(store.clone());
         }
         None
+    }
+
+    pub async fn run_post_init(&self) -> Result<(), Error> {
+        let stores = {
+            let lock = self.stores.read();
+            lock.values().cloned().collect::<Vec<_>>()
+        };
+        for store in stores {
+            store.into_inner().post_init().await?;
+        }
+        Ok(())
     }
 }
 

--- a/nativelink-store/src/verify_store.rs
+++ b/nativelink-store/src/verify_store.rs
@@ -146,6 +146,11 @@ impl VerifyStore {
 
 #[async_trait]
 impl StoreDriver for VerifyStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        self.inner_store.clone().into_inner().post_init().await?;
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         digests: &[StoreKey<'_>],

--- a/nativelink-store/tests/fast_slow_store_test.rs
+++ b/nativelink-store/tests/fast_slow_store_test.rs
@@ -254,6 +254,10 @@ async fn drop_on_eof_completes_store_futures() -> Result<(), Error> {
 
     #[async_trait]
     impl StoreDriver for DropCheckStore {
+        async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+            Ok(())
+        }
+
         async fn has_with_results(
             self: Pin<&Self>,
             digests: &[StoreKey<'_>],
@@ -589,6 +593,10 @@ fn make_stores_with_lazy_slow() -> (Store, Store, Store) {
 
     #[async_trait]
     impl StoreDriver for LazyStore {
+        async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+            Ok(())
+        }
+
         async fn has_with_results(
             self: Pin<&Self>,
             digests: &[StoreKey<'_>],
@@ -728,6 +736,10 @@ struct InstrumentedSlowStore {
 
 #[async_trait]
 impl StoreDriver for InstrumentedSlowStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
@@ -983,6 +995,10 @@ async fn has_sees_in_flight_slow_writes() -> Result<(), Error> {
 
     #[async_trait]
     impl StoreDriver for GatedSlowStore {
+        async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+            Ok(())
+        }
+
         async fn has_with_results(
             self: Pin<&Self>,
             _keys: &[StoreKey<'_>],
@@ -1142,6 +1158,10 @@ async fn has_does_not_consult_fast_store_when_slow_store_hits() -> Result<(), Er
 
     #[async_trait]
     impl StoreDriver for CountingFastStore {
+        async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+            Ok(())
+        }
+
         async fn has_with_results(
             self: Pin<&Self>,
             keys: &[StoreKey<'_>],
@@ -1248,6 +1268,10 @@ struct GatedSlowStore2 {
 
 #[async_trait]
 impl StoreDriver for GatedSlowStore2 {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],
@@ -1405,6 +1429,10 @@ struct MapBackedSlow {
 }
 #[async_trait]
 impl StoreDriver for MapBackedSlow {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
@@ -1583,6 +1611,10 @@ struct CountingSlowStore {
 
 #[async_trait]
 impl StoreDriver for CountingSlowStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         keys: &[StoreKey<'_>],
@@ -1831,6 +1863,10 @@ struct StaleFastStore {
 
 #[async_trait]
 impl StoreDriver for StaleFastStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _digests: &[StoreKey<'_>],

--- a/nativelink-store/tests/ref_store_test.rs
+++ b/nativelink-store/tests/ref_store_test.rs
@@ -24,10 +24,11 @@ use nativelink_store::store_manager::StoreManager;
 use nativelink_util::common::DigestInfo;
 use nativelink_util::store_trait::{Store, StoreDriver, StoreLike};
 use pretty_assertions::assert_eq;
+use tonic::Code;
 
 const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
-fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
+async fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
     let store_manager = Arc::new(StoreManager::new());
 
     let memory_store = Store::new(MemoryStore::new(&MemorySpec::default()));
@@ -40,6 +41,7 @@ fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
         Arc::downgrade(&store_manager),
     ));
     store_manager.add_store("bar", ref_store.clone());
+    store_manager.run_post_init().await.unwrap();
     (store_manager, memory_store, ref_store)
 }
 
@@ -47,7 +49,7 @@ fn setup_stores() -> (Arc<StoreManager>, Store, Store) {
 async fn has_test() -> Result<(), Error> {
     const VALUE1: &str = "13";
 
-    let (_store_manager, memory_store, ref_store) = setup_stores();
+    let (_store_manager, memory_store, ref_store) = setup_stores().await;
 
     {
         // Insert data into memory store.
@@ -77,7 +79,7 @@ async fn has_test() -> Result<(), Error> {
 async fn get_test() -> Result<(), Error> {
     const VALUE1: &str = "13";
 
-    let (_store_manager, memory_store, ref_store) = setup_stores();
+    let (_store_manager, memory_store, ref_store) = setup_stores().await;
 
     {
         // Insert data into memory store.
@@ -108,7 +110,7 @@ async fn get_test() -> Result<(), Error> {
 async fn update_test() -> Result<(), Error> {
     const VALUE1: &str = "13";
 
-    let (_store_manager, memory_store, ref_store) = setup_stores();
+    let (_store_manager, memory_store, ref_store) = setup_stores().await;
 
     {
         // Insert data into ref_store.
@@ -158,12 +160,40 @@ async fn inner_store_test() -> Result<(), Error> {
     ));
     store_manager.add_store("ref_store_outer", ref_store_outer.clone());
 
+    store_manager.run_post_init().await.unwrap();
+
     // Ensure the result of inner_store() points to exact same memory store.
     assert_eq!(
         from_ref::<dyn StoreDriver>(ref_store_outer.inner_store(Option::<DigestInfo>::None))
             .cast::<()>(),
         from_ref::<dyn StoreDriver>(memory_store.into_inner().as_ref()).cast::<()>(),
         "Expected inner store to be memory store"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn no_post_init_failure() -> Result<(), Error> {
+    let store_manager = Arc::new(StoreManager::new());
+
+    let memory_store = Store::new(MemoryStore::new(&MemorySpec::default()));
+    store_manager.add_store("mem_store", memory_store.clone());
+
+    let ref_store = Store::new(RefStore::new(
+        &RefSpec {
+            name: "mem_store".to_string(),
+        },
+        Arc::downgrade(&store_manager),
+    ));
+    store_manager.add_store("ref_store", ref_store.clone());
+
+    // Should fail because we never called post_init
+    assert_eq!(
+        ref_store.has(DigestInfo::try_new(VALID_HASH1, 1)?).await,
+        Err(Error::new(
+            Code::InvalidArgument,
+            "ref_store cannot get store 'mem_store', was post_init called?".into()
+        ))
     );
     Ok(())
 }

--- a/nativelink-util/src/store_trait.rs
+++ b/nativelink-util/src/store_trait.rs
@@ -621,6 +621,10 @@ pub trait StoreLike: Send + Sync + Sized + Unpin + 'static {
 pub trait StoreDriver:
     Sync + Send + Unpin + MetricsComponent + HealthStatusIndicator + 'static
 {
+    // Do "all the stores are setup" init e.g. if we need access to the store manager
+    // for ref stores
+    async fn post_init(self: Arc<Self>) -> Result<(), Error>;
+
     /// See: [`StoreLike::has`] for details.
     #[inline]
     async fn has(self: Pin<&Self>, key: StoreKey<'_>) -> Result<Option<u64>, Error> {

--- a/nativelink-util/tests/origin_event_test.rs
+++ b/nativelink-util/tests/origin_event_test.rs
@@ -48,6 +48,10 @@ struct FlakyStore {
 #[async_trait]
 #[allow(clippy::todo)]
 impl StoreDriver for FlakyStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],

--- a/nativelink-util/tests/store_trait_test.rs
+++ b/nativelink-util/tests/store_trait_test.rs
@@ -18,6 +18,10 @@ struct FakeStore {}
 #[async_trait]
 #[allow(clippy::todo)]
 impl StoreDriver for FakeStore {
+    async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn has_with_results(
         self: Pin<&Self>,
         _keys: &[StoreKey<'_>],

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -213,6 +213,7 @@ async fn inner_main(
                 .err_tip(|| format!("Failed to create store '{name}'"))?;
             store_manager.add_store(&name, store);
         }
+        store_manager.run_post_init().await?;
     }
 
     let mut root_futures: Vec<BoxFuture<Result<(), Error>>> = Vec::new();
@@ -824,13 +825,13 @@ fn main() -> Result<(), Box<dyn core::error::Error>> {
             .expect("Failed to listen to SIGTERM")
             .recv()
             .await;
-        warn!("Process terminated via SIGTERM",);
+        warn!("Process terminated via SIGTERM");
         drop(shutdown_tx_clone.send(shutdown_guard.clone()));
         scheduler_shutdown_rx
             .await
             .expect("Failed to receive scheduler shutdown");
         let () = shutdown_guard.wait_for(Priority::P0).await;
-        warn!("Successfully shut down nativelink.",);
+        warn!("Successfully shut down nativelink.");
         std::process::exit(143);
     });
 


### PR DESCRIPTION
# Description

Previously, if you had a broken `ref_store` config i.e. it pointed to a non-existent store, Nativelink would still boot fine. It would then have errors on every request to that store, but still keep going with anything else. This is a bad behaviour as if we have a permanently broken config (i.e. not a transient error, but one that requires a config change to fix) then we should fail ASAP so the end user can fix it.

## Type of change

Please delete options that aren't relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)

This will break any configs with bad ref stores. They shouldn't have been regarded as valid to begin with, but it's still a breaking change.

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2451)
<!-- Reviewable:end -->
