### PR TITLE
Release NativeLink v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.4](https://github.com/TraceMachina/nativelink/compare/v1.6.3..1.6.4) - 2026-08-04
+
+### ⛰️  Features
+
+- Add issue templating for more approachable reports ([#2471](https://github.com/TraceMachina/nativelink/issues/2471)) - ([4eb80ad](https://github.com/TraceMachina/nativelink/commit/4eb80ad835753eff8e301d9086afe934930d26b7))
+- Add opt-in zstd wire compression to GrpcStore transfers ([#2596](https://github.com/TraceMachina/nativelink/issues/2596)) - ([64ca974](https://github.com/TraceMachina/nativelink/commit/64ca97402b2ce14fe5fcfe255130bb6b69db827b))
+
+### 🐛 Bug Fixes
+
+- Fix deadlock due to worker resource-tracking leak in scheduler [1.6-patch-1] ([#2642](https://github.com/TraceMachina/nativelink/issues/2642)) - ([7ddf1bd](https://github.com/TraceMachina/nativelink/commit/7ddf1bd1e03b5fff6569bf2e32092f8f6aa65208))
+- Fix duplicate executions of the same action that caused scheduler state to get out of sync [1.6-patch-6] ([#2648](https://github.com/TraceMachina/nativelink/issues/2648)) - ([4278d4b](https://github.com/TraceMachina/nativelink/commit/4278d4b3c15edfc6c269dd240f5bdd884478f1ec))
+- Fix S3 credential discovery over HTTP ([#2651](https://github.com/TraceMachina/nativelink/issues/2651)) - ([58dd792](https://github.com/TraceMachina/nativelink/commit/58dd792e274009b9bf3fc128b2ea3ad9ee8dafe6))
+- *(redis)* skip FT.AGGREGATE rows for docs that expired mid-query ([#2656](https://github.com/TraceMachina/nativelink/issues/2656)) - ([f784549](https://github.com/TraceMachina/nativelink/commit/f784549380576efc3556ad4ec3dd26f244f83e51))
+- *(error)* classify transient Redis failures as retryable ([#2657](https://github.com/TraceMachina/nativelink/issues/2657)) - ([56aa6f7](https://github.com/TraceMachina/nativelink/commit/56aa6f705cb53ebdc7eea2dc5aefc4d5a18e3783))
+- *(worker)* don't abort the worker when a disconnect catches an action in transit ([#2658](https://github.com/TraceMachina/nativelink/issues/2658)) - ([bafafc7](https://github.com/TraceMachina/nativelink/commit/bafafc78f8eddb68201ad76b43641b6bd2f45a35))
+
+### 📚 Documentation
+
+- *(config-reference)* regenerate for NativeLink ([#2652](https://github.com/TraceMachina/nativelink/issues/2652)) - ([4649c50](https://github.com/TraceMachina/nativelink/commit/4649c5034b0e04bce676b9825cb9bd15c52c5c69))
+- Zstd transfers consistency ([#2660](https://github.com/TraceMachina/nativelink/issues/2660)) - ([46a3202](https://github.com/TraceMachina/nativelink/commit/46a32026f2a1a572834f18c8c32108d7dc3496b5))
+- Add GTM to the docs site to improve developer experience ([#2661](https://github.com/TraceMachina/nativelink/issues/2661)) - ([af1bd74](https://github.com/TraceMachina/nativelink/commit/af1bd740f114e768b1a40741ce9b09919026b844))
+- remove NativeLink Cloud product listings and links ([#2637](https://github.com/TraceMachina/nativelink/issues/2637)) - ([d16a1d7](https://github.com/TraceMachina/nativelink/commit/d16a1d70b438f8616c93de96857e2f9a29421d5f))
+
+### 🧪 Testing & CI
+
+- bazel-retry improvements ([#2655](https://github.com/TraceMachina/nativelink/issues/2655)) - ([2c23a86](https://github.com/TraceMachina/nativelink/commit/2c23a867b01b5136af54c0e11baf6b5a2f04909b))
+
+### ⚙️ Miscellaneous
+
+- *(worker)* prevent upload_results deadlock when file count exceeds semaphore permits ([#2636](https://github.com/TraceMachina/nativelink/issues/2636)) ([#2638](https://github.com/TraceMachina/nativelink/issues/2638)) - ([7db3f70](https://github.com/TraceMachina/nativelink/commit/7db3f701323d2bdf1cbb271f499b3d3d2ffdd7f1))
+- Move Github bazel retry into a general command ([#2616](https://github.com/TraceMachina/nativelink/issues/2616)) - ([66055ac](https://github.com/TraceMachina/nativelink/commit/66055ac403391cdeeebcd45204b8b45e1c62171e))
+- Remove the marketing site tracker script ([#2612](https://github.com/TraceMachina/nativelink/issues/2612)) - ([4c2269a](https://github.com/TraceMachina/nativelink/commit/4c2269ac3da9508a07bc2b1b4be9f9c14d8fbdd2))
+
 ## [1.6.3](https://github.com/TraceMachina/nativelink/compare/v1.6.2..v1.6.3) - 2026-07-24
 
 ### ⛰️  Features
 
-- Add Google Tag Manager to the marketing site ([#2610](https://github.com/TraceMachina/nativelink/issues/2610)) - ([94f312a](https://github.com/TraceMachina/nativelink/commit/94f312a043847d5dd0f8ca95b676b00d4697c04d))
+- Add GTM to the corporate site ([#2610](https://github.com/TraceMachina/nativelink/issues/2610)) - ([94f312a](https://github.com/TraceMachina/nativelink/commit/94f312a043847d5dd0f8ca95b676b00d4697c04d))
 - Add the Leadfeeder tracker to the marketing site ([#2606](https://github.com/TraceMachina/nativelink/issues/2606)) - ([9700a4a](https://github.com/TraceMachina/nativelink/commit/9700a4a522de525b9121188f19bd1c74b2d4a10e))
 - Prefetch directory-cache tree protos with one GetTree stream ([#2546](https://github.com/TraceMachina/nativelink/issues/2546)) - ([2cbf21e](https://github.com/TraceMachina/nativelink/commit/2cbf21ef52f78ea95d0eb11f9f4396022619b70d))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "axum",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "base64 0.22.1",
  "mongodb",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.6.3"
+version = "1.6.4"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.6.3",
+    version = "1.6.4",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.6.3"
+version = "1.6.4"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.6.3"
+version = "1.6.4"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.6.3"
+version = "1.6.4"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-test/fuzz/Cargo.lock
+++ b/nativelink-test/fuzz/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "base64",
  "mongodb",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "derive_more",
  "prost",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.6.3"
+version = "1.6.4"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.6.3"
+version = "1.6.4"
 
 [features]
 nix = []


### PR DESCRIPTION
# Description

Release PR for NativeLink v1.6.4, bumping from v1.6.3.

Features: 
* Opt-in zstd `GrpcStore` wire compression (#2596),
* S3 credential discovery over HTTP (#2651)

Bug Fixes: 
* Scheduler/worker deadlock fixes (#2642, #2638), 
* Worker disconnect fix (#2658), 
* Transient-Redis-retry fix (#2657), 
* Duplicate-execution scheduler fix (#2648)

## Type of change

- Release (version bump + changelog, non-breaking)

## How Has This Been Tested?

Version bump and changelog only; no code changes. `Cargo.lock` regenerated with
`cargo update --workspace`. Relying on CI to validate the build across targets.

## Checklist

- [x] Updated documentation if needed (CHANGELOG.md)
- [ ] Tests added/amended — N/A, no code changes
- [ ] `bazel test //...` passes locally — relying on CI
- [x] PR is contained in a single commit, using `git amend`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2663)
<!-- Reviewable:end -->
