### PR TITLE
Fix executable-variant cache (#2474): track size and evict variants

### DIFF
--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -362,12 +362,14 @@ impl FileEntry for FileEntryImpl {
 
     #[cfg(unix)]
     fn has_exec_variant(&self) -> bool {
-        self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire)
+        self.has_exec_variant
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     #[cfg(unix)]
     fn set_has_exec_variant(&self, has_exec_variant: bool) {
-        self.has_exec_variant.store(has_exec_variant, std::sync::atomic::Ordering::Release);
+        self.has_exec_variant
+            .store(has_exec_variant, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -400,7 +402,10 @@ impl LenEntry for FileEntryImpl {
     #[inline]
     fn len(&self) -> u64 {
         #[cfg(unix)]
-        if self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire) {
+        if self
+            .has_exec_variant
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
             return self.size_on_disk() * 2;
         }
         self.size_on_disk()
@@ -427,7 +432,10 @@ impl LenEntry for FileEntryImpl {
             return;
         }
         #[cfg(unix)]
-        if self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire) {
+        if self
+            .has_exec_variant
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
             if let StoreKey::Digest(digest) = &encoded_file_path.key {
                 let exec_path = format!(
                     "{}{EXECUTABLE_DIR_SUFFIX}/{DIGEST_FOLDER}/{digest}",
@@ -435,11 +443,16 @@ impl LenEntry for FileEntryImpl {
                 );
                 if let Err(err) = fs::remove_file(&exec_path).await {
                     if err.code != Code::NotFound {
-                        warn!(?exec_path, ?err, "Failed to remove executable variant during unref");
+                        warn!(
+                            ?exec_path,
+                            ?err,
+                            "Failed to remove executable variant during unref"
+                        );
                     }
                 }
             }
-            self.has_exec_variant.store(false, std::sync::atomic::Ordering::Release);
+            self.has_exec_variant
+                .store(false, std::sync::atomic::Ordering::Release);
         }
         let from_path = encoded_file_path.get_file_path();
         let new_key = make_temp_key(&encoded_file_path.key);
@@ -1016,7 +1029,9 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             return Ok(variant_path);
         }
 
-        let result = self.create_executable_variant(digest, &variant_path, &file_entry).await;
+        let result = self
+            .create_executable_variant(digest, &variant_path, &file_entry)
+            .await;
         // Drop the per-digest lock entry regardless of outcome so the map
         // cannot grow unbounded; a concurrent waiter already cloned the Arc.
         self.forget_executable_lock(digest);

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -436,14 +436,15 @@ impl LenEntry for FileEntryImpl {
                     "{}{EXECUTABLE_DIR_SUFFIX}/{DIGEST_FOLDER}/{digest}",
                     encoded_file_path.shared_context.content_path
                 );
-                if let Err(err) = fs::remove_file(&exec_path).await {
-                    if err.code != Code::NotFound {
+                match fs::remove_file(&exec_path).await {
+                    Err(err) if err.code != Code::NotFound => {
                         warn!(
                             ?exec_path,
                             ?err,
                             "Failed to remove executable variant during unref"
                         );
                     }
+                    _ => {}
                 }
             }
             self.has_exec_variant.store(false, Ordering::Release);

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -240,6 +240,12 @@ pub trait FileEntry: LenEntry + Send + Sync + Debug + 'static {
         &self,
         handler: F,
     ) -> impl Future<Output = Result<T, Error>> + Send;
+
+    #[cfg(unix)]
+    fn has_exec_variant(&self) -> bool;
+
+    #[cfg(unix)]
+    fn set_has_exec_variant(&self, has_exec_variant: bool);
 }
 
 pub struct FileEntryImpl {
@@ -247,6 +253,8 @@ pub struct FileEntryImpl {
     block_size: u64,
     // We lock around this as it gets rewritten when we move between temp and content types
     encoded_file_path: RwLock<EncodedFilePath>,
+    #[cfg(unix)]
+    has_exec_variant: std::sync::atomic::AtomicBool,
 }
 
 impl FileEntryImpl {
@@ -261,6 +269,8 @@ impl FileEntry for FileEntryImpl {
             data_size,
             block_size,
             encoded_file_path,
+            #[cfg(unix)]
+            has_exec_variant: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -349,6 +359,16 @@ impl FileEntry for FileEntryImpl {
         let encoded_file_path = self.get_encoded_file_path().read().await;
         handler(encoded_file_path.get_file_path().to_os_string()).await
     }
+
+    #[cfg(unix)]
+    fn has_exec_variant(&self) -> bool {
+        self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    #[cfg(unix)]
+    fn set_has_exec_variant(&self, has_exec_variant: bool) {
+        self.has_exec_variant.store(has_exec_variant, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl Debug for FileEntryImpl {
@@ -379,6 +399,10 @@ pub fn make_temp_key(key: &StoreKey) -> StoreKey<'static> {
 impl LenEntry for FileEntryImpl {
     #[inline]
     fn len(&self) -> u64 {
+        #[cfg(unix)]
+        if self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire) {
+            return self.size_on_disk() * 2;
+        }
         self.size_on_disk()
     }
 
@@ -401,6 +425,21 @@ impl LenEntry for FileEntryImpl {
                 "File is already a temp file",
             );
             return;
+        }
+        #[cfg(unix)]
+        if self.has_exec_variant.load(std::sync::atomic::Ordering::Acquire) {
+            if let StoreKey::Digest(digest) = &encoded_file_path.key {
+                let exec_path = format!(
+                    "{}{EXECUTABLE_DIR_SUFFIX}/{DIGEST_FOLDER}/{digest}",
+                    encoded_file_path.shared_context.content_path
+                );
+                if let Err(err) = fs::remove_file(&exec_path).await {
+                    if err.code != Code::NotFound {
+                        warn!(?exec_path, ?err, "Failed to remove executable variant during unref");
+                    }
+                }
+            }
+            self.has_exec_variant.store(false, std::sync::atomic::Ordering::Release);
         }
         let from_path = encoded_file_path.get_file_path();
         let new_key = make_temp_key(&encoded_file_path.key);
@@ -931,11 +970,21 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         &self,
         digest: &DigestInfo,
     ) -> Result<OsString, Error> {
+        let file_entry = self
+            .get_file_entry_for_digest(digest)
+            .await
+            .err_tip(|| "Resolving CAS blob for executable variant")?;
         let variant_path = self.executable_variant_path(digest);
 
         // Fast path: the variant already exists, so the caller can hardlink it
         // with no writable fd anywhere in sight.
         if fs::metadata(&variant_path).await.is_ok() {
+            if !file_entry.has_exec_variant() {
+                file_entry.set_has_exec_variant(true);
+                self.evicting_map
+                    .adjust_size(&digest.into(), file_entry.size_on_disk() as i64)
+                    .await;
+            }
             return Ok(variant_path);
         }
 
@@ -958,10 +1007,16 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         // Re-check: another task may have constructed it while we waited.
         if fs::metadata(&variant_path).await.is_ok() {
             self.forget_executable_lock(digest);
+            if !file_entry.has_exec_variant() {
+                file_entry.set_has_exec_variant(true);
+                self.evicting_map
+                    .adjust_size(&digest.into(), file_entry.size_on_disk() as i64)
+                    .await;
+            }
             return Ok(variant_path);
         }
 
-        let result = self.create_executable_variant(digest, &variant_path).await;
+        let result = self.create_executable_variant(digest, &variant_path, &file_entry).await;
         // Drop the per-digest lock entry regardless of outcome so the map
         // cannot grow unbounded; a concurrent waiter already cloned the Arc.
         self.forget_executable_lock(digest);
@@ -996,13 +1051,8 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         &self,
         digest: &DigestInfo,
         variant_path: &OsStr,
+        file_entry: &Fe,
     ) -> Result<(), Error> {
-        // Resolve the on-disk CAS blob (0o444) to copy from. Must be present in
-        // this tier; callers populate the fast store first.
-        let file_entry = self
-            .get_file_entry_for_digest(digest)
-            .await
-            .err_tip(|| "Resolving CAS blob for executable variant")?;
         let src_path = file_entry
             .get_file_path_locked(|p| async move { Ok(p) })
             .await?;
@@ -1043,7 +1093,13 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             }
         )
         .await
-        .err_tip(|| "executable-variant spawn_blocking join failed")?
+        .err_tip(|| "executable-variant spawn_blocking join failed")??;
+
+        file_entry.set_has_exec_variant(true);
+        self.evicting_map
+            .adjust_size(&digest.into(), file_entry.size_on_disk() as i64)
+            .await;
+        Ok(())
     }
 
     pub async fn get_file_entry_for_digest(&self, digest: &DigestInfo) -> Result<Arc<Fe>, Error> {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -14,6 +14,8 @@
 
 use core::fmt::{Debug, Formatter};
 use core::pin::Pin;
+#[cfg(unix)]
+use core::sync::atomic::AtomicBool;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::time::Duration;
 use std::borrow::Cow;
@@ -254,7 +256,7 @@ pub struct FileEntryImpl {
     // We lock around this as it gets rewritten when we move between temp and content types
     encoded_file_path: RwLock<EncodedFilePath>,
     #[cfg(unix)]
-    has_exec_variant: std::sync::atomic::AtomicBool,
+    has_exec_variant: AtomicBool,
 }
 
 impl FileEntryImpl {
@@ -270,7 +272,7 @@ impl FileEntry for FileEntryImpl {
             block_size,
             encoded_file_path,
             #[cfg(unix)]
-            has_exec_variant: std::sync::atomic::AtomicBool::new(false),
+            has_exec_variant: AtomicBool::new(false),
         }
     }
 
@@ -362,14 +364,13 @@ impl FileEntry for FileEntryImpl {
 
     #[cfg(unix)]
     fn has_exec_variant(&self) -> bool {
-        self.has_exec_variant
-            .load(std::sync::atomic::Ordering::Acquire)
+        self.has_exec_variant.load(Ordering::Acquire)
     }
 
     #[cfg(unix)]
     fn set_has_exec_variant(&self, has_exec_variant: bool) {
         self.has_exec_variant
-            .store(has_exec_variant, std::sync::atomic::Ordering::Release);
+            .store(has_exec_variant, Ordering::Release);
     }
 }
 
@@ -402,10 +403,7 @@ impl LenEntry for FileEntryImpl {
     #[inline]
     fn len(&self) -> u64 {
         #[cfg(unix)]
-        if self
-            .has_exec_variant
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        if self.has_exec_variant.load(Ordering::Acquire) {
             return self.size_on_disk() * 2;
         }
         self.size_on_disk()
@@ -432,10 +430,7 @@ impl LenEntry for FileEntryImpl {
             return;
         }
         #[cfg(unix)]
-        if self
-            .has_exec_variant
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        if self.has_exec_variant.load(Ordering::Acquire) {
             if let StoreKey::Digest(digest) = &encoded_file_path.key {
                 let exec_path = format!(
                     "{}{EXECUTABLE_DIR_SUFFIX}/{DIGEST_FOLDER}/{digest}",
@@ -451,8 +446,7 @@ impl LenEntry for FileEntryImpl {
                     }
                 }
             }
-            self.has_exec_variant
-                .store(false, std::sync::atomic::Ordering::Release);
+            self.has_exec_variant.store(false, Ordering::Release);
         }
         let from_path = encoded_file_path.get_file_path();
         let new_key = make_temp_key(&encoded_file_path.key);

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -152,6 +152,16 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
             .get_file_path_locked(handler)
             .await
     }
+
+    #[cfg(unix)]
+    fn has_exec_variant(&self) -> bool {
+        self.inner.as_ref().unwrap().has_exec_variant()
+    }
+
+    #[cfg(unix)]
+    fn set_has_exec_variant(&self, has_exec_variant: bool) {
+        self.inner.as_ref().unwrap().set_has_exec_variant(has_exec_variant);
+    }
 }
 
 impl<Hooks: FileEntryHooks + 'static + Sync + Send> LenEntry for TestFileEntry<Hooks> {
@@ -1924,6 +1934,67 @@ async fn unref_does_not_orphan_content_file_when_temp_dir_missing() -> Result<()
         VALUE1.as_bytes(),
         "content file must remain intact after a failed unref rename"
     );
+
+    Ok(())
+}
+
+/// Executable-variant cache (.exec) is tracked by the eviction policy's max_bytes,
+/// is counted against sum_store_size, and is evicted when the store is cleaned.
+#[cfg(unix)]
+#[nativelink_test]
+async fn executable_variant_tracked_and_evicted_at_runtime() -> Result<(), Error> {
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: content_path.clone(),
+            temp_path: temp_path.clone(),
+            eviction_policy: Some(EvictionPolicy {
+                max_bytes: 100,
+                ..Default::default()
+            }),
+            block_size: 1,
+            ..Default::default()
+        })
+        .await?,
+    );
+
+    let digest1 = DigestInfo::try_new(VALID_HASH, 40)?;
+    let hash2 = "0000000000000000000000000000000000000000000000000000000000000002";
+    let digest2 = DigestInfo::try_new(hash2, 40)?;
+
+    // 1. Insert file 1
+    let data1 = vec![0u8; 40];
+    store.update_oneshot(digest1, data1.into()).await?;
+    assert_eq!(store.get_evicting_map().get_store_size().await, 40);
+
+    // 2. Materialize executable variant 1
+    let exec_path1 = store.get_executable_hardlink_source(&digest1).await?;
+    assert!(fs::metadata(&exec_path1).await.is_ok());
+
+    // 3. Tracked size should now be doubled to 80
+    assert_eq!(store.get_evicting_map().get_store_size().await, 80);
+
+    // 4. Insert file 2
+    let data2 = vec![0u8; 40];
+    store.update_oneshot(digest2, data2.into()).await?;
+
+    // Total size is now 80 (file 1 + exec 1) + 40 (file 2) = 120.
+    // Max bytes is 100, so it must evict file 1.
+    // Verify that digest1 is no longer in the store.
+    assert_eq!(store.has(digest1).await?, None);
+
+    // Verify that the executable variant of digest1 is deleted from disk.
+    assert!(fs::metadata(&exec_path1).await.is_err());
+
+    // Verify store size is now 40 (only file 2 is left)
+    assert_eq!(store.get_evicting_map().get_store_size().await, 40);
+
+    // 5. Materialize executable variant 2
+    let exec_path2 = store.get_executable_hardlink_source(&digest2).await?;
+    assert!(fs::metadata(&exec_path2).await.is_ok());
+    assert_eq!(store.get_evicting_map().get_store_size().await, 80);
 
     Ok(())
 }

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -160,7 +160,10 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> FileEntry for TestFileEntry<
 
     #[cfg(unix)]
     fn set_has_exec_variant(&self, has_exec_variant: bool) {
-        self.inner.as_ref().unwrap().set_has_exec_variant(has_exec_variant);
+        self.inner
+            .as_ref()
+            .unwrap()
+            .set_has_exec_variant(has_exec_variant);
     }
 }
 
@@ -1967,14 +1970,14 @@ async fn executable_variant_tracked_and_evicted_at_runtime() -> Result<(), Error
     // 1. Insert file 1
     let data1 = vec![0u8; 40];
     store.update_oneshot(digest1, data1.into()).await?;
-    assert_eq!(store.get_evicting_map().get_store_size().await, 40);
+    assert_eq!(store.get_evicting_map().get_snapshot().current_bytes, 40);
 
     // 2. Materialize executable variant 1
     let exec_path1 = store.get_executable_hardlink_source(&digest1).await?;
     assert!(fs::metadata(&exec_path1).await.is_ok());
 
     // 3. Tracked size should now be doubled to 80
-    assert_eq!(store.get_evicting_map().get_store_size().await, 80);
+    assert_eq!(store.get_evicting_map().get_snapshot().current_bytes, 80);
 
     // 4. Insert file 2
     let data2 = vec![0u8; 40];
@@ -1989,12 +1992,12 @@ async fn executable_variant_tracked_and_evicted_at_runtime() -> Result<(), Error
     assert!(fs::metadata(&exec_path1).await.is_err());
 
     // Verify store size is now 40 (only file 2 is left)
-    assert_eq!(store.get_evicting_map().get_store_size().await, 40);
+    assert_eq!(store.get_evicting_map().get_snapshot().current_bytes, 40);
 
     // 5. Materialize executable variant 2
     let exec_path2 = store.get_executable_hardlink_source(&digest2).await?;
     assert!(fs::metadata(&exec_path2).await.is_ok());
-    assert_eq!(store.get_evicting_map().get_store_size().await, 80);
+    assert_eq!(store.get_evicting_map().get_snapshot().current_bytes, 80);
 
     Ok(())
 }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -221,11 +221,11 @@ pub struct EvictingMap<
 // debugging helper used mostly to get a snapshot of what eviction threshold might be causing issues
 #[derive(Debug, Copy, Clone)]
 pub struct EvictionSnapshot {
-    max_bytes: u64,
-    current_bytes: u64,
-    max_items: u64,
-    current_items: usize,
-    max_seconds: i32,
+    pub max_bytes: u64,
+    pub current_bytes: u64,
+    pub max_items: u64,
+    pub current_items: usize,
+    pub max_seconds: i32,
 }
 
 impl Display for EvictionSnapshot {

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -754,6 +754,33 @@ where
         }
     }
 
