### PR TITLE
evict .exec variant when its digest is evicted

### DIFF
--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -786,6 +786,50 @@ where
     Ok(false)
 }
 
+/// Deletes a digest's `.exec` variant (see
+/// [`FilesystemStore::get_executable_hardlink_source`]) when that digest is
+/// evicted or replaced in the primary CAS `evicting_map`. Without this, the
+/// `.exec` directory is invisible to `max_bytes` and is only ever cleared by
+/// the startup `remove_dir_all`, so it grows without bound at runtime (#2474).
+/// Tying its lifetime to the primary entry instead bounds total disk use to
+/// roughly `2 * max_bytes` in the worst case (every blob also executable).
+#[cfg(unix)]
+#[derive(Debug)]
+struct ExecutableVariantRemover {
+    content_path: String,
+}
+
+#[cfg(unix)]
+impl RemoveItemCallback for ExecutableVariantRemover {
+    fn callback<'a>(
+        &'a self,
+        store_key: StoreKey<'a>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let StoreKey::Digest(digest) = store_key else {
+                return;
+            };
+            let variant_path = format!(
+                "{}{EXECUTABLE_DIR_SUFFIX}/{DIGEST_FOLDER}/{digest}",
+                self.content_path
+            );
+            match fs::remove_file(&variant_path).await {
+                Ok(()) => debug!(
+                    ?variant_path,
+                    "Deleted executable variant for evicted digest"
+                ),
+                // Common case: no variant was ever materialized for this digest.
+                Err(err) if err.code == Code::NotFound => {}
+                Err(err) => warn!(
+                    ?variant_path,
+                    ?err,
+                    "Failed to delete executable variant for evicted digest"
+                ),
+            }
+        })
+    }
+}
+
 #[derive(Debug, MetricsComponent)]
 pub struct FilesystemStore<Fe: FileEntry = FileEntryImpl> {
     #[metric]
@@ -850,6 +894,11 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             fs::create_dir_all(format!("{executable_dir}/{DIGEST_FOLDER}"))
                 .await
                 .err_tip(|| format!("Failed to create executable dir {executable_dir}"))?;
+            evicting_map.add_remove_callback(RemoveItemCallbackHolder::new(Arc::new(
+                ExecutableVariantRemover {
+                    content_path: spec.content_path.clone(),
+                },
+            )));
         }
 
         let shared_context = Arc::new(SharedContext {
@@ -962,6 +1011,24 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         }
 
         let result = self.create_executable_variant(digest, &variant_path).await;
+
+        // The digest may have been evicted mid-copy: its eviction callback ran
+        // before the rename published the variant, so nothing owns the file
+        // anymore. This orphans the variant from eviction accounting, but the
+        // race is rare enough (needs an eviction to land in the narrow window
+        // between rename and this check, on a digest's first-ever variant
+        // materialization) that it's a self-limiting leak, not a systemic one
+        // — cheaper to log and let this action succeed with the still-valid
+        // file than to fail an otherwise-successful action over it.
+        if result.is_ok() && self.evicting_map.get(&digest.into()).await.is_none() {
+            warn!(
+                %digest,
+                ?variant_path,
+                "Digest evicted while materializing its executable variant; \
+                 variant is now untracked by eviction accounting"
+            );
+        }
+
         // Drop the per-digest lock entry regardless of outcome so the map
         // cannot grow unbounded; a concurrent waiter already cloned the Arc.
         self.forget_executable_lock(digest);

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -1663,6 +1663,56 @@ async fn executable_hardlink_source_created_once_and_readonly() -> Result<(), Er
     Ok(())
 }
 
+/// Regression test for #2474: the `.exec` variant directory was never
+/// registered in `evicting_map`, so it was invisible to `max_bytes` and only
+/// ever cleared by the startup `remove_dir_all` — growing without bound at
+/// runtime. Evicting a digest from the primary CAS must also delete its
+/// `.exec` sibling, bounding total `.exec` disk use to the primary store's
+/// own eviction policy instead of letting it grow forever.
+#[cfg(target_family = "unix")]
+#[nativelink_test]
+async fn evicting_digest_deletes_its_executable_variant() -> Result<(), Error> {
+    let content_path = make_temp_path("content_path");
+    let temp_path = make_temp_path("temp_path");
+    let digest1 = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let digest2 = DigestInfo::try_new(HASH2, VALUE2.len())?;
+
+    let store = Box::pin(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: content_path.clone(),
+            temp_path: temp_path.clone(),
+            eviction_policy: Some(EvictionPolicy {
+                max_count: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest1, VALUE1.into()).await?;
+
+    let variant_path = OsString::from(format!("{content_path}.exec/{DIGEST_FOLDER}/{digest1}"));
+    store.get_executable_hardlink_source(&digest1).await?;
+    fs::metadata(&variant_path)
+        .await
+        .err_tip(|| "Executable variant should exist right after creation")?;
+
+    // max_count: 1 means inserting a second digest evicts the first from the
+    // primary evicting_map, which must also delete digest1's `.exec` sibling.
+    store.update_oneshot(digest2, VALUE2.into()).await?;
+
+    let err = fs::metadata(&variant_path)
+        .await
+        .expect_err("Executable variant must be deleted when its digest is evicted");
+    assert_eq!(
+        err.code,
+        Code::NotFound,
+        "Expected the executable variant to be gone, got: {err:?}"
+    );
+
+    Ok(())
+}
+
 /// This test simulates a full disk without needing one. It writes past the `RLIMIT_FSIZE`
 /// cap, thus failing with `EFBIG`, which tokio defers exactly like `ENOSPC`. The
 /// [`SIGXFSZ`](`libc::SIGXFSZ`) signal must be ignored or the kernel will kill the process


### PR DESCRIPTION
# Description

Evict .exec variant when the digest is evicted. Pretty simple..

Fixes #2474 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test`

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2503)
<!-- Reviewable:end -->
