### PR TITLE
Fix S3 credential discovery for EKS Pod Identity

### DIFF
--- a/nativelink-store/src/common_s3_utils.rs
+++ b/nativelink-store/src/common_s3_utils.rs
@@ -60,11 +60,24 @@ pub struct TlsClient {
 impl TlsClient {
     #[must_use]
     pub fn new(common: &CommonObjectSpec) -> Self {
+        Self::new_with_http_support(common, common.insecure_allow_http)
+    }
+
+    /// Creates a client for AWS credential discovery.
+    ///
+    /// The default credential chain uses plain HTTP for link-local metadata
+    /// services, including the EKS Pod Identity, ECS, and EC2 providers.
+    #[must_use]
+    pub fn new_for_credentials(common: &CommonObjectSpec) -> Self {
+        Self::new_with_http_support(common, true)
+    }
+
+    fn new_with_http_support(common: &CommonObjectSpec, allow_http: bool) -> Self {
         install_default_rustls_crypto_provider();
 
         let connector_with_roots = HttpsConnectorBuilder::new().with_platform_verifier();
 
-        let connector_with_schemes = if common.insecure_allow_http {
+        let connector_with_schemes = if allow_http {
             connector_with_roots.https_or_http()
         } else {
             connector_with_roots.https_only()

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -110,12 +110,13 @@ where
         let jitter_fn = spec.common.retry.make_jitter_fn();
         let s3_client = {
             let http_client = TlsClient::new(&spec.common.clone());
+            let credential_http_client = TlsClient::new_for_credentials(&spec.common);
 
             let credential_provider = credentials::DefaultCredentialsChain::builder()
                 .configure(
                     ProviderConfig::without_region()
                         .with_region(Some(Region::new(Cow::Owned(spec.region.clone()))))
-                        .with_http_client(http_client.clone()),
+                        .with_http_client(credential_http_client),
                 )
                 .build()
                 .await;


### PR DESCRIPTION
# Description

The HTTPS client passed into the aws credentials provider does not work with EKS Pod Identity, because an HTTP client is required to access the credentials endpoint.

https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html#pod-id-agent-pod

Per the above link, the injected `AWS_CONTAINER_CREDENTIALS_FULL_URI` is a plain-HTTP endpoint `http://169.254.170.23/v1/credentials`.

This change continues to use the HTTPS client for accessing S3, the HTTP client is only used for the credentials provider.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Built container with change, deployed into EKS cluster with pod identity, verified it could reach S3.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2650)
<!-- Reviewable:end -->
