### PR TITLE
Adding tag to docs

### DIFF
--- a/web/apps/docs/app/layout.tsx
+++ b/web/apps/docs/app/layout.tsx
@@ -1,4 +1,5 @@
 import { source } from "@/lib/source";
+import { GoogleTagManager } from "@next/third-parties/google";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { GeistMono } from "geist/font/mono";
@@ -24,6 +25,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
       className={`${GeistSans.variable} ${GeistMono.variable}`}
     >
+      <GoogleTagManager gtmId="GTM-NNLLRWGB" />
       <body className="flex min-h-screen flex-col bg-background text-foreground antialiased">
         {/* RootProvider configures the theme via next-themes. Setting BOTH
          * "class" and "data-theme" attributes is intentional:

--- a/web/apps/docs/package.json
+++ b/web/apps/docs/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@nativelink/tokens": "workspace:*",
     "@nativelink/ui": "workspace:*",
+    "@next/third-parties": "^16.2.11",
     "fumadocs-core": "^16",
     "fumadocs-mdx": "^15",
     "fumadocs-ui": "^16",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,6 +16,7 @@
       "dependencies": {
         "@nativelink/tokens": "workspace:*",
         "@nativelink/ui": "workspace:*",
+        "@next/third-parties": "^16.2.11",
         "fumadocs-core": "^16",
         "fumadocs-mdx": "^15",
         "fumadocs-ui": "^16",


### PR DESCRIPTION
# Description

This adds the same container to the docs root layout, mirroring `web/apps/web/app/layout.tsx`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`bun install && bun run --filter @nativelink/docs build` from `web/` (macOS arm64, bun 1.3.14):

- Build passes, 55 routes generated.
- 51 of the 52 prerendered HTML files verified.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2661)
<!-- Reviewable:end -->
