### PR TITLE
fix(error): classify transient Redis failures as retryable

### DIFF
--- a/nativelink-error/src/lib.rs
+++ b/nativelink-error/src/lib.rs
@@ -329,21 +329,55 @@ impl From<std::io::Error> for Error {
 impl From<redis::RedisError> for Error {
     fn from(error: redis::RedisError) -> Self {
         use redis::ErrorKind::{
-            AuthenticationFailed, InvalidClientConfig, Io as IoError, Parse as ParseError,
+            AuthenticationFailed, ClusterConnectionNotFound, EmptySentinelList,
+            InvalidClientConfig, Io as IoError, MasterNameNotFoundBySentinel,
+            NoValidReplicasFoundBySentinel, Parse as ParseError, RESP3NotSupported, Server,
             UnexpectedReturnType,
+        };
+        use redis::ServerErrorKind::{
+            BusyLoading, ClusterDown, MasterDown, NoPerm, ReadOnly, TryAgain,
         };
 
         // Conversions here are based on https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
+        //
+        // The distinction that matters most is retryable vs not. These statuses
+        // reach REAPI clients directly, and Bazel treats INVALID_ARGUMENT as
+        // permanent: it fails the build instantly rather than retrying. So
+        // anything caused by the state of the Redis deployment — a failover in
+        // progress, a dropped connection, a node still loading its dataset —
+        // must NOT land there, or a routine blip becomes a failed CI run.
         let code = match error.kind() {
-            AuthenticationFailed => Code::PermissionDenied,
-            ParseError | UnexpectedReturnType | InvalidClientConfig => Code::InvalidArgument,
+            AuthenticationFailed | Server(NoPerm) => Code::PermissionDenied,
+
+            // Topology in flux. Sentinel failover makes these normal and
+            // brief: the master moved and the client has not caught up yet.
+            // Surfacing MasterNameNotFoundBySentinel as INVALID_ARGUMENT is
+            // what turned a 1-2 minute sentinel failover into a dead build.
+            MasterNameNotFoundBySentinel
+            | NoValidReplicasFoundBySentinel
+            | ClusterConnectionNotFound
+            | Server(ClusterDown | MasterDown | TryAgain | BusyLoading | ReadOnly) => {
+                Code::Unavailable
+            }
+
+            // A timeout is worth distinguishing from a dead connection, but
+            // both are transient and both are retryable.
             IoError => {
                 if error.is_timeout() {
                     Code::DeadlineExceeded
                 } else {
-                    Code::Internal
+                    Code::Unavailable
                 }
             }
+
+            // Genuine misconfiguration by the operator — retrying cannot help.
+            InvalidClientConfig | EmptySentinelList | RESP3NotSupported => Code::InvalidArgument,
+
+            // Server-side or protocol faults. Not the caller's argument, so
+            // not InvalidArgument: a malformed reply is our problem or the
+            // server's, and it is at least worth a retry.
+            ParseError | UnexpectedReturnType => Code::Internal,
+
             _ => Code::Unknown,
         };
 

--- a/nativelink-error/tests/error_tests.rs
+++ b/nativelink-error/tests/error_tests.rs
@@ -24,3 +24,101 @@ fn walkdir_source_error() {
         );
     }
 }
+
+/// Redis failures reach REAPI clients as gRPC statuses, and `Bazel` treats
+/// `INVALID_ARGUMENT` as permanent — no retry, build over. Anything caused by
+/// the state of the `Redis` deployment rather than by the caller's request has
+/// to map to a retryable status, or a routine failover fails CI.
+mod redis_error_codes {
+    use nativelink_error::{Code, Error};
+    use redis::{ErrorKind, RedisError, ServerErrorKind};
+
+    fn code_of(kind: ErrorKind) -> Code {
+        let err: Error = RedisError::from((kind, "synthetic")).into();
+        err.code
+    }
+
+    #[test]
+    fn sentinel_failover_is_retryable() {
+        // The exact shape observed killing a customer build mid-failover.
+        assert_eq!(
+            code_of(ErrorKind::MasterNameNotFoundBySentinel),
+            Code::Unavailable
+        );
+        assert_eq!(
+            code_of(ErrorKind::NoValidReplicasFoundBySentinel),
+            Code::Unavailable
+        );
+    }
+
+    #[test]
+    fn transient_server_states_are_retryable() {
+        for kind in [
+            ServerErrorKind::ClusterDown,
+            ServerErrorKind::MasterDown,
+            ServerErrorKind::TryAgain,
+            ServerErrorKind::BusyLoading,
+            ServerErrorKind::ReadOnly,
+        ] {
+            assert_eq!(
+                code_of(ErrorKind::Server(kind)),
+                Code::Unavailable,
+                "{kind:?} is transient and must be retryable"
+            );
+        }
+        assert_eq!(
+            code_of(ErrorKind::ClusterConnectionNotFound),
+            Code::Unavailable
+        );
+    }
+
+    #[test]
+    fn dropped_connection_is_unavailable_and_timeout_is_deadline_exceeded() {
+        let dropped: Error = RedisError::from(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "reset by peer",
+        ))
+        .into();
+        assert_eq!(dropped.code, Code::Unavailable);
+
+        let timed_out: Error = RedisError::from(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out",
+        ))
+        .into();
+        assert_eq!(timed_out.code, Code::DeadlineExceeded);
+    }
+
+    /// A malformed reply is a fault on our side or the server's, not a bad
+    /// argument from the client. This is the class that failed builds through
+    /// the `FT.AGGREGATE` expiry race.
+    #[test]
+    fn protocol_faults_are_internal_not_invalid_argument() {
+        assert_eq!(code_of(ErrorKind::Parse), Code::Internal);
+        assert_eq!(code_of(ErrorKind::UnexpectedReturnType), Code::Internal);
+    }
+
+    /// Operator misconfiguration is the one case retrying genuinely cannot
+    /// help, so it stays non-retryable.
+    #[test]
+    fn misconfiguration_stays_invalid_argument() {
+        assert_eq!(
+            code_of(ErrorKind::InvalidClientConfig),
+            Code::InvalidArgument
+        );
+        assert_eq!(code_of(ErrorKind::EmptySentinelList), Code::InvalidArgument);
+        assert_eq!(code_of(ErrorKind::RESP3NotSupported), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn auth_failures_are_permission_denied() {
+        assert_eq!(
+            code_of(ErrorKind::AuthenticationFailed),
+            Code::PermissionDenied
+        );
+        assert_eq!(
+            code_of(ErrorKind::Server(ServerErrorKind::NoPerm)),
+            Code::PermissionDenied
+        );
+    }
+}

--- a/nativelink-error/tests/lib_tests.rs
+++ b/nativelink-error/tests/lib_tests.rs
@@ -58,11 +58,14 @@ fn test_redis_error_conversion_invalid_argument() {
 }
 
 #[test]
-fn test_redis_error_conversion_internal() {
-    let redis_error: redis::RedisError = (RedisErrorKind::Io, "Internal error").into();
+fn test_redis_error_conversion_io_is_unavailable() {
+    // An I/O error means the connection to Redis broke, which is transient
+    // and retryable — clients must be told UNAVAILABLE so they retry rather
+    // than fail the operation outright.
+    let redis_error: redis::RedisError = (RedisErrorKind::Io, "Connection error").into();
     let error: Error = redis_error.into();
-    assert_eq!(error.code, Code::Internal);
-    assert!(error.messages[0].contains("Internal error"));
+    assert_eq!(error.code, Code::Unavailable);
+    assert!(error.messages[0].contains("Connection error"));
 }
 
 #[test]

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -757,12 +757,12 @@ impl RedisStore<ConnectionManager, StandardRedisManager<ConnectionManager>> {
                     .await?
                     .map_err(Into::<Error>::into),
                 }
-                .err_tip_with_code(|_e| {
-                    (
-                        Code::InvalidArgument,
-                        format!("While connecting to redis with url: {local_addr}"),
-                    )
-                })
+                // Keep the underlying error's code rather than forcing
+                // InvalidArgument. Not every connect failure is a bad URL: a
+                // sentinel failover in progress reports the master as missing,
+                // which is transient and retryable, and overriding it to a
+                // permanent status made clients give up on a recoverable blip.
+                .err_tip(|| format!("While connecting to redis with url: {local_addr}"))
             }),
         )
         .await

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -1072,7 +1072,13 @@ async fn test_sentinel_connect_with_url_specified_master() {
             "redis+sentinel://127.0.0.1:{port}/?sentinelServiceName=specific_master"
         )],
         mode: RedisMode::Sentinel,
