### PR TITLE
Flush in detect_duplicate_upload

### DIFF
--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -1819,11 +1819,12 @@ async fn detect_duplicate_upload() -> Result<(), Error> {
     info!(?temp_full_path, "Temp full path");
     let mut data = Bytes::from_static(VALUE1.as_bytes());
     temp_file.write_all_buf(&mut data).await?;
+    temp_file.flush().await?;
     *entry.data_size_mut() = 10;
 
     let arc_entry = Arc::new(entry);
     assert!(
-        check_duplicate_files(&store.get_evicting_map(), key, &arc_entry.clone()).await?,
+        check_duplicate_files(&store.get_evicting_map(), key, &arc_entry).await?,
         "Expected duplicate"
     );
     assert!(logs_contain(
@@ -1843,6 +1844,7 @@ async fn detect_same_key_different_contents() -> Result<(), Error> {
     let (mut entry, mut temp_file, _temp_full_path) = store.make_temp_file(temp_key).await?;
     let mut data = Bytes::from_static(VALUE2.as_bytes());
     temp_file.write_all_buf(&mut data).await?;
+    temp_file.flush().await?;
     *entry.data_size_mut() = 10;
 
     assert!(


### PR DESCRIPTION
# Description

`detect_duplicate_upload` periodically fails (e.g. https://github.com/TraceMachina/nativelink/actions/runs/28882857625/job/85723957794?pr=2525) and we're doing everything right _except_ explicitly flushing, which this PR adds. I suspect it's a timing issue, so hard to tell if we've totally solved it, but this is definitely an improvement.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2528)
<!-- Reviewable:end -->
