### PR TITLE
pricing: make the feature-comparison table scroll on mobile

### DIFF
--- a/web/apps/web/app/pricing/page.tsx
+++ b/web/apps/web/app/pricing/page.tsx
@@ -234,8 +234,11 @@ export default function PricingPage() {
         </Reveal>
 
         <Reveal>
-          <div className="mx-auto max-w-[980px] overflow-hidden rounded-2xl border border-border bg-surface">
-            <table className="w-full border-collapse text-left">
+          <div className="mx-auto max-w-[980px] overflow-x-auto rounded-2xl border border-border bg-surface">
+            {/* overflow-x-auto + min-w let the 4-column table scroll on mobile
+                instead of squishing; on desktop it fits the wrapper, so nothing
+                scrolls and the layout is unchanged. */}
+            <table className="w-full min-w-[680px] border-collapse text-left">
               <thead>
                 <tr>
                   <th className="w-[40%] bg-surface-elevated px-6 py-4 font-mono text-[10px] uppercase tracking-widest text-muted">


### PR DESCRIPTION
### Problem
The **Feature-for-feature comparison** table on `/pricing` is malformed on mobile. It's a 4-column `<table className="w-full …">` inside an `overflow-hidden` wrapper, so on narrow viewports the columns squish and the cells overflow/wrap awkwardly.

### Fix
Make the table **scroll horizontally on mobile** instead of squishing — the standard responsive-table pattern:
- wrapper `overflow-hidden` → `overflow-x-auto`
- table gets `min-w-[680px]`

On narrow screens the table keeps a readable width and the wrapper scrolls; on desktop the table fits within the existing `max-w-[980px]` wrapper, so **nothing scrolls and the layout is byte-for-byte unchanged**. Two-class change, no structural/markup churn.

### Notes
- Desktop rendering is intentionally identical (verified: `980px` wrapper > `680px` min-width, so no overflow on wide viewports; `overflow-x-auto` still clips the rounded corners).
- Worth a quick visual check at a phone width (~375px) to confirm the scroll feel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2490)
<!-- Reviewable:end -->
