### PR TITLE
ci(release): keep legacy cosign signature/cert outputs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,7 +140,12 @@ jobs:
           set -euo pipefail
           ASSET="${{ steps.package.outputs.asset }}"
           for f in "${ASSET}.tar.gz" "${ASSET}.spdx.json"; do
+            # Newer cosign defaults --new-bundle-format on, which ignores the
+            # --output-signature/--output-certificate flags and writes a single
+            # bundle instead. Keep the legacy split .sig/.pem outputs the
+            # release assets and verifiers expect.
             cosign sign-blob --yes \
+              --new-bundle-format=false \
               --output-signature "${f}.sig" \
               --output-certificate "${f}.pem" \
               "${f}"


### PR DESCRIPTION
## Problem

The release signing step fails on every release now:

```
Error: signing nativelink-1.5.2-...tar.gz: create bundle file: open : no such file or directory
```
Added Pass `--new-bundle-format=false` as a fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2478)
<!-- Reviewable:end -->
