### PR TITLE
memory_store: skip writes larger than max_bytes instead of buffering them

### DIFF
--- a/nativelink-store/src/memory_store.rs
+++ b/nativelink-store/src/memory_store.rs
@@ -68,6 +68,11 @@ pub struct MemoryStore {
         SystemTime,
         RemoveItemCallbackHolder,
     >,
+    /// The eviction policy's `max_bytes` (0 = unbounded). Cached here so `update`
+    /// can skip writes larger than the entire store budget without buffering
+    /// them — see the note in `update`.
+    #[metric(help = "Maximum bytes this store will hold before eviction (0 = unbounded)")]
+    max_bytes: u64,
 }
 
 impl MemoryStore {
@@ -75,6 +80,7 @@ impl MemoryStore {
         let empty_policy = nativelink_config::stores::EvictionPolicy::default();
         let eviction_policy = spec.eviction_policy.as_ref().unwrap_or(&empty_policy);
         Arc::new(Self {
+            max_bytes: eviction_policy.max_bytes as u64,
             evicting_map: EvictingMap::new(eviction_policy, SystemTime::now()),
         })
     }
@@ -138,8 +144,27 @@ impl StoreDriver for MemoryStore {
         self: Pin<&Self>,
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
-        _size_info: UploadSizeInfo,
+        size_info: UploadSizeInfo,
     ) -> Result<u64, Error> {
+        // A write whose exact size exceeds this store's `max_bytes` can never be
+        // usefully cached: the moment it's inserted, eviction would drop it (and
+        // everything else) since one entry alone is over the budget. Buffering it
+        // into memory first is therefore pure waste — and under concurrent large
+        // writes (e.g. a `memory` fast tier inside a `fast_slow` store fronting
+        // CAS) it is a real OOM vector, because each in-flight write materializes
+        // its whole payload before the eviction ever runs. Drain the stream and
+        // skip instead. Only `ExactSize` is trusted here; a `MaxSize` upper bound
+        // could over-estimate and wrongly skip a blob that would actually fit.
+        if self.max_bytes != 0
+            && let UploadSizeInfo::ExactSize(sz) = size_info
+            && sz > self.max_bytes
+        {
+            let drained = reader
+                .drain()
+                .await
+                .err_tip(|| "Failed to drain oversized write in memory_store::update")?;
+            return Ok(drained);
+        }
         // Internally Bytes might hold a reference to more data than just our data. To prevent
         // this potential case, we make a full copy of our data for long-term storage.
         let final_buffer = {

--- a/nativelink-store/tests/memory_store_test.rs
+++ b/nativelink-store/tests/memory_store_test.rs
@@ -82,6 +82,56 @@ async fn insert_one_item_then_update() -> Result<(), Error> {
     Ok(())
 }
 
+// A write whose exact size exceeds the store's `max_bytes` is skipped (drained,
+// never buffered) rather than materialized-then-evicted. It could never be
+// retained anyway, and buffering it is an OOM vector under concurrent large
+// writes (e.g. a `memory` fast tier in a `fast_slow` store fronting CAS).
+#[nativelink_test]
+async fn skips_writes_larger_than_max_bytes() -> Result<(), Error> {
+    const SMALL: &str = "ab";
+    const BIG: &str = "0123456789"; // 10 bytes > 4 max_bytes
+
+    let spec = MemorySpec {
+        eviction_policy: Some(nativelink_config::stores::EvictionPolicy {
+            max_bytes: 4,
+            ..Default::default()
+        }),
+    };
+    let store = MemoryStore::new(&spec);
+
+    // A write within budget is retained as normal.
+    store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, SMALL.len() as u64)?,
+            SMALL.into(),
+        )
+        .await?;
+    assert_eq!(
+        store
+            .has(DigestInfo::try_new(VALID_HASH1, SMALL.len() as u64)?)
+            .await,
+        Ok(Some(SMALL.len() as u64)),
+        "within-budget write should be stored",
+    );
+
+    // A write larger than max_bytes succeeds but is NOT cached.
+    store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH2, BIG.len() as u64)?,
+            BIG.into(),
+        )
+        .await?;
+    assert_eq!(
+        store
+            .has(DigestInfo::try_new(VALID_HASH2, BIG.len() as u64)?)
+            .await,
+        Ok(None),
+        "oversized write should be skipped, not stored",
+    );
+
+    Ok(())
+}
+
 // Regression test for: https://github.com/TraceMachina/nativelink/issues/289.
 #[nativelink_test]
 async fn ensure_full_copy_of_bytes_is_made_test() -> Result<(), Error> {


### PR DESCRIPTION
# Description

`MemoryStore::update` reads the **entire** payload into memory (`reader.consume(None)`, plus a defensive full copy) before inserting into the evicting map and running eviction.

For a write whose size already exceeds the store's `max_bytes`, that buffering is wasted: `EvictingMap::evict_items` pops LRU entries `while sum_store_size >= max_bytes` with no "keep the newest" guard, so an entry that alone exceeds the budget is evicted the instant it's inserted. The blob was never retainable — yet we materialized its whole payload (and a second copy) in RAM to get there.

Under **concurrent large writes that's an OOM vector.** A `memory` fast tier inside a `fast_slow` store fronting CAS receives every blob regardless of size (`fast_slow` fans writes to both tiers), so a burst of oversized ByteStream uploads each materializes its full payload before eviction runs — enough parallel uploads can blow the pod's memory limit even though the steady-state cache is tiny. (Surfaced from a production CAS pod getting `OOMKilled` during a build's upload burst.)

**Fix:** when the eviction policy caps size (`max_bytes != 0`) and the write's `ExactSize` exceeds it, drain the stream and return without buffering:

```rust
if self.max_bytes != 0
    && let UploadSizeInfo::ExactSize(sz) = size_info
    && sz > self.max_bytes
{
    let drained = reader.drain().await.err_tip(|| /* ... */)?;
    return Ok(drained);
}
```

This has **no observable behavior change** — an over-budget blob is not retained either way (today it's inserted then immediately evicted, so `has`/`get` already return not-found); the change just skips the pointless materialization in between. Only `ExactSize` is trusted (a `MaxSize` upper bound could over-estimate and wrongly skip a blob that fits), and it's guarded on `max_bytes != 0` so count/time-only and unbounded stores are untouched.

**Scope:** this targets the single-write-exceeds-budget case. It does **not** address many *concurrent sub-budget* writes collectively exhausting memory — that needs a global in-flight-bytes / write-concurrency budget in the memory (or `fast_slow`) store, which is out of scope here.

Fixes # _(no tracked issue — surfaced from a production CAS OOM incident; see above)_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `nativelink-store/tests/memory_store_test.rs::skips_writes_larger_than_max_bytes`: with a small `max_bytes`, a within-budget write is stored (`has()` returns its size), and a write larger than `max_bytes` succeeds but is not cached (`has()` returns `None`). Existing `memory_store_test` cases continue to cover within-budget reads/writes and the full-copy guarantee.

## Checklist

- [x] Updated documentation if needed (none required — internal store behavior)
- [x] Tests added/amended
- [ ] `bazel test //...` passes locally — please run before merge (not run in this environment)
- [x] PR is contained in a single commit, using `git amend`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2467)
<!-- Reviewable:end -->
