### PR TITLE
Handle zero digests in CompressionStore

### DIFF
--- a/nativelink-store/src/compression_store.rs
+++ b/nativelink-store/src/compression_store.rs
@@ -288,7 +288,38 @@ impl StoreDriver for CompressionStore {
         digests: &[StoreKey<'_>],
         results: &mut [Option<u64>],
     ) -> Result<(), Error> {
-        self.inner_store.has_with_results(digests, results).await
+        if !digests.iter().any(|digest| is_zero_digest(digest.borrow())) {
+            return self.inner_store.has_with_results(digests, results).await;
+        }
+
+        for (digest, result) in digests.iter().zip(results.iter_mut()) {
+            if is_zero_digest(digest.borrow()) {
+                *result = Some(0);
+            }
+        }
+
+        let nonzero_digests = digests
+            .iter()
+            .filter(|digest| !is_zero_digest(digest.borrow()))
+            .map(StoreKey::borrow)
+            .collect::<Vec<_>>();
+        if nonzero_digests.is_empty() {
+            return Ok(());
+        }
+
+        let mut nonzero_results = vec![None; nonzero_digests.len()];
+        self.inner_store
+            .has_with_results(&nonzero_digests, &mut nonzero_results)
+            .await?;
+        for (result, inner_result) in digests
+            .iter()
+            .zip(results.iter_mut())
+            .filter_map(|(digest, result)| (!is_zero_digest(digest.borrow())).then_some(result))
+            .zip(nonzero_results)
+        {
+            *result = inner_result;
+        }
+        Ok(())
     }
 
     async fn update(
@@ -297,6 +328,16 @@ impl StoreDriver for CompressionStore {
         mut reader: DropCloserReadHalf,
         upload_size: UploadSizeInfo,
     ) -> Result<u64, Error> {
+        if is_zero_digest(key.borrow()) {
+            return reader.recv().await.and_then(|should_be_empty| {
+                if should_be_empty.is_empty() {
+                    Ok(0)
+                } else {
+                    Err(make_err!(Code::Internal, "Zero byte hash not empty"))
+                }
+            });
+        }
+
         let mut output_state = UploadState::new(&self, upload_size)?;
 
         let (mut tx, rx) = make_buf_channel_pair();

--- a/nativelink-store/tests/compression_store_test.rs
+++ b/nativelink-store/tests/compression_store_test.rs
@@ -15,26 +15,34 @@
 use core::cmp;
 use core::pin::Pin;
 use core::str::from_utf8;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Cursor;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use nativelink_config::stores::{CompressionSpec, MemorySpec, StoreSpec};
 use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
+use nativelink_metric::MetricsComponent;
+use nativelink_store::cas_utils::ZERO_BYTE_DIGESTS;
 use nativelink_store::compression_store::{
     CURRENT_STREAM_FORMAT_VERSION, CompressionStore, DEFAULT_BLOCK_SIZE, FOOTER_FRAME_TYPE, Footer,
     Lz4Config, SliceIndex, WincodeConfig,
 };
 use nativelink_store::memory_store::MemoryStore;
-use nativelink_util::buf_channel::make_buf_channel_pair;
+use nativelink_util::buf_channel::{
+    DropCloserReadHalf, DropCloserWriteHalf, make_buf_channel_pair,
+};
 use nativelink_util::common::DigestInfo;
+use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
 use nativelink_util::spawn;
-use nativelink_util::store_trait::{Store, StoreLike, UploadSizeInfo};
+use nativelink_util::store_trait::{
+    RemoveItemCallback, Store, StoreKey, StoreLike, UploadSizeInfo,
+};
 use pretty_assertions::assert_eq;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
 /// Utility function that will build a Footer object from the input.
@@ -66,6 +74,105 @@ fn extract_footer(data: &[u8]) -> Result<Footer, Error> {
 const VALID_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
 const DUMMY_DATA_SIZE: usize = 100; // Some dummy size to populate DigestInfo with.
 const MEGABYTE_SZ: usize = 1024 * 1024;
+
+mod recording_store {
+    use nativelink_util::store_trait::StoreDriver;
+
+    use super::*;
+
+    #[derive(MetricsComponent)]
+    pub(super) struct RecordingStore {
+        pub(super) has_call_count: AtomicUsize,
+        pub(super) has_key_count: AtomicUsize,
+        pub(super) has_keys: Mutex<Vec<StoreKey<'static>>>,
+        pub(super) update_count: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl StoreDriver for RecordingStore {
+        async fn post_init(self: Arc<Self>) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn has_with_results(
+            self: Pin<&Self>,
+            keys: &[StoreKey<'_>],
+            results: &mut [Option<u64>],
+        ) -> Result<(), Error> {
+            self.has_call_count.fetch_add(1, Ordering::Relaxed);
+            self.has_key_count.fetch_add(keys.len(), Ordering::Relaxed);
+            *self.has_keys.lock().unwrap() =
+                keys.iter().map(|key| key.borrow().into_owned()).collect();
+            for (size, result) in (100..).zip(results.iter_mut()) {
+                *result = Some(size);
+            }
+            Ok(())
+        }
+
+        async fn update(
+            self: Pin<&Self>,
+            _key: StoreKey<'_>,
+            _reader: DropCloserReadHalf,
+            _size_info: UploadSizeInfo,
+        ) -> Result<u64, Error> {
+            self.update_count.fetch_add(1, Ordering::Relaxed);
+            Ok(0)
+        }
+
+        async fn get_part(
+            self: Pin<&Self>,
+            _key: StoreKey<'_>,
+            _writer: &mut DropCloserWriteHalf,
+            _offset: u64,
+            _length: Option<u64>,
+        ) -> Result<(), Error> {
+            Err(make_err!(Code::NotFound, "Not found"))
+        }
+
+        fn inner_store(&self, _key: Option<StoreKey>) -> &dyn StoreDriver {
+            self
+        }
+
+        fn as_any(&self) -> &(dyn core::any::Any + Sync + Send + 'static) {
+            self
+        }
+
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn core::any::Any + Sync + Send + 'static> {
+            self
+        }
+
+        fn register_remove_callback(
+            self: Arc<Self>,
+            _callback: Arc<dyn RemoveItemCallback>,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    default_health_status_indicator!(RecordingStore);
+}
+
+use recording_store::RecordingStore;
+
+fn make_recording_compression_store() -> Result<(Arc<CompressionStore>, Arc<RecordingStore>), Error>
+{
+    let inner_store = Arc::new(RecordingStore {
+        has_call_count: AtomicUsize::new(0),
+        has_key_count: AtomicUsize::new(0),
+        has_keys: Mutex::new(Vec::new()),
+        update_count: AtomicUsize::new(0),
+    });
+    let store = CompressionStore::new(
+        &CompressionSpec {
+            backend: StoreSpec::Memory(MemorySpec::default()),
+            compression_algorithm: nativelink_config::stores::CompressionAlgorithm::Lz4(
+                nativelink_config::stores::Lz4Config::default(),
+            ),
+        },
+        Store::new(inner_store.clone()),
+    )?;
+    Ok((store, inner_store))
+}
 
 #[nativelink_test]
 async fn simple_smoke_test() -> Result<(), Error> {
@@ -469,7 +576,7 @@ async fn check_footer_test() -> Result<(), Error> {
 async fn get_part_is_zero_digest() -> Result<(), Error> {
     const BLOCK_SIZE: u32 = 32 * 1024;
 
-    let digest = DigestInfo::new(Sha256::new().finalize().into(), 0);
+    let digest = ZERO_BYTE_DIGESTS[0];
 
     let inner_store = MemoryStore::new(&MemorySpec::default());
     let store_owned = CompressionStore::new(
@@ -507,6 +614,109 @@ async fn get_part_is_zero_digest() -> Result<(), Error> {
     let empty_bytes = Bytes::new();
     assert_eq!(&file_data, &empty_bytes, "Expected file content to match");
 
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_zero_digest_skips_inner_store() -> Result<(), Error> {
+    let (store, inner_store) = make_recording_compression_store()?;
+    for digest in ZERO_BYTE_DIGESTS {
+        store.update_oneshot(digest, Bytes::new()).await?;
+    }
+    assert_eq!(inner_store.update_count.load(Ordering::Relaxed), 0);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn update_zero_digest_rejects_nonempty_data() -> Result<(), Error> {
+    let (store, inner_store) = make_recording_compression_store()?;
+    for digest in ZERO_BYTE_DIGESTS {
+        let err = store
+            .update_oneshot(digest, Bytes::from_static(b"not empty"))
+            .await
+            .expect_err("Expected nonempty data for a zero digest to fail");
+        assert!(
+            err.to_string().contains("Zero byte hash not empty"),
+            "Unexpected error: {err}"
+        );
+    }
+    assert_eq!(inner_store.update_count.load(Ordering::Relaxed), 0);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_zero_digests_skips_inner_store() -> Result<(), Error> {
+    let (store, inner_store) = make_recording_compression_store()?;
+    let keys = ZERO_BYTE_DIGESTS.map(StoreKey::from);
+    let mut results = [None; ZERO_BYTE_DIGESTS.len()];
+
+    store.has_with_results(&keys, &mut results).await?;
+    let expected_keys: &[StoreKey<'static>] = &[];
+    assert_eq!(
+        (
+            results,
+            inner_store.has_call_count.load(Ordering::Relaxed),
+            inner_store.has_key_count.load(Ordering::Relaxed),
+            inner_store.has_keys.lock().unwrap().as_slice(),
+        ),
+        ([Some(0); ZERO_BYTE_DIGESTS.len()], 0, 0, expected_keys,)
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_mixed_digests_preserves_result_order() -> Result<(), Error> {
+    let (store, inner_store) = make_recording_compression_store()?;
+    let keys = [
+        StoreKey::from(ZERO_BYTE_DIGESTS[0]),
+        StoreKey::new_str("first"),
+        StoreKey::from(ZERO_BYTE_DIGESTS[1]),
+        StoreKey::new_str("second"),
+    ];
+    let mut results = [None; 4];
+
+    store.has_with_results(&keys, &mut results).await?;
+    let expected_keys = [
+        StoreKey::new_str("first").into_owned(),
+        StoreKey::new_str("second").into_owned(),
+    ];
+    assert_eq!(
+        (
+            results,
+            inner_store.has_call_count.load(Ordering::Relaxed),
+            inner_store.has_key_count.load(Ordering::Relaxed),
+            inner_store.has_keys.lock().unwrap().as_slice(),
+        ),
+        (
+            [Some(0), Some(100), Some(0), Some(101)],
+            1,
+            2,
+            expected_keys.as_slice(),
+        )
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn has_nonzero_digests_delegates_single_batch() -> Result<(), Error> {
+    let (store, inner_store) = make_recording_compression_store()?;
+    let keys = [StoreKey::new_str("first"), StoreKey::new_str("second")];
+    let mut results = [None; 2];
+
+    store.has_with_results(&keys, &mut results).await?;
+    let expected_keys = [
+        StoreKey::new_str("first").into_owned(),
+        StoreKey::new_str("second").into_owned(),
+    ];
+    assert_eq!(
+        (
+            results,
+            inner_store.has_call_count.load(Ordering::Relaxed),
+            inner_store.has_key_count.load(Ordering::Relaxed),
+            inner_store.has_keys.lock().unwrap().as_slice(),
+        ),
+        ([Some(100), Some(101)], 1, 2, expected_keys.as_slice())
+    );
     Ok(())
 }
 


### PR DESCRIPTION
# Description

Fix `CompressionStore` handling of canonical zero-byte digests.

`CompressionStore` previously forwarded zero-byte uploads to its inner store after producing compression metadata. This breaks when the inner store already optimizes canonical zero digests and returns immediately without consuming the stream.

For example, when `CompressionStore` wraps `FilesystemStore`, `FilesystemStore` recognizes the zero digest, returns `Ok(0)`, and closes its reader. `CompressionStore` then attempts to write the compressed stream footer to that closed reader and fails with a disconnected-receiver error.

This change makes `CompressionStore` consistently handle canonical zero-byte digests before delegating to its backend.

## Changes

### Uploads

For both canonical zero-byte digest algorithms supported by NativeLink:

- SHA-256
- BLAKE3

`CompressionStore::update` now:

- returns `Ok(0)` for an empty upload;
- rejects non-empty data supplied under a canonical zero digest;
- does not invoke the inner store in either case.

This prevents the compression stream from being created when there is no content to compress and avoids the disconnected-reader failure described in
#2542.

### Existence checks

`CompressionStore::has_with_results` now:

- returns `Some(0)` for canonical zero digests without consulting the inner
  store;
- avoids calling the inner store entirely when a batch contains only zero
  digests;
- forwards only non-zero keys when a batch contains both zero and non-zero
  keys;
- forwards mixed-batch non-zero keys in a single inner-store call;
- reconstructs results in the same order as the original request;
- retains the existing direct delegation path for batches containing no zero
  digests.

## Tests

Regression coverage verifies that:

- empty SHA-256 and BLAKE3 zero-digest uploads return successfully;
- successful zero-digest uploads never reach the inner store;
- non-empty data is rejected for both canonical zero digests;
- rejected uploads also never reach the inner store;
- zero-only existence batches return `Some(0)` without an inner-store call;
- mixed batches preserve result ordering;
- mixed batches forward the exact expected non-zero keys;
- non-zero keys are forwarded in one batch rather than as individual calls;
- all-nonzero batches continue using a single direct delegation.

## Scope

This PR addresses the `CompressionStore` portion of the broader zero-byte digest audit in #2034. It does not modify zero-digest behavior in unrelated store implementations.

Fixes #2542
Part of #2034

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The following checks pass locally:

- `cargo test -p nativelink-store --test compression_store_test`
- `cargo test -p nativelink-store`
- `cargo clippy -p nativelink-store --test compression_store_test -- -D warnings`
- `bazel test //... --lockfile_mode=error --extra_toolchains=@rust_toolchains//:all --verbose_failures`
- `git diff --check`

The focused CompressionStore suite passes all 13 tests. The complete `nativelink-store` Cargo suite passes, and all 99 Bazel test targets pass, including the repository's rustfmt and Clippy aspects.

## Checklist

- [x] Updated documentation if needed (no documentation changes were required)
- [x] Tests added/amended
- [x] `bazel test //...` passes locally
- [x] PR is contained in a single signed commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2548)
<!-- Reviewable:end -->
