### PR TITLE
Record the execution metrics that were declared but never emitted

### DIFF
--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -747,6 +747,7 @@ where
                 }
             }
 
+            let mut is_retry = false;
             let stage = match &update {
                 UpdateOperationType::KeepAlive => {
                     awaited_action.worker_keep_alive((self.now_fn)().now());
@@ -795,6 +796,7 @@ where
                             ..ActionResult::default()
                         })
                     } else {
+                        is_retry = true;
                         ActionStage::Queued
                     }
                 }
@@ -826,6 +828,7 @@ where
                             ..ActionResult::default()
                         })
                     } else {
+                        is_retry = true;
                         ActionStage::Queued
                     }
                 }
@@ -920,12 +923,28 @@ where
                     };
                     attrs.push(KeyValue::new(EXECUTION_RESULT, result));
                     EXECUTION_METRICS.execution_completed_count.add(1, &attrs);
+                    nativelink_util::metrics::record_completed_execution_metrics(
+                        action_result,
+                        instance_name,
+                        worker_id.as_deref(),
+                        priority,
+                    );
                 }
                 ActionStage::CompletedFromCache(_) => {
                     attrs.push(KeyValue::new(EXECUTION_RESULT, ExecutionResult::CacheHit));
                     EXECUTION_METRICS.execution_completed_count.add(1, &attrs);
                 }
                 _ => {}
+            }
+
+            // A failed attempt that re-queued the action counts as a retry.
+            if is_retry {
+                let retry_attrs = nativelink_util::metrics::make_execution_attributes(
+                    instance_name,
+                    worker_id.as_deref(),
+                    priority,
+                );
+                EXECUTION_METRICS.execution_retry_count.add(1, &retry_attrs);
             }
 
             debug!(

--- a/nativelink-util/src/metrics.rs
+++ b/nativelink-util/src/metrics.rs
@@ -15,10 +15,11 @@
 // limitations under the License.
 
 use std::sync::LazyLock;
+use std::time::SystemTime;
 
 use opentelemetry::{InstrumentationScope, KeyValue, Value, global, metrics};
 
-use crate::action_messages::ActionStage;
+use crate::action_messages::{ActionResult, ActionStage};
 
 // Metric attribute keys for cache operations.
 pub const CACHE_TYPE: &str = "cache.type";
@@ -566,39 +567,6 @@ pub static EXECUTION_METRICS: LazyLock<ExecutionMetrics> = LazyLock::new(|| {
             ])
             .build(),
 
-        execution_cpu_time: meter
-            .f64_histogram("execution.cpu.time")
-            .with_description("CPU time consumed by action execution in seconds")
-            .with_unit("s")
-            .with_boundaries(vec![
-                0.01,   // 10ms
-                0.1,    // 100ms
-                1.0,    // 1s
-                10.0,   // 10s
-                60.0,   // 1 minute
-                300.0,  // 5 minutes
-                600.0,  // 10 minutes
-                1800.0, // 30 minutes
-                3600.0, // 1 hour
-            ])
-            .build(),
-
-        execution_memory_usage: meter
-            .u64_histogram("execution.memory.usage")
-            .with_description("Peak memory usage during execution in bytes")
-            .with_unit("By")
-            .with_boundaries(vec![
-                1_048_576.0,      // 1MB
-                10_485_760.0,     // 10MB
-                104_857_600.0,    // 100MB
-                524_288_000.0,    // 500MB
-                1_073_741_824.0,  // 1GB
-                5_368_709_120.0,  // 5GB
-                10_737_418_240.0, // 10GB
-                53_687_091_200.0, // 50GB
-            ])
-            .build(),
-
         execution_retry_count: meter
             .u64_counter("execution.retry.count")
             .with_description("Number of execution retries")
@@ -624,10 +592,6 @@ pub struct ExecutionMetrics {
     pub execution_stage_transitions: metrics::Counter<u64>,
     /// Histogram of output sizes in bytes
     pub execution_output_size: metrics::Histogram<u64>,
-    /// Histogram of CPU time in seconds
-    pub execution_cpu_time: metrics::Histogram<f64>,
-    /// Histogram of peak memory usage in bytes
-    pub execution_memory_usage: metrics::Histogram<u64>,
     /// Counter for execution retries
     pub execution_retry_count: metrics::Counter<u64>,
 }
@@ -650,4 +614,79 @@ pub fn make_execution_attributes(
     }
 
     attrs
+}
+
+/// Records the histogram metrics derivable from a completed action's result.
+pub fn record_completed_execution_metrics(
+    action_result: &ActionResult,
+    instance_name: &str,
+    worker_id: Option<&str>,
+    priority: Option<i32>,
+) {
+    let m = &*EXECUTION_METRICS;
+    let md = &action_result.execution_metadata;
+    let base = make_execution_attributes(instance_name, worker_id, priority);
+
+    let record_secs =
+        |hist: &metrics::Histogram<f64>, start: SystemTime, end: SystemTime, attrs: &[KeyValue]| {
+            if start > SystemTime::UNIX_EPOCH
+                && let Ok(d) = end.duration_since(start)
+            {
+                hist.record(d.as_secs_f64(), attrs);
+            }
+        };
+
+    // Queue wait (queued -> worker picked it up) and end-to-end duration.
+    record_secs(
+        &m.execution_queue_time,
+        md.queued_timestamp,
+        md.worker_start_timestamp,
+        &base,
+    );
+    record_secs(
+        &m.execution_total_duration,
+        md.queued_timestamp,
+        md.worker_completed_timestamp,
+        &base,
+    );
+
+    // Per-phase stage durations, labeled by phase on the stage attribute.
+    for (phase, start, end) in [
+        (
+            "input_fetch",
+            md.input_fetch_start_timestamp,
+            md.input_fetch_completed_timestamp,
+        ),
+        (
+            "execution",
+            md.execution_start_timestamp,
+            md.execution_completed_timestamp,
+        ),
+        (
+            "output_upload",
+            md.output_upload_start_timestamp,
+            md.output_upload_completed_timestamp,
+        ),
+    ] {
+        let mut attrs = base.clone();
+        attrs.push(KeyValue::new(EXECUTION_STAGE, phase));
+        record_secs(&m.execution_stage_duration, start, end, &attrs);
+    }
+
+    // Total bytes produced: output files plus stdout/stderr.
+    m.execution_output_size
+        .record(execution_output_bytes(action_result), &base);
+}
+
+/// Total output bytes produced by an action: the output file digests plus the
+/// stdout and stderr digests.
+#[must_use]
+pub fn execution_output_bytes(action_result: &ActionResult) -> u64 {
+    action_result
+        .output_files
+        .iter()
+        .map(|f| f.digest.size_bytes())
+        .sum::<u64>()
+        + action_result.stdout_digest.size_bytes()
+        + action_result.stderr_digest.size_bytes()
 }

