### PR TITLE
Add troubleshooting tips for macOS Nix setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ it via the [next-gen nix installer](https://github.com/NixOS/experimental-nix-in
 > Executables built for MacOS are dynamically linked against libraries from Nix
 > and won't work on systems that don't have these libraries present.
 
+> [!TIP]
+> **Common setup gotchas for Nix on macOS / Linux:**
+> * **Active shell environment**: If the installer finishes but your shell doesn't recognize `nix` commands, you need to either restart your terminal session or source the daemon profile manually:
+>   ```bash
+>   . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+>   ```
+> * **Enabling experimental features**: If you used the standard Nix installer and get an error saying `experimental Nix feature 'nix-command' is disabled`, enable them by creating or editing `~/.config/nix/nix.conf`:
+>   ```text
+>   experimental-features = nix-command flakes
+>   ```
+> * **Disk Space**: Unpacking and building compilers and dependencies requires significant storage. Make sure you have at least **15–20 GB of free space** on your system volume before running setup commands.
+
 **Linux, MacOS, WSL2**
 
 ```bash

--- a/web/apps/docs/content/docs/contribute/nix.mdx
+++ b/web/apps/docs/content/docs/contribute/nix.mdx
@@ -22,6 +22,18 @@ curl --proto '=https' --tlsv1.2 -sSf \
 
 It enables flakes by default.
 
+<Callout type="warn" title="macOS / Linux Nix Setup Gotchas">
+  - **Environment Paths**: If your shell doesn't recognize `nix` commands immediately after installation, you need to restart your terminal or run:
+    ```bash
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    ```
+  - **Experimental Features**: If you used the standard Nix installer and get `experimental Nix feature 'nix-command' is disabled`, enable them by adding the following to your `~/.config/nix/nix.conf` file:
+    ```text
+    experimental-features = nix-command flakes
+    ```
+  - **Disk Space**: Unpacking toolchains, compiler binaries, and caching build artifacts requires considerable storage. Ensure you have at least **15–20 GB of free space** on your drive before running `nix develop`.
+</Callout>
+
 ## Enter the dev shell
 
 ```bash

--- a/web/apps/docs/content/docs/getting-started/setup.mdx
+++ b/web/apps/docs/content/docs/getting-started/setup.mdx
@@ -50,7 +50,9 @@ macOS (Apple Silicon and Intel) and any Linux with Nix. Also the only path
 that supports Apple Silicon natively at the moment.
 
 <Callout type="warn">
-  Executables built for macOS link dynamically against libraries from the
+  - **Prerequisites**: Make sure your Nix installation has experimental features enabled (add `experimental-features = nix-command flakes` to your `~/.config/nix/nix.conf`).
+  - **Disk Space**: The installation and build process requires downloading and compiling toolchains and compilers. Ensure you have at least **15–20 GB of free space** on your drive.
+  - **Portability**: Executables built for macOS link dynamically against libraries from the
   Nix store. They will not run on systems without those libraries
   available. Stick to the Docker path if you need to copy the binary to
   another machine.


### PR DESCRIPTION
# Description

This PR improves the onboarding and setup documentation for macOS users running the Nix development environment for the first time. It addresses three major friction points:
1. **Active Shell Environment Paths**: Warns users that they may need to restart their terminal or source the Nix daemon profile script (`. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`) if the `nix` command is not recognized right after installation.
2. **Experimental Features (Flakes)**: Provides the instructions to enable `nix-command` and `flakes` in `~/.config/nix/nix.conf` if they are using standard Nix installations.
3. **Disk Space Requirements**: Advises users that the Nix environment downloads and compiles compilers and toolchains, requiring at least 15–20 GB of free space on their system volume.

Fixes #2504 

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

*   Ran `pre-commit run -a` locally, and all validation checks (including `vale`, `typos`, and markdown formatting) passed successfully.
*   Verified documentation rendered correctly and hot-reloaded successfully on the local Fumadocs server.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] PR is contained in a single commit, using `git amend`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2505)
<!-- Reviewable:end -->
