### PR TITLE
Adds timer to hyper

### DIFF
--- a/deployment-examples/docker-compose/local-storage-cas.json5
+++ b/deployment-examples/docker-compose/local-storage-cas.json5
@@ -54,6 +54,16 @@
       listener: {
         http: {
           socket_address: "0.0.0.0:50051",
+
+          // TODO(palfrey): These are only tested here so far
+          advanced_http: {
+            http2_keep_alive_interval: 60,
+            experimental_http2_keep_alive_timeout: 20,
+            experimental_http2_max_concurrent_streams: 2000,
+            experimental_http2_max_pending_accept_reset_streams: 2000,
+            experimental_http2_initial_connection_window_size: 16777216,
+            experimental_http2_initial_stream_window_size: 8388608,
+          },
         },
       },
       services: {

--- a/nativelink-config/examples/advanced_http.json5
+++ b/nativelink-config/examples/advanced_http.json5
@@ -1,0 +1,231 @@
+{
+  stores: [
+    {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "/tmp/nativelink/data-worker-test/content_path-ac",
+        temp_path: "/tmp/nativelink/data-worker-test/tmp_path-ac",
+        eviction_policy: {
+          // 1gb.
+          max_bytes: 1000000000,
+        },
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        // "fast" must be a "filesystem" store because the worker uses it to make
+        // hardlinks on disk to a directory where the jobs are running.
+        fast: {
+          filesystem: {
+            content_path: "/tmp/nativelink/data-worker-test/content_path-cas",
+            temp_path: "/tmp/nativelink/data-worker-test/tmp_path-cas",
+            eviction_policy: {
+              // 10gb.
+              max_bytes: 10000000000,
+            },
+          },
+        },
+        slow: {
+          /// Discard data.
+          /// This example usage has the CAS and the Worker live in the same place,
+          /// so they share the same underlying CAS. Since workers require a fast_slow
+          /// store, we use the fast store as our primary data store, and the slow store
+          /// is just a noop, since there's no shared storage in this config.
+          noop: {},
+        },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          memory_kb: "minimum",
+          network_kbps: "minimum",
+          disk_read_iops: "minimum",
+          disk_read_bps: "minimum",
+          disk_write_iops: "minimum",
+          disk_write_bps: "minimum",
+          shm_size: "minimum",
+          gpu_count: "minimum",
+          gpu_model: "exact",
+          cpu_vendor: "exact",
+          cpu_arch: "exact",
+          cpu_model: "exact",
+          kernel_version: "exact",
+          OSFamily: "priority",
+          "container-image": "priority",
+          "lre-rs": "priority",
+          ISA: "exact",
+          InputRootAbsolutePath: "ignore", // used by chromium builds, but we can drop it
+        },
+      },
+    },
+  ],
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: {
+          uri: "grpc://127.0.0.1:50061",
+        },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "AC_MAIN_STORE",
+        },
+        work_directory: "/tmp/nativelink/work",
+        additional_environment: {
+          foo: "from_environment",
+          bar: {
+            value: "something",
+          },
+          baz: "timeout_millis",
+          channel: "side_channel_file",
+          action: "action_directory",
+        },
+        platform_properties: {
+          cpu_count: {
+            values: [
+              "16",
+            ],
+          },
+          memory_kb: {
+            values: [
+              "500000",
+            ],
+          },
+          network_kbps: {
+            values: [
+              "100000",
+            ],
+          },
+          cpu_arch: {
+            values: [
+              "x86_64",
+            ],
+          },
+          OSFamily: {
+            values: [
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+          "lre-rs": {
+            values: [
+              "",
+            ],
+          },
+          ISA: {
+            values: [
+              "x86-64",
+            ],
+          },
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      name: "public",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50051",
+          advanced_http: {
+            http2_keep_alive_interval: 60,
+            experimental_http2_keep_alive_timeout: 20,
+            experimental_http2_max_concurrent_streams: 2000,
+            experimental_http2_max_pending_accept_reset_streams: 2000,
+            experimental_http2_initial_connection_window_size: 16777216,
+            experimental_http2_initial_stream_window_size: 8388608,
+          },
+        },
+      },
+      services: {
+        cas: [
+          {
+            instance_name: "",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+          {
+            instance_name: "main",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+        ac: [
+          {
+            instance_name: "",
+            ac_store: "AC_MAIN_STORE",
+          },
+          {
+            instance_name: "main",
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            instance_name: "",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+          {
+            instance_name: "main",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            instance_name: "",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+          {
+            instance_name: "main",
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+        bytestream: [
+          {
+            instance_name: "",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+          {
+            instance_name: "main",
+            cas_store: "WORKER_FAST_SLOW_STORE",
+          },
+        ],
+      },
+    },
+    {
+      name: "private_workers_servers",
+      listener: {
+        http: {
+          socket_address: "0.0.0.0:50061",
+        },
+      },
+      services: {
+        // Note: This should be served on a different port, because it has
+        // a different permission set than the other services.
+        // In other words, this service is a backend api. The ones above
+        // are a frontend api.
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        admin: {},
+        health: {},
+      },
+    },
+  ],
+  global: {
+    max_open_files: 24576,
+  },
+}

--- a/src/bin/nativelink.rs
+++ b/src/bin/nativelink.rs
@@ -25,6 +25,7 @@ use clap::Parser;
 use futures::FutureExt;
 use futures::future::{BoxFuture, Either, OptionFuture, TryFutureExt, try_join_all};
 use hyper::StatusCode;
+use hyper_util::rt::TokioTimer;
 use hyper_util::rt::tokio::TokioIo;
 use hyper_util::server::conn::auto;
 use hyper_util::service::TowerToHyperService;
@@ -559,6 +560,7 @@ async fn inner_main(
                 .append(format!("Failed to bind to socket address '{socket_addr}'")),
         })?;
         let mut http = auto::Builder::new(TaskExecutor::default());
+        http.http2().timer(TokioTimer::new());
 
         let http_config = &http_config.advanced_http;
         if let Some(value) = http_config.http2_keep_alive_interval {


### PR DESCRIPTION
# Description

This is only currently tested via the integration tests, as anything else would need ripping apart `src/bin/nativelink.rs` and refactoring a pile of the core HTTP support there as more testable lumps.

Fixes #2518

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`RUST_BACKTRACE=full cargo run --bin nativelink nativelink-config/examples/advanced_http.json5`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2523)
<!-- Reviewable:end -->
