### PR TITLE
Don't update config reference without changes

### DIFF
--- a/web/apps/docs/scripts/gen-config-reference.mjs
+++ b/web/apps/docs/scripts/gen-config-reference.mjs
@@ -26,7 +26,7 @@
 // the worktrees don't each spend disk on a full target/ tree.
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -193,6 +193,17 @@ function generateOne(v, sharedTargetDir) {
     sourceDir = worktree;
   }
 
+  const outfile = outFileFor(v);
+  let existingMdx = "";
+  if (existsSync(outfile)) {
+    existingMdx = readFileSync(outfile, { encoding: 'utf8', flag: 'r' });
+  }
+  const existingVersionMatches = existingMdx.match(/Source: nativelink-config @ (.+)/);
+  var existingVersion = "<none>";
+  if (existingVersionMatches !== null) {
+    existingVersion = existingVersionMatches[1];
+  }
+
   try {
     const schema = buildSchema(sourceDir, v.isDev ? null : sharedTargetDir);
     const mdx = schemaToMdx(schema, {
@@ -203,7 +214,14 @@ function generateOne(v, sharedTargetDir) {
       switcher: "<ConfigVersionSwitcher />",
       githubBase: GITHUB_BASE,
     });
-    writeFileSync(outFileFor(v), mdx);
+    const newVersion = mdx.match(/Source: nativelink-config @ (.+)/)[1]
+
+    if (mdx.replace(newVersion, existingVersion) != existingMdx) {
+      console.log(`Diff between '${existingVersion}' and '${newVersion}', so writing file`);
+      writeFileSync(outfile, mdx);
+    } else {
+      console.log(`No diff between '${existingVersion}' and '${newVersion}', so not writing file`);
+    }
     return { ...v, commit, defs: Object.keys(schema.$defs ?? schema.definitions ?? {}).length };
   } finally {
     if (worktree) {


### PR DESCRIPTION
# Description

Our config generator makes changes even if there's no changes other than the commit ref. See for example https://github.com/TraceMachina/nativelink/pull/2560. This PR changes that only write on real changes, which means the config generator can be [freely run periodically](https://github.com/TraceMachina/nativelink/pull/2551) without getting PRs when there's no real changes.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bun --filter @nativelink/docs gen:config-reference main` and ~~https://github.com/TraceMachina/nativelink/actions/runs/29510913007~~ which doesn't work because it needs to checkout main, not this branch :(

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2562)
<!-- Reviewable:end -->
