### PR TITLE
ci(release): pin cosign to v2.5.3 for legacy .sig/.pem output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,11 @@ jobs:
       - name: Install Cosign
         uses: >- # v4.1.2
           sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          # Pin cosign: v3.x forces the new bundle format and drops the legacy
+          # split signature/certificate output the release assets and verifiers
+          # depend on. v2.5.3 still emits .sig/.pem files.
+          cosign-release: v2.5.3
 
       - name: Build static binary
         run: |
@@ -140,10 +145,9 @@ jobs:
           set -euo pipefail
           ASSET="${{ steps.package.outputs.asset }}"
           for f in "${ASSET}.tar.gz" "${ASSET}.spdx.json"; do
-            # Newer cosign defaults --new-bundle-format on, which ignores the
-            # --output-signature/--output-certificate flags and writes a single
-            # bundle instead. Keep the legacy split .sig/.pem outputs the
-            # release assets and verifiers expect.
+            # Cosign is pinned to v2.5.3 (see the install step) so these flags
+            # produce the split .sig/.pem files the release assets and verifiers
+            # expect; --new-bundle-format=false keeps that explicit.
             cosign sign-blob --yes \
               --new-bundle-format=false \
               --output-signature "${f}.sig" \


### PR DESCRIPTION
## Problem

Release signing is still failing — now with:

```
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

Pin `cosign-release: v2.5.3` — the newest cosign that still emits the split `*.sig` + `*.pem` files. Nothing else in the workflow changes: the `gh release upload` list and the documented `*.sig` verification contract stay intact. The `sign-blob` flags (including `--new-bundle-format=false`) work as-is on v2.5.x.



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2480)
<!-- Reviewable:end -->
