### PR TITLE
ci(release): build aarch64 Linux binary on a native arm64 runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,11 +72,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-26
             attr: nativelink-aarch64-darwin
-          # macos-26-intel is the x86_64 macOS runner; drop this entry if Intel
-          # macOS runners are retired and x86_64 macOS binaries aren't required.
-          - target: x86_64-apple-darwin
-            os: macos-26-intel
-            attr: nativelink-x86_64-darwin
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,10 @@ jobs:
             os: ubuntu-24.04
             attr: nativelink-x86_64-linux
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-24.04
+            # Build natively on ARM64 so older tags build too: the aarch64
+            # cross-compile fix (#2454) isn't in releases like v1.5.2, where
+            # cross-compiling fails on gnu/stubs-32.h.
+            os: ubuntu-24.04-arm
             attr: nativelink-aarch64-linux
           - target: aarch64-apple-darwin
             os: macos-26


### PR DESCRIPTION
The release build fails on the `aarch64-unknown-linux-musl` target, so running it on `ubuntu-24.04-arm` now. Removes the macos target as well. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2483)
<!-- Reviewable:end -->
