### PR TITLE
ci(release): cross-compile the aarch64 Linux binary on x86

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,10 +64,7 @@ jobs:
             os: ubuntu-24.04
             attr: nativelink-x86_64-linux
           - target: aarch64-unknown-linux-musl
-            # Build natively on ARM64 so older tags build too: the aarch64
-            # cross-compile fix (#2454) isn't in releases like v1.5.2, where
-            # cross-compiling fails on gnu/stubs-32.h.
-            os: ubuntu-24.04-arm
+            os: ubuntu-24.04
             attr: nativelink-aarch64-linux
           - target: aarch64-apple-darwin
             os: macos-26


### PR DESCRIPTION
# Description
cross-compile the aarch64 Linux binary on x86

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test in the CI

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2529)
<!-- Reviewable:end -->