--- a/nativelink-util/tests/metrics_test.rs
+++ b/nativelink-util/tests/metrics_test.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nativelink_util::action_messages::{ActionResult, ActionStage};
+use nativelink_util::action_messages::{
+    ActionResult, ActionStage, ExecutionMetadata, FileInfo, NameOrPath,
+};
+use nativelink_util::common::DigestInfo;
 use nativelink_util::metrics::{
     CACHE_METRICS, CacheMetricAttrs, EXECUTION_METRICS, ExecutionMetricAttrs, ExecutionStage,
-    make_execution_attributes,
+    execution_output_bytes, make_execution_attributes, record_completed_execution_metrics,
 };
 use opentelemetry::KeyValue;
 
@@ -194,4 +197,56 @@ fn test_action_stage_conversion_avoids_clone() {
         elapsed.as_millis() < 100,
         "Reference conversion took too long: {elapsed:?}"
     );
+}
+
+#[test]
+fn execution_output_bytes_sums_files_and_streams() {
+    let hash = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+    let result = ActionResult {
+        output_files: vec![
+            FileInfo {
+                name_or_path: NameOrPath::Path("out1".to_string()),
+                digest: DigestInfo::try_new(hash, 1000).unwrap(),
+                is_executable: false,
+            },
+            FileInfo {
+                name_or_path: NameOrPath::Path("out2".to_string()),
+                digest: DigestInfo::try_new(hash, 234).unwrap(),
+                is_executable: false,
+            },
+        ],
+        stdout_digest: DigestInfo::try_new(hash, 10).unwrap(),
+        stderr_digest: DigestInfo::try_new(hash, 20).unwrap(),
+        ..ActionResult::default()
+    };
+    assert_eq!(execution_output_bytes(&result), 1000 + 234 + 10 + 20);
+}
+
+#[test]
+fn record_completed_execution_metrics_guards_unpopulated_metadata() {
+    use core::time::Duration;
+    use std::time::SystemTime;
+
+    let queued = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    let at = |n| queued + Duration::from_secs(n);
+    let populated = ActionResult {
+        execution_metadata: ExecutionMetadata {
+            queued_timestamp: queued,
+            worker_start_timestamp: at(2),
+            worker_completed_timestamp: at(12),
+            input_fetch_start_timestamp: at(2),
+            input_fetch_completed_timestamp: at(4),
+            execution_start_timestamp: at(4),
+            execution_completed_timestamp: at(11),
+            output_upload_start_timestamp: at(11),
+            output_upload_completed_timestamp: at(12),
+            ..ExecutionMetadata::default()
+        },
+        ..ActionResult::default()
+    };
+    // Should record without panicking.
+    record_completed_execution_metrics(&populated, "instance", Some("worker-1"), Some(3));
+
+    // Default (UNIX_EPOCH) metadata must skip the duration records cleanly.
+    record_completed_execution_metrics(&ActionResult::default(), "instance", None, None);
 }

