### PR TITLE
fix(worker): don't abort the worker when a disconnect catches an action in transit

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -459,6 +459,18 @@ impl ApiWorkerSchedulerImpl {
     ) -> Result<(), Error> {
         let mut result = Ok(());
         if let Some(mut worker) = self.remove_worker(worker_id) {
+            // Log every eviction here rather than in each caller, so a worker
+            // can never leave the pool unexplained. Without this, a worker that
+            // vanished mid-build left nothing on the scheduler side to
+            // attribute it to, and the only visible symptom was the worker
+            // reconnecting with a fresh id.
+            info!(
+                ?worker_id,
+                is_disconnect,
+                running_actions = worker.running_action_infos.len(),
+                reason = %err.message_string(),
+                "Evicting worker from pool"
+            );
             // We don't care if we fail to send message to worker, this is only a best attempt.
             drop(worker.notify_update(WorkerUpdate::Disconnect).await);
             let update = if is_disconnect {

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -891,24 +891,36 @@ impl<T: WorkerApiClientTrait + 'static, U: RunningActionsManager> LocalWorker<T,
 
             // Now listen for connections and run all other services.
             if let Err(err) = inner.run(update_for_worker_stream, &mut shutdown_rx).await {
-                'no_more_actions: {
-                    // Ensure there are no actions in transit before we try to kill
-                    // all our actions.
-                    const ITERATIONS: usize = 1_000;
+                // Give in-transit actions a chance to settle before we kill
+                // them, so their results still reach the scheduler.
+                const ITERATIONS: usize = 1_000;
 
-                    const ERROR_MSG: &str = "Actions in transit did not reach zero before we disconnected from the scheduler";
-
-                    let sleep_duration = ACTIONS_IN_TRANSIT_TIMEOUT_S / ITERATIONS as f32;
-                    for _ in 0..ITERATIONS {
-                        if inner.actions_in_transit.load(Ordering::Acquire) == 0 {
-                            break 'no_more_actions;
-                        }
-                        (sleep_fn_pin)(Duration::from_secs_f32(sleep_duration)).await;
+                let sleep_duration = ACTIONS_IN_TRANSIT_TIMEOUT_S / ITERATIONS as f32;
+                let mut drained = false;
+                for _ in 0..ITERATIONS {
+                    if inner.actions_in_transit.load(Ordering::Acquire) == 0 {
+                        drained = true;
+                        break;
                     }
-                    error!(ERROR_MSG);
-                    return Err(err.append(ERROR_MSG));
+                    (sleep_fn_pin)(Duration::from_secs_f32(sleep_duration)).await;
                 }
-                error!(?err, "Worker disconnected from scheduler");
+                if !drained {
+                    // Deliberately not fatal. Returning here propagates out of
+                    // the worker's main loop and aborts the process, so a
+                    // scheduler blip that happened to catch an action in
+                    // transit took the whole worker down — and every action it
+                    // held then had to run again elsewhere. At fleet scale that
+                    // is a restart storm. kill_all() below discards these
+                    // actions anyway, so the wait is a courtesy and overrunning
+                    // it costs nothing beyond the actions we were already
+                    // giving up on.
+                    error!(
+                        actions_in_transit = inner.actions_in_transit.load(Ordering::Acquire),
+                        "Actions in transit did not reach zero before we disconnected from the scheduler"
+                    );
+                }
+
+                error!(?err, "Worker disconnected from scheduler, reconnecting");
                 // Kill off any existing actions because if we re-connect, we'll
                 // get some more and it might resource lock us.
                 self.running_actions_manager.kill_all().await;

--- a/nativelink-worker/tests/local_worker_test.rs
+++ b/nativelink-worker/tests/local_worker_test.rs
@@ -193,6 +193,84 @@ async fn kill_all_called_on_disconnect() -> Result<(), Error> {
     Ok(())
 }
 
+/// A disconnect that catches an action mid-handoff must still reconnect.
+/// Returning from the worker's main loop here aborts the process, so a
+/// scheduler blip that happened to land while an action was in transit took
+/// the whole worker down and every action it held had to run again elsewhere.
+#[nativelink_test]
+async fn reconnects_when_action_stuck_in_transit_on_disconnect() -> Result<(), Error> {
+    let mut test_context = setup_local_worker(HashMap::new()).await;
+    let streaming_response = test_context.maybe_streaming_response.take().unwrap();
+
+    test_context
+        .client
+        .expect_connect_worker(Ok(streaming_response))
+        .await;
+
+    let expected_worker_id = "foobar".to_string();
+    let tx_stream = test_context.maybe_tx_stream.take().unwrap();
+    tx_stream
+        .send(Frame::data(
+            encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::ConnectionResult(ConnectionResult {
+                    worker_id: expected_worker_id.clone(),
+                })),
+            })
+            .unwrap(),
+        ))
+        .await
+        .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+
+    let action_info = ActionInfo {
+        command_digest: DigestInfo::new([1u8; 32], 10),
+        input_root_digest: DigestInfo::new([2u8; 32], 10),
+        timeout: Duration::from_secs(1),
+        platform_properties: HashMap::new(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: SystemTime::UNIX_EPOCH,
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
+            instance_name: INSTANCE_NAME.to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: DigestInfo::new([3u8; 32], 10),
+        }),
+    };
+
+    // Start an action, but deliberately never answer create_and_add_action.
+    // The action stays counted as in transit, so the drain wait on disconnect
+    // runs to its limit instead of settling.
+    tx_stream
+        .send(Frame::data(
+            encode_stream_proto(&UpdateForWorker {
+                update: Some(Update::StartAction(StartExecute {
+                    execute_request: Some((&action_info).into()),
+                    operation_id: String::new(),
+                    queued_timestamp: None,
+                    platform: Some(Platform::default()),
+                    worker_id: expected_worker_id,
+                })),
+            })
+            .unwrap(),
+        ))
+        .await
+        .map_err(|e| make_input_err!("Could not send : {:?}", e))?;
+
+    // Disconnect while that action is still in transit.
+    drop(tx_stream);
+
+    test_context.actions_manager.expect_kill_all().await;
+
+    // The worker must come back rather than exiting.
+    let (_, streaming_response) = setup_grpc_stream();
+    let props = test_context
+        .client
+        .expect_connect_worker(Ok(streaming_response))
+        .await;
+    assert_eq!(props, ConnectWorkerRequest::default());
+
+    Ok(())
+}
+
 #[nativelink_test]
 async fn blake3_digest_function_registered_properly() -> Result<(), Error> {
     let mut test_context = setup_local_worker(HashMap::new()).await;


### PR DESCRIPTION
## Problem

`LocalWorker::run` already reconnects on disconnect — except on one path.
If actions were still in transit when the stream closed and they did not
settle within `ACTIONS_IN_TRANSIT_TIMEOUT_S`, `run()` returned `Err`. That
propagates out of `try_join_all` in `main` and **panics the process**
(exit 101).

So a scheduler blip that happened to land while an action was mid-handoff
took the whole worker down, and every action it held had to run again
elsewhere. During a customer stress test three workers died inside one
seven-minute window, two of them 21 seconds apart — a correlated
scheduler-side event turning into a restart storm.

Worse, nothing on the scheduler side explained why. Some eviction callers
logged and some did not, so a worker could leave the pool silently; the only
visible symptom was it reconnecting later with a fresh id. That blocked root
cause attribution entirely.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Full  suites pass.

## Checklist

- [x] Updated documentation if needed
- [x] `bazel test //...` passes locally
- [x] PR is contained in a single commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2658)
<!-- Reviewable:end -->
