### PR TITLE
Amend release steps in CONTRIBUTING.md

### DIFF
--- a/.github/styles/config/vocabularies/TraceMachina/accept.txt
+++ b/.github/styles/config/vocabularies/TraceMachina/accept.txt
@@ -154,6 +154,8 @@ kubectl
 [Mm]inikube
 [Mm]itigations
 [Pp]recompute
+[Pp]repend
+[Pp]repending
 attrs
 Bzlmod
 [Dd]eps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -462,7 +462,7 @@ most automatically generated changelogs provide.
    Then prepend the new section:
 
    ```bash
-   git cliff --unreleased --tag=v0.x.y --prepend CHANGELOG.md
+   git cliff --unreleased --tag=v1.x.y --prepend CHANGELOG.md
    ```
 
    Verify with `git diff CHANGELOG.md` that the change is purely additive:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,11 +435,40 @@ most automatically generated changelogs provide.
 
    - `MODULE.bazel`
    - `Cargo.toml`
-   - `nativelink-*/Cargo.toml`
+   - The `Cargo.toml` of every `nativelink-*` crate — including nested ones
+     like `nativelink-metric/nativelink-metric-macro-derive/Cargo.toml` —
+     and the regenerated lock files (`Cargo.lock`,
+     `nativelink-test/fuzz/Cargo.lock`)
 
-2. Run `git cliff --tag=0.x.y > CHANGELOG.md` to update the changelog. You might
-   need to make manual adjustments to `cliff.toml` if `git-cliff` doesn't put a
-   commit in the right subsection.
+   As a sanity check, a standard release touches 17 files.
+
+2. Update the changelog by prepending the new release section to the existing
+   `CHANGELOG.md`. Don't regenerate the whole file — that rewrites previous
+   release entries and drops manual curation.
+
+   First make sure your local tags match upstream, since `--unreleased` means
+   "commits not contained in any tag":
+
+   ```bash
+   git fetch upstream --tags
+   ```
+
+   Sanity check which commits will form the new release section:
+
+   ```bash
+   git log --oneline "$(git describe --tags --abbrev=0)"..HEAD
+   ```
+
+   Then prepend the new section:
+
+   ```bash
+   git cliff --unreleased --tag=v0.x.y --prepend CHANGELOG.md
+   ```
+
+   Verify with `git diff CHANGELOG.md` that the change is purely additive:
+   only added lines, with all previous release entries untouched. You might
+   need to make manual adjustments to `cliff.toml` if `git-cliff` doesn't put
+   a commit in the right subsection.
 
 3. Create the commit and PR. Call it `Release NativeLink v0.x.y`.
 


### PR DESCRIPTION
# Description

There are updates to two steps in the release process description:

1. The version-bump list now makes it clearer that the version bump is more
   than 3 files and adds a sanity check step.
2. Git cliff process is now amended with a workflow to ensure that changes are additive.  This addresses a previous pitfall that relied on users to remember to consistently manually edit and fix the changelog.md.


## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Documentation-only change; verified the Markdown renders correctly,
including the `> [!WARNING]` admonition.

## Checklist

- [x] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2665)
<!-- Reviewable:end -->