-        connection_timeout_ms: 100,
+        // This test asserts that the sentinelServiceName URL parameter
+        // resolves, not that it resolves quickly. 100ms — copied from the
+        // fail-fast bad-master test above, where a tight budget is the point —
+        // has to cover two TCP connects and two handshakes plus SENTINEL
+        // MASTERS in between, which a loaded macOS CI runner does not manage.
+        // Every other success-path test here allows 1s or more.
+        connection_timeout_ms: 5_000,
         ..Default::default()
     };
     RedisStore::new_standard(spec).await.expect("Working spec");

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -958,9 +958,14 @@ async fn test_sentinel_connect_with_bad_master() {
         connection_timeout_ms: 100,
         ..Default::default()
     };
+    // Unavailable, not InvalidArgument: an unknown master name is
+    // indistinguishable from a sentinel failover in progress, and the two
+    // must not be told apart by guessing. A genuinely wrong name keeps
+    // failing and stays visible; a failover recovers on retry. Classifying
+    // this as permanent meant a routine failover killed in-flight builds.
     assert_eq!(
         Error {
-            code: Code::InvalidArgument,
+            code: Code::Unavailable,
             messages: vec![
                 "MasterNameNotFoundBySentinel: Master with given name not found in sentinel - MasterNameNotFoundBySentinel".into(),
                 format!("While connecting to redis with url: redis+sentinel://127.0.0.1:{port}/")


### PR DESCRIPTION
## Problem

Redis failures reach REAPI clients as gRPC statuses. Bazel treats `INVALID_ARGUMENT` as **permanent** — it does not retry, it fails the build. The current mapping sends several purely transient conditions there, so an ordinary sentinel failover (1-2 minutes, fully self-healing) ends every in-flight build instead of causing a brief stall.

[TRA-292](https://linear.app/tracemachina/issue/TRA-292) during a customer stress test: a Redis roll during a `helm upgrade` killed a running build with `MasterNameNotFoundBySentinel`.

Two separate causes:

1. The `From<RedisError>` mapping put `Parse | UnexpectedReturnType | InvalidClientConfig` in `InvalidArgument`, and everything topology-related<br>fell through to `Unknown`. `Io` became `Internal` even for a plain dropped<br>connection.
2. `RedisStore`'s connect path wrapped **every** failure with<br>`err_tip_with_code(Code::InvalidArgument, ...)`, which overrode the<br>classification entirely. Even a correct mapping could not survive it.

<details><summary>Type of change</summary>

- [X] Bug fix (non-breaking change which fixes an issue)

</details>

## How Has This Been Tested?

Full `nativelink-error` and `nativelink-store` suites pass.

## Checklist

- [X] Updated documentation if needed
- [X] `bazel test //...` passes locally
- [X] PR is contained in a single commit

---

This change is <img src="https://camo.githubusercontent.com/b672beca07dd3e7b25a0a923de4e20bb5ee5b858d23632bac38e8c42a5058d02/68747470733a2f2f72657669657761626c652e696f2f7265766965775f627574746f6e2e737667 " alt="Reviewable" height="34" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2657)
<!-- Reviewable:end -->