+    pub async fn adjust_size(&self, key: &Q, size_delta: i64) {
+        let (items_to_unref, removal_futures) = {
+            let mut state = self.state.lock();
+            if state.lru.get_mut(key.borrow()).is_some() {
+                if size_delta < 0 {
+                    state.sum_store_size = state.sum_store_size.saturating_sub(size_delta.unsigned_abs());
+                } else {
+                    state.sum_store_size = state.sum_store_size.saturating_add(size_delta as u64);
+                }
+            }
+            self.evict_items(&mut state)
+        };
+
+        let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();
+        while futures.next().await.is_some() {}
+
+        // Unref items outside of lock
+        let futures: FuturesUnordered<_> = items_to_unref
+            .into_iter()
+            .map(|item| async move {
+                item.unref().await;
+                item
+            })
+            .collect();
+        drop(futures.collect::<Vec<_>>().await);
+    }
+
     pub fn add_remove_callback(&self, callback: C) {
         self.state.lock().add_remove_callback(callback);
     }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -759,7 +759,9 @@ where
             let mut state = self.state.lock();
             if state.lru.get_mut(key.borrow()).is_some() {
                 if size_delta < 0 {
-                    state.sum_store_size = state.sum_store_size.saturating_sub(size_delta.unsigned_abs());
+                    state.sum_store_size = state
+                        .sum_store_size
+                        .saturating_sub(size_delta.unsigned_abs());
                 } else {
                     state.sum_store_size = state.sum_store_size.saturating_add(size_delta as u64);
                 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2495)
<!-- Reviewable:end -->
