### PR TITLE
web: add security and trust responsibilities to careers job description

### DIFF
--- a/web/apps/web/app/careers/member-of-technical-staff/page.mdx
+++ b/web/apps/web/app/careers/member-of-technical-staff/page.mdx
@@ -50,6 +50,16 @@ As a Member of Technical Staff you own real systems end to end, from the schedul
 
 - Experience in safety-critical environments, aerospace especially.
 
+## Security and trust responsibilities
+
+We run infrastructure our customers' builds — and their source code — depend on, so every engineer here shares responsibility for keeping the platform trustworthy. In this role you will:
+
+- **Security:** follow our security policies and secure development practices, design and review changes with security in mind, and report and help remediate vulnerabilities promptly.
+- **Availability:** build and operate production systems to meet our availability commitments, including monitoring, capacity planning, and participating in incident response.
+- **Processing integrity:** ensure build, cache, and execution results are processed completely, accurately, and only as authorized.
+- **Confidentiality:** protect confidential customer and company information, and access systems and data only as your role requires, following least privilege.
+- **Privacy:** handle personal data in line with our privacy policy and applicable data-protection law.
+
 ## What we offer
 
 - Real ownership: you own systems end to end on a small team, and your work ships in the open to everyone who runs NativeLink.


### PR DESCRIPTION
# Description

Follow-up to #2621. Adds a **Security and trust responsibilities** section to the Member of Technical Staff job description on the careers page, spelling out what the role owns around security, availability, processing integrity, confidentiality, and privacy — secure development practices, on-call and incident response, integrity of build and cache results, least-privilege access, and data protection.

Content-only change to `web/apps/web/app/careers/member-of-technical-staff/page.mdx` — no layout, component, or config changes.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- `biome check` passes for the changed file (remaining formatter warnings in `careers/page.tsx` are pre-existing and untouched).
- MDX change only, using the same `Prose` markdown structure as the existing sections on the page.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended (content-only change)
- [ ] `bazel test //...` passes locally (web content, not covered by bazel)
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2622)
<!-- Reviewable:end -->
