### PR TITLE
bazel-retry improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bazel-*
+/bazel-*
 target/
 nativelink-test/fuzz/target/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/bazel-*
+bazel-*
+!tools/bazel-retry.sh
 target/
 nativelink-test/fuzz/target/
 .vscode/

--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -27,6 +27,7 @@ ARG ADDITIONAL_SETUP_WORKER_CMD=
 FROM ubuntu:noble-20250925@sha256:728785b59223d755e3e5c5af178fab1be7031f3522c5ccd7a0b32b80d8248123 AS dependencies
 ARG BAZELISK_URL
 ARG BAZELISK_SHA256
+COPY ./tools/bazel-retry.sh /usr/local/bin/bazel-retry
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends -y \
@@ -37,7 +38,8 @@ RUN apt-get update \
         ca-certificates=20240203 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && python3 -c 'import hashlib, pathlib, stat, sys, urllib.request; data = urllib.request.urlopen(sys.argv[1], timeout=60).read(); digest = hashlib.sha256(data).hexdigest(); assert digest == sys.argv[2], f"sha256 mismatch: {digest}"; path = pathlib.Path("/usr/local/bin/bazel"); path.write_bytes(data); path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)' "$BAZELISK_URL" "$BAZELISK_SHA256"
+    && python3 -c 'import hashlib, pathlib, stat, sys, urllib.request; data = urllib.request.urlopen(sys.argv[1], timeout=60).read(); digest = hashlib.sha256(data).hexdigest(); assert digest == sys.argv[2], f"sha256 mismatch: {digest}"; path = pathlib.Path("/usr/local/bin/bazel"); path.write_bytes(data); path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)' "$BAZELISK_URL" "$BAZELISK_SHA256" \
+    && chmod +x /usr/local/bin/bazel-retry
 
 # Build the binary.
 FROM dependencies AS builder
@@ -46,7 +48,7 @@ COPY . .
 ARG OPT_LEVEL
 ARG ADDITIONAL_BAZEL_FLAGS
 # Add startup options to prevent Bazel server issues on ARM64
-RUN bazel \
+RUN bazel-retry \
     --batch \
     --output_base=/tmp/bazel_output \
     build -c ${OPT_LEVEL} ${ADDITIONAL_BAZEL_FLAGS} nativelink && \

