### PR TITLE
Fix S3 credential discovery for EKS Pod Identity

### DIFF
--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -127,6 +127,7 @@ rust_test_suite(
         "tests/ac_utils_test.rs",
         "tests/azure_blob_store_test.rs",
         "tests/cache_metrics_store_test.rs",
+        "tests/common_s3_utils_test.rs",
         "tests/completeness_checking_store_test.rs",
         "tests/compression_store_test.rs",
         "tests/dedup_store_test.rs",

--- a/nativelink-store/src/common_s3_utils.rs
+++ b/nativelink-store/src/common_s3_utils.rs
@@ -60,11 +60,24 @@ pub struct TlsClient {
 impl TlsClient {
     #[must_use]
     pub fn new(common: &CommonObjectSpec) -> Self {
+        Self::new_with_http_support(common, common.insecure_allow_http)
+    }
+
+    /// Creates a client for AWS credential discovery.
+    ///
+    /// The default credential chain uses plain HTTP for link-local metadata
+    /// services, including the EKS Pod Identity, ECS, and EC2 providers.
+    #[must_use]
+    pub fn new_for_credentials(common: &CommonObjectSpec) -> Self {
+        Self::new_with_http_support(common, true)
+    }
+
+    fn new_with_http_support(common: &CommonObjectSpec, allow_http: bool) -> Self {
         install_default_rustls_crypto_provider();
 
         let connector_with_roots = HttpsConnectorBuilder::new().with_platform_verifier();
 
-        let connector_with_schemes = if common.insecure_allow_http {
+        let connector_with_schemes = if allow_http {
             connector_with_roots.https_or_http()
         } else {
             connector_with_roots.https_only()

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -110,12 +110,13 @@ where
         let jitter_fn = spec.common.retry.make_jitter_fn();
         let s3_client = {
             let http_client = TlsClient::new(&spec.common.clone());
+            let credential_http_client = TlsClient::new_for_credentials(&spec.common);
 
             let credential_provider = credentials::DefaultCredentialsChain::builder()
                 .configure(
                     ProviderConfig::without_region()
                         .with_region(Some(Region::new(Cow::Owned(spec.region.clone()))))
-                        .with_http_client(http_client.clone()),
+                        .with_http_client(credential_http_client),
                 )
                 .build()
                 .await;

--- a/nativelink-store/tests/common_s3_utils_test.rs
+++ b/nativelink-store/tests/common_s3_utils_test.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    See LICENSE file for details
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verifies that AWS credential discovery can use link-local HTTP endpoints
+//! without allowing unencrypted HTTP for S3 requests.
+
+use aws_smithy_runtime_api::client::http::HttpConnector;
+use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+use nativelink_config::stores::CommonObjectSpec;
+use nativelink_macro::nativelink_test;
+use nativelink_store::common_s3_utils::TlsClient;
+use nativelink_util::spawn;
+use nativelink_util::task::JoinHandleDropGuard;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+async fn start_http_server() -> (String, JoinHandleDropGuard<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = spawn!("credential HTTP test server", async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0; 1024];
+        let _bytes_read = socket.read(&mut request).await.unwrap();
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+    });
+    (format!("http://{address}/credentials"), server)
+}
+
+#[nativelink_test]
+async fn credential_client_allows_http() {
+    let common = CommonObjectSpec::default();
+    assert!(!common.insecure_allow_http);
+
+    let (credential_url, credential_server) = start_http_server().await;
+    let credential_result = TlsClient::new_for_credentials(&common)
+        .call(HttpRequest::get(credential_url).unwrap())
+        .await;
+    assert!(
+        credential_result.is_ok(),
+        "credential client should allow HTTP: {credential_result:?}"
+    );
+    credential_server.await.unwrap();
+}
+
+#[nativelink_test]
+async fn s3_client_rejects_http_by_default() {
+    let common = CommonObjectSpec::default();
+    assert!(!common.insecure_allow_http);
+
+    let (s3_url, s3_server) = start_http_server().await;
+    let s3_result = TlsClient::new(&common)
+        .call(HttpRequest::get(s3_url).unwrap())
+        .await;
+    drop(s3_server);
+    assert!(
+        s3_result.is_err(),
+        "S3 client should reject HTTP: {s3_result:?}"
+    );
+}


### PR DESCRIPTION
# Description

The HTTPS client passed into the aws credentials provider does not work with EKS Pod Identity, because an HTTP client is required to access the credentials endpoint.

https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html#pod-id-agent-pod

Per the above link, the injected `AWS_CONTAINER_CREDENTIALS_FULL_URI` is a plain-HTTP endpoint `http://169.254.170.23/v1/credentials`.

This change continues to use the HTTPS client for accessing S3, the HTTP client is only used for the credentials provider.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit coverage verifying the credential client allows HTTP while the S3 client rejects HTTP by default.
- `cargo test -p nativelink-store --test common_s3_utils_test`
- `cargo clippy -p nativelink-store --test common_s3_utils_test -- -D warnings`
- Built container with change, deployed into EKS cluster with pod identity, verified it could reach S3.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2651)
<!-- Reviewable:end -->

