### PR TITLE
Fix zstd upload decoder rejecting exact-buffer-multiple blobs

### DIFF
--- a/nativelink-service/src/wire_compression.rs
+++ b/nativelink-service/src/wire_compression.rs
@@ -322,7 +322,16 @@ pub async fn stream_decode_compressed_upload(
                 hasher.update(&produced);
                 tx.send(produced).await?;
             }
-            if in_buffer.pos() == in_buffer.src.len() && !output_was_full {
+            // `hint == 0` means the frame is completely decoded AND fully
+            // flushed. It must terminate the loop even when the output
+            // buffer was filled exactly: polling the decoder again after
+            // frame end would return the input-size hint for a NEW frame
+            // header, and the post-EOF `frame_input_hint != 0` check would
+            // then misreport a fully-decoded stream as truncated. This is
+            // deterministic for blobs whose decompressed size is an exact
+            // multiple of the decoder output buffer size.
+            if in_buffer.pos() == in_buffer.src.len() && (frame_input_hint == 0 || !output_was_full)
+            {
                 break;
             }
         }

--- a/nativelink-service/tests/wire_compression_test.rs
+++ b/nativelink-service/tests/wire_compression_test.rs
@@ -267,3 +267,70 @@ fn held_compressed_download_streams_must_not_starve_blocking_pool() {
     // threads indefinitely; a normal runtime drop would join them and hang.
     runtime.shutdown_background();
 }
+
+// Regression: a blob whose decompressed size is an exact multiple of the
+// decoder output buffer made the final `run` fill the output exactly with
+// `hint == 0` (frame done); the loop then polled the finished decoder once
+// more, received the new-frame-header hint, and the EOF check misreported
+// the complete stream as truncated.
+#[nativelink_test]
+async fn decode_accepts_exact_output_buffer_multiple() -> Result<(), Error> {
+    use nativelink_service::wire_compression::{
+        ZSTD_COMPRESSION_LEVEL, stream_decode_compressed_upload,
+    };
+    use nativelink_util::common::DigestInfo;
+    use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
+
+    const SPLIT_AT: usize = 65536;
+
+    let content = {
+        let mut data = vec![0u8; 1024 * 1024];
+        for (i, b) in data.iter_mut().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let byte = match i % 8 {
+                0..=4 => 0xB2,
+                5 => (i / 8) as u8,
+                _ => (i / 4096) as u8,
+            };
+            *b = byte;
+        }
+        Bytes::from(data)
+    };
+    let digest: DigestInfo = {
+        let mut hasher = DigestHasherFunc::Sha256.hasher();
+        hasher.update(&content);
+        hasher.finalize_digest()
+    };
+    let frame =
+        Bytes::from(zstd::bulk::compress(&content, ZSTD_COMPRESSION_LEVEL).expect("compress"));
+
+    let (mut compressed_tx, compressed_rx) = make_buf_channel_pair();
+    let (decoded_tx, mut decoded_rx) = make_buf_channel_pair();
+    let decode_fut = stream_decode_compressed_upload(
+        compressed_rx,
+        compressor::Value::Zstd,
+        digest,
+        DigestHasherFunc::Sha256,
+        decoded_tx,
+    );
+    let feed_fut = async move {
+        compressed_tx.send(frame.slice(0..SPLIT_AT)).await?;
+        compressed_tx.send(frame.slice(SPLIT_AT..)).await?;
+        compressed_tx.send_eof()
+    };
+    let pump_fut = async move {
+        let mut total = 0usize;
+        loop {
+            let chunk = decoded_rx.recv().await?;
+            if chunk.is_empty() {
+                return Ok::<_, Error>(total);
+            }
+            total += chunk.len();
+        }
+    };
+    let (feed_result, decode_result, pump_result) = tokio::join!(feed_fut, decode_fut, pump_fut);
+    feed_result.expect("feed must succeed");
+    decode_result.expect("exact-multiple frame must decode");
+    assert_eq!(pump_result.expect("pump"), content.len());
+    Ok(())
+}


### PR DESCRIPTION
## Problem

The streaming zstd decoder for REAPI `compressed-blobs` uploads
(`stream_decode_compressed_upload`) misreports a fully-decoded stream as
truncated whenever the blob's decompressed size is an exact multiple of the
decoder output buffer size (`DCtx::out_size()`, 128KiB-class). The final
`run` fills the output buffer exactly with `hint == 0` (frame complete and
flushed), but the drain loop treated a full output buffer as "may have more
to flush" and polled the finished decoder once more. A finished decoder
returns the input-size hint for a *new* frame header, so the post-EOF
`frame_input_hint != 0` truncation check fires and the upload fails with
`InvalidArgument` ("stream ended in the middle of a zstd frame").

This is deterministic and hits spec-conforming clients today: a Bazel
upload with `--remote_cache_compression` fails for any blob whose
uncompressed size lands on the buffer-multiple boundary.

## Fix

Exit the drain loop when the decoder reports the frame complete and fully
flushed (`hint == 0`), regardless of whether the output buffer was filled
exactly. One condition change plus an explanatory comment.

## Verification

- New regression test `decode_accepts_exact_output_buffer_multiple`
  (1MiB blob, exact multiple of the output buffer): **fails without the
  fix** (misreported as truncated), **passes with it**.
- Suites: bazel `//nativelink-service/...` 14/14 including clippy pedantic
  + nightly rustfmt aspects; `cargo check --tests --workspace` clean;
  wire-compression cargo suite 10/10.

Found while building compressed-upload support for NativeLink's own
`GrpcStore` transfers, where round-trip tests hit the boundary case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXVtatcR9YMecBiu9RjwpC

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2594)
<!-- Reviewable:end -->