--- a/flake.nix
+++ b/flake.nix
@@ -437,7 +437,7 @@
               inherit nativelink mongodb wait4x bazelisk;
             };
             rbe-toolchain-with-nativelink-test = pkgs.callPackage toolchain-examples/rbe-toolchain-test.nix {
-              inherit nativelink bazelisk;
+              inherit nativelink;
             };
             buck2-with-nativelink-test = pkgs.callPackage integration_tests/buck2/buck2-with-nativelink-test.nix {
               inherit nativelink buck2;
@@ -515,7 +515,7 @@
               unset TMPDIR TMP
               exec ${pkgs.bazelisk}/bin/bazelisk "$@"
             '';
-            bazel-retry = pkgs.writeShellScriptBin "bazel-retry" (builtins.readFile ./tools/bazel-retry.sh);
+            bazel-retry = pkgs.writeScriptBin "bazel-retry" (builtins.readFile ./tools/bazel-retry.sh);
           in
             [
               # Development tooling

--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,12 @@
 
         docs = pkgs.callPackage ./tools/docs.nix {rust = pkgs.lre.stable-rust;};
 
+        bazel = pkgs.writeShellScriptBin "bazel" ''
+          unset TMPDIR TMP
+          exec ${pkgs.bazelisk}/bin/bazelisk "$@"
+        '';
+        bazel-retry = pkgs.writeScriptBin "bazel-retry" (builtins.readFile ./tools/bazel-retry.sh);
+
         inherit (nix2container.packages.${system}.nix2container) pullImage;
         inherit (nix2container.packages.${system}.nix2container) buildImage;
 
@@ -437,7 +443,7 @@
               inherit nativelink mongodb wait4x bazelisk;
             };
             rbe-toolchain-with-nativelink-test = pkgs.callPackage toolchain-examples/rbe-toolchain-test.nix {
-              inherit nativelink;
+              inherit nativelink bazel-retry bazel;
             };
             buck2-with-nativelink-test = pkgs.callPackage integration_tests/buck2/buck2-with-nativelink-test.nix {
               inherit nativelink buck2;
@@ -510,13 +516,7 @@
           "${gnused}/bin"
         ];
         devShells.default = pkgs.mkShell {
-          packages = let
-            bazel = pkgs.writeShellScriptBin "bazel" ''
-              unset TMPDIR TMP
-              exec ${pkgs.bazelisk}/bin/bazelisk "$@"
-            '';
-            bazel-retry = pkgs.writeScriptBin "bazel-retry" (builtins.readFile ./tools/bazel-retry.sh);
-          in
+          packages =
             [
               # Development tooling
               pkgs.git

--- a/flake.nix
+++ b/flake.nix
@@ -527,7 +527,7 @@
                   exit 0
                 fi
                 grep -E '^ERROR:' ''${BAZEL_LOG} \
-                  | grep -Eq 'GET returned (403|429|5[0-9][0-9])|Bad Gateway|Connection (reset|timed out)|read timed out|Could not resolve host' || {
+                  | grep -Eq 'GET returned (403|429|5[0-9][0-9])|Bad Gateway|Connection (reset|timed out)|read timed out|Could not resolve host|Error downloading' || {
                   echo "Bazel failed (non-transient); not retrying"
                   exit 1
                 }

--- a/flake.nix
+++ b/flake.nix
@@ -515,30 +515,7 @@
               unset TMPDIR TMP
               exec ${pkgs.bazelisk}/bin/bazelisk "$@"
             '';
-            bazel-retry = pkgs.writeShellScriptBin "bazel-retry" ''
-              set -o pipefail
-              BAZEL_LOG=$(mktemp -t)
-              unset TMPDIR TMP
-              # Bazel's downloader retry only covers truncated downloads, not HTTP 5xx/403 failures,
-              # so a flaky fetch aborts the build with no retry. We retry the download in this case.
-              delay=5
-              for attempt in 1 2 3; do
-                if exec ${pkgs.bazelisk}/bin/bazelisk "$@" | tee ''${BAZEL_LOG}; then
-                  exit 0
-                fi
-                grep -E '^ERROR:' ''${BAZEL_LOG} \
-                  | grep -Eq 'GET returned (403|429|5[0-9][0-9])|Bad Gateway|Connection (reset|timed out)|read timed out|Could not resolve host|Error downloading' || {
-                  echo "Bazel failed (non-transient); not retrying"
-                  exit 1
-                }
-                [ "$attempt" -lt 3 ] || break
-                echo "Transient fetch error (attempt ''${attempt}); retrying in ''${delay}s..."
-                sleep "$delay"
-                delay=$((delay * 2))
-              done
-              echo "Bazel still failing after 3 attempts."
-              exit 1
-            '';
+            bazel-retry = pkgs.writeShellScriptBin "bazel-retry" (builtins.readFile ./tools/bazel-retry.sh);
           in
             [
               # Development tooling

--- a/toolchain-examples/rbe-toolchain-test.nix
+++ b/toolchain-examples/rbe-toolchain-test.nix
@@ -2,6 +2,8 @@
   nativelink,
   writeShellScriptBin,
   jo,
+  bazel-retry,
+  bazel,
 }:
 writeShellScriptBin "rbe-toolchain-test" ''
   set -uo pipefail
@@ -62,7 +64,7 @@ writeShellScriptBin "rbe-toolchain-test" ''
 
   run_cmd() {
     cmd=$1
-    FULL_CMD="bazel-retry $cmd $CORE_BAZEL_ARGS"
+    FULL_CMD="PATH=${bazel}/bin:$PATH ${bazel-retry}/bin/bazel-retry $cmd $CORE_BAZEL_ARGS"
     echo $FULL_CMD
     echo -e \\n$FULL_CMD\\n >> toolchain-examples/cmd.log
     cmd_output=$(cd toolchain-examples && eval "$FULL_CMD" 2>&1 | tee -ai cmd.log)

--- a/toolchain-examples/rbe-toolchain-test.nix
+++ b/toolchain-examples/rbe-toolchain-test.nix
@@ -1,7 +1,6 @@
 {
   nativelink,
   writeShellScriptBin,
-  bazelisk,
   jo,
 }:
 writeShellScriptBin "rbe-toolchain-test" ''
@@ -63,7 +62,7 @@ writeShellScriptBin "rbe-toolchain-test" ''
 
   run_cmd() {
     cmd=$1
-    FULL_CMD="${bazelisk}/bin/bazelisk $cmd $CORE_BAZEL_ARGS"
+    FULL_CMD="bazel-retry $cmd $CORE_BAZEL_ARGS"
     echo $FULL_CMD
     echo -e \\n$FULL_CMD\\n >> toolchain-examples/cmd.log
     cmd_output=$(cd toolchain-examples && eval "$FULL_CMD" 2>&1 | tee -ai cmd.log)

--- a/tools/bazel-retry.sh
+++ b/tools/bazel-retry.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -o pipefail
+BAZEL_LOG=$(mktemp -t)
+# Bazel's downloader retry only covers truncated downloads, not HTTP 5xx/403 failures,
+# so a flaky fetch aborts the build with no retry. We retry the download in this case.
+delay=5
+for attempt in 1 2 3; do
+    if exec bazel "$@" 2>&1 | tee "${BAZEL_LOG}"; then
+        exit 0
+    fi
+    grep -E '^ERROR:' "${BAZEL_LOG}" |
+        grep -Eq 'GET returned (403|429|5[0-9][0-9])|Bad Gateway|Connection (reset|timed out)|read timed out|Could not resolve host' || {
+        echo "Bazel failed (non-transient); not retrying"
+        exit 1
+    }
+    [ "$attempt" -lt 3 ] || break
+    echo "Transient fetch error (attempt ${attempt}); retrying in ${delay}s..."
+    sleep "$delay"
+    delay=$((delay * 2))
+done
+echo "Bazel still failing after 3 attempts."
+exit 1


### PR DESCRIPTION
# Description

* Fix the transient error case from https://github.com/TraceMachina/nativelink/actions/runs/30807540422/job/91666280153?pr=2640 by using it with "2>&1" to get all the logs into `tee`
* Split it out of the flake and into a standalone file so we can fix Dockerfile builds as well e.g. https://github.com/TraceMachina/nativelink/actions/runs/30808648620/job/91669833449
* Also use the split out script for `rbe-toolchain-test` to fix things like https://github.com/TraceMachina/nativelink/actions/runs/30807540454/job/91668703689?pr=2640

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2655)
<!-- Reviewable:end -->
