### PR TITLE
Let GCS get_part defer NotFound to the retrier

### DIFF
--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -429,9 +429,11 @@ where
                         .await
                     {
                         Ok(stream) => stream,
-                        Err(e) if e.code == Code::NotFound => {
-                            return Some((RetryResult::Err(e), (offset, writer)));
-                        }
+                        // NotFound is intentionally not special-cased here:
+                        // the retrier doesn't retry NotFound by default, but
+                        // emitting `Retry` lets `retry.retry_on_errors` opt
+                        // reads into retrying read-after-write races where
+                        // an object is still finalizing or being repopulated.
                         Err(e) => return Some((RetryResult::Retry(e), (offset, writer))),
                     };
 

--- a/nativelink-store/tests/gcs_store_test.rs
+++ b/nativelink-store/tests/gcs_store_test.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use mock_instant::thread_local::MockClock;
-use nativelink_config::stores::{CommonObjectSpec, ExperimentalGcsSpec};
+use nativelink_config::stores::{CommonObjectSpec, ErrorCode, ExperimentalGcsSpec, Retry};
 use nativelink_error::{Code, Error, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_store::cas_utils::ZERO_BYTE_DIGESTS;
@@ -176,6 +176,90 @@ async fn get_part_handles_not_found_error() -> Result<(), Error> {
         err.code,
         Code::NotFound,
         "Expected NotFound error to be propagated immediately"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_part_not_found_not_retried_by_default() -> Result<(), Error> {
+    // Create mock GCS operations without adding any object, so reads
+    // yield NotFound.
+    let mock_ops = Arc::new(MockGcsOperations::new());
+    let store = create_test_store_with_retry(
+        mock_ops.clone(),
+        Retry {
+            max_retries: 2,
+            delay: 0.001,
+            jitter: 0.0,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 100)?;
+    let store_key: StoreKey = to_store_key(digest);
+    let (mut tx, _rx) = make_buf_channel_pair();
+
+    let store_clone = store.clone();
+    let get_part_fut = nativelink_util::spawn!("get_part_task", async move {
+        store_clone.get_part(store_key, &mut tx, 0, None).await
+    });
+
+    let err = get_part_fut.await?.unwrap_err();
+    assert_eq!(err.code, Code::NotFound, "Expected NotFound error");
+
+    // Even with a retry budget configured, NotFound must not consume it
+    // unless explicitly opted in via `retry_on_errors`.
+    let call_counts = mock_ops.get_call_counts();
+    assert_eq!(
+        call_counts.read_calls.load(Ordering::Relaxed),
+        1,
+        "read_object_content should not be retried on NotFound by default"
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn get_part_retries_not_found_when_opted_in() -> Result<(), Error> {
+    // Create mock GCS operations without adding any object, so reads
+    // yield NotFound.
+    let mock_ops = Arc::new(MockGcsOperations::new());
+    let store = create_test_store_with_retry(
+        mock_ops.clone(),
+        Retry {
+            max_retries: 2,
+            delay: 0.001,
+            jitter: 0.0,
+            retry_on_errors: Some(vec![ErrorCode::NotFound]),
+        },
+    )
+    .await?;
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 100)?;
+    let store_key: StoreKey = to_store_key(digest);
+    let (mut tx, _rx) = make_buf_channel_pair();
+
+    let store_clone = store.clone();
+    let get_part_fut = nativelink_util::spawn!("get_part_task", async move {
+        store_clone.get_part(store_key, &mut tx, 0, None).await
+    });
+
+    let err = get_part_fut.await?.unwrap_err();
+    assert_eq!(
+        err.code,
+        Code::NotFound,
+        "Expected NotFound error after retries are exhausted"
+    );
+
+    // With NotFound in `retry_on_errors`, the read should be attempted
+    // once plus `max_retries` more times before giving up.
+    let call_counts = mock_ops.get_call_counts();
+    assert_eq!(
+        call_counts.read_calls.load(Ordering::Relaxed),
+        3,
+        "read_object_content should be retried on NotFound when opted in"
     );
 
     Ok(())
@@ -696,6 +780,26 @@ async fn create_test_store(
             bucket: BUCKET_NAME.to_string(),
             common: CommonObjectSpec {
                 key_prefix: Some(KEY_PREFIX.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ops,
+        MockInstantWrapped::default,
+    )
+}
+
+// Helper function to create a test GCS store with a custom retry config
+async fn create_test_store_with_retry(
+    ops: Arc<MockGcsOperations>,
+    retry: Retry,
+) -> Result<Arc<GcsStore<MockGcsOperations, fn() -> MockInstantWrapped>>, Error> {
+    GcsStore::new_with_ops(
+        &ExperimentalGcsSpec {
+            bucket: BUCKET_NAME.to_string(),
+            common: CommonObjectSpec {
+                key_prefix: Some(KEY_PREFIX.to_string()),
+                retry,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
# Description

`gcs_store::get_part` returned `RetryResult::Err` when
`read_object_content` failed with `Code::NotFound`, which bypasses the
`Retrier` entirely. That makes a read-404 terminal at the store layer,
even though `retry.retry_on_errors` already exists as an opt-in
mechanism for classifying `NotFound` as retryable. For content-addressed
reads of blobs the caller already believes exist (validated via
`FindMissingBlobs`, referenced as an action input, or a BwoB output), a
404 is frequently a read-after-write race — the object is still
finalizing or being repopulated — and turning it terminal pushes all
recovery onto the scheduler's `max_job_retries`, which concurrent cold
builds can exhaust (`Job cancelled because it attempted to execute too
many times`).

This change removes the `NotFound` special case in `get_part` so the
error is emitted as `RetryResult::Retry` and the `Retrier` classifies
it:

- **Default behavior is unchanged.** The retrier does not retry
  `NotFound` unless it's listed in `retry_on_errors`, so a missing
  object still fails immediately without consuming the retry budget.
- **Operators can now opt in** to read-404 retries on
  `experimental_cloud_object_store` (GCS) with the existing config
  surface, no new knob needed:

  ```json5
  "retry": {
    "max_retries": 6,
    "delay": 0.3,
    "jitter": 0.5,
    // Default retryable codes plus NotFound. Note this list
    // replaces the defaults, so include them explicitly.
    "retry_on_errors": [
      "Unknown", "Cancelled", "DeadlineExceeded", "ResourceExhausted",
      "Aborted", "Internal", "Unavailable", "DataLoss", "NotFound"
    ]
  }
  ```
- `has()` is untouched: it maps `NotFound` to `Ok(None)` before the
  retrier, which is correct for an existence probe.

This is options 2+3 from the issue via existing config rather than a
new store-level knob (option 1, a separately-bounded consistency-retry
budget). Happy to build that instead/on top if maintainers prefer a
default-on bounded retry for the finalization window.

Note for a possible follow-up: `s3_store::get_part` has the same
terminal `RetryResult::Err` pattern for `NoSuchKey`, so the same
treatment would apply there. Kept out of this PR to stay single-purpose.

Fixes #2582

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test -p nativelink-store --test gcs_store_test` — 20 passed,
  including two new tests:
  - `get_part_not_found_not_retried_by_default`: with `max_retries: 2`
    and default classification, a missing object yields `NotFound`
    after exactly 1 read call (no behavior change).
  - `get_part_retries_not_found_when_opted_in`: with
    `retry_on_errors: [NotFound]` and `max_retries: 2`, the read is
    attempted 3 times before surfacing `NotFound`.
  - The pre-existing `get_part_handles_not_found_error` still passes
    unmodified.
- `cargo clippy -p nativelink-store --tests` — clean.
- `rustfmt --check` on touched files — clean. (No local nix/bazel env,
  so relying on CI for `bazel test //...`.)

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2584)
<!-- Reviewable:end -->
