### PR TITLE
Revert prepare-nix to the Determinate Nix installer

### DIFF
--- a/.github/actions/prepare-nix/action.yaml
+++ b/.github/actions/prepare-nix/action.yaml
@@ -11,11 +11,14 @@ runs:
       uses: ./.github/actions/free-disk
 
     - name: Install Nix
-      uses: >- # https://github.com/nixbuild/nix-quick-install-action/releases/tag/v35
-        nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c
+      # Stay on the Determinate installer: the nix-quick-install switch (Nix
+      # 2.34.7) makes the nix2container multi-arch image publish fail with a
+      # layer digest mismatch. See the tagged image workflow.
+      uses: >- # https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v22
+        DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
       with:
-        nix_version: 2.34.7
-        nix_conf: |
+        source-tag: v3.13.0
+        extra-conf: |
           fallback = true # So we always work even if the cache is down
           log-lines = 100 # Necessary in CI to get enough failure context
           keep-outputs = true # Don't delete non-root outputs, because might be needed for other builds


### PR DESCRIPTION
# Description

Restores the Determinate Nix installer in `.github/actions/prepare-nix`, reverting the switch to `nix-quick-install-action` (Nix 2.34.7) from #2618 due to [problems with image publish digests](https://github.com/TraceMachina/nativelink/actions/runs/30207223208/job/89952840958)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI on this branch exercises the same `prepare-nix` action across the Nix
workflows.

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...` passes locally
- [x] PR is contained in a single commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2635)
<!-- Reviewable:end -->
