### PR TITLE
Disable various things we don't want renovate to upgrade

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,14 @@
       enabled: false,
     },
     {
+      matchDepNames: [
+        "grafana/grafana", // In deployment-examples/metrics/docker-compose.yaml which we don't test in CI
+        "azure_core", // Need to upgrade the other azure packages, which is a non-trivial upgrade
+        "ubuntu", // Ubuntu tags need hand-upgrading because of various package version changes
+      ],
+      enabled: false,
+    },
+    {
       matchPackageNames: [
         "*",
       ],


### PR DESCRIPTION
# Description

Disables a few things we don't want Renovate to upgrade:

* Grafana (e.g. https://github.com/TraceMachina/nativelink/pull/2468) because we don't test the relevant file in CI
* `azure_core` (e.g. https://github.com/TraceMachina/nativelink/pull/2465) because we need to upgrade `azure_storage` as well, and that's a non-trivial upgrade because they've changed a lot of thing
* `ubuntu` because we hardcode various bits of versions Renovate doesn't cope with. This is already disabled in Renovate, but just as a double-check I've added it here.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2469)
<!-- Reviewable:end -->
