### PR TITLE
Add multi-arch images for worker-init

### DIFF
--- a/.github/images-matrix.json
+++ b/.github/images-matrix.json
@@ -6,8 +6,9 @@
       "multi-arch": true
     },
     {
+      "components": "nativelink-init-for-x64 nativelink-init-for-aarch64",
       "image": "nativelink-worker-init",
-      "multi-arch": false
+      "multi-arch": true
     },
     {
       "image": "nativelink-worker-lre-cc",

--- a/flake.nix
+++ b/flake.nix
@@ -241,7 +241,19 @@
           then nativelink-image-for-x64
           else nativelink-image-for-aarch64;
 
-        nativelink-worker-init = pkgs.callPackage ./tools/nativelink-worker-init.nix {inherit buildImage self nativelink-image;};
+        nativelinkWorkerInitFor = archImage: archPackages: arch:
+          pkgs.callPackage ./tools/nativelink-worker-init.nix {
+            inherit buildImage self arch archPackages;
+            nativelink-image = archImage;
+          };
+
+        nativelink-init-for-x64 = nativelinkWorkerInitFor nativelink-image-for-x64 pkgs.pkgsCross.musl64 "amd64";
+        nativelink-init-for-aarch64 = nativelinkWorkerInitFor nativelink-image-for-aarch64 pkgs.pkgsCross.aarch64-multiplatform-musl "arm64";
+
+        nativelink-worker-init =
+          if pkgs.stdenv.isx86_64
+          then nativelink-init-for-x64
+          else nativelink-init-for-aarch64;
 
         createWorker = pkgs.nativelink-tools.lib.createWorker self;
 
@@ -396,6 +408,8 @@
               nativelink-image-for-x64
               nativelink-is-executable-test
               nativelink-worker-init
+              nativelink-init-for-x64
+              nativelink-init-for-aarch64
               nativelink-x86_64-linux
               ;
 

--- a/tools/nativelink-worker-init.nix
+++ b/tools/nativelink-worker-init.nix
@@ -2,8 +2,9 @@
   buildImage,
   self,
   lib,
-  pkgsMusl,
+  archPackages,
   nativelink-image,
+  arch,
 }:
 # This image copies a bundled `nativelink` executable to a specified location.
 #
@@ -15,7 +16,7 @@
 # Deployment. Then mount that volume into the toolchain container and set the
 # Deployment's entrypoint to the mounted `nativelink` executable.
 let
-  copyToDestination = pkgsMusl.writeShellScriptBin "copyToDestination" ''
+  copyToDestination = archPackages.writeShellScriptBin "copyToDestination" ''
     cp -Lv /bin/nativelink "$@"
   '';
 in
@@ -26,7 +27,8 @@ in
     # manage multiple tags.
     fromImage = nativelink-image;
     tag = nativelink-image.imageTag;
-    copyToRoot = [pkgsMusl.coreutils];
+    copyToRoot = [archPackages.coreutils];
+    inherit arch;
     config = {
       Entrypoint = [(lib.getExe' copyToDestination "copyToDestination")];
       Labels = {


### PR DESCRIPTION
# Description

Continues the work from https://github.com/TraceMachina/nativelink/pull/2454, but this time for worker-init as well.

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2459)
<!-- Reviewable:end -->
