### PR TITLE
Fixes various docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NativeLink is trusted in production environments to reduce costs and developer i
    - Utilizes remote resources to offload computational burden from local machines
    - Ensures consistency with a uniform, controlled build environment
 
-NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and [Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md). CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
+NativeLink seamlessly integrates with build tools that use the Remote Execution protocol, such as [Bazel](https://bazel.build), [Buck2](https://buck2.build), [Goma](https://chromium.googlesource.com/infra/goma/client/), and [Siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md). CMake projects work too via [`recc`](https://buildgrid.gitlab.io/recc). See [Build CMake projects with NativeLink](https://docs.nativelink.com/getting-started/other-build-systems/cmake-recc). It supports Unix-based operating systems and Windows, ensuring broad compatibility across different development environments.
 
 ## 🚀 Quickstart
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,7 +10,7 @@ NativeLink provides the following templates to use caching and remote execution:
   C/C++ with CMake using [`recc`](https://buildgrid.gitlab.io/recc) as the
   bridge to NativeLink. Cache-only by default. Compiles run locally and
   only their outputs travel through the cache. Works on Linux and macOS.
-  Tutorial: [Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc).
+  Tutorial: [Build CMake projects with NativeLink](https://docs.nativelink.com/getting-started/other-build-systems/cmake-recc).
 
 # Getting started
 

--- a/templates/cmake/README.md
+++ b/templates/cmake/README.md
@@ -1,7 +1,7 @@
 # CMake template
 
 The full tutorial lives at
-[Build CMake projects with NativeLink](https://nativelink.com/docs/rbe/cmake-recc).
+[Build CMake projects with NativeLink](https://docs.nativelink.com/getting-started/other-build-systems/cmake-recc).
 
 This directory holds the example sources (`CMakeLists.txt`, `main.cpp`)
 that the tutorial references. Copy them into a fresh project directory

--- a/web/apps/docs/content/docs/configuration/production.mdx
+++ b/web/apps/docs/content/docs/configuration/production.mdx
@@ -210,6 +210,26 @@ What's worth alerting on:
 The [Metrics deployment guide](/deployment/metrics) has a Grafana
 dashboard JSON file you can import.
 
+
+## Sandboxing
+
+We've seen in some client configurations issues where Bazel in particular can leave zombie processes around on workers.
+To solve this, we've two options around sandboxing that are currently switched off by default for backwards
+compatibility, but are recommended for production configurations
+
+```json5
+workers: [{
+  local: {
+    use_namespaces: true,
+    use_mount_namespace: true
+    // rest of your config
+  }
+}]
+```
+
+`use_namespaces` enables process namespacing for workers, and `use_mount_namespace` then also isolates the worker
+root in a new mount namespace. Note, `use_mount_namespace` only works if `use_namespaces` is switched on as well.
+
 ## A reference production config
 
 A working complete production config (CAS + AC + scheduler + workers,

--- a/web/apps/docs/content/docs/faq/rust.mdx
+++ b/web/apps/docs/content/docs/faq/rust.mdx
@@ -3,9 +3,9 @@ title: Why Rust?
 description: Memory safety without garbage collection — the right shape for a service that has to be fast and never lie.
 ---
 
-Three reasons:
+## Three reasons
 
-## No GC pauses
+### No GC pauses
 
 Build infrastructure runs under sustained load. A scheduler hiccup
 during a `p99` request is the difference between "the build felt
@@ -16,7 +16,7 @@ heap.
 Rust has no garbage collector. The tail latency on a NativeLink
 cluster comes from network and storage, not the language runtime.
 
-## Memory safety
+### Memory safety
 
 A miscompiled binary that ships across an organisation is a serious
 problem. Worse, build systems are pure-function critical
@@ -27,7 +27,7 @@ Rust catches those bugs at compile time. The class of incident
 involving "we shipped something that wasn't what we compiled" doesn't
 happen.
 
-## Throughput
+### Throughput
 
 A single NativeLink instance handles over a billion build requests
 per month on modest hardware. That's `~400 req/s` sustained,


### PR DESCRIPTION
# Description

Fixes a few issues with the docs:

* Corrects the link to the cmake docs
* Redoes the headers for the "why rust" doc
* Re-adds [sandboxing docs](https://github.com/TraceMachina/nativelink/pull/2289) which I suspect got dropped somewhere in  the docs platform rebuild

## Type of change

Please delete options that aren't relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

`bun dev:docs`

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2586)
<!-- Reviewable:end -->
