### PR TITLE
Improve logging for detect_duplicate_upload and fake redis sync

### DIFF
--- a/nativelink-redis-tester/src/dynamic_fake_redis.rs
+++ b/nativelink-redis-tester/src/dynamic_fake_redis.rs
@@ -22,6 +22,7 @@ use redis::Value;
 use redis_protocol::resp2::decode::decode;
 use redis_protocol::resp2::types::{OwnedFrame, Resp2Frame};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot::{self, Sender};
 use tracing::{debug, info, trace};
 
 use crate::fake_redis::{arg_as_string, fake_redis_internal};
@@ -70,7 +71,7 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
             .replace(subscription_manager);
     }
 
-    async fn dynamic_fake_redis(self, listener: TcpListener) {
+    async fn dynamic_fake_redis(self, listener: TcpListener, listener_ready_tx: Sender<()>) {
         let inner = move |buf: &[u8]| -> String {
             let mut output = String::new();
             let mut buf_index = 0;
@@ -399,7 +400,7 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
             }
             output
         };
-        fake_redis_internal(listener, vec![inner]).await;
+        fake_redis_internal(listener, listener_ready_tx, vec![inner]).await;
     }
 
     pub async fn run(self) -> u16 {
@@ -407,9 +408,15 @@ impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
         let port = listener.local_addr().unwrap().port();
         info!("Using port {port}");
 
+        let (listener_ready_tx, listener_ready_rx) = oneshot::channel::<()>();
+
         background_spawn!("listener", async move {
-            self.dynamic_fake_redis(listener).await;
+            self.dynamic_fake_redis(listener, listener_ready_tx).await;
         });
+
+        listener_ready_rx
+            .await
+            .expect("Expected successful listener boot");
 
         port
     }

--- a/nativelink-redis-tester/src/fake_redis.rs
+++ b/nativelink-redis-tester/src/fake_redis.rs
@@ -21,6 +21,7 @@ use redis::Value;
 use redis_test::IntoRedisValue;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot::{self, Sender};
 use tracing::{error, info, warn};
 
 fn cmd_as_string(cmd: &redis::Cmd) -> String {
@@ -198,16 +199,22 @@ pub fn fake_redis_sentinel_stream(master_name: &str, redis_port: u16) -> HashMap
     response
 }
 
-pub(crate) async fn fake_redis_internal<H>(listener: TcpListener, handlers: Vec<H>)
-where
+pub(crate) async fn fake_redis_internal<H>(
+    listener: TcpListener,
+    listener_ready_tx: Sender<()>,
+    handlers: Vec<H>,
+) where
     H: Fn(&[u8]) -> String + Send + Clone + 'static + Sync,
 {
     let mut handler_iter = handlers.iter().cloned().cycle();
+    info!(
+        "Waiting for connection on {}",
+        listener.local_addr().unwrap()
+    );
+    listener_ready_tx
+        .send(())
+        .expect("Expected successful send");
     loop {
-        info!(
-            "Waiting for connection on {}",
-            listener.local_addr().unwrap()
-        );
         let Ok((mut stream, _)) = listener.accept().await else {
             error!("accept error");
             panic!("error");
@@ -229,8 +236,11 @@ where
     }
 }
 
-async fn fake_redis<B>(listener: TcpListener, all_responses: Vec<HashMap<String, String, B>>)
-where
+async fn fake_redis<B>(
+    listener: TcpListener,
+    listener_ready_tx: Sender<()>,
+    all_responses: Vec<HashMap<String, String, B>>,
+) where
     B: BuildHasher + Clone + Send + 'static + Sync,
 {
     let funcs = all_responses
@@ -254,7 +264,7 @@ where
             }
         })
         .collect();
-    fake_redis_internal(listener, funcs).await;
+    fake_redis_internal(listener, listener_ready_tx, funcs).await;
 }
 
 async fn make_fake_redis_with_multiple_responses<B: BuildHasher + Clone + Send + 'static + Sync>(
@@ -262,11 +272,17 @@ async fn make_fake_redis_with_multiple_responses<B: BuildHasher + Clone + Send +
 ) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
