### PR TITLE
Increase the attic retry time

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -26,8 +26,10 @@ runs:
       with:
         timeout_minutes: 30
         max_attempts: 3
+        retry_wait_seconds: 30 # if we're failing, we want to wait a reasonable amount of time
         command: |
           set -euo pipefail
+          date
           cd /tmp
           nix build nixpkgs#attic-client
           # Note NATIVELINK_ATTIC_TOKEN is blank for PR builds as they don't have secret access


### PR DESCRIPTION
# Description

We've recently seen some failures (e.g. https://github.com/TraceMachina/nativelink/actions/runs/28876410500/job/85652609685) so this PR increases the inter-attempt timing and adds a `date` run at the beginning so we can check timestamps

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2524)
<!-- Reviewable:end -->