--- a/web/apps/docs/content/docs/deployment/metrics.mdx
+++ b/web/apps/docs/content/docs/deployment/metrics.mdx
@@ -168,19 +168,28 @@ results include `hit`, `miss`, `expired`, `success`, and `error`.
 
 ### Execution metrics
 
+Base labels below are `execution_instance`, `execution_worker_id` (when a worker
+is known), and `execution_priority`.
+
 | Metric | Type | Description | Labels |
 | ------ | ---- | ----------- | ------ |
-| `nativelink_execution_stage_duration` | Histogram | Time spent in each execution stage | `execution_stage` |
-| `nativelink_execution_total_duration` | Histogram | Total execution time from submission to completion | `execution_instance` |
-| `nativelink_execution_queue_time` | Histogram | Time spent waiting in queue | `execution_priority` |
+| `nativelink_execution_stage_duration` | Histogram | Time spent in each worker phase, in seconds | base + `execution_stage` (phase) |
+| `nativelink_execution_total_duration` | Histogram | End-to-end time from queued to worker completion, in seconds | base |
+| `nativelink_execution_queue_time` | Histogram | Time waiting in queue before a worker started, in seconds | base |
 | `nativelink_execution_active_count` | Gauge | Current actions in each stage | `execution_stage` |
 | `nativelink_execution_completed_count_total` | Counter | Completed executions | `execution_result`, `execution_action_digest` |
 | `nativelink_execution_stage_transitions_total` | Counter | Stage transition events | `execution_instance`, `execution_priority` |
-| `nativelink_execution_output_size` | Histogram | Size of execution outputs | - |
-| `nativelink_execution_retry_count_total` | Counter | Number of retries | - |
+| `nativelink_execution_output_size` | Histogram | Total output bytes (output files plus stdout/stderr) | base |
+| `nativelink_execution_retry_count_total` | Counter | Execution retries (a failed attempt that re-queued the action) | base |
 
-Execution stages are `unknown`, `cache_check`, `queued`, `executing`, and
-`completed`.
+The `execution_stage` label differs by metric. For `nativelink_execution_active_count`
+and `nativelink_execution_stage_transitions_total` it is one of `unknown`,
+`cache_check`, `queued`, `executing`, or `completed`. For
+`nativelink_execution_stage_duration` it is the worker phase: `input_fetch`,
+`execution`, or `output_upload`.
+
+The histograms and `nativelink_execution_retry_count_total` are populated once an
+action runs on a worker; cache hits do not emit them.
 
 Counter metrics are exposed with a `_total` suffix in Prometheus. The Docker
 Compose quickstart, recording rules, and included dashboards assume `_total`


### PR DESCRIPTION
# Description

nativelink-util defined execution_stage_duration, execution_total_duration, execution_queue_time, execution_output_size, and execution_retry_count, but nothing ever recorded them, so they never reached OTLP/Prometheus even though the metrics catalog documented them.

Fixes #2583 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [X] Added tests 
- [x] Tested on a real environment. 

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2599)
<!-- Reviewable:end -->
