### PR TITLE
Fix AsyncFixedBuffer with zstd compression

### DIFF
--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -50,9 +50,9 @@ use nativelink_util::digest_hasher::{
 };
 use nativelink_util::proto_stream_utils::WriteRequestStreamWrapper;
 use nativelink_util::resource_info::ResourceInfo;
+use nativelink_util::spawn;
 use nativelink_util::store_trait::{Store, StoreLike, StoreOptimizations, UploadSizeInfo};
 use nativelink_util::task::JoinHandleDropGuard;
-use nativelink_util::{spawn, spawn_blocking};
 use opentelemetry::context::FutureExt;
 use parking_lot::Mutex;
 use tokio::time::sleep;
@@ -1086,19 +1086,16 @@ impl ByteStreamServer {
                 .map(|_| ())
                 .err_tip(|| "Failed to store decompressed data")
         };
-        let decode_fut = async move {
-            spawn_blocking!("bytestream_decode_compressed_upload", move || {
-                crate::wire_compression::stream_decode_compressed_upload(
-                    compressed_rx,
-                    wire_compressor,
-                    digest,
-                    digest_function,
-                    decompressed_tx,
-                )
-            })
-            .await
-            .map_err(|e| make_err!(Code::Internal, "Decompression task failed: {}", e))?
-        };
+        // Plain async future: decode progresses at the pace of the client
+        // upload and the store write without occupying a blocking-pool thread
+        // for the stream's lifetime.
+        let decode_fut = crate::wire_compression::stream_decode_compressed_upload(
+            compressed_rx,
+            wire_compressor,
+            digest,
+            digest_function,
+            decompressed_tx,
+        );
         let client_stream_fut =
             process_compressed_client_stream(stream, compressed_tx, &bytes_received);
         let (client_stream_result, decode_result, store_update_result) =

--- a/nativelink-service/src/bytestream_server.rs
+++ b/nativelink-service/src/bytestream_server.rs
@@ -1207,17 +1207,16 @@ impl ByteStreamServer {
                 .await
                 .err_tip(|| "Failed to read blob for wire compression")
         });
