### PR TITLE
Remove reclient in favor of Siso

### DIFF
--- a/.claude/skills/migrate-to-bazelmod/SKILL.md
+++ b/.claude/skills/migrate-to-bazelmod/SKILL.md
@@ -711,4 +711,4 @@ If a migration step in this skill doesn't fit the project (unusual repository la
 - Email: support@nativelink.com
 - Cloud: https://app.nativelink.com (zero-config remote cache plus remote execution)
 
-NativeLink ships build cache and remote execution for Bazel/Buck2/Goma/Reclient at over a billion requests per month, and the team handles Bazel-modules migrations as part of normal customer support.
+NativeLink ships build cache and remote execution for Bazel/Buck2/Goma/Siso at over a billion requests per month, and the team handles Bazel-modules migrations as part of normal customer support.

--- a/.github/styles/config/vocabularies/TraceMachina/accept.txt
+++ b/.github/styles/config/vocabularies/TraceMachina/accept.txt
@@ -52,11 +52,10 @@ onboarding
 OSSF
 protobuf
 Recc
-Reclient
+Siso
 Rosetta
 [Rr]epository
 [Ss]harding
-Siso
 SPDX
 Starlark
 Tokio

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NativeLink is trusted in production environments to reduce costs and developer i
    - Utilizes remote resources to offload computational burden from local machines
    - Ensures consistency with a uniform, controlled build environment
 
-NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and Siso. CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
+NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and [Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md). CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
 
 ## 🚀 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NativeLink is trusted in production environments to reduce costs and developer i
    - Utilizes remote resources to offload computational burden from local machines
    - Ensures consistency with a uniform, controlled build environment
 
-NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and [Reclient](https://github.com/bazelbuild/reclient). CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
+NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and Siso. CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
 
 ## 🚀 Quickstart
 

--- a/deploy/chromium-example/build_chromium_tests.sh
+++ b/deploy/chromium-example/build_chromium_tests.sh
@@ -59,10 +59,10 @@ else
 fi
 
 echo "Generating ninja projects"
-gn gen --args="use_remoteexec=true use_siso=true siso_cfg_dir=\"../../buildtools/siso_cfgs/linux\"" out/Default
+gn gen --args="use_remoteexec=true use_siso=true" out/Default
 
 # Fetch cache and schedular IP address for passing to ninja
 NATIVELINK=$(kubectl get gtw nativelink-gateway -o=jsonpath='{.status.addresses[0].value}')
 
 echo "Starting autoninja build"
-RBE_service=${NATIVELINK}:80 RBE_cas_service=${NATIVELINK}:80 RBE_instance='' RBE_siso_timeout=60m RBE_exec_timeout=4m RBE_alsologtostderr=true RBE_service_no_security=true RBE_service_no_auth=true RBE_local_resource_fraction=0.00001 RBE_automatic_auth=false RBE_gcert_refresh_timeout=20 RBE_compression_threshold=-1 RBE_metrics_namespace='' RBE_platform='' RBE_experimental_credentials_helper='' RBE_experimental_credentials_helper_args='' RBE_log_http_calls=true RBE_use_rpc_credentials=false RBE_exec_strategy=remote_local_fallback autoninja -v -j 50 -C out/Default cc_unittests
+SISO_REAPI_ADDRESS=${NATIVELINK}:80 SISO_REAPI_CAS_ADDRESS=${NATIVELINK}:80 SISO_REAPI_INSTANCE='' RBE_service_no_security=true autoninja -v -j 50 -C out/Default cc_unittests

--- a/deploy/chromium-example/build_chromium_tests.sh
+++ b/deploy/chromium-example/build_chromium_tests.sh
@@ -59,10 +59,10 @@ else
 fi
 
 echo "Generating ninja projects"
-gn gen --args="use_remoteexec=true reclient_cfg_dir=\"../../buildtools/reclient_cfgs/linux\"" out/Default
+gn gen --args="use_remoteexec=true use_siso=true siso_cfg_dir=\"../../buildtools/siso_cfgs/linux\"" out/Default
 
 # Fetch cache and schedular IP address for passing to ninja
 NATIVELINK=$(kubectl get gtw nativelink-gateway -o=jsonpath='{.status.addresses[0].value}')
 
 echo "Starting autoninja build"
-RBE_service=${NATIVELINK}:80 RBE_cas_service=${NATIVELINK}:80 RBE_instance='' RBE_reclient_timeout=60m RBE_exec_timeout=4m RBE_alsologtostderr=true RBE_service_no_security=true RBE_service_no_auth=true RBE_local_resource_fraction=0.00001 RBE_automatic_auth=false RBE_gcert_refresh_timeout=20 RBE_compression_threshold=-1 RBE_metrics_namespace='' RBE_platform='' RBE_experimental_credentials_helper='' RBE_experimental_credentials_helper_args='' RBE_log_http_calls=true RBE_use_rpc_credentials=false RBE_exec_strategy=remote_local_fallback autoninja -v -j 50 -C out/Default cc_unittests
+RBE_service=${NATIVELINK}:80 RBE_cas_service=${NATIVELINK}:80 RBE_instance='' RBE_siso_timeout=60m RBE_exec_timeout=4m RBE_alsologtostderr=true RBE_service_no_security=true RBE_service_no_auth=true RBE_local_resource_fraction=0.00001 RBE_automatic_auth=false RBE_gcert_refresh_timeout=20 RBE_compression_threshold=-1 RBE_metrics_namespace='' RBE_platform='' RBE_experimental_credentials_helper='' RBE_experimental_credentials_helper_args='' RBE_log_http_calls=true RBE_use_rpc_credentials=false RBE_exec_strategy=remote_local_fallback autoninja -v -j 50 -C out/Default cc_unittests

--- a/kubernetes/nativelink/nativelink-config.json5
+++ b/kubernetes/nativelink/nativelink-config.json5
@@ -94,7 +94,7 @@
     {
       name: "MAIN_SCHEDULER",
 
-      // TODO(palfrey): use the right scheduler because reclient doesn't use the cached results?
+      // TODO(palfrey): use the right scheduler because siso doesn't use the cached results?
       // TODO(palfrey): max_bytes_per_stream
       simple: {
         supported_platform_properties: {

--- a/web/apps/docs/content/docs/deployment/chromium.mdx
+++ b/web/apps/docs/content/docs/deployment/chromium.mdx
@@ -1,10 +1,9 @@
 ---
 title: Chromium
-description: Building Chromium with NativeLink as the Reclient backend — a worked example for the largest public consumer.
+description: Building Chromium with NativeLink as the Siso backend — a worked example for the largest public consumer.
 ---
 
-Chromium's build system shells out to
-[Reclient](https://github.com/bazelbuild/reclient), which speaks the
+Chromium's build system shells out to Siso, which speaks the
 Remote Execution API. Pointing it at a NativeLink cluster is a
 configuration change — no patches to the Chromium tree.
 
@@ -16,13 +15,13 @@ any Chromium-based browser.
 
 - A NativeLink cluster reachable from your build machines. Cache-only
   is fine to start; remote execution drops build times further.
-- Reclient installed and on `$PATH`. Chromium's `gclient sync` will
+- Siso installed and on `$PATH`. Chromium's `gclient sync` will
   install it under `buildtools/`.
 - The Chromium source checkout (`fetch chromium`).
 
-## Configure Reclient
+## Configure Siso
 
-Reclient reads its server settings from environment variables. Add
+Siso reads its server settings from environment variables. Add
 to your build shell:
 
 ```bash
@@ -51,21 +50,21 @@ In your Chromium checkout:
 gn gen out/Default --args='
   use_remoteexec=true
   use_goma=false
-  use_siso=false
-  reclient_cfg_dir="../../buildtools/reclient_cfgs/chromium-browser-clang"
+  use_siso=true
+  siso_cfg_dir="../../buildtools/siso_cfgs/chromium-browser-clang"
 '
 ```
 
 The `use_remoteexec=true` flag is the one that matters — it tells the
-build to wrap every compile invocation with Reclient.
+build to wrap every compile invocation with Siso.
 
 ## Start the reproxy daemon
 
-Reclient uses a long-lived daemon (`reproxy`) that batches requests
+Siso uses a long-lived daemon (`reproxy`) that batches requests
 to the RE-API server. Start it before invoking the build:
 
 ```bash
-buildtools/reclient/bootstrap --re_proxy=buildtools/reclient/reproxy
+buildtools/siso/bootstrap --re_proxy=buildtools/siso/reproxy
 ```
 
 The daemon stays up; `bootstrap --shutdown` shuts it down when
@@ -83,10 +82,10 @@ of the time.
 
 ## What good looks like
 
-The Reclient stats endpoint reports cache statistics per build:
+The Siso stats endpoint reports cache statistics per build:
 
 ```bash
-buildtools/reclient/reclient stats
+buildtools/siso/siso stats
 ```
 
 Healthy numbers on warm builds:
@@ -113,12 +112,12 @@ directory in the source tree has the worker config Samsung uses.
 ## Troubleshooting
 
 - **All actions falling back to local.** Likely a platform-property
-  mismatch. Compare what Chromium is requesting (in the reclient
+  mismatch. Compare what Chromium is requesting (in the siso
   log) against what your workers advertise.
 - **Cache writes succeed, reads always miss.** Almost always a
   toolchain version mismatch between the action that wrote the
   cache and the one trying to read.
-- **Reproxy hangs on shutdown.** Known issue — `reclient_cleanup`
+- **Reproxy hangs on shutdown.** Known issue — `siso_cleanup`
   fixes it.
 
 ## What's next

--- a/web/apps/docs/content/docs/deployment/chromium.mdx
+++ b/web/apps/docs/content/docs/deployment/chromium.mdx
@@ -3,7 +3,7 @@ title: Chromium
 description: Building Chromium with NativeLink as the Siso backend — a worked example for the largest public consumer.
 ---
 
-Chromium's build system shells out to Siso, which speaks the
+Chromium's build system shells out to [Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md), which speaks the
 Remote Execution API. Pointing it at a NativeLink cluster is a
 configuration change — no patches to the Chromium tree.
 

--- a/web/apps/docs/content/docs/deployment/chromium.mdx
+++ b/web/apps/docs/content/docs/deployment/chromium.mdx
@@ -3,8 +3,9 @@ title: Chromium
 description: Building Chromium with NativeLink as the Siso backend — a worked example for the largest public consumer.
 ---
 
-Chromium's build system shells out to [Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md), which speaks the
-Remote Execution API. Pointing it at a NativeLink cluster is a
+Chromium's build system shells out to
+[Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md),
+which speaks the Remote Execution API. Pointing it at a NativeLink cluster is a
 configuration change — no patches to the Chromium tree.
 
 The Samsung Internet team runs this configuration in production for
@@ -15,8 +16,7 @@ any Chromium-based browser.
 
 - A NativeLink cluster reachable from your build machines. Cache-only
   is fine to start; remote execution drops build times further.
-- Siso installed and on `$PATH`. Chromium's `gclient sync` will
-  install it under `buildtools/`.
+- A Chromium checkout with `depot_tools` on `$PATH`.
 - The Chromium source checkout (`fetch chromium`).
 
 ## Configure Siso
@@ -25,9 +25,8 @@ Siso reads its server settings from environment variables. Add
 to your build shell:
 
 ```bash
-export RBE_service=cas.nativelink.internal:50051
-export RBE_instance=chromium
-export RBE_use_application_default_credentials=false
+export SISO_REAPI_ADDRESS=cas.nativelink.internal:50051
+export SISO_REAPI_INSTANCE=chromium
 export RBE_service_no_security=false   # mTLS in production
 export RBE_tls_client_auth_cert=/etc/nativelink/tls/client.crt
 export RBE_tls_client_auth_key=/etc/nativelink/tls/client.key
@@ -37,8 +36,8 @@ export RBE_tls_ca_cert=/etc/nativelink/tls/ca.crt
 For local development against a non-TLS NativeLink:
 
 ```bash
-export RBE_service=localhost:50051
-export RBE_instance=chromium
+export SISO_REAPI_ADDRESS=localhost:50051
+export SISO_REAPI_INSTANCE=chromium
 export RBE_service_no_security=true
 ```
 
@@ -51,24 +50,11 @@ gn gen out/Default --args='
   use_remoteexec=true
   use_goma=false
   use_siso=true
-  siso_cfg_dir="../../buildtools/siso_cfgs/chromium-browser-clang"
 '
 ```
 
-The `use_remoteexec=true` flag is the one that matters — it tells the
-build to wrap every compile invocation with Siso.
-
-## Start the reproxy daemon
-
-Siso uses a long-lived daemon (`reproxy`) that batches requests
-to the RE-API server. Start it before invoking the build:
-
-```bash
-buildtools/siso/bootstrap --re_proxy=buildtools/siso/reproxy
-```
-
-The daemon stays up; `bootstrap --shutdown` shuts it down when
-you're done.
+`autoninja` reads `args.gn`; with `use_siso=true`, it invokes
+`siso ninja` for the build.
 
 ## Build
 
@@ -82,16 +68,8 @@ of the time.
 
 ## What good looks like
 
-The Siso stats endpoint reports cache statistics per build:
-
-```bash
-buildtools/siso/siso stats
-```
-
-Healthy numbers on warm builds:
-
 - **Cache hit rate**: 85-95% on incremental builds; 60-80% on full
-  builds.
+  builds, visible from NativeLink cache metrics.
 - **Local fallback rate**: under 1%. Higher means workers are
   rejecting actions (platform mismatch, capacity).
 - **Network errors**: zero. Anything else is a problem.
@@ -106,7 +84,7 @@ config should advertise:
 - `cpu_count: 8` (minimum; 16+ recommended for link steps)
 
 The
-[`deployment-examples/chromium/`](https://github.com/TraceMachina/nativelink/tree/main/deployment-examples/chromium)
+[`deploy/chromium-example/`](https://github.com/TraceMachina/nativelink/tree/main/deploy/chromium-example)
 directory in the source tree has the worker config Samsung uses.
 
 ## Troubleshooting
@@ -114,11 +92,12 @@ directory in the source tree has the worker config Samsung uses.
 - **All actions falling back to local.** Likely a platform-property
   mismatch. Compare what Chromium is requesting (in the siso
   log) against what your workers advertise.
+- **Siso is not being selected.** If the output directory was already
+  generated for Ninja, run `gn clean out/Default`, regenerate with
+  `use_siso=true`, and build again.
 - **Cache writes succeed, reads always miss.** Almost always a
   toolchain version mismatch between the action that wrote the
   cache and the one trying to read.
-- **Reproxy hangs on shutdown.** Known issue — `siso_cleanup`
-  fixes it.
 
 ## What's next
 

--- a/web/apps/docs/content/docs/explanations/architecture.mdx
+++ b/web/apps/docs/content/docs/explanations/architecture.mdx
@@ -11,7 +11,7 @@ real clusters run them together.
 ## The four roles
 
 <Mermaid>{`sequenceDiagram
-    participant client as Client (Bazel / Buck2 / Reclient)
+    participant client as Client (Bazel / Buck2 / Siso)
     participant sched as Scheduler
     participant worker as Worker
     participant cas as CAS + AC

--- a/web/apps/docs/content/docs/faq/caching.mdx
+++ b/web/apps/docs/content/docs/faq/caching.mdx
@@ -46,7 +46,7 @@ never touched it. You paid the cost of one HTTP request.
 
 NativeLink implements the standard
 [Remote Execution API](https://github.com/bazelbuild/remote-apis) —
-the same protocol Bazel, Buck2, Reclient, Goma, and Pants speak. You
+the same protocol Bazel, Buck2, Siso, Goma, and Pants speak. You
 point your build at a NativeLink server, and every action gets cached
 automatically.
 

--- a/web/apps/docs/content/docs/faq/cost.mdx
+++ b/web/apps/docs/content/docs/faq/cost.mdx
@@ -37,7 +37,7 @@ comparison.
 
 - The full RE-API server: CAS, AC, scheduler, worker.
 - Every storage backend: filesystem, S3, Redis, GCS, Azure Blob.
-- Every supported build client: Bazel, Buck2, Reclient, Pants, Goma.
+- Every supported build client: Bazel, Buck2, Siso, Pants, Goma.
 - The CLI tooling and Helm chart.
 
 No artificial limits on cache size, action count, worker count, or

--- a/web/apps/docs/content/docs/faq/remote-execution.mdx
+++ b/web/apps/docs/content/docs/faq/remote-execution.mdx
@@ -51,7 +51,7 @@ NativeLink is a Remote Execution API server. Any build tool that
 speaks the protocol —
 [Bazel](https://bazel.build),
 [Buck2](https://buck2.build),
-Siso,
+[Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md),
 [Pants](https://www.pantsbuild.org),
 [Goma](https://chromium.googlesource.com/infra/goma/client/) —
 plugs in with no code changes.

--- a/web/apps/docs/content/docs/faq/remote-execution.mdx
+++ b/web/apps/docs/content/docs/faq/remote-execution.mdx
@@ -51,7 +51,7 @@ NativeLink is a Remote Execution API server. Any build tool that
 speaks the protocol —
 [Bazel](https://bazel.build),
 [Buck2](https://buck2.build),
-[Reclient](https://github.com/bazelbuild/reclient),
+Siso,
 [Pants](https://www.pantsbuild.org),
 [Goma](https://chromium.googlesource.com/infra/goma/client/) —
 plugs in with no code changes.

--- a/web/apps/docs/content/docs/getting-started/other-build-systems/index.mdx
+++ b/web/apps/docs/content/docs/getting-started/other-build-systems/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Other build systems
-description: Use NativeLink without Bazel — Buck2, Reclient, Pants, BuildStream, and CMake with recc.
+description: Use NativeLink without Bazel — Buck2, Siso, Pants, BuildStream, and CMake with recc.
 ---
 
 NativeLink speaks the standard Remote Execution API. If your build tool
@@ -12,7 +12,7 @@ your build files.
 - [Buck2](/getting-started/other-build-systems/buck2) — use Buck2's
   built-in remote execution client with NativeLink as CAS, Action Cache,
   and executor.
-- [Reclient](/getting-started/other-build-systems/reclient) — configure
+- [Siso](/getting-started/other-build-systems/siso) — configure
   `reproxy` and `rewrapper` for Chromium-style builds.
 - [Pants](/getting-started/other-build-systems/pants) — enable remote
   cache reads and writes from `pants.toml`.

--- a/web/apps/docs/content/docs/getting-started/other-build-systems/index.mdx
+++ b/web/apps/docs/content/docs/getting-started/other-build-systems/index.mdx
@@ -13,7 +13,7 @@ your build files.
   built-in remote execution client with NativeLink as CAS, Action Cache,
   and executor.
 - [Siso](/getting-started/other-build-systems/siso) — configure
-  `reproxy` and `rewrapper` for Chromium-style builds.
+  Chromium's Ninja replacement to use NativeLink through the RE API.
 - [Pants](/getting-started/other-build-systems/pants) — enable remote
   cache reads and writes from `pants.toml`.
 - [BuildStream](/getting-started/other-build-systems/buildstream) — point

--- a/web/apps/docs/content/docs/getting-started/other-build-systems/meta.json
+++ b/web/apps/docs/content/docs/getting-started/other-build-systems/meta.json
@@ -1,7 +1,7 @@
 {
   "pages": [
     "buck2",
-    "reclient",
+    "siso",
     "pants",
     "buildstream",
     "cmake-recc"

--- a/web/apps/docs/content/docs/getting-started/other-build-systems/siso.mdx
+++ b/web/apps/docs/content/docs/getting-started/other-build-systems/siso.mdx
@@ -3,30 +3,23 @@ title: Siso
 description: Point Siso at NativeLink for Chromium-style remote caching and execution.
 ---
 
-Siso speaks the Remote Execution API through a local daemon,
-`reproxy`, and command wrapper, `rewrapper`. NativeLink can be the
-backend for Siso clients such as Chromium and other GN/Ninja builds.
+[Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md)
+is Chromium's Ninja replacement. It runs build actions on RBE natively,
+and NativeLink can be the RE API backend for Chromium and other
+Siso-driven builds.
 
 For a production Chromium walkthrough, see
 [Deployment → Chromium](/deployment/chromium).
 
-## Local cache-only setup
+## Local endpoint setup
 
 Start NativeLink on `localhost:50051` with instance name `main`, then
 export the environment variables Siso reads:
 
 ```bash
-export RBE_service=localhost:50051
-export RBE_instance=main
+export SISO_REAPI_ADDRESS=localhost:50051
+export SISO_REAPI_INSTANCE=main
 export RBE_service_no_security=true
-```
-
-For cache-only compiler wrapping, run `reproxy` and invoke a command with
-`rewrapper`:
-
-```bash
-reproxy &
-rewrapper -- clang++ -c hello.cc -o hello.o
 ```
 
 For CMake projects, [`recc`](/getting-started/other-build-systems/cmake-recc)
@@ -43,14 +36,13 @@ gn gen out/Default --args='
   use_remoteexec=true
   use_goma=false
   use_siso=true
-  siso_cfg_dir="../../buildtools/siso_cfgs/chromium-browser-clang"
 '
 ```
 
-Start the daemon before building:
+Build normally with `autoninja`; it detects `use_siso=true` and invokes
+`siso ninja`:
 
 ```bash
-buildtools/siso/bootstrap --re_proxy=buildtools/siso/reproxy
 autoninja -C out/Default chrome
 ```
 
@@ -60,8 +52,8 @@ For a secured NativeLink endpoint, set the Siso TLS variables instead
 of `RBE_service_no_security=true`:
 
 ```bash
-export RBE_service=cas.nativelink.internal:50051
-export RBE_instance=main
+export SISO_REAPI_ADDRESS=cas.nativelink.internal:50051
+export SISO_REAPI_INSTANCE=main
 export RBE_service_no_security=false
 export RBE_tls_client_auth_cert=/etc/nativelink/tls/client.crt
 export RBE_tls_client_auth_key=/etc/nativelink/tls/client.key
@@ -69,12 +61,6 @@ export RBE_tls_ca_cert=/etc/nativelink/tls/ca.crt
 ```
 
 ## Confirm it is working
-
-Use Siso stats after a build:
-
-```bash
-siso stats
-```
 
 On a warm cache, cache hits should climb and network errors should stay at
 zero. If actions fall back to local execution, compare the platform

--- a/web/apps/docs/content/docs/getting-started/other-build-systems/siso.mdx
+++ b/web/apps/docs/content/docs/getting-started/other-build-systems/siso.mdx
@@ -1,11 +1,11 @@
 ---
-title: Reclient
-description: Point Reclient at NativeLink for Chromium-style remote caching and execution.
+title: Siso
+description: Point Siso at NativeLink for Chromium-style remote caching and execution.
 ---
 
-Reclient speaks the Remote Execution API through a local daemon,
+Siso speaks the Remote Execution API through a local daemon,
 `reproxy`, and command wrapper, `rewrapper`. NativeLink can be the
-backend for Reclient clients such as Chromium and other GN/Ninja builds.
+backend for Siso clients such as Chromium and other GN/Ninja builds.
 
 For a production Chromium walkthrough, see
 [Deployment → Chromium](/deployment/chromium).
@@ -13,7 +13,7 @@ For a production Chromium walkthrough, see
 ## Local cache-only setup
 
 Start NativeLink on `localhost:50051` with instance name `main`, then
-export the environment variables Reclient reads:
+export the environment variables Siso reads:
 
 ```bash
 export RBE_service=localhost:50051
@@ -35,28 +35,28 @@ CMake compiler-launcher workflows directly.
 
 ## Chromium-style setup
 
-Chromium checks in Reclient configs. Point them at NativeLink by enabling
+Chromium checks in Siso configs. Point them at NativeLink by enabling
 remote execution in GN:
 
 ```bash
 gn gen out/Default --args='
   use_remoteexec=true
   use_goma=false
-  use_siso=false
-  reclient_cfg_dir="../../buildtools/reclient_cfgs/chromium-browser-clang"
+  use_siso=true
+  siso_cfg_dir="../../buildtools/siso_cfgs/chromium-browser-clang"
 '
 ```
 
 Start the daemon before building:
 
 ```bash
-buildtools/reclient/bootstrap --re_proxy=buildtools/reclient/reproxy
+buildtools/siso/bootstrap --re_proxy=buildtools/siso/reproxy
 autoninja -C out/Default chrome
 ```
 
 ## Production TLS settings
 
-For a secured NativeLink endpoint, set the Reclient TLS variables instead
+For a secured NativeLink endpoint, set the Siso TLS variables instead
 of `RBE_service_no_security=true`:
 
 ```bash
@@ -70,13 +70,13 @@ export RBE_tls_ca_cert=/etc/nativelink/tls/ca.crt
 
 ## Confirm it is working
 
-Use Reclient stats after a build:
+Use Siso stats after a build:
 
 ```bash
-reclient stats
+siso stats
 ```
 
 On a warm cache, cache hits should climb and network errors should stay at
 zero. If actions fall back to local execution, compare the platform
-properties Reclient requests with the properties your NativeLink workers
+properties Siso requests with the properties your NativeLink workers
 advertise.

--- a/web/apps/docs/content/docs/getting-started/setup.mdx
+++ b/web/apps/docs/content/docs/getting-started/setup.mdx
@@ -9,7 +9,7 @@ system to the running cluster.
 
 <Callout type="info" title="Prerequisites">
   You need a build tool that speaks the Remote Execution API — Bazel,
-  Buck2, Reclient, Pants, Goma, or CMake via recc. For the Docker path,
+  Buck2, Siso, Pants, Goma, or CMake via recc. For the Docker path,
   Docker 24+. For the Nix path, a recent Nix install with flakes enabled.
 </Callout>
 
@@ -93,7 +93,7 @@ the connection succeeding does.
 
 ## Point your build system at it
 
-<Tabs items={["Bazel", "Buck2", "Reclient", "Pants"]}>
+<Tabs items={["Bazel", "Buck2", "Siso", "Pants"]}>
 
   <Tab value="Bazel">
 
@@ -138,9 +138,9 @@ buck2 build //... --remote-cache
 
   </Tab>
 
-  <Tab value="Reclient">
+  <Tab value="Siso">
 
-Set the environment variables Reclient reads:
+Set the environment variables Siso reads:
 
 ```bash
 export RBE_service=localhost:50051
@@ -151,7 +151,7 @@ reproxy &
 rewrapper -- <your-compile-command>
 ```
 
-The Chromium build is the canonical Reclient consumer; see
+The Chromium build is the canonical Siso consumer; see
 [Deployment → Chromium](/deployment/chromium) for a full example.
 
   </Tab>

--- a/web/apps/docs/content/docs/getting-started/setup.mdx
+++ b/web/apps/docs/content/docs/getting-started/setup.mdx
@@ -140,15 +140,12 @@ buck2 build //... --remote-cache
 
   <Tab value="Siso">
 
-Set the environment variables Siso reads:
+Set the endpoint variables Siso reads:
 
 ```bash
-export RBE_service=localhost:50051
-export RBE_instance=main
+export SISO_REAPI_ADDRESS=localhost:50051
+export SISO_REAPI_INSTANCE=main
 export RBE_service_no_security=true   # only for local TLS-free dev
-
-reproxy &
-rewrapper -- <your-compile-command>
 ```
 
 The Chromium build is the canonical Siso consumer; see

--- a/web/apps/docs/content/docs/index.mdx
+++ b/web/apps/docs/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: NativeLink is a high-performance remote build cache and execution p
 ---
 
 NativeLink is a high-performance remote build cache and execution platform for
-build systems that speak the Remote Execution API — **Bazel, Buck2, Reclient,
+build systems that speak the Remote Execution API — **Bazel, Buck2, Siso,
 Pants, Goma**, and **CMake via recc**. It's open source, written in Rust, and
 battle-tested on over a billion build requests a month.
 
@@ -31,7 +31,7 @@ serves its job well.
 - [NativeLink on-prem](/getting-started/on-prem) — a single-server
   deployment that survives a team-wide rollout.
 - [Other build systems](/getting-started/other-build-systems) — using NativeLink
-  without Bazel (Buck2, Reclient, Pants, CMake).
+  without Bazel (Buck2, Siso, Pants, CMake).
 
 ### I want to configure or operate it
 

--- a/web/apps/docs/next.config.mjs
+++ b/web/apps/docs/next.config.mjs
@@ -15,6 +15,11 @@ const nextConfig = {
         destination: "/configuration/production",
         permanent: true,
       },
+      {
+        source: "/getting-started/other-build-systems/reclient",
+        destination: "/getting-started/other-build-systems/siso",
+        permanent: true,
+      },
     ];
   },
 };

--- a/web/apps/web/app/page.tsx
+++ b/web/apps/web/app/page.tsx
@@ -16,11 +16,10 @@ export const metadata = {
 const integrations = [
   "Bazel",
   "Buck2",
-  "Reclient",
+  "Siso",
   "Buildstream",
   "recc",
   "GN",
-  "Siso",
   "Pants",
   "Goma",
   "CMake",
@@ -86,7 +85,7 @@ const stats = [
   {
     value: "0",
     label: "build-system rewrites",
-    body: "required for Bazel, Buck2, Reclient, Goma, or CMake via recc or BuildStream.",
+    body: "required for Bazel, Buck2, Siso, Goma, or CMake via recc or BuildStream.",
   },
 ];
 
@@ -113,11 +112,11 @@ const benefits = [
   },
   {
     title: "Ten minutes to your first cache hit.",
-    body: "One Docker command. Drops into your existing Bazel, Buck2, Reclient, or CMake setup with zero rewrites.",
+    body: "One Docker command. Drops into your existing Bazel, Buck2, Siso, or CMake setup with zero rewrites.",
   },
   {
     title: "Works with what you've got.",
-    body: "C++, Rust, Python, Go, and more. Bazel, Buck2, Reclient, CMake. AWS, GCP, Azure, or your own hardware. No lock-in.",
+    body: "C++, Rust, Python, Go, and more. Bazel, Buck2, Siso, CMake. AWS, GCP, Azure, or your own hardware. No lock-in.",
   },
 ];
 
@@ -144,7 +143,7 @@ const industries = [
   },
   {
     title: "Browsers & Web Platforms",
-    body: "Chromium and its descendants are some of the largest C++ codebases on the open web. NativeLink speaks reclient natively.",
+    body: "Chromium and its descendants are some of the largest C++ codebases on the open web. NativeLink speaks Siso natively.",
   },
 ];
 

--- a/web/apps/web/app/pricing/page.tsx
+++ b/web/apps/web/app/pricing/page.tsx
@@ -13,7 +13,7 @@ const tiers = [
       "Self-hosted",
       "Community support on Slack",
       "Distributed scheduler & remote caching",
-      "All build systems (Bazel, Buck2, Reclient, Pants)",
+      "All build systems (Bazel, Buck2, Siso, Pants)",
       "All major cloud providers",
     ],
     cta: { label: "Get started", href: "/docs" },

--- a/web/apps/web/app/product/page.tsx
+++ b/web/apps/web/app/product/page.tsx
@@ -15,7 +15,7 @@ const pillars = [
   {
     eyebrow: "Remote cache",
     title: "Cache once. Reuse forever.",
-    body: "Content-addressable storage deduplicates every artifact your team produces. If a teammate, your CI, or an agent has already built it, you get it back in milliseconds. Drops into Bazel, Buck2, Reclient, Pants, Goma — and CMake via recc.",
+    body: "Content-addressable storage deduplicates every artifact your team produces. If a teammate, your CI, or an agent has already built it, you get it back in milliseconds. Drops into Bazel, Buck2, Siso, Pants, Goma — and CMake via recc.",
     metric: "1B+",
     metricLabel: "requests / month",
     icon: (
@@ -62,7 +62,7 @@ const integrationGroups = [
   { label: "Languages", items: ["C++", "Rust", "Python", "Go", "Java", "Kotlin", "Swift"] },
   {
     label: "Build systems",
-    items: ["Bazel", "Buck2", "Reclient", "Soong", "Pants", "Goma", "CMake (recc)"],
+    items: ["Bazel", "Buck2", "Siso", "Soong", "Pants", "Goma", "CMake (recc)"],
   },
   { label: "Cloud", items: ["AWS", "GCP", "Azure", "Bare metal"] },
   { label: "CI", items: ["GitHub Actions", "GitLab", "Buildkite", "Jenkins"] },
@@ -105,7 +105,7 @@ const faqItems: FAQItem[] = [
   },
   {
     q: "Does it work with my existing tools?",
-    a: "Yes. Anything that speaks the Remote Execution API — Bazel, Buck2, Reclient, Goma, Pants, or CMake via recc — works without modification.",
+    a: "Yes. Anything that speaks the Remote Execution API — Bazel, Buck2, Siso, Goma, Pants, or CMake via recc — works without modification.",
   },
   {
     q: "How do I keep my Bazel setup hermetic?",

--- a/web/apps/web/components/architecture-diagram.tsx
+++ b/web/apps/web/components/architecture-diagram.tsx
@@ -100,7 +100,7 @@ export function ArchitectureDiagram() {
             fontSize="10"
             fill="rgb(var(--nl-color-muted))"
           >
-            Reclient · Pants
+            Siso · Pants
           </text>
         </g>
 

--- a/web/apps/web/content/posts/Announcement_NativeLink.mdx
+++ b/web/apps/web/content/posts/Announcement_NativeLink.mdx
@@ -9,7 +9,7 @@ pubDate: 2024-09-17
 Today, we're excited to release NativeLink–a Rust implementation of Bazel's
 Remote Build Execution protocol (RBE) and Content Addressable Storage (CAS)
 designed to run your code and get out of the way. NativeLink seamlessly
-integrates with Bazel, Reclient, Goma, and Buck2. It comes at no cost and
+integrates with Bazel, Siso, Goma, and Buck2. It comes at no cost and
 works on every major operating system.
 
 

--- a/web/apps/web/content/posts/Announcement_TraceMachina_Seedfunding.mdx
+++ b/web/apps/web/content/posts/Announcement_TraceMachina_Seedfunding.mdx
@@ -54,7 +54,7 @@ Rust-based simulation infrastructure platform designed to provide an
 advanced simulation environment for technologies where safety is paramount.
 
 
-NativeLink is the only platform for Bazel, Buck2, and Reclient written in
+NativeLink is the only platform for Bazel, Buck2, and Siso written in
 native code, tailored to handle large objects and intricate systems, across
 native and interpreted programming languages.
 

--- a/web/apps/web/content/posts/CaseStudy_ThirdwaveAutomation.mdx
+++ b/web/apps/web/content/posts/CaseStudy_ThirdwaveAutomation.mdx
@@ -65,7 +65,7 @@ Open and extensible platform built on Bazel
 
 Licensed as Apache 2.0 open source, NativeLink seamlessly integrates with Bazel, the modern build client developed by Google and now used by 1,000+ organizations including Tesla, Nvidia, Ford, Stripe, Dropbox, Datadog, and Databricks.
 
-NativeLink works with all client-side build tools that support the Remote Bazel Execution (RBE) protocol such as Bazel, Buck2, Pantsbuild, and Reclient.
+NativeLink works with all client-side build tools that support the Remote Bazel Execution (RBE) protocol such as Bazel, Buck2, Pantsbuild, and Siso.
 
 You can customize NativeLink via JSON or YAML, as well as via Starlark, a Python-based declarative language for configuring Bazel with custom build rules and macros for specific projects and platforms.
 


### PR DESCRIPTION
# Description

While we have mostly kep the Chromium docs up to date, we haven't renamed Reclient to Siso. 

Fixes #2509 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

pre-commit checks, largely.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2510)
<!-- Reviewable:end -->
