### PR TITLE
Fix skopeo login on ubuntu-24.04 for all image workflows

### DIFF
--- a/.github/actions/test-and-upload-image/action.yaml
+++ b/.github/actions/test-and-upload-image/action.yaml
@@ -23,6 +23,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Upgrade registries config to v2
+        run: |
+          echo 'unqualified-search-registries = ["docker.io", "quay.io"]' | sudo tee /etc/containers/registries.conf
+        shell: bash -euo pipefail {0}
+
       # FIXME: merge the multi-arch and single-arch paths
       - name: Test multi-arch image
         if: ${{ inputs.multi-arch == 'true' && inputs.testing == 'true' }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -51,13 +51,6 @@ jobs:
         uses: >- # v6.0.2
           actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # Skopeo login otherwise complains with
-      # "get credentials: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"
-      - name: Upgrade registries config to v2
-        run: |
-          cat /etc/containers/registries.conf
-          echo "unqualified-search-registries = [\"docker.io\", \"quay.io\"]" | sudo tee /etc/containers/registries.conf
-
       - name: Prepare Worker
         uses: ./.github/actions/prepare-nix
         with:


### PR DESCRIPTION
# Description

The v1.6.2 release image build failed at skopeo login on the `ubuntu-24.04` runner:

```
level=fatal msg="get credentials: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"
```

`image.yaml` already worked around this with an "Upgrade registries config to v2" **workflow step**, but `tagged_image.yaml` (the SemVer release-tag images) and `custom-image.yaml` never got it. All three use the shared `test-and-upload-image` action for the skopeo login/inspect calls, so the release-tag build hit the v1 config and failed.

Move the registries.conf v2 rewrite into the shared `test-and-upload-image` action as its first step, so it runs before any skopeo call for **every** workflow that uses the action, and remove the now-redundant step from `image.yaml`. This fixes the failing tagged-image build and prevents the same drift from recurring in `custom-image.yaml`.

## Type of change

Please delete options that aren't relevant.

- [x] Bug Fix

## How Has This Been Tested?

CI

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2577)
<!-- Reviewable:end -->