-        let encode_fut = Box::pin(async move {
-            spawn_blocking!("bytestream_encode_compressed_download", move || {
-                crate::wire_compression::stream_encode_compressed_download(
-                    raw_rx,
-                    wire_compressor,
-                    compressed_tx,
-                )
-            })
-            .await
-            .map_err(|e| make_err!(Code::Internal, "Compression task failed: {}", e))?
-        });
+        // The encode runs as a plain async future: it must not occupy a
+        // blocking-pool thread for the stream's lifetime, because it only
+        // progresses at the client's drain rate. Dropping the returned
+        // stream drops this future, which tears the encode down exactly
+        // like the previous task-abort-on-drop did.
+        let encode_fut = Box::pin(crate::wire_compression::stream_encode_compressed_download(
+            raw_rx,
+            wire_compressor,
+            compressed_tx,
+        ));
 
         let state = Some(ReaderState {
             max_bytes_per_stream: instance.max_bytes_per_stream,

--- a/nativelink-service/src/wire_compression.rs
+++ b/nativelink-service/src/wire_compression.rs
@@ -363,11 +363,31 @@ pub fn stream_decode_compressed_upload(
     Ok(())
 }
 
-pub fn stream_encode_compressed_download(
-    raw_rx: DropCloserReadHalf,
+/// Encode a raw byte stream into a single zstd frame on `tx`, asynchronously.
+///
+/// This runs entirely on the async runtime and must never occupy a tokio
+/// blocking-pool thread for the stream's lifetime: `tx` drains at the gRPC
+/// client's pace, so a blocking implementation (blocking reads from `raw_rx`
+/// plus `blocking_send` into `tx`) parks one pool thread per concurrent
+/// compressed download until the client finishes. Enough concurrent downloads
+/// with slow consumers then exhaust the blocking pool and starve every other
+/// `spawn_blocking` user (filesystem store I/O, upload decode, credential
+/// resolution). The zstd frame is instead produced incrementally with the raw
+/// streaming API: the CPU cost per iteration is bounded by the channel chunk
+/// size (small — micro/milliseconds), so it is acceptable inline on a worker
+/// thread, and `tx.send(...).await` gives backpressure without a parked
+/// thread.
+///
+/// The output is one well-formed zstd frame, identical in wire format to what
+/// `zstd::stream::read::Encoder` produces (both drive `ZSTD_compressStream`
+/// on a fresh `CCtx`).
+pub async fn stream_encode_compressed_download(
+    mut raw_rx: DropCloserReadHalf,
     wire_compressor: compressor::Value,
     mut tx: DropCloserWriteHalf,
 ) -> Result<(), Error> {
+    use zstd::stream::raw::{Encoder, InBuffer, Operation, OutBuffer};
+
     if wire_compressor != compressor::Value::Zstd {
         return Err(make_input_err!(
             "Streaming download compression only supports zstd, got {:?}",
@@ -375,18 +395,47 @@ pub fn stream_encode_compressed_download(
         ));
     }
 
-    let reader = BufChannelReader::new(raw_rx);
-    let mut encoder = zstd::stream::read::Encoder::new(reader, ZSTD_COMPRESSION_LEVEL)
+    let mut encoder = Encoder::new(ZSTD_COMPRESSION_LEVEL)
         .map_err(|e| make_err!(Code::Internal, "Zstd compression failed: {}", e))?;
-    let mut buffer = vec![0u8; 64 * 1024];
+    // `CCtx::out_size()` guarantees a full compressed block always fits, so
+    // the encoder never stalls for lack of output space within one `run`.
+    let mut out_buf = vec![0u8; zstd::zstd_safe::CCtx::out_size()];
     loop {
-        let read = encoder
-            .read(&mut buffer)
+        let chunk = raw_rx
+            .recv()
+            .await
+            .err_tip(|| "Failed to receive raw data in stream_encode_compressed_download")?;
+        if chunk.is_empty() {
+            break; // EOF.
+        }
+        let mut in_buffer = InBuffer::around(&chunk);
+        while in_buffer.pos() < in_buffer.src.len() {
+            let mut out_buffer = OutBuffer::around(out_buf.as_mut_slice());
+            encoder
+                .run(&mut in_buffer, &mut out_buffer)
+                .map_err(|e| make_err!(Code::Internal, "Zstd compression failed: {}", e))?;
+            let produced = out_buffer.as_slice();
+            if !produced.is_empty() {
+                tx.send(Bytes::copy_from_slice(produced)).await?;
+            }
+        }
+    }
+
+    // Finish the frame: flush any internally buffered compressed data plus
+    // the frame epilogue. `finish` reports the bytes still pending, so loop
+    // until it reports none.
+    loop {
+        let mut out_buffer = OutBuffer::around(out_buf.as_mut_slice());
+        let remaining = encoder
+            .finish(&mut out_buffer, true)
             .map_err(|e| make_err!(Code::Internal, "Zstd compression failed: {}", e))?;
-        if read == 0 {
+        let produced = out_buffer.as_slice();
+        if !produced.is_empty() {
+            tx.send(Bytes::copy_from_slice(produced)).await?;
+        }
+        if remaining == 0 {
             break;
         }
-        tx.blocking_send(Bytes::copy_from_slice(&buffer[..read]))?;
     }
 
     tx.send_eof()

--- a/nativelink-service/src/wire_compression.rs
+++ b/nativelink-service/src/wire_compression.rs
@@ -291,13 +291,30 @@ pub async fn decompress_batch_update(
     }
 }
 
-pub fn stream_decode_compressed_upload(
-    compressed_rx: DropCloserReadHalf,
+/// Decode a client's zstd wire stream into raw bytes on `tx`, asynchronously.
+///
+/// Like [`stream_encode_compressed_download`], this must not occupy a tokio
+/// blocking-pool thread for the stream's lifetime: the input arrives at the
+/// client's upload pace and `tx` drains at the store's write pace, so a
+/// blocking implementation parks a pool thread on whichever side is slower
+/// for as long as the upload lasts. The zstd frame is consumed incrementally
+/// with the raw streaming API instead; per-chunk decode cost is bounded by
+/// the channel chunk size, so it runs inline on the async runtime with
+/// channel-native backpressure on both sides.
+///
+/// Validation semantics match the REAPI compressed-blobs contract: the
+/// decoded byte count may never exceed the digest size (checked per chunk so
+/// a decompression bomb is rejected as soon as it overshoots), the final
+/// count must equal it exactly, and the decoded bytes must hash to `digest`.
+pub async fn stream_decode_compressed_upload(
+    mut compressed_rx: DropCloserReadHalf,
     wire_compressor: compressor::Value,
     digest: DigestInfo,
     digest_function: DigestHasherFunc,
     mut tx: DropCloserWriteHalf,
 ) -> Result<(), Error> {
+    use zstd::stream::raw::{Decoder, InBuffer, Operation, OutBuffer};
+
     if wire_compressor != compressor::Value::Zstd {
         return Err(make_input_err!(
             "Streaming upload decompression only supports zstd, got {:?}",
@@ -308,36 +325,62 @@ pub fn stream_decode_compressed_upload(
     let expected_size = digest.size_bytes();
     let mut hasher = digest_function.hasher();
     let mut decoded_size = 0u64;
-    let mut buffer = vec![0u8; zstd::zstd_safe::DCtx::out_size()];
-
-    let reader = BufChannelReader::new(compressed_rx);
-    let mut decoder = zstd::stream::read::Decoder::new(reader)
+    let mut decoder = Decoder::new()
         .map_err(|e| make_err!(Code::InvalidArgument, "Zstd decompression failed: {}", e))?;
+    // `DCtx::out_size()` guarantees a full decompressed block always fits, so
+    // the decoder never stalls for lack of output space within one `run`.
+    let mut out_buf = vec![0u8; zstd::zstd_safe::DCtx::out_size()];
+    // Last input-size hint from the decoder: nonzero at input EOF means the
+    // stream ended in the middle of a frame and must be rejected.
+    let mut frame_input_hint = 0usize;
     loop {
-        let read = decoder
-            .read(&mut buffer)
-            .map_err(|e| make_err!(Code::InvalidArgument, "Zstd decompression failed: {}", e))?;
-        if read == 0 {
-            break;
+        let chunk = compressed_rx
+            .recv()
+            .await
+            .err_tip(|| "Failed to receive compressed data in stream_decode_compressed_upload")?;
+        if chunk.is_empty() {
+            break; // EOF.
         }
-        let read_u64 =
-            u64::try_from(read).err_tip(|| "Decoded chunk size was not convertible to u64")?;
-        decoded_size = decoded_size.checked_add(read_u64).ok_or_else(|| {
-            make_err!(
-                Code::InvalidArgument,
-                "Decoded compressed upload size overflow"
-            )
-        })?;
-        if decoded_size > expected_size {
-            return Err(make_err!(
-                Code::InvalidArgument,
-                "Decoded compressed upload size {} bytes exceeds digest size {} bytes",
-                decoded_size,
-                expected_size
-            ));
+        let mut in_buffer = InBuffer::around(&chunk);
+        loop {
+            let mut out_buffer = OutBuffer::around(out_buf.as_mut_slice());
+            frame_input_hint = decoder.run(&mut in_buffer, &mut out_buffer).map_err(|e| {
+                make_err!(Code::InvalidArgument, "Zstd decompression failed: {}", e)
+            })?;
+            let produced = Bytes::copy_from_slice(out_buffer.as_slice());
+            // A completely full output buffer means the decoder may still
+            // have buffered output to flush, even with no input left.
+            let output_was_full = produced.len() == out_buf.len();
+            if !produced.is_empty() {
+                let produced_u64 = u64::try_from(produced.len())
+                    .err_tip(|| "Decoded chunk size was not convertible to u64")?;
+                decoded_size = decoded_size.checked_add(produced_u64).ok_or_else(|| {
+                    make_err!(
+                        Code::InvalidArgument,
+                        "Decoded compressed upload size overflow"
+                    )
+                })?;
+                if decoded_size > expected_size {
+                    return Err(make_err!(
+                        Code::InvalidArgument,
+                        "Decoded compressed upload size {} bytes exceeds digest size {} bytes",
+                        decoded_size,
+                        expected_size
+                    ));
+                }
+                hasher.update(&produced);
+                tx.send(produced).await?;
+            }
+            if in_buffer.pos() == in_buffer.src.len() && !output_was_full {
+                break;
+            }
         }
-        hasher.update(&buffer[..read]);
-        tx.blocking_send(Bytes::copy_from_slice(&buffer[..read]))?;
+    }
+    if frame_input_hint != 0 {
+        return Err(make_err!(
+            Code::InvalidArgument,
+            "Compressed upload stream ended in the middle of a zstd frame"
+        ));
     }
 
     if decoded_size != expected_size {

--- a/nativelink-service/tests/wire_compression_test.rs
+++ b/nativelink-service/tests/wire_compression_test.rs
@@ -18,8 +18,8 @@
 //! path, and the blocking [`BufChannelReader`] adapter used by the streaming
 //! zstd encoder/decoder.
 
+use core::time::Duration;
 use std::io::Read;
-use std::time::Duration;
 
 use bytes::Bytes;
 use nativelink_error::{Code, Error};
@@ -30,7 +30,7 @@ use nativelink_service::wire_compression::{
     stream_encode_compressed_download,
 };
 use nativelink_util::buf_channel::make_buf_channel_pair;
-use nativelink_util::spawn_blocking;
+use nativelink_util::{spawn, spawn_blocking};
 use pretty_assertions::assert_eq;
 
 #[nativelink_test]
@@ -213,6 +213,11 @@ async fn buf_channel_reader_reads_partial_and_multiple_chunks() -> Result<(), Er
 /// held streams than blocking-pool threads, and asserts that a trivial
 /// unrelated `spawn_blocking` closure still gets to run.
 #[test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "the defect under test is blocking-pool capacity, so the test needs \
+              a dedicated runtime with a deterministically small blocking pool"
+)]
 fn held_compressed_download_streams_must_not_starve_blocking_pool() {
     // More encode streams than blocking-pool threads. The streams never
     // complete during the test: their input never reaches EOF and their
@@ -249,15 +254,15 @@ fn held_compressed_download_streams_must_not_starve_blocking_pool() {
                 // output channel — the "slow client" that holds the stream
                 // open. Async sends here mean the feeders themselves never
                 // occupy blocking-pool threads.
-                let feeder = tokio::spawn(async move {
+                let feeder = spawn!("test_raw_data_feeder", async move {
                     let mut state = 0x9E37_79B9_7F4A_7C15_u64;
                     loop {
                         let mut chunk = vec![0u8; 64 * 1024];
-                        for byte in &mut chunk {
+                        for word in chunk.chunks_exact_mut(8) {
                             state = state
                                 .wrapping_mul(6_364_136_223_846_793_005)
                                 .wrapping_add(1_442_695_040_888_963_407);
-                            *byte = (state >> 33) as u8;
+                            word.copy_from_slice(&state.to_le_bytes());
                         }
                         if raw_tx.send(Bytes::from(chunk)).await.is_err() {
                             break;
@@ -266,14 +271,16 @@ fn held_compressed_download_streams_must_not_starve_blocking_pool() {
                 });
 
                 // Start the encode stream the same way
-                // `ByteStreamServer::inner_read_compressed` does.
-                let encode_task = spawn_blocking!("test_encode_compressed_download", move || {
+                // `ByteStreamServer::inner_read_compressed` does: as a plain
+                // async future on the runtime, never on the blocking pool.
+                let encode_task = spawn!(
+                    "test_encode_compressed_download",
                     stream_encode_compressed_download(
                         raw_rx,
                         compressor::Value::Zstd,
                         compressed_tx,
                     )
-                });
+                );
 
                 held_streams.push((feeder, encode_task, compressed_rx));
             }

--- a/nativelink-service/tests/wire_compression_test.rs
+++ b/nativelink-service/tests/wire_compression_test.rs
@@ -19,6 +19,7 @@
 //! zstd encoder/decoder.
 
 use std::io::Read;
+use std::time::Duration;
 
 use bytes::Bytes;
 use nativelink_error::{Code, Error};
@@ -26,6 +27,7 @@ use nativelink_macro::nativelink_test;
 use nativelink_proto::build::bazel::remote::execution::v2::compressor;
 use nativelink_service::wire_compression::{
     BufChannelReader, compress, decompress, decompress_batch_update, resolve_wire_compressor,
+    stream_encode_compressed_download,
 };
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::spawn_blocking;
@@ -198,4 +200,101 @@ async fn buf_channel_reader_reads_partial_and_multiple_chunks() -> Result<(), Er
         .await
         .map_err(|e| Error::new(Code::Internal, format!("reader task panicked: {e:?}")))?;
     Ok(())
+}
+
+/// A compressed-download encode stream lives at the gRPC CLIENT's drain rate:
+/// its output channel only empties as fast as the client reads, and a blob can
+/// take arbitrarily long to stream out. If each such stream occupies a tokio
+/// blocking-pool thread for its whole lifetime, N concurrent downloads with
+/// slow consumers occupy N threads and every unrelated `spawn_blocking` user
+/// (filesystem store I/O, upload decode, credential providers) queues behind
+/// streams that may not finish for minutes. This test wires up encode streams
+/// exactly the way `ByteStreamServer::inner_read_compressed` does, with more
+/// held streams than blocking-pool threads, and asserts that a trivial
+/// unrelated `spawn_blocking` closure still gets to run.
+#[test]
+fn held_compressed_download_streams_must_not_starve_blocking_pool() {
+    // More encode streams than blocking-pool threads. The streams never
+    // complete during the test: their input never reaches EOF and their
+    // consumer never reads, so any per-stream thread is held indefinitely.
+    // The blocking pool schedules FIFO, so if each stream occupies a thread
+    // the sentinel spawned afterwards can never run — no sleeps or timing
+    // races are needed for the starvation to be deterministic.
+    const MAX_BLOCKING_THREADS: usize = 4;
+    const NUM_STREAMS: usize = 8;
+    const SENTINEL_TIMEOUT: Duration = Duration::from_secs(2);
+    const OVERALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .expect("failed to build test runtime");
+
+    runtime.block_on(async {
+        tokio::time::timeout(OVERALL_TIMEOUT, async {
+            // Held alive for the duration of the sentinel probe: dropping the
+            // feeders, encode handles, or receivers early would tear the
+            // streams down and release any held threads.
+            let mut held_streams = Vec::with_capacity(NUM_STREAMS);
+            for _ in 0..NUM_STREAMS {
+                let (mut raw_tx, raw_rx) = make_buf_channel_pair();
+                let (compressed_tx, compressed_rx) = make_buf_channel_pair();
+
+                // Feed incompressible pseudo-random data forever (no EOF) so
+                // the encoder always has input and keeps producing output.
+                // The output channel has a small fixed capacity and nothing
+                // reads `compressed_rx`, so the encoder soon waits on a full
+                // output channel — the "slow client" that holds the stream
+                // open. Async sends here mean the feeders themselves never
+                // occupy blocking-pool threads.
+                let feeder = tokio::spawn(async move {
+                    let mut state = 0x9E37_79B9_7F4A_7C15_u64;
+                    loop {
+                        let mut chunk = vec![0u8; 64 * 1024];
+                        for byte in &mut chunk {
+                            state = state
+                                .wrapping_mul(6_364_136_223_846_793_005)
+                                .wrapping_add(1_442_695_040_888_963_407);
+                            *byte = (state >> 33) as u8;
+                        }
+                        if raw_tx.send(Bytes::from(chunk)).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+
+                // Start the encode stream the same way
+                // `ByteStreamServer::inner_read_compressed` does.
+                let encode_task = spawn_blocking!("test_encode_compressed_download", move || {
+                    stream_encode_compressed_download(
+                        raw_rx,
+                        compressor::Value::Zstd,
+                        compressed_tx,
+                    )
+                });
+
+                held_streams.push((feeder, encode_task, compressed_rx));
+            }
+
+            // Unrelated blocking work must not starve behind held
+            // compressed-download streams.
+            let sentinel = spawn_blocking!("test_blocking_pool_sentinel", || ());
+            let sentinel_result = tokio::time::timeout(SENTINEL_TIMEOUT, sentinel).await;
+            assert!(
+                sentinel_result.is_ok(),
+                "unrelated blocking work must not starve behind {NUM_STREAMS} held \
+                 compressed-download streams on a {MAX_BLOCKING_THREADS}-thread blocking pool"
+            );
+
+            drop(held_streams);
+        })
+        .await
+        .expect("test exceeded overall timeout");
+    });
+
+    // Encode streams stuck on a full output channel park their blocking-pool
+    // threads indefinitely; a normal runtime drop would join them and hang.
+    runtime.shutdown_background();
 }


### PR DESCRIPTION
# Description

- Both paths now drive zstd's raw streaming API as plain async futures — async recv/send, no thread parked on either channel. Wire format and validation (bomb rejection, size checks, digest checks) are unchanged.
- Adds a regression test that holds more encode streams than the blocking pool has threads and asserts an unrelated spawn_blocking closure still runs.

_*Note*: I'm picking up this pull request from an enterprise customer and their respective fork because there is a bug they encountered and this is the fix we are evaluating._ 

Fixes: #2571

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2573)
<!-- Reviewable:end -->
