### PR TITLE
Add free-disk to Redis store tester

### DIFF
--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -100,6 +100,9 @@ jobs:
         uses: >- # v6.0.2
           actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk
+
       - uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
         with:
           compose-file: src/bin/docker-compose.store-tester.yaml


### PR DESCRIPTION
# Description

We're seeing occasional disk free issues on redis store tester CI step (https://github.com/TraceMachina/nativelink/actions/runs/29035275362/job/86178411740?pr=2539 for example) and this brings it in line with the wider bazel testing

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2543)
<!-- Reviewable:end -->
