### PR TITLE
Remove macos from CI workflows

### DIFF
--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -24,11 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-26]
+        os: [ubuntu-24.04]
         toolchain: [lre-cc, lre-rs]
-        exclude:
-          - os: macos-26
-            toolchain: lre-cc
     name: Local / ${{ matrix.toolchain }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -29,9 +29,6 @@ jobs:
           - os: ubuntu-24.04
             bazel_version: 9.1.1
             check_name: ubuntu-24.04
-          - os: macos-26
-            bazel_version: 9.1.1
-            check_name: macos-26
           # Deterministic Bazel compatibility lane. Randomizing Bazel versions
           # makes failures harder to reproduce. Bazel 8 cannot read the
           # Bazel 9 lockfile format, so this lane tests source compatibility

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-26]
+        os: [ubuntu-24.04]
     name: Bazel Dev / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-26]
+        os: [ubuntu-24.04]
     name: Cargo Dev / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
@@ -102,7 +102,6 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - macos-26
     name: Installation / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -29,7 +29,6 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - macos-26
     name: Web Build / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
# Description

We're temporarily disabling macos-26 from ci while we migrate to our own mac resources.  

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [x] ci/cd


## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2662)
<!-- Reviewable:end -->
