### PR TITLE
Skip empty chunks in GCS get_part read stream

### DIFF
--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -440,6 +440,13 @@ where
                     while let Some(next_chunk) = stream.next().await {
                         match next_chunk {
                             Ok(bytes) => {
+                                // HTTP/2 peers may emit zero-length DATA frames
+                                // (e.g. a bare END_STREAM frame), which surface
+                                // here as empty chunks. `send()` rejects empty
+                                // buffers by contract, so skip them.
+                                if bytes.is_empty() {
+                                    continue;
+                                }
                                 offset += bytes.len() as u64;
                                 if let Err(err) = writer.send(bytes).await {
                                     return Some((RetryResult::Err(err), (offset, writer)));

--- a/nativelink-store/tests/gcs_store_test.rs
+++ b/nativelink-store/tests/gcs_store_test.rs
@@ -875,3 +875,148 @@ async fn check_health_failed_on_object_exists_error() -> Result<(), Error> {
         other => panic!("expected HealthStatus::Failed, got {other:?}"),
     }
 }
+
+#[nativelink_test]
+async fn get_part_ignores_empty_stream_chunks() -> Result<(), Error> {
+    use futures::stream::{self, Stream, StreamExt};
+    use nativelink_store::gcs_client::types::GcsObject;
+    use nativelink_util::buf_channel::DropCloserReadHalf;
+
+    /// Wraps `MockGcsOperations`, re-chunking every content read so the
+    /// stream interleaves zero-length chunks the way an HTTP/2 peer that
+    /// emits empty DATA frames does.
+    #[derive(Debug)]
+    struct EmptyChunkOps(Arc<MockGcsOperations>);
+
+    impl GcsOperations for EmptyChunkOps {
+        async fn read_object_metadata(
+            &self,
+            object: &ObjectPath,
+        ) -> Result<Option<GcsObject>, Error> {
+            self.0.read_object_metadata(object).await
+        }
+
+        async fn read_object_content(
+            &self,
+            object_path: &ObjectPath,
+            start: u64,
+            end: Option<u64>,
+        ) -> Result<Box<dyn Stream<Item = Result<Bytes, Error>> + Send + Unpin>, Error> {
+            let mut inner = self.0.read_object_content(object_path, start, end).await?;
+            let mut content = BytesMut::new();
+            while let Some(chunk) = inner.next().await {
+                content.put(chunk?);
+            }
+            let content = content.freeze();
+            let mid = content.len() / 2;
+            Ok(Box::new(stream::iter(vec![
+                Ok(Bytes::new()),
+                Ok(content.slice(..mid)),
+                Ok(Bytes::new()),
+                Ok(content.slice(mid..)),
+                Ok(Bytes::new()),
+            ])))
+        }
+
+        async fn write_object(
+            &self,
+            object_path: &ObjectPath,
+            content: Vec<u8>,
+        ) -> Result<(), Error> {
+            self.0.write_object(object_path, content).await
+        }
+
+        async fn start_resumable_write(&self, object_path: &ObjectPath) -> Result<String, Error> {
+            self.0.start_resumable_write(object_path).await
+        }
+
+        async fn upload_chunk(
+            &self,
+            upload_url: &str,
+            object_path: &ObjectPath,
+            data: Bytes,
+            offset: u64,
+            end_offset: u64,
+            total_size: Option<u64>,
+        ) -> Result<(), Error> {
+            self.0
+                .upload_chunk(
+                    upload_url,
+                    object_path,
+                    data,
+                    offset,
+                    end_offset,
+                    total_size,
+                )
+                .await
+        }
+
+        async fn upload_from_reader(
+            &self,
+            object_path: &ObjectPath,
+            reader: &mut DropCloserReadHalf,
+            upload_id: &str,
+            max_size: u64,
+        ) -> Result<(), Error> {
+            self.0
+                .upload_from_reader(object_path, reader, upload_id, max_size)
+                .await
+        }
+
+        async fn object_exists(&self, object_path: &ObjectPath) -> Result<bool, Error> {
+            self.0.object_exists(object_path).await
+        }
+    }
+
+    let mock_ops = Arc::new(MockGcsOperations::new());
+    let digest = DigestInfo::try_new(VALID_HASH1, 11)?; // "hello world" length
+    let store_key: StoreKey = to_store_key(digest);
+    let object_path = create_object_path(&store_key);
+    mock_ops
+        .add_object(&object_path, b"hello world".to_vec())
+        .await;
+
+    let store = GcsStore::new_with_ops(
+        &ExperimentalGcsSpec {
+            bucket: BUCKET_NAME.to_string(),
+            common: CommonObjectSpec {
+                key_prefix: Some(KEY_PREFIX.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Arc::new(EmptyChunkOps(mock_ops)),
+        MockInstantWrapped::default,
+    )?;
+
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let store_clone = store.clone();
+    let store_key_clone = store_key.clone();
+
+    let handle = nativelink_util::spawn!("get_part_task", async move {
+        store_clone
+            .get_part(store_key_clone, &mut tx, 0, None)
+            .await
+    });
+
+    let received_data =
+        match tokio::time::timeout(Duration::from_secs(5), rx.consume(Some(100))).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(make_err!(
+                    Code::DeadlineExceeded,
+                    "Timeout waiting for data"
+                ));
+            }
+        };
+
+    assert_eq!(
+        received_data.as_ref(),
+        b"hello world",
+        "Received data should match original despite empty stream chunks"
+    );
+
+    handle.await??;
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

`gcs_store::get_part` forwards every chunk from the `read_object_content` stream into `buf_channel::send()`. `send()` rejects zero-length buffers by contract (`Cannot send EOF in send(). Instead use send_eof()`), but HTTP/2 peers are allowed to end a response body with a zero-length DATA frame, and reqwest surfaces that as an empty `Bytes` chunk. When it happens, a perfectly healthy 200 OK read fails with a terminal `Internal` error on the first attempt (the send failure is returned as `RetryResult::Err`, so the retrier never engages).

We hit this in production against a GCS-backed CAS: Google's storage front end emits the trailing empty DATA frame intermittently under real load, and every affected read failed hard with

```
Cannot send EOF in send(). Instead use send_eof() : On attempt 1
```

Wire captures show clean 200 responses with complete bodies, so this is purely client-side frame handling. The read loop is identical on current main and v1.6.2, so both are affected. Go-based test servers (e.g. fake-gcs-server) never reproduce it because of their h1/h2 framing choices, which is probably why it has gone unnoticed.

The fix skips empty chunks in the read loop. Behavior for non-empty chunks is unchanged, and offset accounting is unaffected since an empty chunk contributes zero bytes.

## Reproduction

Putting a reverse proxy that always terminates streams with a bare END_STREAM DATA frame (mitmproxy in `--mode reverse:https://storage.googleapis.com`) in front of GCS makes the failure deterministic: unpatched, 0/10 ByteStream `Read` calls through the CAS succeed; with this change, 10/10. Direct against GCS it reproduces intermittently, dependent on Google's framing at that moment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New regression test `get_part_ignores_empty_stream_chunks` wraps `MockGcsOperations` so the content stream interleaves zero-length chunks the way an HTTP/2 peer that emits empty DATA frames does. It fails without the fix (same `Cannot send EOF` error) and passes with it.
- Full `gcs_store_test` suite passes (21/21).
- The deterministic mitmproxy reproduction above, against real GCS.
- Running in our RBE farm (patched build of `0e7580f`) since 2026-07-23 with the failure gone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2620)
<!-- Reviewable:end -->
