### PR TITLE
Multi arch image publish

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -1,0 +1,12 @@
+name: 'Version generator'
+outputs:
+  version-string:
+    description: "Version string"
+    value: ${{ steps.generate-version.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Generate version
+      run: echo "version=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_OUTPUT
+      id: generate-version
+      shell: bash

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '.github/styles/**'
       - 'web/**'
@@ -30,6 +28,11 @@ jobs:
       id-token: write
       security-events: write
     timeout-minutes: 30
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
     steps:
       - name: Checkout
         uses: >- # v6.0.2
@@ -40,18 +43,38 @@ jobs:
         with:
           nativelink_attic_token: ${{ secrets.NATIVELINK_ATTIC_TOKEN }}
 
+      - id: version
+        uses: ./.github/actions/generate-version
+
+      # FIXME: merge the multi-arch and single-arch paths
+      - name: Test multi-arch image
+        if: ${{ matrix.image == 'image'}}
+        run: |
+          nix run --fallback .#create-multi-arch-image localhost:5000 nativelink:${{ steps.version.outputs.version-string }} nativelink-image-for-x64 nativelink-image-for-aarch64
+          nix run --fallback .#local-image-test localhost:5000/nativelink:${{ steps.version.outputs.version-string }}
+
+      - name: Upload multi-arch image
+        if: ${{ matrix.image != 'image' && github.ref == 'refs/heads/main'}}
+        run: |
+          nix run --fallback .#regctl-ghcr-login
+          nix run --fallback .#create-multi-arch-image ghcr.io ${{ github.repository_owner }}/nativelink:${{ steps.version.outputs.version-string }} nativelink-image-for-x64 nativelink-image-for-aarch64
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test image
+        if: ${{ matrix.image != 'image'}}
         run: |
           nix run --fallback .#local-image-test ${{ matrix.image }}
 
       - name: Upload image
+        if: ${{ matrix.image != 'image' && github.ref == 'refs/heads/main'}}
         run: |
           nix run --fallback .#publish-ghcr ${{ matrix.image }}
         env:
           GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        if: github.ref == 'refs/heads/main'
 
       - name: Upload trivy scan results to GitHub Security tab
         uses: >- # v2.16.3

--- a/flake.lock
+++ b/flake.lock
@@ -99,17 +99,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1767430085,
-        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
         "type": "github"
       },
       "original": {
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
     nix2container = {
       # TODO(SchahinRohani): Use a specific commit hash until nix2container is stable.
-      url = "github:nlewo/nix2container/66f4b8a47e92aa744ec43acbb5e9185078983909";
+      url = "github:nlewo/nix2container/76be9608a7f4d6c985d28b0e7be903ae2547df3e";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -109,6 +109,7 @@
         commonArgsFor = p: let
           isLinuxBuild = p.stdenv.buildPlatform.isLinux;
           isLinuxTarget = p.stdenv.targetPlatform.isLinux;
+          isCrossCompile = p.stdenv.targetPlatform.system != pkgs.stdenv.targetPlatform.system;
           # Map the nix system to the Rust target triple that we'd want to target
           # by default.
           targetArch =
@@ -155,9 +156,12 @@
               ];
             CARGO_BUILD_TARGET = targetArch;
           }
+          // (pkgs.lib.optionalAttrs (isLinuxTarget && !isCrossCompile) {
+            # customClang is only defined for the host compiler, so doesn't work for cross-compiling
+            TARGET_CC = "${pkgs.lre.clang}/bin/customClang"; # So mimalloc gets the right compiler not defaulting to gcc
+          })
           // (pkgs.lib.optionalAttrs isLinuxTarget {
             CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-            TARGET_CC = "${pkgs.lre.clang}/bin/customClang"; # So mimalloc gets the right compiler not defaulting to gcc
             # FIXME(palfrey): Attempted workaround from https://github.com/llvm/llvm-project/issues/32849#issuecomment-2353071071 but doesn't work
             # CFLAGS = "-femit-all-decls";
             ${linkerEnvVar} = linkerPath;
@@ -204,26 +208,19 @@
         inherit (nix2container.packages.${system}.nix2container) pullImage;
         inherit (nix2container.packages.${system}.nix2container) buildImage;
 
