### PR TITLE
Caching the attic client

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -20,6 +20,14 @@ runs:
           log-lines = 100 # Necessary in CI to get enough failure context
           keep-outputs = true # Don't delete non-root outputs, because might be needed for other builds
 
+    # only doing the cache around attic for now to avoid massive Nix caches overloading
+    # Github cache
+    - uses: >- # https://github.com/nix-community/cache-nix-action/releases/tag/v7
+        nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569
+      id: restore-cache
+      with:
+        primary-key: ${{ runner.os }}-nix-attic-cache
+
     - name: Setup attic cache
       uses: >- # v4
         nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
@@ -50,3 +58,8 @@ runs:
             ./result/bin/attic push nativelink $(nix eval --raw github:TraceMachina/attic)
           fi
         shell: bash
+
+    - uses: >- # https://github.com/nix-community/cache-nix-action/releases/tag/v7
+        nix-community/cache-nix-action/save@7df957e333c1e5da7721f60227dbba6d06080569
+      with:
+        primary-key: ${{ steps.restore-cache.outputs.primary-key }}


### PR DESCRIPTION
# Description

Ideally we'd like to cache a static version of the attic client for fastest builds, but [that doesn't currently build](https://github.com/zhaofengli/attic/issues/354) so instead this PR tries caching around Nix for just that bit. We [removed the `magic-nix-cache` before](https://github.com/TraceMachina/nativelink/pull/2059) due to size/speed issues, so I'm hoping restricting this to just attic should get us the benefits without the drawbacks....

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2625)
<!-- Reviewable:end -->
