### PR TITLE
Tag config regen builds to our bot account

### DIFF
--- a/.github/workflows/config-reference.yaml
+++ b/.github/workflows/config-reference.yaml
@@ -61,7 +61,7 @@ jobs:
           else
             TAG="${{ github.ref_name }}"
           fi
-          if [[ "${TAG}" != "" && ( ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ) ]]; then
+          if [[ "${TAG}" != "" && "${TAG}" != "main" && ( ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ) ]]; then
             echo "::error::'${TAG}' is not a release tag (vMAJOR.MINOR.PATCH); refusing to regenerate."
             exit 1
           fi
@@ -109,8 +109,8 @@ jobs:
           fi
 
           BRANCH="docs/config-reference-${TAG}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "config reference bot"
+          git config user.email "bot@tracemachina.com"
           git switch -c "${BRANCH}"
           git add web/apps/docs
           git commit -m "docs(config-reference): regenerate for NativeLink ${TAG}"


### PR DESCRIPTION
# Description

Now we've got [stable config regen builds](https://github.com/TraceMachina/nativelink/actions/runs/29491980873) I've got a few small tidy-ups there.

* Sets the bot account for config regen to our bot account, which means we can accept the CLA on it's behalf v.s. a random Github generated email
* Allows main-only config regen builds, which might be useful periodically when we're merging new code.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2554)
<!-- Reviewable:end -->
