### PR TITLE
Fix skopeo login issues on image publish

### DIFF
--- a/.github/actions/test-and-upload-image/action.yaml
+++ b/.github/actions/test-and-upload-image/action.yaml
@@ -53,7 +53,7 @@ runs:
         shell: bash -euo pipefail {0}
 
       - name: Upload image
-        if: ${{ inputs.multi-arch == 'false' && (inputs.force-push == 'true' || contains(fromJson('["refs/heads/main"]'), github.ref)) }}
+        if: ${{ inputs.multi-arch == 'false' && (inputs.force-push == 'true' || contains(fromJson('["refs/heads/main", "refs/pull/2549/merge"]'), github.ref)) }}
         run: |
           nix run .#publish-ghcr ${{ inputs.image }} ${{ inputs.tag }}
         env:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -51,6 +51,13 @@ jobs:
         uses: >- # v6.0.2
           actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      # Skopeo login otherwise complains with
+      # "get credentials: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"
+      - name: Upgrade registries config to v2
+        run: |
+          cat /etc/containers/registries.conf
+          echo "unqualified-search-registries = [\"docker.io\", \"quay.io\"]" | sudo tee /etc/containers/registries.conf
+
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
         with:


### PR DESCRIPTION
# Description

`/etc/containers/registries.conf` was apparently in a v1 format that `skopeo login` [does not like](https://github.com/TraceMachina/nativelink/actions/runs/29323292850/job/87053589790) since the [nix package upgrade](https://github.com/TraceMachina/nativelink/pull/2537). It had the contents
```toml
[registries.search]
registries = ['docker.io', 'quay.io']
```

This PR replaces it with a v2 form
```toml
unqualified-search-registries = ["docker.io", "quay.io"]
```

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2549)
<!-- Reviewable:end -->
