### PR TITLE
Clarify release steps in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,11 +397,18 @@ most automatically generated changelogs provide.
 
    - `MODULE.bazel`
    - `Cargo.toml`
-   - `nativelink-*/Cargo.toml`
+   - The `Cargo.toml` of every `nativelink-*` crate (that is, all
+     `nativelink-*/Cargo.toml` files, not just a select few)
 
 2. Run `git cliff --tag=0.x.y > CHANGELOG.md` to update the changelog. You might
    need to make manual adjustments to `cliff.toml` if `git-cliff` doesn't put a
    commit in the right subsection.
+
+   > [!WARNING]
+   > This command rewrites `CHANGELOG.md` from scratch and may unexpectedly
+   > drop entries for previous releases. Diff the regenerated changelog
+   > against the previous version and manually restore any earlier release
+   > entries that went missing.
 
 3. Create the commit and PR. Call it `Release NativeLink v0.x.y`.
 


### PR DESCRIPTION
Two clarifications to the release process docs:

1. The version-bump list now makes explicit that `nativelink-*/Cargo.toml` means the `Cargo.toml` of **every** `nativelink-*` crate — the previous wording implied only a few files.
2. Added a warning under the `git cliff` step: the command regenerates `CHANGELOG.md` from scratch and can unexpectedly drop entries for previous releases, so the regenerated file should be diffed against the previous version and missing entries restored manually.

Closes TRA-297

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2664)
<!-- Reviewable:end -->
