### PR TITLE
cargo-llvm-cov gets flagged, but doesn't have actual vulnerabilities

### DIFF
--- a/tools/cargo-llvm-cov/osv-scanner.toml
+++ b/tools/cargo-llvm-cov/osv-scanner.toml
@@ -1,0 +1,9 @@
+# Ignore false positives as per https://github.com/taiki-e/cargo-llvm-cov/blob/main/.deny.toml
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0194"
+reason = "quick-xml (via lcov2cobertura). Not affected since lcov2cobertura emits xml, but doesn't parse."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0195"
+reason = "quick-xml (via lcov2cobertura). Not affected since lcov2cobertura doesn't use affected APIs."


### PR DESCRIPTION
# Description

We upgraded quick-xml ourselves in https://github.com/TraceMachina/nativelink/pull/2566. Cargo-llvm-cov, which we have a patched version of gets similarly flagged, but has evaluated and determined upstream it's not an issue, so this PR tells the OpenSSF scanner about that.

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

OpenSSF scorecard scanner run locally.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2585)
<!-- Reviewable:end -->
