### PR TITLE
Update the OCI store with the tests and docs

### DIFF
--- a/nativelink-store/src/oci_store.rs
+++ b/nativelink-store/src/oci_store.rs
@@ -20,7 +20,10 @@ use aws_config::default_provider::credentials::DefaultCredentialsChain;
 use aws_config::provider_config::ProviderConfig;
 use aws_config::{AppName, BehaviorVersion};
 use aws_sdk_s3::Client;
-use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::config::{
+    Credentials, Region, RequestChecksumCalculation, ResponseChecksumValidation,
+};
+use aws_smithy_runtime_api::client::http::HttpClient as SmithyHttpClient;
 use nativelink_config::stores::{ExperimentalAwsSpec, ExperimentalOciSpec};
 use nativelink_error::Error;
 use nativelink_util::instant_wrapper::InstantWrapper;
@@ -52,10 +55,27 @@ impl OciStore {
         I: InstantWrapper,
         NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
     {
+        Self::new_with_http_client(spec, TlsClient::new(&spec.common.clone()), now_fn).await
+    }
+
+    /// Builds the store with a caller-supplied HTTP client. Production uses
+    /// [`Self::new`] (which injects a [`TlsClient`]); tests inject a mock (e.g.
+    /// `StaticReplayClient`) to exercise the OCI-specific wire behavior —
+    /// path-style URLs and the absence of `aws-chunked` — without a live bucket.
+    #[allow(clippy::new_ret_no_self)]
+    pub async fn new_with_http_client<I, NowFn, C>(
+        spec: &ExperimentalOciSpec,
+        http_client: C,
+        now_fn: NowFn,
+    ) -> Result<Arc<S3Store<NowFn>>, Error>
+    where
+        I: InstantWrapper,
+        NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
+        C: SmithyHttpClient + Clone + 'static,
+    {
         let aws_spec = Self::build_aws_spec(spec);
         let jitter_fn = spec.common.retry.make_jitter_fn();
 
-        let http_client = TlsClient::new(&spec.common.clone());
         let endpoint = Self::derive_endpoint(spec);
         let region = Region::new(Cow::Owned(spec.region.clone()));
 
@@ -72,6 +92,10 @@ impl OciStore {
             // OCI's compatibility endpoint embeds the bucket in the path, not as
             // a subdomain, so virtual-hosted addressing must be disabled.
             .force_path_style(true)
+            // OCI does not support the AWS SDK's default flexible-checksum
+            // behavior.
+            .request_checksum_calculation(RequestChecksumCalculation::WhenRequired)
+            .response_checksum_validation(ResponseChecksumValidation::WhenRequired)
             .http_client(http_client.clone());
 
         config_builder = if let Some(key_id) = &spec.access_key_id

--- a/nativelink-store/tests/oci_store_test.rs
+++ b/nativelink-store/tests/oci_store_test.rs
@@ -12,13 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `OciStore` builds an SDK client and hands it to `S3Store`. The S3 wire
-//! behaviour is covered by `s3_store_test.rs`.
+//! `OciStore` builds an SDK client and hands it to `S3Store`. These tests cover
+//! the config -> client mapping and the OCI-specific wire behavior (path-style
+//! URLs and non-`aws-chunked` uploads) using a `StaticReplayClient`, all without
+//! a live bucket. The generic S3 wire behavior is covered by `s3_store_test.rs`;
+//! live round-trip / multipart / load coverage is kept out of the repo.
 
+use std::sync::Arc;
+
+use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
+use aws_smithy_types::body::SdkBody;
+use http::{StatusCode, header};
 use nativelink_config::stores::{CommonObjectSpec, ExperimentalOciSpec};
-use nativelink_error::Error;
+use nativelink_error::{Code, Error};
 use nativelink_macro::nativelink_test;
 use nativelink_store::oci_store::OciStore;
+use nativelink_store::s3_store::S3Store;
+use nativelink_util::common::DigestInfo;
+use nativelink_util::instant_wrapper::MockInstantWrapped;
+use nativelink_util::store_trait::StoreLike;
 use pretty_assertions::assert_eq;
 
 #[nativelink_test]
@@ -55,5 +67,206 @@ async fn aws_spec_passes_region_bucket_and_common_through() -> Result<(), Error>
     assert_eq!(aws_spec.bucket, "test-bucket");
     assert_eq!(aws_spec.common.key_prefix.as_deref(), Some("cas/"));
     assert_eq!(aws_spec.common.consider_expired_after_s, 86400);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Mock wire-behavior tests. Drive the store through `new_with_http_client` with
+// a `StaticReplayClient` to verify the OCI-specific request shaping without a
+// live bucket.
+// ---------------------------------------------------------------------------
+
+const NAMESPACE: &str = "ns";
+const REGION: &str = "us-region-1";
+const BUCKET: &str = "test-bucket";
+const HOST: &str = "ns.compat.objectstorage.us-region-1.oci.customer-oci.com";
+const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+
+// Coerces the function item to a plain fn pointer matching the store type.
+const NOW_FN: fn() -> MockInstantWrapped = MockInstantWrapped::default;
+
+fn mock_spec() -> ExperimentalOciSpec {
+    ExperimentalOciSpec {
+        namespace: NAMESPACE.to_string(),
+        region: REGION.to_string(),
+        bucket: BUCKET.to_string(),
+        access_key_id: Some("AKIDTEST".to_string()),
+        secret_access_key: Some("SECRETTEST".to_string()),
+        ..Default::default()
+    }
+}
+
+async fn store_with(
+    mock: StaticReplayClient,
+) -> Result<Arc<S3Store<fn() -> MockInstantWrapped>>, Error> {
+    OciStore::new_with_http_client(&mock_spec(), mock, NOW_FN).await
+}
+
+#[nativelink_test]
+async fn has_object_found_uses_path_style_endpoint() -> Result<(), Error> {
+    const SIZE: u64 = 512;
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder()
+            .method("HEAD")
+            .uri(format!("https://{HOST}/{BUCKET}/{VALID_HASH1}-{SIZE}"))
+            .body(SdkBody::empty())
+            .unwrap(),
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_LENGTH, SIZE.to_string())
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let store = store_with(mock.clone()).await?;
+
+    let result = store.has(DigestInfo::try_new(VALID_HASH1, SIZE)?).await?;
+    assert_eq!(result, Some(SIZE), "expected object to be found");
+    mock.assert_requests_match(&[]);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_object_not_found_returns_none() -> Result<(), Error> {
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let store = store_with(mock).await?;
+
+    let result = store.has(DigestInfo::try_new(VALID_HASH1, 100)?).await?;
+    assert_eq!(result, None, "expected absent object to map to None");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_missing_object_maps_to_not_found() -> Result<(), Error> {
+    // OCI (like S3) returns a NoSuchKey error document on a missing GET; the SDK
+    // parses it and the store maps it to `Code::NotFound`.
+    const NO_SUCH_KEY: &str = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Error><Code>NoSuchKey</Code>",
+        "<Message>The specified key does not exist.</Message></Error>"
+    );
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(SdkBody::from(NO_SUCH_KEY))
+            .unwrap(),
+    )]);
+    let store = store_with(mock).await?;
+
+    let err = store
+        .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, 100)?, 0, None)
+        .await
+        .expect_err("get on a missing object must error");
+    assert_eq!(
+        err.code,
+        Code::NotFound,
+        "expected NotFound code for an absent object"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_single_put_is_path_style_and_unchunked() -> Result<(), Error> {
+    const DATA: &[u8] = b"hello-oci-single-put-body";
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::empty()).unwrap(),
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let store = store_with(mock.clone()).await?;
+
+    store
+        .update_oneshot(
+            DigestInfo::try_new(VALID_HASH1, DATA.len() as u64)?,
+            DATA.into(),
+        )
+        .await?;
+
+    let reqs: Vec<_> = mock.actual_requests().collect();
+    assert_eq!(reqs.len(), 1, "expected exactly one PutObject request");
+    let req = &reqs[0];
+    assert_eq!(req.method(), "PUT", "single-shot upload should be a PUT");
+    let want_prefix = format!("https://{HOST}/{BUCKET}/{VALID_HASH1}-{}", DATA.len());
+    assert!(
+        req.uri().starts_with(&want_prefix),
+        "expected path-style URL starting with {want_prefix}, got {}",
+        req.uri()
+    );
+    let sha = req
+        .headers()
+        .get("x-amz-content-sha256")
+        .unwrap_or_default();
+    assert!(
+        !sha.contains("STREAMING") && !sha.contains("CHUNKED"),
+        "PutObject must not use aws-chunked payload signing, got x-amz-content-sha256={sha}"
+    );
+    assert_ne!(
+        req.headers().get("content-encoding"),
+        Some("aws-chunked"),
+        "PutObject must not set Content-Encoding: aws-chunked"
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_object_returns_bytes() -> Result<(), Error> {
+    const VALUE: &str = "oci-object-contents";
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder()
+            .uri(format!(
+                "https://{HOST}/{BUCKET}/{VALID_HASH1}-1000?x-id=GetObject"
+            ))
+            .body(SdkBody::empty())
+            .unwrap(),
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .body(SdkBody::from(VALUE))
+            .unwrap(),
+    )]);
+    let store = store_with(mock.clone()).await?;
+
+    let got = store
+        .get_part_unchunked(DigestInfo::try_new(VALID_HASH1, 1000)?, 0, None)
+        .await?;
+    assert_eq!(got, VALUE.as_bytes());
+    mock.assert_requests_match(&[]);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn ranged_get_sends_range_header_path_style() -> Result<(), Error> {
+    const OFFSET: usize = 105;
+    const LENGTH: usize = 50_000;
+    let mock = StaticReplayClient::new(vec![ReplayEvent::new(
+        http::Request::builder()
+            .uri(format!(
+                "https://{HOST}/{BUCKET}/{VALID_HASH1}-1000?x-id=GetObject"
+            ))
+            .header("range", format!("bytes={OFFSET}-{}", OFFSET + LENGTH))
+            .body(SdkBody::empty())
+            .unwrap(),
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .body(SdkBody::empty())
+            .unwrap(),
+    )]);
+    let store = store_with(mock.clone()).await?;
+
+    store
+        .get_part_unchunked(
+            DigestInfo::try_new(VALID_HASH1, 1000)?,
+            OFFSET as u64,
+            Some(LENGTH as u64),
+        )
+        .await?;
+    mock.assert_requests_match(&[]);
     Ok(())
 }

