### PR TITLE
fix(redis): skip FT.AGGREGATE rows for docs that expired mid-query

### DIFF
--- a/nativelink-store/src/redis_utils/ft_aggregate.rs
+++ b/nativelink-store/src/redis_utils/ft_aggregate.rs
@@ -264,12 +264,25 @@ fn resp3_data_parse(
                         };
                         match map_key.as_str() {
                             "extra_attributes" => {
-                                let Value::Map(extra_attributes_values) = raw_map_value else {
-                                    return Err(RedisError::from((
-                                        ErrorKind::Parse,
-                                        "Expected Map for extra_attributes",
-                                        format!("{raw_map_value:?}"),
-                                    )));
+                                let extra_attributes_values = match raw_map_value {
+                                    Value::Map(extra_attributes_values) => extra_attributes_values,
+                                    // A document that expired or was deleted between
+                                    // the search phase and the load phase comes back
+                                    // as a row with Nil attributes. Under load this is
+                                    // routine — completed awaited-action records expire
+                                    // constantly — so drop the row instead of failing
+                                    // the whole aggregate. Failing here surfaced to
+                                    // clients as INVALID_ARGUMENT, which Bazel treats
+                                    // as permanent, so a single expiry race killed the
+                                    // build.
+                                    Value::Nil => continue,
+                                    other => {
+                                        return Err(RedisError::from((
+                                            ErrorKind::Parse,
+                                            "Expected Map for extra_attributes",
+                                            format!("{other:?}"),
+                                        )));
+                                    }
                                 };
                                 let mut output_array = vec![];
                                 for (e_key, e_value) in extra_attributes_values {
@@ -384,5 +397,115 @@ impl TryFrom<Value> for RedisCursorData {
         };
         output.cursor = cursor as u64;
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use redis::{ErrorKind, Value};
+
+    use crate::redis_utils::aggregate_types::RedisCursorData;
+
+    /// One RESP3 result row: a doc whose LOAD'ed fields came back populated.
+    fn loaded_row(key: &str, val: &str) -> Value {
+        Value::Map(vec![
+            (
+                Value::SimpleString("extra_attributes".into()),
+                Value::Map(vec![(
+                    Value::SimpleString(key.into()),
+                    Value::SimpleString(val.into()),
+                )]),
+            ),
+            (Value::SimpleString("values".into()), Value::Array(vec![])),
+        ])
+    }
+
+    /// One RESP3 result row for a doc that no longer exists by the time
+    /// `RediSearch` loads its fields: matched during the search phase, gone
+    /// during the load phase, so the attributes come back Nil.
+    fn expired_row() -> Value {
+        Value::Map(vec![
+            (Value::SimpleString("extra_attributes".into()), Value::Nil),
+            (Value::SimpleString("values".into()), Value::Array(vec![])),
+        ])
+    }
+
+    fn resp3_reply(rows: Vec<Value>, cursor: i64) -> Value {
+        Value::Array(vec![
+            Value::Map(vec![
+                (
+                    Value::SimpleString("attributes".into()),
+                    Value::Array(vec![]),
+                ),
+                (
+                    Value::SimpleString("format".into()),
+                    Value::SimpleString("STRING".into()),
+                ),
+                (Value::SimpleString("results".into()), Value::Array(rows)),
+            ]),
+            Value::Int(cursor),
+        ])
+    }
+
+    /// A doc that expires between the search and load phases must drop out of
+    /// the results, not fail the aggregate. Completed awaited-action records
+    /// expire constantly, so any busy scheduler hits this race; failing the
+    /// whole call surfaced to Bazel as a non-retryable INVALID_ARGUMENT and
+    /// killed the build.
+    #[test]
+    fn nil_extra_attributes_row_is_skipped() {
+        let reply = resp3_reply(
+            vec![
+                loaded_row("unique_qualifier", "abc"),
+                expired_row(),
+                loaded_row("unique_qualifier", "def"),
+            ],
+            0,
+        );
+
+        let parsed = RedisCursorData::try_from(reply).expect("expired row must not fail the parse");
+
+        // Only the two surviving docs produce output; the expired one
+        // contributes nothing at all.
+        assert_eq!(parsed.data.len(), 2);
+        assert_eq!(
+            parsed.data[0],
+            Value::Array(vec![
+                Value::SimpleString("unique_qualifier".into()),
+                Value::SimpleString("abc".into()),
+            ])
+        );
+        assert_eq!(
+            parsed.data[1],
+            Value::Array(vec![
+                Value::SimpleString("unique_qualifier".into()),
+                Value::SimpleString("def".into()),
+            ])
+        );
+    }
+
+    /// Every row expiring is still a success, just an empty page.
+    #[test]
+    fn all_rows_nil_parses_to_empty() {
+        let parsed = RedisCursorData::try_from(resp3_reply(vec![expired_row(), expired_row()], 0))
+            .expect("all-expired page must not fail the parse");
+        assert!(parsed.data.is_empty());
+    }
+
+    /// The Nil case is narrow: any other unexpected shape for the attributes
+    /// is still a parse error, so real protocol breakage stays loud.
+    #[test]
+    fn non_map_non_nil_extra_attributes_still_errors() {
+        let bad_row = Value::Map(vec![
+            (
+                Value::SimpleString("extra_attributes".into()),
+                Value::SimpleString("not a map".into()),
+            ),
+            (Value::SimpleString("values".into()), Value::Array(vec![])),
+        ]);
+
+        let err = RedisCursorData::try_from(resp3_reply(vec![bad_row], 0))
+            .expect_err("a non-map, non-nil attributes value must still be rejected");
+        assert_eq!(err.kind(), ErrorKind::Parse);
     }
 }

--- a/nativelink-store/src/redis_utils/ft_aggregate.rs
+++ b/nativelink-store/src/redis_utils/ft_aggregate.rs
@@ -272,7 +272,7 @@ fn resp3_data_parse(
                                     // routine — completed awaited-action records expire
                                     // constantly — so drop the row instead of failing
                                     // the whole aggregate. Failing here surfaced to
-                                    // clients as INVALID_ARGUMENT, which Bazel treats
+                                    // clients as `INVALID_ARGUMENT`, which Bazel treats
                                     // as permanent, so a single expiry race killed the
                                     // build.
                                     Value::Nil => continue,
@@ -397,115 +397,5 @@ impl TryFrom<Value> for RedisCursorData {
         };
         output.cursor = cursor as u64;
         Ok(output)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use redis::{ErrorKind, Value};
-
-    use crate::redis_utils::aggregate_types::RedisCursorData;
-
-    /// One RESP3 result row: a doc whose LOAD'ed fields came back populated.
-    fn loaded_row(key: &str, val: &str) -> Value {
-        Value::Map(vec![
-            (
-                Value::SimpleString("extra_attributes".into()),
-                Value::Map(vec![(
-                    Value::SimpleString(key.into()),
-                    Value::SimpleString(val.into()),
-                )]),
-            ),
-            (Value::SimpleString("values".into()), Value::Array(vec![])),
-        ])
-    }
-
-    /// One RESP3 result row for a doc that no longer exists by the time
-    /// `RediSearch` loads its fields: matched during the search phase, gone
-    /// during the load phase, so the attributes come back Nil.
-    fn expired_row() -> Value {
-        Value::Map(vec![
-            (Value::SimpleString("extra_attributes".into()), Value::Nil),
-            (Value::SimpleString("values".into()), Value::Array(vec![])),
-        ])
-    }
-
-    fn resp3_reply(rows: Vec<Value>, cursor: i64) -> Value {
-        Value::Array(vec![
-            Value::Map(vec![
-                (
-                    Value::SimpleString("attributes".into()),
-                    Value::Array(vec![]),
-                ),
-                (
-                    Value::SimpleString("format".into()),
-                    Value::SimpleString("STRING".into()),
-                ),
-                (Value::SimpleString("results".into()), Value::Array(rows)),
-            ]),
-            Value::Int(cursor),
-        ])
-    }
-
-    /// A doc that expires between the search and load phases must drop out of
-    /// the results, not fail the aggregate. Completed awaited-action records
-    /// expire constantly, so any busy scheduler hits this race; failing the
-    /// whole call surfaced to Bazel as a non-retryable INVALID_ARGUMENT and
-    /// killed the build.
-    #[test]
-    fn nil_extra_attributes_row_is_skipped() {
-        let reply = resp3_reply(
-            vec![
-                loaded_row("unique_qualifier", "abc"),
-                expired_row(),
-                loaded_row("unique_qualifier", "def"),
-            ],
-            0,
-        );
-
-        let parsed = RedisCursorData::try_from(reply).expect("expired row must not fail the parse");
-
-        // Only the two surviving docs produce output; the expired one
-        // contributes nothing at all.
-        assert_eq!(parsed.data.len(), 2);
-        assert_eq!(
-            parsed.data[0],
-            Value::Array(vec![
-                Value::SimpleString("unique_qualifier".into()),
-                Value::SimpleString("abc".into()),
-            ])
-        );
-        assert_eq!(
-            parsed.data[1],
-            Value::Array(vec![
-                Value::SimpleString("unique_qualifier".into()),
-                Value::SimpleString("def".into()),
-            ])
-        );
-    }
-
-    /// Every row expiring is still a success, just an empty page.
-    #[test]
-    fn all_rows_nil_parses_to_empty() {
-        let parsed = RedisCursorData::try_from(resp3_reply(vec![expired_row(), expired_row()], 0))
-            .expect("all-expired page must not fail the parse");
-        assert!(parsed.data.is_empty());
-    }
-
-    /// The Nil case is narrow: any other unexpected shape for the attributes
-    /// is still a parse error, so real protocol breakage stays loud.
-    #[test]
-    fn non_map_non_nil_extra_attributes_still_errors() {
-        let bad_row = Value::Map(vec![
-            (
-                Value::SimpleString("extra_attributes".into()),
-                Value::SimpleString("not a map".into()),
-            ),
-            (Value::SimpleString("values".into()), Value::Array(vec![])),
-        ]);
-
-        let err = RedisCursorData::try_from(resp3_reply(vec![bad_row], 0))
-            .expect_err("a non-map, non-nil attributes value must still be rejected");
-        assert_eq!(err.kind(), ErrorKind::Parse);
     }
 }

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -1409,6 +1409,126 @@ fn test_search_by_index_retries_on_failover() -> Result<(), Error> {
     Ok(())
 }
 
+/// `RediSearch` matches documents in the search phase and reads their fields
+/// in the load phase. A document that expires or is deleted between the two
+/// comes back as a RESP3 row whose `extra_attributes` is Nil. That is routine
+/// on a busy scheduler — completed awaited-action records expire constantly —
+/// so the row must drop out of the results rather than fail the whole
+/// aggregate. Failing it reached clients as `INVALID_ARGUMENT`, which Bazel
+/// treats as permanent, so one expiry race ended the build.
+#[nativelink_test]
+fn test_search_by_index_skips_docs_that_expired_mid_query() -> Result<(), Error> {
+    fn loaded_row(content: &str) -> Value {
+        Value::Map(vec![
+            (
+                Value::SimpleString("extra_attributes".into()),
+                Value::Map(vec![
+                    (
+                        Value::BulkString(b"data".to_vec()),
+                        Value::BulkString(content.as_bytes().to_vec()),
+                    ),
+                    (
+                        Value::BulkString(b"version".to_vec()),
+                        Value::BulkString(b"1".to_vec()),
+                    ),
+                ]),
+            ),
+            (Value::SimpleString("values".into()), Value::Array(vec![])),
+        ])
+    }
+
+    fn expired_row() -> Value {
+        Value::Map(vec![
+            (Value::SimpleString("extra_attributes".into()), Value::Nil),
+            (Value::SimpleString("values".into()), Value::Array(vec![])),
+        ])
+    }
+
+    fn make_ft_aggregate() -> MockCmd {
+        MockCmd::new(
+            redis::cmd("FT.AGGREGATE")
+                .arg("test:_content_prefix_sort_key_3e762c15")
+                .arg("@content_prefix:{ Searchable }")
+                .arg("TIMEOUT")
+                .arg(10000_u64)
+                .arg("LOAD")
+                .arg(2)
+                .arg("data")
+                .arg("version")
+                .arg("WITHCURSOR")
+                .arg("COUNT")
+                .arg(1500)
+                .arg("MAXIDLE")
+                .arg(30000)
+                .arg("SORTBY")
+                .arg(2usize)
+                .arg("@sort_key")
+                .arg("ASC"),
+            // A page whose middle document expired between match and load.
+            Ok(Value::Array(vec![
+                Value::Map(vec![
+                    (
+                        Value::SimpleString("attributes".into()),
+                        Value::Array(vec![]),
+                    ),
+                    (
+                        Value::SimpleString("format".into()),
+                        Value::SimpleString("STRING".into()),
+                    ),
+                    (
+                        Value::SimpleString("results".into()),
+                        Value::Array(vec![loaded_row("1234"), expired_row(), loaded_row("5678")]),
+                    ),
+                ]),
+                Value::Int(0),
+            ])),
+        )
+    }
+
+    let commands = vec![
+        make_ft_aggregate(),
+        MockCmd::new(
+            redis::cmd("FT.CREATE")
+                .arg("test:_content_prefix__3e762c15")
+                .arg("ON")
+                .arg("HASH")
+                .arg("NOHL")
+                .arg("NOFIELDS")
+                .arg("NOFREQS")
+                .arg("NOOFFSETS")
+                .arg("TEMPORARY")
+                .arg(86400)
+                .arg("PREFIX")
+                .arg(1)
+                .arg("test:")
+                .arg("SCHEMA")
+                .arg("content_prefix")
+                .arg("TAG"),
+            Ok(Value::Nil),
+        ),
+        make_ft_aggregate(),
+    ];
+    let store = make_mock_store(commands).await;
+    let search_provider = SearchByContentPrefix {
+        prefix: "Searchable".to_string(),
+    };
+
+    let search_results: Vec<TestSchedulerDataUnversioned> = store
+        .search_by_index_prefix(search_provider)
+        .await
+        .err_tip(|| "The expired row must not fail the aggregate")?
+        .try_collect()
+        .await?;
+
+    // Only the two surviving documents come back; the expired one contributes
+    // nothing rather than taking the other two down with it.
+    assert_eq!(search_results.len(), 2, "Should skip only the expired row");
+    assert_eq!(search_results[0].content, "1234");
+    assert_eq!(search_results[1].content, "5678");
+
+    Ok(())
+}
+
 #[nativelink_test]
 fn test_search_by_index_failure() -> Result<(), Error> {
     let store = make_mock_store(vec![]).await;


### PR DESCRIPTION
## Description

`RediSearch` matches documents in the search phase and reads their fields in
the load phase. A document that expires or is deleted between the two comes
back as a result row whose `extra_attributes` is `Nil`. The parser rejected
that outright and failed the **entire** aggregate:

```
Expected Map for extra_attributes - Parse: nil
```

The scheduler's awaited-action index hits this constantly, because completed
action records expire while queries are running over them. On a busy
scheduler it showed up two ways:

- the every-10s worker-matching sweep failing repeatedly, and
- `add_action` failing outright which reaches Bazel as `INVALID_ARGUMENT`.
  Bazel treats that status as permanent and does not retry, so a single
  expiry race ended the build.

## Fix

A `Nil`-attributes row is now skipped, which is what it means: the document
no longer exists. Any other unexpected shape for the attributes is still a
parse error, so real protocol breakage stays loud.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Three unit tests over `RedisCursorData::try_from`, covering a page that
mixes live and expired rows, an all-expired page, and the negative case.
Verified they fail without the fix with the exact production message
(`Expected Map for extra_attributes - Parse: nil`) and pass with it.

Also confirmed in production: a customer cluster has run this patch over
v1.6.3 for several days of stress builds, and the errors stopped.

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...` passes locally
- [x] PR is contained in a single commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2656)
<!-- Reviewable:end -->
