### PR TITLE
Add trace logging for bytestream read

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -1363,13 +1363,19 @@ impl ByteStream for ByteStreamServer {
         let start_time = Instant::now();
 
         let read_request = grpc_request.into_inner();
-        let resource_info = ResourceInfo::new(&read_request.resource_name, false)?;
+        let resource_name = read_request.resource_name.clone();
+        let resource_info = ResourceInfo::new(&resource_name, false)?;
         let instance_name = resource_info.instance_name.as_ref();
         let expected_size = resource_info.expected_size as u64;
         let instance = self
             .instance_infos
             .get(instance_name)
             .err_tip(|| format!("'instance_name' not configured for '{instance_name}'"))?;
+
+        trace!(
+            resource_name,
+            instance_name, expected_size, "Starting bytestream request"
+        );
 
         // Track read request
         instance
@@ -1423,12 +1429,18 @@ impl ByteStream for ByteStreamServer {
         };
 
         // Track metrics based on result
+        let elapsed = start_time.elapsed();
         #[allow(clippy::cast_possible_truncation)]
-        let elapsed_ns = start_time.elapsed().as_nanos() as u64;
+        let elapsed_ns = elapsed.as_nanos() as u64;
         instance
             .metrics
             .read_duration_ns
             .fetch_add(elapsed_ns, Ordering::Relaxed);
+
+        trace!(
+            ?elapsed,
+            resource_name, instance_name, expected_size, "Completed bytestream request"
+        );
 
         match &resp {
             Ok(_) => {

--- a/nativelink-service/tests/bytestream_server_test.rs
+++ b/nativelink-service/tests/bytestream_server_test.rs
@@ -1243,6 +1243,21 @@ pub async fn chunked_stream_reads_small_set_of_data() -> Result<(), Box<dyn core
             "Expected response to match what is in store"
         );
     }
+
+    assert!(logs_contain(
+        "Starting bytestream request resource_name=\"foo_instance_name/blobs/0123456789abcdef000000000000000000000000000000000123456789abcdef/19\" instance_name=\"foo_instance_name\" expected_size=19"
+    ));
+
+    logs_assert(|lines| {
+        for line in lines {
+            // elapsed value varies due to timing, so can't exact match
+            if line.contains("Completed bytestream request elapsed=") && line.contains("resource_name=\"foo_instance_name/blobs/0123456789abcdef000000000000000000000000000000000123456789abcdef/19\" instance_name=\"foo_instance_name\" expected_size=19") {
+                return Ok(());
+            }
+        }
+        Err("No completion log!".into())
+    });
+
     Ok(())
 }
 


### PR DESCRIPTION
# Description

Adds trace logging to bytestream server to allow tracking down various cases of stalling

## Type of change

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2482)
<!-- Reviewable:end -->