--- a/web/apps/docs/content/docs/deployment/meta.json
+++ b/web/apps/docs/content/docs/deployment/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "on-prem-overview",
     "kubernetes",
+    "oci-object-storage",
     "chromium",
     "metrics",
     "persistent-workers"

--- a/web/apps/docs/content/docs/deployment/oci-object-storage.mdx
+++ b/web/apps/docs/content/docs/deployment/oci-object-storage.mdx
@@ -1,0 +1,139 @@
+---
+title: Oracle Cloud (OCI) Object Storage
+description: Back NativeLink's CAS and Action Cache with Oracle Cloud Infrastructure Object Storage via its S3 Compatibility API.
+---
+
+NativeLink can use [Oracle Cloud Infrastructure (OCI) Object
+Storage](https://www.oracle.com/cloud/storage/object-storage/) as the backing
+store for the CAS and Action Cache. It is configured through the
+`experimental_cloud_object_store` store with `provider: "oci"`, alongside the
+`aws`, `gcs`, `azure`, and `r2` providers.
+
+## How it works
+
+OCI Object Storage exposes an [S3 Compatibility
+API](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm).
+The OCI store is a thin adapter that points NativeLink's S3 store
+at OCI's S3-compatible endpoint, so it reuses the same multipart upload, retry,
+and streaming code paths as the AWS backend. Two OCI-specific adjustments are
+applied automatically:
+
+- **Path-style addressing** - OCI requires `endpoint/bucket/key` rather than
+  virtual-hosted (`bucket.endpoint/key`) URLs.
+- **Checksums downgraded to "when required"** - the AWS SDK otherwise adds a
+  default trailing checksum that forces `Content-Encoding: aws-chunked`, which
+  OCI rejects with `501 NotImplemented: AWS chunked encoding not supported`.
+  Without this, small single-`PUT` objects (notably Action Cache entries) fail.
+
+You do not need to configure either of these; they are handled by the store.
+
+## Prerequisites
+
+1. **A bucket.** Create one in the OCI Console under *Storage → Buckets*, or
+   with `oci os bucket create`. Note the bucket's **region** (e.g.
+   `ap-mumbai-1`).
+2. **Your Object Storage namespace.** A tenancy-wide identifier shown under
+   *Tenancy details*, or via `oci os ns get`. The endpoint is derived as
+   `https://{namespace}.compat.objectstorage.{region}.oci.customer-oci.com`.
+3. **A Customer Secret Key** (see [Authentication](#authentication)).
+
+## Authentication
+
+OCI's S3 Compatibility API authenticates with **Customer Secret Keys** - a
+static access-key / secret-key pair, used as the S3 `access_key_id` and
+`secret_access_key`.
+
+Generate one in the Console under *Profile → Customer Secret Keys → Generate
+Secret Key*:
+
+- The **Secret Key** is shown **only once** at generation time - copy it
+  immediately.
+- The **Access Key** is listed permanently in the Customer Secret Keys table and
+  can be copied at any time.
+
+Grant the associated user read/write on the bucket with a least-privilege
+policy:
+
+```
+Allow group <your-group> to manage object-family in compartment <compartment> where target.bucket.name='<bucket>'
+```
+
+We recommend supplying the keys via environment variables and referencing them
+with shellexpand.
+
+<Callout type="warn">
+  The S3 Compatibility API supports **only** Customer Secret Keys. OCI-native
+  authentication - API signing keys, and instance/resource principals - is **not**
+  available through this store. If you run NativeLink on OCI compute and want
+  keyless workload-identity auth, that is not currently supported; you must use
+  static Customer Secret Keys and rotate them yourself.
+</Callout>
+
+## Configuration
+
+A minimal CAS + Action Cache setup (see also
+[`oci_backend.json5`](https://github.com/TraceMachina/nativelink/blob/main/nativelink-config/examples/oci_backend.json5)):
+
+```json5
+{
+  stores: [
+    {
+      name: "CAS_MAIN_STORE",
+      experimental_cloud_object_store: {
+        provider: "oci",
+        namespace: "storagenamespace",
+        region: "ap-mumbai-1",
+        bucket: "nativelink-cas",
+        access_key_id: "${OCI_ACCESS_KEY_ID}",
+        secret_access_key: "${OCI_SECRET_ACCESS_KEY}",
+        key_prefix: "cas/",
+        retry: { max_retries: 6, delay: 0.3, jitter: 0.5 },
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      experimental_cloud_object_store: {
+        provider: "oci",
+        namespace: "storagenamespace",
+        region: "ap-mumbai-1",
+        bucket: "nativelink-cas",
+        access_key_id: "${OCI_ACCESS_KEY_ID}",
+        secret_access_key: "${OCI_SECRET_ACCESS_KEY}",
+        key_prefix: "ac/",
+        retry: { max_retries: 6, delay: 0.3, jitter: 0.5 },
+      },
+    },
+  ],
+  // ...servers omitted; see oci_backend.json5
+}
+```
+
+In production, wrap the CAS store in `verify` (for integrity) and front it with
+a `fast_slow` filesystem/memory layer to cut round-trips to OCI, exactly as you
+would for the AWS backend.
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `namespace` | yes | Object Storage namespace; used to derive the endpoint. |
+| `region` | yes | OCI region id (e.g. `ap-mumbai-1`); also the SigV4 signing region. |
+| `bucket` | yes | Target bucket. |
+| `access_key_id` | no | Customer Secret Key access key. Falls back to the AWS default credential chain if unset. |
+| `secret_access_key` | no | Customer Secret Key secret. |
+| `key_prefix`, `retry`, ... | no | Shared `experimental_cloud_object_store` options. |
+
+## Operational notes
+
+- **Reap incomplete multipart uploads.** When a multipart upload fails
+  mid-flight the store issues `AbortMultipartUpload` to clean up (verified that
+  OCI honors both `ListMultipartUploads` and `AbortMultipartUpload`). A process
+  killed *before* it can abort still leaves orphaned parts, so add a bucket
+  lifecycle rule to abort incomplete multipart uploads after a few days as a
+  backstop.
+- **Status.** This backend lives under `experimental_cloud_object_store`. Its
+  core paths - read, write, existence checks, ranged reads, multipart, and
+  integrity - are verified against live OCI, including an end-to-end Bazel remote
+  cache round-trip, a 2 GiB multipart upload (~400 parts) with full byte
+  verification, multipart abort/cleanup, and 200-way concurrent load. It has not
+  been benchmarked at sustained production scale or duration.


### PR DESCRIPTION
# Description

Updates the OCI Store with the fixes and adds various mock tests. This also adds the documentation on how to use the OCI Store. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

The new OCI Store has been tested locally against a live OCI environment, with various core functionalities validated to ensure the store operates correctly. These tests primarily focused on functional correctness and verifying that the Remote Cache works as expected with the OCI Store as a new storage backend. Multipart uploads were also validated using multi-GB objects to ensure large upload operations function correctly.

While these tests provide confidence in the implementation’s functionality, large-scale performance and stress testing have not yet been conducted and would further validate the solution. Since the OCI Store leverages the existing S3 implementation for its backend operations, it's highly unlikely that we will face any OCI-specific issues during stress testing.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2506)
<!-- Reviewable:end -->
