### PR TITLE
[web] restore blog posts deleted by the site redesign

### DIFF
--- a/web/apps/web/app/resources/blog/[slug]/page.tsx
+++ b/web/apps/web/app/resources/blog/[slug]/page.tsx
@@ -1,0 +1,93 @@
+import { Badge, Eyebrow, Prose, Section } from "@nativelink/ui";
+import { marked } from "marked";
+import { notFound } from "next/navigation";
+import { formatPostDate, getAllPosts, getPost } from "../../../../lib/posts";
+
+export function generateStaticParams() {
+  return getAllPosts().map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const post = getPost((await params).slug);
+  if (!post) return {};
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: "article",
+      ...(post.image ? { images: [{ url: post.image }] } : {}),
+    },
+  };
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const post = getPost((await params).slug);
+  if (!post) notFound();
+
+  const html = marked.parse(post.body, { async: false });
+
+  return (
+    <>
+      <section className="relative overflow-hidden">
+        <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[400px] bg-[radial-gradient(ellipse_900px_400px_at_50%_-10%,rgb(var(--nl-color-brand)/0.10),transparent_70%)]" />
+        <Section width="default" className="pt-24 pb-10 md:pt-32">
+          <div className="mx-auto max-w-[760px]">
+            <a
+              href="/resources/blog"
+              className="font-mono text-sm text-brand transition-colors hover:text-foreground"
+            >
+              ← All posts
+            </a>
+            <div className="mt-8 flex flex-wrap items-center gap-2">
+              {post.tags.map((tag) => (
+                <Badge key={tag} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+            <h1 className="mt-5 text-balance text-[34px] font-semibold leading-[1.1] tracking-[-0.03em] md:text-[46px]">
+              {post.title}
+            </h1>
+            <p className="mt-5 font-mono text-sm text-muted">
+              {formatPostDate(post.pubDate)}
+              {post.readTime ? ` · ${post.readTime}` : null}
+            </p>
+          </div>
+        </Section>
+      </section>
+
+      <Section width="default" className="pb-28">
+        <div className="mx-auto max-w-[760px]">
+          <Prose
+            className="max-w-none [&_img]:my-6 [&_img]:max-w-full [&_img]:rounded-xl"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: Post bodies are trusted repo content, rendered from markdown at build time.
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <div className="mt-16 border-t border-border pt-8">
+            <Eyebrow tone="muted" className="text-[10px]">
+              NativeLink Blog
+            </Eyebrow>
+            <p className="mt-3 text-sm text-muted-foreground">
+              <a
+                href="/resources/blog"
+                className="text-brand transition-colors hover:text-foreground"
+              >
+                ← Back to all posts
+              </a>
+            </p>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/web/apps/web/app/resources/blog/page.tsx
+++ b/web/apps/web/app/resources/blog/page.tsx
@@ -1,0 +1,71 @@
+import { Badge, Eyebrow, Reveal, Section } from "@nativelink/ui";
+import { formatPostDate, getAllPosts } from "../../../lib/posts";
+
+export const metadata = { title: "Blog" };
+
+export default function BlogIndexPage() {
+  const posts = getAllPosts();
+
+  return (
+    <>
+      <section className="relative overflow-hidden">
+        <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[400px] bg-[radial-gradient(ellipse_900px_400px_at_50%_-10%,rgb(var(--nl-color-brand)/0.13),transparent_70%)]" />
+        <Section width="default" className="pt-24 pb-14 md:pt-32">
+          <Reveal>
+            <div className="mx-auto max-w-[820px] text-center">
+              <Eyebrow className="mb-5">Blog</Eyebrow>
+              <h1 className="text-balance text-[40px] font-semibold leading-[1.05] tracking-[-0.04em] md:text-[56px]">
+                Writing from the team
+              </h1>
+              <p className="mx-auto mt-5 max-w-[640px] text-[17px] leading-relaxed text-muted-foreground">
+                Tutorials, case studies, and announcements from the people building NativeLink.
+              </p>
+            </div>
+          </Reveal>
+        </Section>
+      </section>
+
+      <Section width="default" className="pb-28">
+        <div className="grid gap-5 md:grid-cols-2">
+          {posts.map((post, i) => (
+            <Reveal key={post.slug} delay={(i % 2) * 0.04}>
+              <a
+                href={`/resources/blog/${post.slug}`}
+                className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
+              >
+                <div>
+                  <div className="mb-4 flex flex-wrap items-center gap-2">
+                    {post.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                    <span className="font-mono text-xs text-muted">
+                      {formatPostDate(post.pubDate)}
+                      {post.readTime ? ` · ${post.readTime}` : null}
+                    </span>
+                  </div>
+                  <h2 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
+                    {post.title}
+                  </h2>
+                  <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+                    {post.excerpt}
+                  </p>
+                </div>
+                <div className="mt-6 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
+                  Read post{" "}
+                  <span
+                    aria-hidden="true"
+                    className="transition-transform group-hover:translate-x-1"
+                  >
+                    →
+                  </span>
+                </div>
+              </a>
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/web/apps/web/app/resources/blog/page.tsx
+++ b/web/apps/web/app/resources/blog/page.tsx
@@ -30,7 +30,7 @@ export default function BlogIndexPage() {
           {posts.map((post, i) => (
             <Reveal key={post.slug} delay={(i % 2) * 0.04}>
               <a
-                href={`/resources/blog/${post.slug}`}
+                href={`/resources/blog/${encodeURIComponent(post.slug)}`}
                 className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
               >
                 <div>

--- a/web/apps/web/app/resources/blog/page.tsx
+++ b/web/apps/web/app/resources/blog/page.tsx
@@ -1,68 +1,8 @@
-import { Badge, Eyebrow, Reveal, Section } from "@nativelink/ui";
-import { type Post, formatPostDate, getAllPosts } from "../../../lib/posts";
+import { Eyebrow, Reveal, Section } from "@nativelink/ui";
+import { getAllPosts } from "../../../lib/posts";
+import { PostSection, postToCard } from "../post-sections";
 
 export const metadata = { title: "Blog" };
-
-function PostCard({ post, index }: { post: Post; index: number }) {
-  return (
-    <Reveal key={post.slug} delay={(index % 2) * 0.04}>
-      <a
-        href={`/resources/blog/${encodeURIComponent(post.slug)}`}
-        className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
-      >
-        <div>
-          <div className="mb-4 flex flex-wrap items-center gap-2">
-            {post.tags.map((tag) => (
-              <Badge key={tag} variant="outline">
-                {tag}
-              </Badge>
-            ))}
-            <span className="font-mono text-xs text-muted">
-              {formatPostDate(post.pubDate)}
-              {post.readTime ? ` · ${post.readTime}` : null}
-            </span>
-          </div>
-          <h2 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
-            {post.title}
-          </h2>
-          <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">{post.excerpt}</p>
-        </div>
-        <div className="mt-6 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
-          Read post{" "}
-          <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
-            →
-          </span>
-        </div>
-      </a>
-    </Reveal>
-  );
-}
-
-function PostSection({
-  title,
-  posts,
-  className,
-}: {
-  title: string;
-  posts: Post[];
-  className?: string;
-}) {
-  if (posts.length === 0) {
-    return null;
-  }
-  return (
-    <Section width="default" className={className}>
-      <Reveal>
-        <Eyebrow className="mb-8">{title}</Eyebrow>
-      </Reveal>
-      <div className="grid gap-5 md:grid-cols-2">
-        {posts.map((post, i) => (
-          <PostCard key={post.slug} post={post} index={i} />
-        ))}
-      </div>
-    </Section>
-  );
-}
 
 export default function BlogIndexPage() {
   const posts = getAllPosts();
@@ -93,15 +33,15 @@ export default function BlogIndexPage() {
         </Section>
       </section>
 
-      <PostSection title="Case studies" posts={caseStudies} className="pb-16" />
+      <PostSection title="Case studies" cards={caseStudies.map(postToCard)} className="pb-16" />
       <PostSection
         title="Announcements"
-        posts={announcements}
+        cards={announcements.map(postToCard)}
         className="border-t border-border/60 pt-16 pb-16"
       />
       <PostSection
         title="More from the blog"
-        posts={others}
+        cards={others.map(postToCard)}
         className="border-t border-border/60 pt-16 pb-28"
       />
     </>

--- a/web/apps/web/app/resources/blog/page.tsx
+++ b/web/apps/web/app/resources/blog/page.tsx
@@ -40,7 +40,7 @@ export default function BlogIndexPage() {
         className="border-t border-border/60 pt-16 pb-16"
       />
       <PostSection
-        title="More from the blog"
+        title="Blog"
         cards={others.map(postToCard)}
         className="border-t border-border/60 pt-16 pb-28"
       />

--- a/web/apps/web/app/resources/blog/page.tsx
+++ b/web/apps/web/app/resources/blog/page.tsx
@@ -1,10 +1,78 @@
 import { Badge, Eyebrow, Reveal, Section } from "@nativelink/ui";
-import { formatPostDate, getAllPosts } from "../../../lib/posts";
+import { type Post, formatPostDate, getAllPosts } from "../../../lib/posts";
 
 export const metadata = { title: "Blog" };
 
+function PostCard({ post, index }: { post: Post; index: number }) {
+  return (
+    <Reveal key={post.slug} delay={(index % 2) * 0.04}>
+      <a
+        href={`/resources/blog/${encodeURIComponent(post.slug)}`}
+        className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
+      >
+        <div>
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {post.tags.map((tag) => (
+              <Badge key={tag} variant="outline">
+                {tag}
+              </Badge>
+            ))}
+            <span className="font-mono text-xs text-muted">
+              {formatPostDate(post.pubDate)}
+              {post.readTime ? ` · ${post.readTime}` : null}
+            </span>
+          </div>
+          <h2 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
+            {post.title}
+          </h2>
+          <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">{post.excerpt}</p>
+        </div>
+        <div className="mt-6 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
+          Read post{" "}
+          <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+            →
+          </span>
+        </div>
+      </a>
+    </Reveal>
+  );
+}
+
+function PostSection({
+  title,
+  posts,
+  className,
+}: {
+  title: string;
+  posts: Post[];
+  className?: string;
+}) {
+  if (posts.length === 0) {
+    return null;
+  }
+  return (
+    <Section width="default" className={className}>
+      <Reveal>
+        <Eyebrow className="mb-8">{title}</Eyebrow>
+      </Reveal>
+      <div className="grid gap-5 md:grid-cols-2">
+        {posts.map((post, i) => (
+          <PostCard key={post.slug} post={post} index={i} />
+        ))}
+      </div>
+    </Section>
+  );
+}
+
 export default function BlogIndexPage() {
   const posts = getAllPosts();
+  const caseStudies = posts.filter((p) => p.tags.includes("case-studies"));
+  const announcements = posts.filter(
+    (p) => p.tags.includes("announcements") && !p.tags.includes("case-studies"),
+  );
+  const others = posts.filter(
+    (p) => !p.tags.includes("case-studies") && !p.tags.includes("announcements"),
+  );
 
   return (
     <>
@@ -25,47 +93,17 @@ export default function BlogIndexPage() {
         </Section>
       </section>
 
-      <Section width="default" className="pb-28">
-        <div className="grid gap-5 md:grid-cols-2">
-          {posts.map((post, i) => (
-            <Reveal key={post.slug} delay={(i % 2) * 0.04}>
-              <a
-                href={`/resources/blog/${encodeURIComponent(post.slug)}`}
-                className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
-              >
-                <div>
-                  <div className="mb-4 flex flex-wrap items-center gap-2">
-                    {post.tags.map((tag) => (
-                      <Badge key={tag} variant="outline">
-                        {tag}
-                      </Badge>
-                    ))}
-                    <span className="font-mono text-xs text-muted">
-                      {formatPostDate(post.pubDate)}
-                      {post.readTime ? ` · ${post.readTime}` : null}
-                    </span>
-                  </div>
-                  <h2 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
-                    {post.title}
-                  </h2>
-                  <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
-                    {post.excerpt}
-                  </p>
-                </div>
-                <div className="mt-6 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
-                  Read post{" "}
-                  <span
-                    aria-hidden="true"
-                    className="transition-transform group-hover:translate-x-1"
-                  >
-                    →
-                  </span>
-                </div>
-              </a>
-            </Reveal>
-          ))}
-        </div>
-      </Section>
+      <PostSection title="Case studies" posts={caseStudies} className="pb-16" />
+      <PostSection
+        title="Announcements"
+        posts={announcements}
+        className="border-t border-border/60 pt-16 pb-16"
+      />
+      <PostSection
+        title="More from the blog"
+        posts={others}
+        className="border-t border-border/60 pt-16 pb-28"
+      />
     </>
   );
 }

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -29,6 +29,7 @@ const announcements = [
     date: "April 18, 2026",
     readingTime: "32 min video",
     accent: "default",
+    href: "https://www.youtube.com/watch?v=uokjTev8myk",
   },
 ];
 
@@ -162,7 +163,9 @@ export default function ResourcesPage() {
             {announcements.map((p, i) => (
               <Reveal key={p.title} delay={i * 0.05}>
                 <a
-                  href="#"
+                  href={p.href}
+                  target="_blank"
+                  rel="noreferrer"
                   className={cn(
                     "group block rounded-2xl border p-6 transition-all hover:-translate-y-0.5",
                     p.accent === "brand"

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -1,14 +1,6 @@
-import {
-  Badge,
-  Button,
-  Eyebrow,
-  Reveal,
-  Section,
-  YouTubeEmbed,
-  cn,
-} from "@nativelink/ui";
-
-// (Badge is used in featured + announcement cards below.)
+import { Badge, Eyebrow, Reveal, Section } from "@nativelink/ui";
+import { getAllPosts } from "../../lib/posts";
+import { type PostCardData, PostSection, postToCard } from "./post-sections";
 
 export const metadata = { title: "Resources" };
 
@@ -22,19 +14,30 @@ const featuredPost = {
   href: "https://reidkleckner.dev/posts/llvm-recc-nativelink/",
 };
 
-const announcements = [
-  {
-    tag: "Talk",
-    title: "Hermetic toolchain creation with LRE & Nix",
-    excerpt: "Aaron Mondal walks through Local Remote Execution — running fully hermetic Bazel builds on your own laptop, no Docker required.",
-    date: "April 18, 2026",
-    readingTime: "32 min video",
-    accent: "default",
-    href: "https://www.youtube.com/watch?v=uokjTev8myk",
-  },
-];
+// The BazelCon talk lives among the post cards rather than as an
+// embedded video so the page stays light and the blog content leads.
+const talkCard: PostCardData = {
+  key: "talk-hermetic-toolchains",
+  href: "https://www.youtube.com/watch?v=uokjTev8myk",
+  external: true,
+  tags: ["talk"],
+  meta: "BazelCon 2024 · 32 min video",
+  title: "Hermetic toolchain creation with LRE & Nix",
+  excerpt:
+    "Aaron Mondal walks through Local Remote Execution — running fully hermetic Bazel builds on your own laptop, no Docker required.",
+  cta: "Watch talk",
+};
 
 export default function ResourcesPage() {
+  const posts = getAllPosts();
+  const caseStudies = posts.filter((p) => p.tags.includes("case-studies"));
+  const announcements = posts.filter(
+    (p) => p.tags.includes("announcements") && !p.tags.includes("case-studies"),
+  );
+  const others = posts.filter(
+    (p) => !p.tags.includes("case-studies") && !p.tags.includes("announcements"),
+  );
+
   return (
     <>
       {/* HERO */}
@@ -52,8 +55,8 @@ export default function ResourcesPage() {
                 .
               </h1>
               <p className="mx-auto mt-6 max-w-[640px] text-[17px] leading-relaxed text-muted-foreground md:text-lg">
-                Case studies, conference talks, and write-ups from the team building
-                NativeLink — plus highlights from the broader community.
+                Case studies, conference talks, and write-ups from the team building NativeLink —
+                plus highlights from the broader community.
               </p>
             </div>
           </Reveal>
@@ -87,7 +90,10 @@ export default function ResourcesPage() {
                 </div>
                 <div className="mt-8 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
                   Read the write-up{" "}
-                  <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+                  <span
+                    aria-hidden="true"
+                    className="transition-transform group-hover:translate-x-1"
+                  >
                     →
                   </span>
                 </div>
@@ -122,76 +128,35 @@ export default function ResourcesPage() {
         </Reveal>
       </Section>
 
-      {/* ANNOUNCEMENTS + VIDEO */}
-      <Section width="default" className="border-t border-border/60 bg-surface-elevated/40 py-24">
-        <Reveal>
-          <div className="mb-12 flex items-end justify-between">
+      {/* FROM THE TEAM — full blog listing */}
+      <section className="border-t border-border/60 bg-surface-elevated/40">
+        <Section width="default" className="pt-24 pb-4">
+          <Reveal>
             <div>
-              <Eyebrow className="mb-4">Announcements</Eyebrow>
+              <Eyebrow className="mb-4">Blog</Eyebrow>
               <h2 className="text-balance text-3xl font-semibold leading-[1.1] tracking-[-0.025em] md:text-4xl">
                 From the team
               </h2>
             </div>
-            <Button asChild variant="outline" size="sm">
-              <a href="/resources/blog">All posts →</a>
-            </Button>
-          </div>
-        </Reveal>
-
-        <div className="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
-          <Reveal>
-            <div className="overflow-hidden rounded-2xl">
-              <YouTubeEmbed
-                id="uokjTev8myk"
-                title="Hermetic Toolchain Creation with Local Remote Execution (LRE) & Nix"
-              />
-            </div>
-            <p className="mt-4 text-base leading-relaxed text-foreground">
-              <span className="font-mono text-xs uppercase tracking-widest text-muted">
-                Featured talk ·{" "}
-              </span>
-              Hermetic Toolchain Creation with Local Remote Execution & Nix
-            </p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Aaron Mondal, Trace Machina — 32 min
-            </p>
           </Reveal>
+        </Section>
 
-          <div className="flex flex-col gap-3">
-            {announcements.map((p, i) => (
-              <Reveal key={p.title} delay={i * 0.05}>
-                <a
-                  href={p.href}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={cn(
-                    "group block rounded-2xl border p-6 transition-all hover:-translate-y-0.5",
-                    p.accent === "brand"
-                      ? "border-brand/40 bg-brand-soft/30 hover:border-brand"
-                      : "border-border bg-surface hover:border-border-strong",
-                  )}
-                >
-                  <div className="mb-3 flex items-center gap-2">
-                    <Badge variant={p.accent === "brand" ? "brand" : "default"}>
-                      {p.tag}
-                    </Badge>
-                    <span className="font-mono text-xs text-muted">
-                      {p.date} · {p.readingTime}
-                    </span>
-                  </div>
-                  <h3 className="text-lg font-semibold leading-tight tracking-tight text-foreground">
-                    {p.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                    {p.excerpt}
-                  </p>
-                </a>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </Section>
-
+        <PostSection
+          title="Case studies"
+          cards={caseStudies.map(postToCard)}
+          className="pt-12 pb-16"
+        />
+        <PostSection
+          title="Announcements"
+          cards={announcements.map(postToCard)}
+          className="border-t border-border/60 pt-16 pb-16"
+        />
+        <PostSection
+          title="More from the blog"
+          cards={[...others.map(postToCard), talkCard]}
+          className="border-t border-border/60 pt-16 pb-28"
+        />
+      </section>
     </>
   );
 }

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -130,7 +130,10 @@ export default function ResourcesPage() {
                 From the team
               </h2>
             </div>
-            <a href="#" className="hidden font-mono text-sm text-brand md:inline-flex">
+            <a
+              href="/resources/blog"
+              className="hidden font-mono text-sm text-brand md:inline-flex"
+            >
               All posts →
             </a>
           </div>

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -133,7 +133,7 @@ export default function ResourcesPage() {
         <Section width="default" className="pt-24 pb-4">
           <Reveal>
             <h2 className="text-balance text-3xl font-semibold leading-[1.1] tracking-[-0.025em] md:text-4xl">
-              Blog
+              From the team
             </h2>
           </Reveal>
         </Section>
@@ -149,7 +149,7 @@ export default function ResourcesPage() {
           className="border-t border-border/60 pt-16 pb-16"
         />
         <PostSection
-          title="More from the blog"
+          title="Blog"
           cards={[...others.map(postToCard), talkCard]}
           className="border-t border-border/60 pt-16 pb-28"
         />

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -132,12 +132,9 @@ export default function ResourcesPage() {
       <section className="border-t border-border/60 bg-surface-elevated/40">
         <Section width="default" className="pt-24 pb-4">
           <Reveal>
-            <div>
-              <Eyebrow className="mb-4">Blog</Eyebrow>
-              <h2 className="text-balance text-3xl font-semibold leading-[1.1] tracking-[-0.025em] md:text-4xl">
-                From the team
-              </h2>
-            </div>
+            <h2 className="text-balance text-3xl font-semibold leading-[1.1] tracking-[-0.025em] md:text-4xl">
+              Blog
+            </h2>
           </Reveal>
         </Section>
 

--- a/web/apps/web/app/resources/page.tsx
+++ b/web/apps/web/app/resources/page.tsx
@@ -1,5 +1,6 @@
 import {
   Badge,
+  Button,
   Eyebrow,
   Reveal,
   Section,
@@ -131,12 +132,9 @@ export default function ResourcesPage() {
                 From the team
               </h2>
             </div>
-            <a
-              href="/resources/blog"
-              className="hidden font-mono text-sm text-brand md:inline-flex"
-            >
-              All posts →
-            </a>
+            <Button asChild variant="outline" size="sm">
+              <a href="/resources/blog">All posts →</a>
+            </Button>
           </div>
         </Reveal>
 

--- a/web/apps/web/app/resources/post-sections.tsx
+++ b/web/apps/web/app/resources/post-sections.tsx
@@ -1,0 +1,85 @@
+import { Badge, Eyebrow, Reveal, Section } from "@nativelink/ui";
+import type { Post } from "../../lib/posts";
+import { formatPostDate } from "../../lib/posts";
+
+export interface PostCardData {
+  key: string;
+  href: string;
+  external?: boolean;
+  tags: string[];
+  meta: string;
+  title: string;
+  excerpt: string;
+  cta: string;
+}
+
+export function postToCard(post: Post): PostCardData {
+  return {
+    key: post.slug,
+    href: `/resources/blog/${encodeURIComponent(post.slug)}`,
+    tags: post.tags,
+    meta: `${formatPostDate(post.pubDate)}${post.readTime ? ` · ${post.readTime}` : ""}`,
+    title: post.title,
+    excerpt: post.excerpt,
+    cta: "Read post",
+  };
+}
+
+export function PostCard({ card, index }: { card: PostCardData; index: number }) {
+  return (
+    <Reveal delay={(index % 2) * 0.04}>
+      <a
+        href={card.href}
+        {...(card.external ? { target: "_blank", rel: "noreferrer" } : {})}
+        className="group flex h-full flex-col justify-between rounded-2xl border border-border bg-surface p-7 transition-all hover:border-brand/40 hover:shadow-[0_20px_50px_-25px_rgb(var(--nl-color-brand)/0.35)]"
+      >
+        <div>
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {card.tags.map((tag) => (
+              <Badge key={tag} variant="outline">
+                {tag}
+              </Badge>
+            ))}
+            <span className="font-mono text-xs text-muted">{card.meta}</span>
+          </div>
+          <h3 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
+            {card.title}
+          </h3>
+          <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">{card.excerpt}</p>
+        </div>
+        <div className="mt-6 inline-flex items-center gap-1.5 font-mono text-sm text-brand">
+          {card.cta}{" "}
+          <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+            →
+          </span>
+        </div>
+      </a>
+    </Reveal>
+  );
+}
+
+export function PostSection({
+  title,
+  cards,
+  className,
+}: {
+  title: string;
+  cards: PostCardData[];
+  className?: string;
+}) {
+  if (cards.length === 0) {
+    return null;
+  }
+  return (
+    <Section width="default" className={className}>
+      <Reveal>
+        <Eyebrow className="mb-8">{title}</Eyebrow>
+      </Reveal>
+      <div className="grid gap-5 md:grid-cols-2">
+        {cards.map((card, i) => (
+          <PostCard key={card.key} card={card} index={i} />
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/web/apps/web/content/posts/Accelerating_CMake.mdx
+++ b/web/apps/web/content/posts/Accelerating_CMake.mdx
@@ -1,0 +1,256 @@
+---
+title: "Supercharge Your C/C++ Builds without Migrating to Bazel: A Tutorial for CMake, Nativelink and BuildStream"
+tags: ["tutorial", "cmake", "build-acceleration", "blog-posts"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_logo.webp
+slug: accelerating-cmake-with-nativelink
+pubDate: 2025-08-12
+readTime: 8 minutes
+---
+
+## Supercharge Your C/C++ Builds without Migrating to Bazel: A Tutorial for CMake Acceleration with Nativelink and BuildStream
+
+Slow build times can be a major drag on developer productivity. Waiting for your code to compile and build can interrupt your flow and waste valuable time. Lots of companies have moved to Bazel and Buck2 to deal with this issue. But for many companies that investment in migrating to Bazel is too risky or too costly. What if you could accelerate your C/C++ projects using CMake? This tutorial will guide you through setting up a blazing-fast build environment using [Nativelink](https://github.com/TraceMachina/nativelink) and [Apache BuildStream](https://buildstream.build/) for remote caching and execution. We'll walk through a "hello, world" example to get you up and running in under 15 minutes.
+
+-----
+
+### What are Nativelink and Apache BuildStream?
+
+  * **BuildStream** is a flexible and extensible tool for building and integrating software stacks. It creates a sandbox environment for your builds, ensuring they're reproducible and isolated.
+  * **Nativelink** is a high-performance remote execution and caching service that's compatible with the Remote Execution API (REAPI). It acts as a server to store and retrieve build artifacts, and to execute build tasks on remote workers.
+
+By using them together, you can distribute your build jobs and cache their results, leading to significant speedups, especially in large projects.
+
+-----
+
+### Project Setup
+
+Let's start by setting up our project directory. We'll create a structure to hold our source code, Makefile, and BuildStream configuration.
+
+```bash
+mkdir -p first-project/elements/base first-project/files/src
+cd first-project
+```
+
+Your directory structure should look like this:
+
+```shell
+first-project/
+├── elements/
+│   └── base/
+│
+└── files/
+    └── src/
+```
+
+-----
+
+### The "Hello, World" Application
+
+Next, let's create our C application and the corresponding Makefile.
+
+#### `hello.c`
+
+Create a file named `hello.c` inside the `files/src` directory:
+
+```c
+/*
+ * hello.c - a hello world program
+ */
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  printf("Hello World\n");
+  return 0;
+}
+```
+
+#### `Makefile`
+
+Now, create a `Makefile` in the same `files/src` directory:
+
+```makefile
+.PHONY: all
+
+all: hello
+hello: hello.c
+	$(CC) -Wall -o $@ $<
+```
+
+-----
+
+### Configuring BuildStream
+
+Now, let's configure BuildStream to build our project.
+
+#### `project.conf`
+
+First, create a `project.conf` file in the root of your `first-project` directory. This file defines the basic properties of your project.
+
+```shell
+# Unique project name
+name: first-project
+
+# Required BuildStream version
+min-version: 2.4
+
+# Subdirectory where elements are stored
+element-path: elements
+
+# Define an alias for our alpine tarball
+aliases:
+  alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
+```
+
+#### `elements/base/alpine.bst`
+
+Next, we need to define our base system. We'll use a pre-built, trimmed-down Alpine Linux image. Create `elements/base/alpine.bst`:
+
+```yaml
+kind: import
+description: |
+
+    Alpine Linux base runtime
+
+sources:
+- kind: tar
+  # This is a post doctored, trimmed down system image
+  # of the Alpine linux distribution.
+  #
+  url: alpine:integration-tests-base.v1.x86_64.tar.xz
+  ref: 3eb559250ba82b64a68d86d0636a6b127aa5f6d25d3601a79f79214dc9703639
+```
+
+#### `elements/base.bst`
+
+Now, create a `elements/base.bst` file to create a stack with the Alpine base:
+
+```yaml
+kind: stack
+description: Base stack
+
+depends:
+- base/alpine.bst
+```
+
+####`elements/hello.bst`
+
+Finally, create the element for our "hello, world" application in `elements/hello.bst`. This element specifies how to build our application.
+
+```yaml
+kind: manual
+description: |
+
+  Building manually
+
+# Depend on the base system
+depends:
+- base.bst
+
+# Stage the files/src directory for building
+sources:
+  - kind: local
+    path: files/src
+
+# Now configure the commands to run
+config:
+
+  build-commands:
+  - make hello
+```
+
+-----
+
+### Configuring Nativelink for Remote Caching & Execution
+
+With our project set up, it's time to bring in Nativelink to accelerate the build.
+
+#### `buildstream.conf`
+
+To tell BuildStream to use a remote execution service, create a `buildstream.conf` file in your project's root directory:
+
+```yaml
+cachedir: /tmp/buildstream
+
+artifacts:
+  servers:
+  - url: http://localhost:50051
+    push: true
+remote-execution:
+  execution-service:
+    url: http://localhost:50051
+  action-cache-service:
+    url: http://localhost:50051
+  storage-service:
+    url: http://localhost:50051
+```
+
+This configuration tells BuildStream to connect to a Nativelink instance running on `localhost:50051` for artifact caching and remote execution.
+
+-----
+
+### Running the Build
+
+We'll use a script to launch the Nativelink service and then run the BuildStream build. The example below uses Nix to manage the dependencies, but you can adapt it to your environment.
+
+#### Launch Script
+
+Here is an example script, similar to `buildstream-with-nativelink-test.nix`, that shows how to run the build.
+
+```nix
+{
+  nativelink,
+  buildstream,
+  buildbox,
+  writeShellScriptBin,
+}:
+writeShellScriptBin "buildstream-with-nativelink-test" ''
+  set -uo pipefail
+
+  cleanup() {
+    local pids=$(jobs -pr)
+    [ -n "$pids" ] && kill $pids
+  }
+  trap "cleanup" INT QUIT TERM EXIT
+
+  ${nativelink}/bin/nativelink -- integration_tests/buildstream/buildstream_cas.json5 | tee -i integration_tests/buildstream/nativelink.log &
+
+  # TODO(palfrey): PATH is workaround for https://github.com/NixOS/nixpkgs/issues/248000#issuecomment-2934704963
+  bst_output=$(cd integration_tests/buildstream && PATH=${buildbox}/bin:$PATH ${buildstream}/bin/bst -c buildstream.conf build hello.bst 2>&1 | tee -i buildstream.log)
+
+  case $bst_output in
+    *"SUCCESS Build"* )
+      echo "Saw a successful buildstream build"
+    ;;
+    *)
+      echo 'Failed buildstream build:'
+      echo $bst_output
+      exit 1
+    ;;
+  esac
+
+  nativelink_output=$(cat integration_tests/buildstream/nativelink.log)
+
+  case $nativelink_output in
+    *"ERROR"* )
+      echo "Error in nativelink build"
+      exit 1
+    ;;
+    *)
+      echo 'Successful nativelink build'
+    ;;
+  esac
+''
+```
+
+To run the build, you would execute this script. It first starts the `nativelink` service in the background, then runs `bst build`.
+
+The first time you run the build, it will compile the code and store the result in the Nativelink cache. Subsequent builds will be significantly faster as the results will be fetched directly from the cache, skipping the compilation step entirely.
+
+-----
+
+### Conclusion
+
+You have now successfully set up a project with BuildStream and Nativelink for accelerated builds with code pulled directly from Nativelink's production [integration tests](https://github.com/TraceMachina/nativelink/tree/main/integration_tests/buildstream). By leveraging remote caching and execution, you can dramatically reduce build times, especially for larger and more complex projects. This allows you to iterate faster and stay in the creative flow. Finally, developers and managers alike can appreciate a developer productivity tool!
+
+If you have any questions or want to learn more, feel free to reach out to **contact@nativelink.com**. Happy building\! 🚀

--- a/web/apps/web/content/posts/Adding_Support_for_Trust_Roots.mdx
+++ b/web/apps/web/content/posts/Adding_Support_for_Trust_Roots.mdx
@@ -1,0 +1,143 @@
+---
+title: "Trust Root Support in Nativelink"
+tags: ["news", "blog-posts"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_logo.webp
+slug: adding-trust-roots-to-nativelink
+pubDate: 2025-05-15
+readTime: 5 minutes
+---
+
+# Native Root Certificate Support in Nativelink
+
+**Open source thrives on community contributions, and today’s story is a perfect example of why.**
+External engineer [Sam Eskandar](https://github.com/s6eskand) identified a pain point in Nativelink's TLS configuration and delivered [a clean solution](https://github.com/TraceMachina/nativelink/pull/1782) that eliminates deployment friction for teams using managed certificates.
+
+## Problem: Manual Certificate Management
+
+Before this change, connecting to gRPC endpoints using TLS required specifying [`ClientTlsConfig`](https://nativelink.com/docs/reference/nativelink-config/#clienttlsconfig) like this:
+
+```json
+{
+  ca_file: "path/to/ca.pem",
+  cert_file: "path/to/client.pem",
+  key_file: "path/to/client-key.pem"
+}
+```
+
+Teams had to distribute CA certificates, client certificates, and key files across workers - creating friction for cloud deployments and potential security concerns when secrets need to be managed manually.
+
+## Solution: Native Root Certificate Support
+
+The new implementation adds a `use_native_roots` option that leverages the system's native root certificate store, eliminating manual certificate file management for most deployment scenarios.
+
+The core change is:
+
+```rust
+if config.use_native_roots == Some(true) {
+    if config.ca_file.is_some() {
+        warn!("Native root certificates are being used, all certificate files will be ignored");
+    }
+    return Ok(Some(
+        tonic::transport::ClientTlsConfig::new().with_native_roots(),
+    ));
+}
+```
+
+This implementation provides three distinct behaviors:
+- **Native roots enabled:** Use system native root certificates, ignore any provided certificate files
+- **Manual certificate path:** Use existing manual certificate configuration
+- **Clear validation:** Warn users when configurations conflict
+
+## Configuration Examples
+
+Here are the main ways to configure TLS in Nativelink.
+For complete configuration options, see the [configuration reference](https://www.nativelink.com/docs/reference/nativelink-config).
+
+### Native Root Certificates
+
+For the majority of modern deployments, you can now enable native roots with one parameter:
+
+```json
+{
+  "tls_config": {
+    "use_native_roots": true
+  }
+}
+```
+
+This configuration automatically trusts certificates signed by any certificate authority in your system’s trust store - perfect for cloud environments with managed certificates.
+
+### Manual Certificate Path
+
+Since `use_native_roots` defaults to `false`, you can still use the previous configuration:
+
+```json
+{
+  "tls_config": {
+    "ca_file": "/path/to/ca.pem",
+    "cert_file": "/path/to/client.pem",
+    "key_file": "/path/to/client-key.pem"
+  }
+}
+```
+
+### gRPC Store and Local Worker Configuration
+
+The `tls_config` field can be used in gRPC store endpoints:
+
+```json
+"stores": [
+  {
+    "grpc": {
+      "endpoints": [
+        {
+          "address": "grpcs://example.com:443",
+          "tls_config": {
+            "use_native_roots": true
+          }
+        }
+      ],
+      "instance_name": "main",
+      "store_type": "cas"
+    },
+    "name": "CAS_STORE"
+  }
+]
+```
+
+And in worker API endpoints:
+
+```json
+"workers": [{
+  "local": {
+    "worker_api_endpoint": {
+      "uri": "grpcs://127.0.0.1:50061",
+      "tls_config": {
+        "use_native_roots": true
+      }
+    },
+    // ...
+  }
+}]
+```
+
+## Community Contributions
+
+The [PR discussion](https://github.com/TraceMachina/nativelink/pull/1782) shows how the review process strengthened the implementation.
+The contributor included comprehensive unit tests covering all configuration scenarios.
+Reviewers suggested UX improvements like warning users when certificate files are ignored, identified documentation needs, and planned future enhancements.
+One reviewer opened a follow-up PR to extend native roots to S3 stores.
+
+This collaborative refinement process caught edge cases, improved error handling, and identified future improvements - resulting in a more robust implementation than any single contributor could have produced alone.
+
+## Looking forward
+
+With native root certificate support, Nativelink becomes more accessible to teams across diverse infrastructure environments.
+Whether you’re running containerized workloads in Kubernetes, deploying on traditional virtual machines with corporate PKI, or prototyping locally, TLS configuration no longer presents a barrier to adoption.
+
+**This is the power of open source in action** - community-driven improvements that make technology more accessible, secure, and flexible for everyone building the future.
+We’re grateful for contributions like this that strengthen Nativelink’s position as the premier open source remote execution platform.
+
+---
+
+*Interested in contributing? Check out our [GitHub repository](https://github.com/TraceMachina/nativelink).*

--- a/web/apps/web/content/posts/Announcement_NativeLink.mdx
+++ b/web/apps/web/content/posts/Announcement_NativeLink.mdx
@@ -1,0 +1,36 @@
+---
+title: "NativeLink - The free & open source simulation infrastructure platform written in Rust"
+tags: ["news", "announcements"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_open_source.webp
+slug: NativeLink
+readTime: 30 seconds
+pubDate: 2024-09-17
+---
+Today, we're excited to release NativeLink–a Rust implementation of Bazel's
+Remote Build Execution protocol (RBE) and Content Addressable Storage (CAS)
+designed to run your code and get out of the way. NativeLink seamlessly
+integrates with Bazel, Reclient, Goma, and Buck2. It comes at no cost and
+works on every major operating system.
+
+
+Offering a vendor neutral solution out the gate was important to us and we
+will soon offer more options. Part of vendor neutrality began with
+supporting four different build systems that implement the RBE protocol.
+Given our focus on mission-critical systems with native code,
+reproducibility and hermiticity have been our guiding lights.
+
+
+Based on feedback from our earliest users, we made a few design choices
+around the runtime, I/O, and software supply chain. We don't have any
+garbage collection, supporting more deterministic and predictable
+execution. In addition, the tunable and highly performant asynchronicity
+afforded by Rust has allowed us to achieve concurrency and memory safety that were previously impracticable in most industries prior to its
+creation. Ultimately, we  strive for scale, modern SBOM transparency, and
+verifiability. The software supply chain is the biggest threat to computer
+security in 2023. For mission critical products, the risks are much
+greater. Critical systems can't rely on closed source.
+
+Your contributions, questions, and community support are encouraged. Join
+our Slack to learn more.
+
+The free & open source simulation infrastructure platform, in Rust

--- a/web/apps/web/content/posts/Announcement_TraceMachina_Seedfunding.mdx
+++ b/web/apps/web/content/posts/Announcement_TraceMachina_Seedfunding.mdx
@@ -1,0 +1,113 @@
+---
+title: "TraceMachina: Seed Funding"
+tags: ["news", "announcements"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/tracemachina_seedfunding.webp
+slug: tracemachina-seedfunding
+pubDate: 2024-09-10
+readTime: 30 seconds
+---
+Trace Machina secures funding and launches NativeLink out of stealth to
+deliver simulation infrastructure for safety-critical technologies
+
+Today marks an exciting milestone for Trace Machina as we officially come
+out of stealth mode and secured $4.7 million in seed funding to drive our
+mission forward.
+
+
+First, I am immensely grateful for the work that has been put in by the
+entire Trace Machina team to get us here today. I’d like to thank our lead
+investor, Van Jones from Wellington Management for believing in our vision
+from the start. In addition to our partners at Samsung Next, Green Bay
+Ventures, and Verissimo Ventures for everything they have done.
+Instrumental angel investors and mentors including Clem Delangue, CEO of
+Hugging Face, Mitch Wainer, Co-founder of DigitalOcean, Gert Lackriet,
+Director of Applied Machine Learning at Amazon; and other industry leaders
+from OpenAI and MongoDB.
+
+
+Why we started Trace Machina
+The inception of Trace Machina originated from a shared vision among a
+group of passionate engineers and product leaders who have experience
+developing cutting-edge technologies and solving complex problems in AI,
+robotics, and autonomous systems at companies including Apple and Google.
+
+
+Nathan Bruer, my Co-Founder, and I have always been driven by the challenge
+of pushing the boundaries of technology. Nathan’s work at Google X on
+autonomous driving software and my contributions to MongoDB Atlas Vector Search and other major open source projects laid the foundation for what
+would become Trace Machina. We realized there was a significant gap in the
+market for a robust simulation infrastructure that could support the
+development of advanced systems. This realization led to the birth of Trace
+Machina.
+
+
+We're committed to developing tools that enable teams working on advanced
+technologies like physical AI, specialized chip design, robotics, and
+autonomous mobility. Our mission is to enable the next generation of
+builders to create technology that has previously been unattainable or
+uneconomical.
+
+
+Launching NativeLink
+NativeLink, our first product, embodies this mission. It's an open-source,
+Rust-based simulation infrastructure platform designed to provide an
+advanced simulation environment for technologies where safety is paramount.
+
+
+NativeLink is the only platform for Bazel, Buck2, and Reclient written in
+native code, tailored to handle large objects and intricate systems, across
+native and interpreted programming languages.
+
+
+From self-driving cars to aviation and robotics, NativeLink brings AI to
+the edge, turning local devices into supercomputers and drastically
+reducing cloud costs and accelerating builds.
+
+
+NativeLink powers over one billion requests per month for some of the
+largest companies in the world, providing speed and reliability in your
+production workloads that unlocks possibilities previously unattainable
+with any existing solution.
+
+
+What's next
+As we launch out of stealth, we're excited to share our vision and invite
+the community to join us in building the future.
+
+
+NativeLink is free and open source forever. With over a thousand stars on
+GitHub and contributions from engineers at Tesla, General Motors, Samsung,
+and others, we will continue to make NativeLink the best in class for
+safety-critical technologies. Our focus will be on improving its
+capabilities and expanding its adoption across various industries.
+
+
+Building a strong, collaborative community is at the heart of our mission.
+We encourage developers, engineers, and researchers to join our Slack,
+contribute to our projects, and share their feedback. Together, we can
+drive innovation and create a safer, more advanced future.
+
+
+We’re already working on additional tools and infrastructure solutions to
+address the evolving needs of developers in AI and autonomous systems. Stay
+tuned for more announcements as we continue to innovate and push the
+boundaries of what’s possible.
+
+
+Trace Machina is more than just a company; it’s a movement. We invite you
+to be a part of this exciting journey as we strive to revolutionize the
+development of safety-critical technologies.
+
+
+Thank you for your support.
+
+
+Marcus Eagan
+
+CEO and Co-Founder, Trace Machina
+
+
+For more information about Trace Machina and NativeLink, visit our website
+and GitHub repository.
+
+Trace Machina launches NativeLink, announces seed round

--- a/web/apps/web/content/posts/CaseStudy_CIQ.mdx
+++ b/web/apps/web/content/posts/CaseStudy_CIQ.mdx
@@ -1,0 +1,121 @@
+---
+title: "Case Study: CIQ"
+tags: ["news", "case-studies"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_ciq.webp
+slug: case-study-ciq
+pubDate: 2024-08-13
+readTime: 2 minutes
+---
+CIQ is an enterprise company that specializes in Linux distribution,
+computing infrastructure, and cluster management and provisioning systems.
+They have a deep running commitment to supporting open source projects and
+creating enterprise-level support for them: They're the Founding Sponsor of
+Rocky Linux, an open source operating system that rebuilds sources directly
+from Red Hat Enterprise Linux (RHEL); they support an open source project
+called Warewulf that's a cluster management and provisioning system to help
+simplify deployment and management of compute clusters; and they supported
+and donated Singularity (later named to Apptainer) to the Linux Foundation
+that's designed to bring containers to high performance computing.
+
+
+All of CIQ enterprise solutions, which are developed from their support and
+contributions to the open source projects, are consolidated into one
+repository, known as a monolithic repository (monorepo). A monorepo allows
+CIQ to ensure all projects (solutions) are consistent and integrated
+effectively, simplify dependency management as updates can be made
+uniformly across the codebase, streamline CI/CD pipelines, and facilitate
+cross-team collaboration and more. Since thousands of customers rely on
+their solutions for mission-critical use cases, it’s imperative for them to
+maintain the monorepo to:
+
+ensure consistency across any environment, architectures, libraries,
+services, and tools
+efficiently update and maintain features with no downtime
+rapidly debug issues and patches across the entire codebase
+perform comprehensive testing and validation across all projects
+improve the scalability as the codebase grows
+
+CIQ needed a remote execution service to help dynamically scale their
+compute resources, optimize build times, and handle increasing demands.
+
+
+Storage Scalability Challenges
+Physical disk resizing
+CIQ previously relied on a solution where storage management was based on a
+block-level architecture. Data was stored and accessed in fixed-size blocks
+that’s directly tied to physical storage devices. The only way to increase
+storage capacity is to physically resize the hard drives. As the data volume
+increased, they had to consistently resize the disk. This impracticality was
+time consuming and not scalable. When their previous solution couldn't handle
+the demand and scale for their needs, CIQ turned to NativeLink for a more
+robust and maintainable alternative.
+
+
+Cloud-based storage
+The other challenge CIQ faced was integrating with cloud-based distributed
+storage systems like AWS S3 and Google Cloud Storage (GCS). This obstacle
+primarily stemmed from legacy storage architecture where they heavily relied
+on physical disk-based block storage. The block storage architecture couldn't
+seamlessly interface with cloud-based distributed storage systems that are
+designed to be elastic and offer on-demand scaling. This incompatibility made
+it difficult for CIQ to take advantage of the cloud’s ability to adjust
+storage capacity based on demand. They had high resource utilization waste
+and couldn’t fully capitalize on cost performance benefits that cloud storage
+provides.
+
+
+Implementing and maintaining NativeLink
+One of the standout features of NativeLink for the CIQ team was its intuitive
+codebase housed in a single repository. NativeLink’s logical separation of
+components enabled CIQ’s engineers to efficiently pinpoint the source of any
+errors, and each component's responsibilities were well-defined, allowing for
+swift problem resolution. The simplicity of NativeLink’s architecture meant
+that most issues were addressed during the setup phase, minimizing the risk
+of future errors.
+
+For CIQ, NativeLink is also incredibly low-touch when it comes to
+maintenance. It provided a significant improvement in managing physical disk
+storage compared to BuildBarn. Changing the physical disk sizes required
+adjusting the Persistent Volume Claim (PVC) on Kubernetes (k8s) to reflect
+the desired storage capacity and then update the storage configuration. This
+streamlined CIQ’s process to quickly scale the physical disks with minimal
+effort and adjust eviction policies.
+
+
+Furthermore, NativeLink integrates seamlessly with cloud-based storage
+systems, like S3. This enables CIQ to scale their infrastructure up or down
+with flexibility and elasticity as their needs evolve. They now can
+efficiently run multiple Content Addressable Storage (CAS) nodes. This
+flexibility and reliability allowed CIQ to focus on more critical aspects of
+their operations, knowing that their RBE system was stable and dependable.
+For them, all of NativeLink’s setup was almost a “fire and forget” operation
+for the CIQ team.
+
+The results
+Operational savings - CIQ is able to avoid unnecessary provisioning of
+resources and can scale their node pool with confidence. In addition, because
+they no longer worry about the complexity of client-oriented scheduling,
+higher Bazel jobs that would once overwhelm the system and cause timeouts and
+other issues are handled with ease.
+Efficient resource management - NativeLink has allowed CIQ to maintain a
+consistent spot node pool of workers since deployment. Even with increased
+activity, the system has remained stable, eliminating the need for constant
+scaling. Additionally, NativeLink’s ability to handle all actions remotely
+without the need to download CAS objects to GitHub Actions has provided
+substantial savings in both time and resources.
+Reduced CI and deployment times - Since implementing NativeLink, CIQ has been
+able to reduce their CI times drastically, with average PR CI time from 15
+minutes to 3 minutes and full service deployment times dropping from an
+average of over 1 hour to 15 minutes from code merge.
+
+Conclusion
+Because of NativeLink, CIQ has been able to eliminate significant technical
+challenges, see reduced operational costs, and increased efficiency. With
+NativeLink’s intuitive architecture, ease of use, and minimal maintenance
+requirements, CIQ has been able to scale with confidence and its engineers
+empowered to focus on what they do best—building innovative solutions without
+the distractions of an unreliable RBE system.
+
+
+To learn more about NativeLink, read our documentation, check out our GitHub
+Repository, or contact our team directly at hello@nativelink.com.

--- a/web/apps/web/content/posts/CaseStudy_Fortune50.mdx
+++ b/web/apps/web/content/posts/CaseStudy_Fortune50.mdx
@@ -1,0 +1,28 @@
+---
+title: "Fortune 50 Manufacturer Uses NativeLink For 20x Accelerated Build Speed and 30x Improved Storage Density"
+tags: ["news", "case-studies"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_logo.webp
+slug: case-study-fortune-50-manufacturer
+pubDate: 2025-01-21
+readTime: 3 minutes
+---
+
+# Background
+
+A Fortune 50 Manufacturer builds a Chromium-based browser, and it has been an integral part of their product lineup, requiring robust and efficient build infrastructure to keep up with its evolving complexity. With a need for more advanced solutions due to increasing build complexity and domain variety, the Fortune 50 Manufacturer sought a tool that could provide remote execution and build caching at scale.
+
+## Challenges
+
+Increased build complexity. The heterogeneous nature of our customer’s builds required a solution capable of handling complex compositions across different executors. Existing solutions became inefficient and unscalable with increasing complexity of build domains, and the team needed a remote execution solution to push tasks to the right environments at the right time.
+
+## Solution
+
+Integrating with NativeLink’s remote execution platform and build caching capabilities, our client swiftly streamlined their build processes and reduced build times from 2 days to 2 **hours. Furthermore,** the customer team positioned itself to better handle future development needs, especially with the potential to improve storage density and overall system efficiency.
+
+Future-proofing development. By adopting NativeLink, our customer positioned itself to better handle future development needs, with the potential to improve storage density and overall system efficiency. In early tests, the customer team was able to achieve a 1:4 compression ratio on compressed content and a 30x increase on the storage density of edited CAS content by extending NativeLink's [Dedup store](https://github.com/TraceMachina/nativelink/blob/main/nativelink-store/src/dedup_store.rs).
+
+## Conclusion
+
+The adoption of NativeLink by the Fortune 50 Manufacturer has proven to be a game-changer, enabling the team to efficiently manage complex builds, reduce build times, and scale their infrastructure effectively. This integration highlights the potential of NativeLink to significantly enhance development processes for large-scale projects.
+
+To learn more about NativeLink, read our documentation, check out our GitHub Repository, or contact our team directly at [hello@nativelink.com](mailto:hello@nativelink.com).

--- a/web/apps/web/content/posts/CaseStudy_LastMileAI.mdx
+++ b/web/apps/web/content/posts/CaseStudy_LastMileAI.mdx
@@ -1,0 +1,38 @@
+---
+title: "Case Study: LastMile AI"
+tags: ["news", "case-studies"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/lastmileai-logo.webp
+slug: case-study-last-mile-ai
+pubDate: 2025-09-25
+readTime: 2 minutes
+---
+## **About LastMile AI**
+
+[LastMile AI](https://lastmileai.dev/) is an AI startup creating tools to enable developers to build AI agents. The team comes from backgrounds in top research and engineering organizations, building infrastructure and developer tools, and is backed by leading investors like Gradient Ventures, AME Cloud Ventures and Exceptional Capital.
+
+LastMile AI empowers developers to build and deploy their own AI agents using [**mcp-agent**](https://mcp-agent.com/), a framework built on Model Context Protocol. mcp-agent has become a go-to toolkit for developers looking to connect large language models to real-world tools and workflows, and reflects the philosophy of empowering developers with transparent, composable systems.
+
+As mcp-agent has grown, scaling the infrastructure needed to support different libraries and tech stacks across thousands of developers has become increasingly demanding.
+
+## **Key Outcomes with NativeLink**
+
+* Eliminated repetitive local rebuilds across our engineering team.
+* Enabled custom integrations with complex dependencies (like Temporal and Envoy) without build-time bottlenecks.
+* Accelerated development of AI agents by streamlining interoperability across languages, allowing the best technology to be implemented for each task.
+* Improved reliability of our platform while maintaining developer speed.
+
+## **The Challenge**
+
+LastMile AI relies heavily on a diverse range of technologies to power our platform, such as Temporal and Envoy, with a common denominator of protobuf and gRPC, to form the foundation of mcp-agent’s infrastructure, requiring interoperability across languages. In the world of AI, this challenge compounds:
+
+* **AI is uniquely polyglot.** While application code often lives in Python, the ecosystem depends critically on native libraries written in languages like Rust, C++, and CUDA.
+* **Complex build targets.** To support diverse deployment environments, it’s often necessary to break apart dependencies and reconstruct them with Bazel.
+* **Developer overhead.** Without a shared caching system, every engineer building their own AI agent would be forced to repeatedly recompile these large dependencies, slowing iteration, wasting time and frustrating developers. Shared remote caching lets the team treat foundational components as fixtures that benefit everyone instead of slowing down iteration.
+
+## **The Solution**
+
+NativeLink has eliminated much of the overhead needed in managing all the library dependencies. LastMile uses NativeLink as a remote build cache for Bazel:
+
+* **Eliminating repetitive local rebuilds.** Using NativeLink as a remote build cache for Bazel in our monorepo allows developers to reuse shared build outputs.
+* **Incorporating heavier dependencies.** By caching builds, the team can incorporate heavier dependencies (such as Envoy and Temporal) directly into the build process.
+*  **Reproducible builds.** Because developers don’t have to waste time or resources with local rebuilds, they can get back to building.

--- a/web/apps/web/content/posts/CaseStudy_LastMileAI.mdx
+++ b/web/apps/web/content/posts/CaseStudy_LastMileAI.mdx
@@ -10,7 +10,7 @@ readTime: 2 minutes
 
 [LastMile AI](https://lastmileai.dev/) is an AI startup creating tools to enable developers to build AI agents. The team comes from backgrounds in top research and engineering organizations, building infrastructure and developer tools, and is backed by leading investors like Gradient Ventures, AME Cloud Ventures and Exceptional Capital.
 
-LastMile AI empowers developers to build and deploy their own AI agents using [**mcp-agent**](https://mcp-agent.com/), a framework built on Model Context Protocol. mcp-agent has become a go-to toolkit for developers looking to connect large language models to real-world tools and workflows, and reflects the philosophy of empowering developers with transparent, composable systems.
+LastMile AI empowers developers to build and deploy their own AI agents using [**mcp-agent**](https://github.com/lastmile-ai/mcp-agent), a framework built on Model Context Protocol. mcp-agent has become a go-to toolkit for developers looking to connect large language models to real-world tools and workflows, and reflects the philosophy of empowering developers with transparent, composable systems.
 
 As mcp-agent has grown, scaling the infrastructure needed to support different libraries and tech stacks across thousands of developers has become increasingly demanding.
 

--- a/web/apps/web/content/posts/CaseStudy_ThirdwaveAutomation.mdx
+++ b/web/apps/web/content/posts/CaseStudy_ThirdwaveAutomation.mdx
@@ -1,0 +1,84 @@
+---
+title: "Thirdwave Automation and NativeLink"
+tags: ["news", "case-studies"]
+image: https://nativelink-cdn.s3.us-east-1.amazonaws.com/nativelink_logo.webp
+slug: case-study-thirdwave-automation
+pubDate: 2025-03-06
+readTime: 7 minutes
+---
+
+
+####
+
+#### *How NativeLink’s open software development and validation platform helped a robotics innovator deliver safer products faster (at less cost)*
+
+“Our business relies on delivering autonomous systems with an exceptional level of safety. With NativeLink’s massively-parallel cloud service, we can now iterate faster and continuously learn from our testing, without wasting time managing build cycles and cloud resources. It’s very fast, stable. It just works.”
+
+Nate Gallaher, DevOps Team Lead, Thirdwave Automation
+
+### Summary
+
+Founded in 2018 and funded by Toyota’s growth fund plus Innovation Endeavors, Norwest Venture Partners, Woven Capital, and Qualcomm Ventures, Third Wave Automation (TWA) leverages machine learning and artificial intelligence to manage fleets of automated forklifts and respond to edge cases in a timely and effective manner.
+
+Using automotive grade 3D LIDAR, TWA’s robotic forklifts incorporate Collision Shield, the industry-leading autonomous obstacle detection system running on forklifts. Other innovations include its Shared Autonomy Platform, enabling the TWA Reach line of forklifts to operate autonomously or seek help from remote operators who can take control from the safety of their office.
+
+Key elements of the company’s value proposition are safety, scalability, adaptability, repeatability, stability, and affordability. In order to preserve developer velocity and ensure timely delivery of its solutions, Thirdwave turned to NativeLink to help take its build and validation infrastructure to the next level.
+
+### Key Outcomes
+
+* 80% reduction in build times
+* 50% reduction in cloud costs
+* Transparent cloud scaling (Running 50K simultaneous jobs)
+* Now testing daily vs. weekly or monthly
+* Hundreds of developer hours saved per year
+* Rapid deployment | Bazel compatible
+
+### The Challenge
+
+The company develops complex software for intelligent material-handing, including semi-autonomous robots as well as a fleet management system with remote operation and assistance capabilities.
+
+Written in C/C++ and Python, the TWA software is built upon a micro-services architecture that makes extensive use of containers.
+
+As the code base and number of developers have grown, the team's ability to iterate quickly was significantly hindered by prolonged build and test times, reducing developer productivity.
+
+But given the critical importance of safety, it became even more important to run testing on a more frequent basis, including unit tests, subsystem tests, and system-wide tests. Keeping developer velocity high by reducing test turnaround time was also a key requirement.
+
+At the same time, the company was concerned it was running compilation tasks on the same expensive GPUs as their ML tests. They were looking for a more flexible and configurable approach to save on cloud computing costs.
+
+### The Solution
+
+Massively parallel architecture with remote execution and caching
+
+Leveraging NativeLink’s remote execution and build caching platform, built on a massively-parallel, cloud-optimized service, the firm reduced build times by up to 80% while also removing developer overhead and friction.
+
+Incremental builds are also faster because cache artifacts are reused whenever possible. Developers never need to build or test the same thing twice and can share code across different environments.
+
+Nate reports that having faster cycles actually changed developer behavior by encouraging developers to run tests more frequently, without concerns about potential bottlenecks.
+
+Deterministic builds
+
+As a deterministic build system, NativeLink prevents cross-platform divergence by enforcing a hermetic toolchain and pinning all external dependencies to a given version, helping to prevent the common occurrence of “but it worked fine on my machine” syndrome.
+
+This also helps enforce critical governance controls around the software supply chain, preventing tampering and producing an SBOM required by compliance mandates.
+
+Open and extensible platform built on Bazel
+
+Licensed as Apache 2.0 open source, NativeLink seamlessly integrates with Bazel, the modern build client developed by Google and now used by 1,000+ organizations including Tesla, Nvidia, Ford, Stripe, Dropbox, Datadog, and Databricks.
+
+NativeLink works with all client-side build tools that support the Remote Bazel Execution (RBE) protocol such as Bazel, Buck2, Pantsbuild, and Reclient.
+
+You can customize NativeLink via JSON or YAML, as well as via Starlark, a Python-based declarative language for configuring Bazel with custom build rules and macros for specific projects and platforms.
+
+### About NativeLink
+
+NativeLink is the world's first open software development and validation platform purpose-built for diverse target platforms such as robots, autonomous vehicles, and edge devices.
+
+The platform is also optimized for developers building other types of large artifacts such as Chromium-based browsers, system software, and next-generation semiconductors.
+
+Designed to meet the growing scalability demands and complexity of large-scale software projects, NativeLink accelerates time-to-market by 10x or more without sacrificing reliability, safety, security, or efficiency.
+
+NativeLink is currently deployed in some of the world's largest and most complex environments, including Brex, Citrix, and Menlo Security.
+
+TraceMachina, developer of NativeLink, is backed by leading investors including Sequoia, Wellington Management, Verissimo Ventures, and prominent angel investors.
+
+To learn more about NativeLink, read our documentation, check out our GitHub Repository, or contact our team directly at [hello@nativelink.com](mailto:hello@nativelink.com).

--- a/web/apps/web/content/posts/Finetune_LLM_On_CPU.mdx
+++ b/web/apps/web/content/posts/Finetune_LLM_On_CPU.mdx
@@ -1,0 +1,97 @@
+---
+title: "Fine-tune a Language Model on x86 CPUs using Bazel and NativeLink"
+tags: ["news", "blog-posts"]
+image: https://github.com/user-attachments/assets/ddfb5684-327b-4af9-9618-be707eab894f
+slug: finetune-with-bazel-nativelink
+pubDate: 2025-05-15
+readTime: 20 minutes
+---
+
+## Introduction
+
+The future of AI development belongs not necessarily to those with the most powerful infrastructure but to those who can extract maximum value from available resources. This tutorial emphasizes CPU-based fine-tuning demonstrating that with intelligent resource management through NativeLink, impressive results can be achieved without expensive GPU or TPU infrastructure. As compute becomes increasingly costly, competitive advantage will shift toward teams that optimize resource efficiency rather than those deploying state-of-the-art hardware.
+
+This guide demonstrates how to establish an optimized AI development pipeline by integrating several key technologies:<br></br>
+1\. **Bazel Build System**: For efficient repository management. A repository managed by Bazel allows your team to work in a unified codebase while maintaining clean separation of concerns.<br></br>
+2\. **NativeLink**: A remote execution system hosted in your cloud. With NativeLink's remote execution capabilities, you can leverage your cloud resources optimally without wasteful duplication of work.<br></br>
+3\. **Hugging Face Transformers**: For integrating with the rich ecosystem of open-source models that you can run locally or deploy anywhere. The transformers library also provides a sophisticated caching mechanism for optimizing loading model weights.
+
+
+## Setting Up Your Repository With Bazel
+
+Bazel is a build system designed for repositories that allows you to organize code into logical components while maintaining dependency relationships. For AI workloads, this is particularly valuable as it lets you separate model definitions, data processing pipelines, training code, and inference services.
+
+### Prerequisites
+
+1\. A recent version of Bazel ([installation instructions](https://bazel.build/install)). <br></br>
+2\. [NativeLink 0.6.0](https://github.com/TraceMachina/nativelink/releases/tag/v0.6.0) (Apache-licensed)
+
+### Initial Setup
+
+First, let's download all the files. From the folder where you want to download the files, run the following commands:
+
+<div style="max-height: 250px; max-width: 50vw; overflow: auto;">
+
+```bash
+# Clone the entire repository
+git clone https://github.com/TraceMachina/nativelink-blogs.git
+
+# Navigate to the subdirectory
+cd nativelink-blogs/finetuning_on_cpu
+```
+</div>
+
+
+Here's a description of some of the files:<br></br>
+1\. `README.md` - Instructions on how to connect/use NativeLink Cloud and how to run the code locally as well as remotely<br></br>
+2\. `requirements.lock` - Ensures consistent Python dependencies across all environments<br></br>
+3\. `.bazelrc` - Main Bazel configuration file setting global options for hermetic builds and remote execution<br></br>
+4\. `MODULE.bazel` - Configures the project as a Bazel module, tells Bazel we'll need Python, `pip` and CPU-only PyTorch, and manages external dependencies<br></br>
+5\. `pyproject.toml` - Python package configuration specifying dependencies and development tools<br></br>
+6\. `BUILD.bazel` (root) - Root build file defining lock targets for Python dependency management<br></br>
+7\. `platforms/BUILD` - Defines Linux x86_64 execution platform running in Ubuntu 24.04 for remote builds<br></br>
+8\. `training/BUILD` - Defines the model training targets and their dependencies<br></br>
+9\. `training/main.py` - Main script that handles fine-tuning of language models on CPU using efficient training techniques<br></br>
+
+
+## Important Note About Bazel’s Remote Execution Support
+
+Bazel supports remote execution for building (compiling) and testing, but `bazel run` uses the host platform as its target platform, meaning the executable will be invoked locally rather than on remote machines. To execute binaries on remote servers, a workaround is to design tests that execute the binary, effectively leveraging `bazel test` which runs on the target platform.
+
+**DRAWBACK:**
+
+Logging and print statements that track progress (like "Starting to fine tune model" or "Exiting this function") behave differently in remote execution. Unlike local runs where these appear in real-time, remote testing collects all logs on the server and only displays them after test completion when control returns to the local machine. The expected output is still fully preserved - just delayed until the process finishes running.
+
+
+## Aside - Configuring Remote Execution For ARM (Apple Silicon)
+
+
+Most cloud infrastructure (including NativeLink) runs on x86_64 processors, while Apple Silicon Macs use ARM64. Dependencies such as PyTorch are built for specified architectures and setting up Bazel to handle platform-specific dependencies is complex.
+
+If you want to run this code and you only have a Mac, the simplest way would be to run this code via a cloud-based Linux VM (GCP/AWS). If you don't want to use a cloud server, you could create a minimal docker container for x86_64 (`FROM --platform=linux/amd64 ubuntu:24.04` with just `curl` and `Bazelisk` installed) with **Rosetta enabled** and run from your Mac's terminal using this container. However, we highly recommend against this approach; the correct approach here would be to use toolchain transitions from a local mac platform to the remote Linux runner, but that's outside of the scope of this article.
+
+
+## The NativeLink Difference
+
+To demonstrate NativeLink’s efficacy, consistency, and reliability, we ran the same fine-tuning job on the CPU of an M1 Pro MacBook Pro, the free version of Google Colab on CPU, and [NativeLink](https://github.com/TraceMachina/nativelink), which is free and open-source. We executed the fine-tuning task 5 times and this is what we observed:
+
+1\. The Mac: the quickest run took 18 minutes while the slowest/longest took 20 minutes
+
+2\. Free version of Google Colab: the quickest run took 10 minutes while the slowest/longest took 20 minutes. The execution time was widely varied. We suspect varying traffic on Google’s servers and how Colab allocates its compute resources played a part in this variability.
+
+3\. Free NativeLink: the quickest run took 4 minutes of compute time while the slowest/longest took 6 minutes. NativeLink Cloud provided the quickest execution times by far.
+
+<img src="https://github.com/user-attachments/assets/c2bf8e0e-1500-4ee7-a0f7-6b4ca2196257" width="1000" alt="Model Fine-Tuning Times"></img>
+
+
+## Conclusion: Optimizing AI Development Through Resource Efficiency
+
+As demonstrated through this tutorial, the integration of Bazel's repository management, NativeLink's CPU-optimized remote execution, and Hugging Face's transformers library creates a development ecosystem that prioritizes computational efficiency over raw processing power. This approach addresses several critical challenges facing modern AI teams:
+
+1\. **Resource Optimization**: By leveraging NativeLink's intelligent scheduling and optimization on CPU infrastructure, teams can achieve impressive fine-tuning results without the capital expenditure of specialized GPU/TPU hardware.<br></br>
+2\. **Strategic Advantage**: This CPU-focused approach provides a competitive edge through efficient resource utilization, enabling teams to allocate budget toward innovation rather than hardware acquisition.<br></br>
+3\. **Sustainable Scaling**: As models grow in size and complexity, the ability to efficiently distribute workloads across existing CPU infrastructure provides a more sustainable path to scale than continuously upgrading to the latest accelerators.<br></br>
+
+For forward-thinking AI teams, this infrastructure stack represents a shift from the "bigger is better" hardware arms race toward thoughtful resource utilization. The competitive advantage increasingly belongs to those who can extract maximum value from available compute rather than those who deploy more powerful hardware.
+
+The journey from experimental AI projects to production-grade systems demands both technical sophistication and resource awareness. By adopting this CPU-optimized approach with Bazel and NativeLink, your team can focus less on infrastructure limitations and more on the creative potential of fine-tuned models—developing applications that deliver genuine value while maintaining computational efficiency.

--- a/web/apps/web/content/posts/NativeLink_for_Semiconductors.md
+++ b/web/apps/web/content/posts/NativeLink_for_Semiconductors.md
@@ -1,0 +1,39 @@
+---
+title: "NativeLink for Semiconductors"
+tags: ["news", "blog-posts"]
+image: https://www.gstatic.com/webp/gallery/4.sm.webp
+slug: semiconductors
+pubDate: 2024-12-04
+readTime: 4 minutes
+---
+## Open Source: Enabling the Performance and Deterministic Builds for the Next Era of Semiconductor Innovation
+
+### **Transforming Semiconductor Design with NativeLink**
+
+NativeLink has become a critical architectural component for companies developing custom silicon. From the outset, our mission was to build an open-source simulation platform designed to scale with cutting-edge client technologies and cater to the needs of pioneering industries like autonomous robotics. These innovators have increasingly sought alternatives to proprietary solutions for design simulation, leveraging NativeLink for direct hardware access, no garbage collection, considerable infrastructure cost reduction, and high-fidelity test environments. And now, with the proliferation of large language models (LLMs) and Nvidia’s monopolistic dominance in advanced computing,  NativeLink has garnered significant interest from an unexpected sector: semiconductors.
+
+This shift is fueled by the proliferation of large language models (LLMs) and Nvidia's dominance in advanced computing, which have driven the development of new semiconductor technologies aimed at addressing supply-side challenges. Among the most promising advancements driving the development of new semiconductor technologies are:
+
+1. **Simplified Silicon Architectures**, streamlining traditional designs for efficiency and scalability.
+2. **Diamond Wafers**, leveraging superior thermal and electrical properties.
+3. **Nanophotonic Metamaterials**, pioneering optical solutions for enhanced performance.
+
+While these innovations hold transformative potential across industries from computing to healthcare, the legacy tools dominating electronic design automation (EDA)—such as Cadence, Ansys, and Synopsys—have anchored the space as billion-dollar leaders in EDA, ripe for smaller but hopefully valuable new integrations with their established, proprietary workflows.
+
+### **Open Silicon: Bridging the Gap with Open Source**
+
+The rising demand for compute power has outpaced the silicon industry's ability to deliver. To address this, Google developed the "Open Silicon" strategy, incorporating open-source technologies such as LLVM, XLS, OpenRoad, and Bazel. The traditional silicon design workflow—spanning RTL design, synthesis, and place-and-route—has historically relied on disparate, proprietary tools, creating inefficiencies in iteration and maintenance.
+
+By integrating these workflows into a Bazel-managed ecosystem, NativeLink enables a streamlined, deterministic approach. Using Bazel build rules written in Starlark, users can manage each design stage as version-controlled code within a monorepo, leveraging open-source tools for greater transparency, customizability, and collaboration.
+
+### **Deterministic Execution with Rust and Nix**
+
+NativeLink’s Rust foundation ensures reliability by minimizing race conditions, which are often identified at compile time. Coupled with Nix as a dependency manager, the platform provides a hermetic environment with fine-grained control over pinned dependencies. This approach contrasts with many legacy tools and emerging competitors that rely on garbage-collected languages, introducing nondeterministic behavior.
+
+### **A New Era of Open-Source EDA**
+
+Open-source tools such as Verilog, Bazel, Verilator, `rules_hdl`, and OpenRoad have set the stage for a new generation of silicon providers. RISC-V is new and not for everyone, but it's a glimpse into the opening world of semiconductors. By adopting an open source, instruction set architecture, companies can eliminate licensing fees and leverage modular design benefits. NativeLink furthers this modularity, breaking each system component into self-contained modules that foster maintainability and extensibility. For more details, [explore our GitHub repository](https://github.com/TraceMachina/nativelink).
+
+### **The Future of Semiconductor Innovation**
+
+NativeLink’s remote execution and caching capabilities are expanding rapidly, empowering innovators to explore the potential of open-source tools in semiconductor design. As industries push the boundaries of technology, we're committed to enabling breakthroughs with flexible, scalable, and deterministic infrastructure tools that engineers can rely on.

--- a/web/apps/web/lib/posts.ts
+++ b/web/apps/web/lib/posts.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface Post {
+  slug: string;
+  title: string;
+  tags: string[];
+  image?: string;
+  pubDate: string;
+  readTime?: string;
+  excerpt: string;
+  body: string;
+}
+
+const POSTS_DIR = path.join(process.cwd(), "content/posts");
+
+// The restored posts (recovered from the pre-redesign Astro site) all share
+// the same flat frontmatter shape, so a full YAML parser isn't needed:
+//   title: "..."  tags: [".."]  image: url  slug: str  pubDate: date  readTime: str
+function parseFrontmatter(raw: string): {
+  data: Record<string, string | string[]>;
+  body: string;
+} {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match || match[1] === undefined) return { data: {}, body: raw };
+  const data: Record<string, string | string[]> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z]+):\s*(.*)$/);
+    const key = kv?.[1];
+    if (!kv || key === undefined || kv[2] === undefined) continue;
+    const value = kv[2].trim();
+    if (value.startsWith("[")) {
+      data[key] = value
+        .replace(/^\[|\]$/g, "")
+        .split(",")
+        .map((v) => v.trim().replace(/^["']|["']$/g, ""))
+        .filter(Boolean);
+    } else {
+      data[key] = value.replace(/^["']|["']$/g, "");
+    }
+  }
+  return { data, body: raw.slice(match[0].length) };
+}
+
+function deriveExcerpt(body: string): string {
+  for (const block of body.split(/\r?\n\r?\n/)) {
+    const text = block
+      .replace(/^#+\s.*$/gm, "")
+      .replace(/^-{3,}\s*$/gm, "")
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/[*_`>]/g, "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text.length > 60) {
+      return text.length > 200 ? `${text.slice(0, 197).trimEnd()}…` : text;
+    }
+  }
+  return "";
+}
+
+export function getAllPosts(): Post[] {
+  return fs
+    .readdirSync(POSTS_DIR)
+    .filter((f) => /\.(md|mdx)$/.test(f))
+    .map((file) => {
+      const raw = fs.readFileSync(path.join(POSTS_DIR, file), "utf8");
+      const { data, body } = parseFrontmatter(raw);
+      const slug =
+        typeof data.slug === "string" && data.slug ? data.slug : file.replace(/\.(md|mdx)$/, "");
+      return {
+        slug,
+        title: typeof data.title === "string" ? data.title : slug,
+        tags: Array.isArray(data.tags) ? data.tags : [],
+        image: typeof data.image === "string" ? data.image : undefined,
+        pubDate: typeof data.pubDate === "string" ? data.pubDate : "",
+        readTime: typeof data.readTime === "string" ? data.readTime : undefined,
+        excerpt: deriveExcerpt(body),
+        body,
+      };
+    })
+    .sort((a, b) => b.pubDate.localeCompare(a.pubDate));
+}
+
+export function getPost(slug: string): Post | undefined {
+  return getAllPosts().find((p) => p.slug === slug);
+}
+
+export function formatPostDate(pubDate: string): string {
+  const date = new Date(`${pubDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return pubDate;
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/apps/web/lib/posts.ts
+++ b/web/apps/web/lib/posts.ts
@@ -44,15 +44,20 @@ function parseFrontmatter(raw: string): {
 
 function deriveExcerpt(body: string): string {
   for (const block of body.split(/\r?\n\r?\n/)) {
-    const text = block
+    let text = block
       .replace(/^#+\s.*$/gm, "")
       .replace(/^-{3,}\s*$/gm, "")
       .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
       .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-      .replace(/[*_`>]/g, "")
-      .replace(/<[^>]+>/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
+      .replace(/[*_`>]/g, "");
+    // Strip HTML tags to a fixpoint so overlapping fragments can't
+    // reassemble into a tag after a single pass.
+    let previous: string;
+    do {
+      previous = text;
+      text = text.replace(/<[^>]*>/g, "");
+    } while (text !== previous);
+    text = text.replace(/\s+/g, " ").trim();
     if (text.length > 60) {
       return text.length > 200 ? `${text.slice(0, 197).trimEnd()}…` : text;
     }

--- a/web/apps/web/package.json
+++ b/web/apps/web/package.json
@@ -5,6 +5,7 @@
     "@nativelink/tokens": "workspace:*",
     "@nativelink/ui": "workspace:*",
     "geist": "^1.5.1",
+    "marked": "^16.4.2",
     "motion": "^12.0.0",
     "next": "^16",
     "react": "^19.0.0",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -43,6 +43,7 @@
         "@nativelink/tokens": "workspace:*",
         "@nativelink/ui": "workspace:*",
         "geist": "^1.5.1",
+        "marked": "^16.4.2",
         "motion": "^12.0.0",
         "next": "^16",
         "react": "^19.0.0",


### PR DESCRIPTION
# Description

Restores the 10 real blog posts that were deleted when the site redesign (#2371) replaced the old Astro site (`web/platform/`) with the new Next.js app, leaving `/resources` with placeholder cards linking to `#`.

- **Content**: the 10 original `.md`/`.mdx` posts recovered byte-for-byte from `2c549617^` into `web/apps/web/content/posts/`, original frontmatter intact. 
- **Routes**: `/resources/blog` (standalone index) and `/resources/blog/<slug>` (prerendered post pages; markdown rendered with `marked` — already in the lockfile via the docs app — into the existing `Prose` component). Slugs come from the original frontmatter, so the pre-redesign URLs resolve again.
- **Resources page**: the full listing is inlined on `/resources` under a "From the team" heading, grouped per review feedback into **Case studies / Announcements / Blog**. The hermetic-toolchains talk is no longer an embedded YouTube player — it's a regular card at the end of the Blog group linking out to the recording (its metadata now says "BazelCon 2024", the talk's actual venue, instead of the placeholder date the redesign invented).
- **Link fixes** from a full page audit: the dead `#` talk card now points at the recording, and the LastMile AI post's `mcp-agent.com` link (domain no longer resolves) now points at the project's GitHub repo — the one deviation from the verbatim restore.
- **CodeQL**: both alerts raised on the new code are resolved (fixpoint HTML-tag stripping in the excerpt helper; `encodeURIComponent` on file-derived slugs in hrefs).

Notes for review: the restored index lists all posts (the old Astro index filtered on the `news` tag, which hid the CMake tutorial — surfacing it is intentional). Known content staleness, restored as-is for a faithful restore: the LLM fine-tuning tutorial pins NativeLink v0.6.0 and depends on the `TraceMachina/nativelink-blogs` repo; the trust-roots post's TLS config snippets may have drifted from the current `nativelink-config` schema.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `bun run typecheck`, `biome check`, and `next build` clean; all 10 post pages prerender via `generateStaticParams`
- Local production server: desktop (1280px) and iPhone-width (390px) renders verified for every changed page, including the code-block-heavy tutorials and the raw-HTML post
- Full link audit across `/resources`, `/resources/blog`, and all 10 posts: every internal route 200, every external URL resolves
- CodeQL re-scan green after the fixes; Vercel preview deployments build and serve the restored blog

## Checklist

- [x] Updated documentation if needed (n/a — content restore; no behavior docs affected)
- [ ] Tests added/amended (no test infrastructure exists for the web app's pages)
- [x] Web CI (`Web Build`, pre-commit, vale) passes
- [ ] PR is contained in a single commit — kept as scoped commits (restore / wiring / link fixes / CodeQL / layout) for reviewability; happy to squash on merge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2501)
<!-- Reviewable:end -->