-    info!(port, "Fake redis booted");
+
+    let (listener_ready_tx, listener_ready_rx) = oneshot::channel::<()>();
 
     background_spawn!("listener", async move {
-        fake_redis(listener, responses).await;
+        fake_redis(listener, listener_ready_tx, responses).await;
     });
+
+    listener_ready_rx
+        .await
+        .expect("Expected successful listener boot");
+    info!(port, "Fake redis booted");
 
     port
 }

--- a/nativelink-redis-tester/src/read_only_redis.rs
+++ b/nativelink-redis-tester/src/read_only_redis.rs
@@ -22,6 +22,7 @@ use redis::Value;
 use redis_protocol::resp2::decode::decode;
 use redis_protocol::resp2::types::OwnedFrame;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot::{self, Sender};
 use tracing::info;
 
 use crate::fake_redis::{arg_as_string, fake_redis_internal};
@@ -47,7 +48,7 @@ impl ReadOnlyRedis {
         }
     }
 
-    async fn dynamic_fake_redis(self, listener: TcpListener) {
+    async fn dynamic_fake_redis(self, listener: TcpListener, listener_ready_tx: Sender<()>) {
         let readonly_err_str = "READONLY You can't write against a read only replica.";
         let readonly_err = format!("!{}\r\n{readonly_err_str}\r\n", readonly_err_str.len());
 
@@ -149,7 +150,7 @@ impl ReadOnlyRedis {
             }
             output
         };
-        fake_redis_internal(listener, vec![inner]).await;
+        fake_redis_internal(listener, listener_ready_tx, vec![inner]).await;
     }
 
     pub async fn run(self) -> u16 {
@@ -157,9 +158,15 @@ impl ReadOnlyRedis {
         let port = listener.local_addr().unwrap().port();
         info!("Using port {port}");
 
+        let (listener_ready_tx, listener_ready_rx) = oneshot::channel::<()>();
+
         background_spawn!("listener", async move {
-            self.dynamic_fake_redis(listener).await;
+            self.dynamic_fake_redis(listener, listener_ready_tx).await;
         });
+
+        listener_ready_rx
+            .await
+            .expect("Expected successful listener boot");
 
         port
     }

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1224,6 +1224,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
                     .await;
                 return Err(err);
             }
+            trace!(?key, "Finished emplace file");
             encoded_file_path.path_type = PathType::Content;
             encoded_file_path.key = key;
             Ok(())

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -51,7 +51,7 @@ use tokio::sync::{Barrier, Semaphore};
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReadDirStream;
-use tracing::{Instrument, debug};
+use tracing::{Instrument, debug, info};
 
 const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 
@@ -1765,7 +1765,8 @@ async fn detect_duplicate_upload() -> Result<(), Error> {
 
     let key = &StoreKey::Digest(digest);
     let temp_key = make_temp_key(key);
-    let (mut entry, mut temp_file, _temp_full_path) = store.make_temp_file(temp_key).await?;
+    let (mut entry, mut temp_file, temp_full_path) = store.make_temp_file(temp_key).await?;
+    info!(?temp_full_path, "Temp full path");
     let mut data = Bytes::from_static(VALUE1.as_bytes());
     temp_file.write_all_buf(&mut data).await?;
     *entry.data_size_mut() = 10;

--- a/nativelink-util/src/fs.rs
+++ b/nativelink-util/src/fs.rs
@@ -440,7 +440,7 @@ fn internal_remove_dir_all(path: impl AsRef<Path>) -> Result<(), Error> {
 
     for entry in WalkDir::new(&path) {
         let Ok(entry) = &entry else {
-            debug!("Can't get into {entry:?}, assuming already deleted");
+            debug!(?entry, "Can't get entry, assuming already deleted");
             continue;
         };
         let metadata = entry.metadata()?;


### PR DESCRIPTION
# Description

We've seen intermittent failures for `detect_duplicate_upload` (e.g. https://github.com/TraceMachina/nativelink/actions/runs/28111690083/job/83240488496) but it's not clear why it sometimes fails. This PR adds a bit more logging there to aid debug.

While testing this, we also hit an intermittent issue with the fake redis being talked to before it was booted (https://github.com/TraceMachina/nativelink/actions/runs/28167182697/job/83421971908?pr=2481) so I've also added in some sync on that booting as well.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2481)
<!-- Reviewable:end -->
