### PR TITLE
Make filesystem store posix_fadvise(DONTNEED) opt-in

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -754,6 +754,16 @@ pub struct FilesystemSpec {
     /// Default: unlimited
     #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_concurrent_writes: usize,
+
+    /// When true, advise the kernel to drop the page cache for each blob after
+    /// it is written or read (`posix_fadvise` with `POSIX_FADV_DONTNEED`). On
+    /// real filesystems this takes a globally serialized, all-CPU kernel path
+    /// that stalls on many-core hosts, and it evicts the page-cache tier that
+    /// fast-disk deployments rely on. Leave off unless you specifically want to
+    /// keep this store's I/O out of the page cache.
+    /// Default: false
+    #[serde(default)]
+    pub evict_page_cache: bool,
 }
 
 // NetApp ONTAP S3 Spec

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1110,6 +1110,9 @@ pub struct FilesystemStore<Fe: FileEntry = FileEntryImpl> {
     block_size: u64,
     #[metric(help = "Size of the configured read buffer size")]
     read_buffer_size: usize,
+    /// See [`FilesystemSpec::evict_page_cache`]. When false (the default) the
+    /// per-blob `posix_fadvise(DONTNEED)` calls are skipped.
+    evict_page_cache: bool,
     weak_self: Weak<Self>,
     rename_fn: fn(&OsStr, &OsStr) -> Result<(), std::io::Error>,
     /// Limits concurrent write operations to prevent disk I/O saturation.
@@ -1243,6 +1246,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             evicting_map,
             block_size,
             read_buffer_size,
+            evict_page_cache: spec.evict_page_cache,
             weak_self: weak_self.clone(),
             rename_fn,
             write_semaphore,
@@ -1518,7 +1522,9 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
 
         drop(permit);
 
-        temp_file.advise_dontneed();
+        if self.evict_page_cache {
+            temp_file.advise_dontneed();
+        }
         trace!(?temp_file, "Dropping file to update_file");
         drop(temp_file);
 
@@ -1846,7 +1852,9 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
 
         drop(_permit);
 
-        temp_file.advise_dontneed();
+        if self.evict_page_cache {
+            temp_file.advise_dontneed();
+        }
         drop(temp_file);
 
         *entry.data_size_mut() = data.len() as u64;
@@ -1885,7 +1893,9 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
         // We are done with the file, if we hold a reference to the file here, it could
         // result in a deadlock if `emplace_file()` also needs file descriptors.
         trace!(?file, "Dropping file to to update_with_whole_file");
-        file.advise_dontneed();
+        if self.evict_page_cache {
+            file.advise_dontneed();
+        }
         drop(file);
         self.emplace_file(key.into_owned(), Arc::new(entry))
             .await
@@ -1949,7 +1959,9 @@ impl<Fe: FileEntry> StoreDriver for FilesystemStore<Fe> {
                 .await
                 .err_tip(|| "Failed to send chunk in filesystem store get_part")?;
         }
-        temp_file.get_ref().advise_dontneed();
+        if self.evict_page_cache {
+            temp_file.get_ref().advise_dontneed();
+        }
         writer
             .send_eof()
             .err_tip(|| "Filed to send EOF in filesystem store get_part")?;

--- a/nativelink-store/tests/filesystem_store_test.rs
+++ b/nativelink-store/tests/filesystem_store_test.rs
@@ -272,6 +272,33 @@ const VALUE2: &str = "9876543210";
 const STRING_NAME: &str = "String_Filename";
 
 #[nativelink_test]
+async fn evict_page_cache_defaults_off_and_round_trips_when_on() -> Result<(), Error> {
+    assert!(
+        !FilesystemSpec::default().evict_page_cache,
+        "evict_page_cache should default to off"
+    );
+
+    let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
+    let store = Store::new(
+        FilesystemStore::<FileEntryImpl>::new(&FilesystemSpec {
+            content_path: make_temp_path("content_path"),
+            temp_path: make_temp_path("temp_path"),
+            eviction_policy: None,
+            block_size: 1,
+            evict_page_cache: true,
+            ..Default::default()
+        })
+        .await?,
+    );
+    store.update_oneshot(digest, VALUE1.into()).await?;
+    let content = store
+        .get_part_unchunked(StoreKey::Digest(digest), 0, None)
+        .await?;
+    assert_eq!(content, VALUE1.as_bytes());
+    Ok(())
+}
+
+#[nativelink_test]
 async fn valid_results_after_shutdown_test() -> Result<(), Error> {
     let digest = DigestInfo::try_new(HASH1, VALUE1.len())?;
     let content_path = make_temp_path("content_path");

--- a/web/apps/docs/content/docs/configuration/production.mdx
+++ b/web/apps/docs/content/docs/configuration/production.mdx
@@ -155,6 +155,55 @@ alarm) can read NativeLink's Prometheus output and scale accordingly.
 The [Kubernetes deployment guide](/deployment/kubernetes) has a
 working HPA config.
 
+## Filesystem store: page-cache eviction
+
+The `filesystem` store has an opt-in `evict_page_cache` flag (default
+`false`). When enabled, after every blob it writes or reads it asks the
+kernel to drop that file's pages from the page cache
+(`posix_fadvise(POSIX_FADV_DONTNEED)`).
+
+Most production deployments should leave it **off**. The common
+enterprise topology (an object store with multiple CAS nodes) never
+benefits from it, and enabling it carries two costs.
+
+```json5
+stores: [{
+  filesystem: {
+    content_path: "/var/lib/nativelink/cas",
+    // Leave this off unless the narrow case below applies.
+    evict_page_cache: false,
+  },
+}],
+```
+
+<Callout type="warn" title="The cost grows with core count">
+  On a real filesystem (xfs/ext4), `POSIX_FADV_DONTNEED` takes the
+  kernel's `lru_add_drain_all()` path: it schedules and waits on a drain
+  across **every online CPU**, and concurrent callers serialize on a
+  global lock. The per-call cost therefore grows with the number of
+  cores, and **adding workers or concurrent actions cannot overcome
+  it**: every caller converges on the same serialized kernel path, so
+  throughput is capped no matter how much parallelism you add. On a
+  many-core host this
+  turns a busy store into a bottleneck while CPU and disk sit near idle.
+  (On `tmpfs` the call is a no-op, so this cost is invisible in
+  tmpfs-backed tests.)
+</Callout>
+
+The second cost: it evicts the page cache. A store kept on a fast local
+disk that relies on the page cache as its hot read tier loses that cache
+after every read and write.
+
+**When to enable it:** only for a filesystem-backed store on a low-core
+host where keeping this store's I/O out of the page cache is specifically
+desired (for example, to bound page-cache growth on a co-located
+filesystem-only deployment). It was originally added to relieve page-cache
+pressure that contributed to worker OOM-kills on such a deployment; note
+that page cache is reclaimable and the dominant OOM driver is a worker's
+anonymous memory (action processes and allocator retention), so this flag
+is a narrow mitigation, not a general OOM fix. Do **not** enable it on
+many-core hosts or object-store / multi-CAS deployments.
+
 ## TLS and authentication
 
 In production, every hop runs over mTLS:


### PR DESCRIPTION
# Description

Made the fadvise opt-in: added an `evict_page_cache` config flag (default false) and guarded all four call sites on it. So by default NativeLink no longer issues the advice and operators who genuinely want page-cache eviction can turn it back on.

Fixes #2607 

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit Test and tested on linux

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2608)
<!-- Reviewable:end -->