-        # TODO(palfrey): Allow "crosscompiling" this image. At the moment
-        #                    this would set a wrong container architecture. See:
-        #                    https://github.com/nlewo/nix2container/issues/138.
-        nativelink-image = let
-          nativelinkForImage =
-            if pkgs.stdenv.isx86_64
-            then nativelink-x86_64-linux
-            else nativelink-aarch64-linux;
-        in
+        nativelinkImageFor = archPackages: arch:
           buildImage {
+            inherit arch;
             name = "nativelink";
             copyToRoot = [
               (pkgs.buildEnv {
                 name = "nativelink-buildEnv";
-                paths = [nativelinkForImage];
+                paths = [archPackages];
                 pathsToLink = ["/bin"];
               })
             ];
             config = {
-              Entrypoint = [(pkgs.lib.getExe' nativelinkForImage "nativelink")];
+              Entrypoint = [(pkgs.lib.getExe' archPackages "nativelink")];
               Labels = {
                 "org.opencontainers.image.description" = "An RBE compatible, high-performance cache and remote executor.";
                 "org.opencontainers.image.documentation" = "https://github.com/TraceMachina/nativelink";
@@ -235,6 +232,14 @@
               };
             };
           };
+
+        nativelink-image-for-x64 = nativelinkImageFor nativelink-x86_64-linux "amd64";
+        nativelink-image-for-aarch64 = nativelinkImageFor nativelink-aarch64-linux "arm64";
+
+        nativelink-image =
+          if pkgs.stdenv.isx86_64
+          then nativelink-image-for-x64
+          else nativelink-image-for-aarch64;
 
         nativelink-worker-init = pkgs.callPackage ./tools/nativelink-worker-init.nix {inherit buildImage self nativelink-image;};
 
@@ -387,13 +392,15 @@
               nativelinkCoverageForHost
               nativelink-aarch64-linux
               nativelink-image
+              nativelink-image-for-aarch64
+              nativelink-image-for-x64
               nativelink-is-executable-test
               nativelink-worker-init
               nativelink-x86_64-linux
               ;
 
             # Used by the CI
-            inherit (pkgs.nativelink-tools) local-image-test publish-ghcr;
+            inherit (pkgs.nativelink-tools) local-image-test publish-ghcr create-multi-arch-image regctl-ghcr-login;
 
             default = nativelink;
 
@@ -547,6 +554,7 @@
               pkgs.lre.lre-cc.lre-cc-configs-gen
               pkgs.nativelink-tools.local-image-test
               pkgs.nativelink-tools.create-local-image
+              pkgs.nativelink-tools.create-multi-arch-image
               pkgs.attic-client
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [

--- a/tools/public/create-multi-arch-image.nix
+++ b/tools/public/create-multi-arch-image.nix
@@ -1,0 +1,36 @@
+# FIXME: Really this should be using nix2container or skopeo, but they can't do that
+# See https://github.com/podman-container-tools/skopeo/issues/1136
+# * docker manifest create fails with permission errors (and no logging about _what_)
+# * Podman breaks in CI because fun with permissions
+# So we're down to regctl, but better options welcomed
+{
+  writeShellScriptBin,
+  regclient,
+}:
+writeShellScriptBin "create-multi-arch-image" ''
+  set -euo pipefail
+
+  REGISTRY=$1
+  shift
+  IMAGE_TARGET=$(echo $1 | tr '[:upper:]' '[:lower:]')
+  shift
+  FULL_IMAGE_TARGET=''${REGISTRY}/''${IMAGE_TARGET}
+  echo "Creating multi-arch image for ''${FULL_IMAGE_TARGET} from: $@"
+  set -x
+
+  if [ $REGISTRY == "localhost:5000" ]; then
+    ${regclient}/bin/regctl registry set --tls disabled localhost:5000
+  fi
+
+  IMAGES=
+
+  for image in "$@"
+  do
+    IMAGE_TAG=$(nix eval .#$image.imageTag --raw)
+    IMAGE_DIR=$(mktemp -d)
+    nix run .#$image.copyTo oci:''${IMAGE_DIR}:''${IMAGE_TAG}
+    IMAGES="$IMAGES --ref ocidir://''${IMAGE_DIR}:''${IMAGE_TAG}"
+  done
+
+  ${regclient}/bin/regctl -v info index create ''${FULL_IMAGE_TARGET} ''${IMAGES}
+''

--- a/tools/public/default.nix
+++ b/tools/public/default.nix
@@ -3,9 +3,17 @@
 
   # Note: Only put tools here that should be usable from external flakes.
   nativelink-tools = {
-    local-image-test = final.callPackage ./local-image-test.nix {};
+    local-image-test = final.callPackage ./local-image-test.nix {
+      skopeo = nix2container.packages.${final.stdenv.hostPlatform.system}.skopeo-nix2container;
+    };
     publish-ghcr = final.callPackage ./publish-ghcr.nix {};
     create-local-image = final.callPackage ./create-local-image.nix {};
+    create-multi-arch-image = final.callPackage ./create-multi-arch-image.nix {
+      regclient = final.callPackage ../regclient.nix {};
+    };
+    regctl-ghcr-login = final.callPackage ./regctl-ghcr-login.nix {
+      regclient = final.callPackage ../regclient.nix {};
+    };
 
     lib = {
       createWorker = self:

--- a/tools/public/local-image-test.nix
+++ b/tools/public/local-image-test.nix
@@ -2,33 +2,44 @@
   dive,
   trivy,
   writeShellScriptBin,
+  skopeo,
 }:
 writeShellScriptBin "local-image-test" ''
-  set -xeuo pipefail
+  set -euo pipefail
 
   echo "Testing image: $1"
+  set -x
 
-  # Commit hashes would not be a good choice here as they are not
-  # fully dependent on the inputs to the image. For instance, amending
-  # nothing would still lead to a new hash. Instead we use the
-  # derivation hash as the tag so that the tag is reused if the image
-  # didn't change.
-  IMAGE_TAG=$(nix eval .#$1.imageTag --raw)
-  IMAGE_NAME=$(nix eval .#$1.imageName --raw)
+  if [[ $1 == *:* ]]; then
+    # Nix targets generally don't have a :, so we assume this is an existing docker image name
+    IMAGE_TARGET=$1
+  else
+    # Commit hashes would not be a good choice here as they are not
+    # fully dependent on the inputs to the image. For instance, amending
+    # nothing would still lead to a new hash. Instead we use the
+    # derivation hash as the tag so that the tag is reused if the image
+    # didn't change.
+    IMAGE_TAG=$(nix eval .#$1.imageTag --raw)
+    IMAGE_NAME=$(nix eval .#$1.imageName --raw)
+    IMAGE=$(nix eval .#$1 --raw)
+    IMAGE_TARGET=''${IMAGE_NAME}:''${IMAGE_TAG}
 
-  nix run .#$1.copyTo \
-    docker-daemon:''${IMAGE_NAME}:''${IMAGE_TAG}
+    # Inlining from https://github.com/nlewo/nix2container/blob/76be9608a7f4d6c985d28b0e7be903ae2547df3e/default.nix#L88
+    # so we can run --debug on skopeo
+    # nix run .#$1.copyTo docker-daemon:''${IMAGE_TARGET}
+    nix build .#$1
+    ${skopeo}/bin/skopeo --debug --insecure-policy copy nix:''${IMAGE} docker-daemon:''${IMAGE_TARGET}
+  fi
 
   # Ensure that the image has minimal closure size.
   # TODO(palfrey): The default allows 10% inefficiency. Since we control all
   #                    our images fully we should enforce 0% inefficiency. At
   #                    the moment this breaks lre-cc.
-  CI=1 ${dive}/bin/dive \
-    ''${IMAGE_NAME}:''${IMAGE_TAG}
+  CI=1 ${dive}/bin/dive ''${IMAGE_TARGET}
 
   # TODO(palfrey): Keep monitoring this for better solutions to ratelimits:
   #                    https://github.com/aquasecurity/trivy-action/issues/389
   ${trivy}/bin/trivy image \
-    ''${IMAGE_NAME}:''${IMAGE_TAG} \
+    ''${IMAGE_TARGET} \
     --db-repository public.ecr.aws/aquasecurity/trivy-db:2
 ''

--- a/tools/public/regctl-ghcr-login.nix
+++ b/tools/public/regctl-ghcr-login.nix
@@ -1,0 +1,11 @@
+{
+  writeShellScriptBin,
+  regclient,
+}:
+writeShellScriptBin "regctl-ghcr-login" ''
+  set -xeuo pipefail
+  echo $GHCR_PASSWORD | ${regclient}/bin/regctl \
+    registry login ghcr.io \
+    --user=$GHCR_USERNAME \
+    --pass-stdin
+''

--- a/tools/regclient.nix
+++ b/tools/regclient.nix
@@ -1,0 +1,89 @@
+# FIXME: Based off of https://github.com/NixOS/nixpkgs/blob/nixos-26.05/pkgs/by-name/re/regclient/package.nix
+# plus https://github.com/regclient/regclient/pull/1106 for better "not found"
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  lndir,
+  testers,
+  regclient,
+}: let
+  bins = [
+    "regbot"
+    "regctl"
+    "regsync"
+  ];
+in
+  buildGoModule rec {
+    pname = "regclient";
+    version = "0.11.5";
+    tag = "v${version}";
+
+    src = fetchFromGitHub {
+      owner = "regclient";
+      repo = "regclient";
+      rev = "8a3d428f8503450580f60e71f08ac4cecfdcc01d";
+      sha256 = "sha256-Ho5XKxK+xEhnUryZY0KGcu19fH26nPn6DqsDsoW30p4=";
+    };
+    vendorHash = "sha256-5SI1c0yszMTiC20bBXKIrtHVuDWA9BaSC5RY0F8B1Us=";
+
+    outputs = ["out"] ++ bins;
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X github.com/regclient/regclient/internal/version.vcsTag=${tag}"
+    ];
+
+    nativeBuildInputs = [
+      installShellFiles
+      lndir
+    ];
+
+    postInstall =
+      lib.concatMapStringsSep "\n" (bin: ''
+        export bin=''$${bin}
+        export outputBin=bin
+
+        mkdir -p $bin/bin
+        mv $out/bin/${bin} $bin/bin
+
+        installShellCompletion --cmd ${bin} \
+          --bash <($bin/bin/${bin} completion bash) \
+          --fish <($bin/bin/${bin} completion fish) \
+          --zsh <($bin/bin/${bin} completion zsh)
+
+        lndir -silent $bin $out
+
+        unset bin outputBin
+      '')
+      bins;
+
+    doCheck = false;
+
+    checkFlags = [
+      # touches network
+      "-skip=^ExampleNew$"
+    ];
+
+    passthru.tests = lib.mergeAttrsList (
+      map (bin: {
+        "${bin}Version" = testers.testVersion {
+          package = regclient;
+          command = "${bin} version";
+          version = tag;
+        };
+      })
+      bins
+    );
+
+    __darwinAllowLocalNetworking = true;
+
+    meta = {
+      description = "Docker and OCI Registry Client in Go and tooling using those libraries";
+      homepage = "https://github.com/regclient/regclient";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [maxbrunet];
+    };
+  }


### PR DESCRIPTION
# Description

Fixes #2401. Makes our image publishing multiarch (x86_64 + aarch64).

This does two things:
* Unbreaks ARM image building which I think I broke fixing `mimalloc` on Macs at some point
* Makes it possible to build/push multi-arch Nativelink images.

Note this still leaves the other remaining image types (nativelink-worker-init, nativelink-worker-lre-cc, nativelink-worker-lre-rs) in x86-only setup, but this is a good step forwards. I think lre-cc/lre-rs mostly need Mac-specific ones, but worker-init should be made multi-arch in a future PR.

Annoyingly, it's not able to do things in a pure-Nix way, so we end up currently with a non-nix2container setup where we need to specify the set of images to bolt together, but it does at least work which is good enough for now. As a side-effect of that, I've added in date-based image naming as that makes it a lot easier to go "how old is this random Nativelink tag".

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`nix run .#create-multi-arch-image nativelinkImageForX64 nativelinkImageForAarch64`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2454)
<!-- Reviewable:end -->
