### PR TITLE
fix(worker): 🐛 lease active action inputs across eviction

### DIFF
--- a/nativelink-config/src/cas_server.rs
+++ b/nativelink-config/src/cas_server.rs
@@ -1009,6 +1009,23 @@ pub struct LocalWorkerConfig {
     /// Default: None (directory cache disabled)
     pub directory_cache: Option<DirectoryCacheConfig>,
 
+    /// Optional and experimental: lease every digest in an active action's
+    /// input Merkle closure in the worker's locally eviction-managed CAS
+    /// tiers (the `cas_fast_slow_store`'s filesystem-backed stores) until the
+    /// action has finished cleanup. This prevents `Lost inputs no longer
+    /// available remotely` failures caused by local fast-tier eviction while
+    /// inputs are being materialized under cache pressure.
+    ///
+    /// Trade-off: while leases are held, a local filesystem tier may
+    /// temporarily exceed its configured `max_bytes` / `max_count` eviction
+    /// limits; normal eviction resumes once the action's leases are released.
+    /// Operators should leave headroom on the underlying disk when enabling
+    /// this.
+    ///
+    /// Default: false (eviction behavior is unchanged)
+    #[serde(default)]
+    pub experimental_active_input_leases: bool,
+
     /// Whether to use namespaces to isolate the execution. This is only available
     /// on Linux. It is highly recommended as it avoids a number of issues with
     /// zombie processes and also provides additional hermeticity. If explicitly set

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -215,10 +215,11 @@ impl FastSlowStore {
 
     /// Returns the filesystem-backed tiers that can evict a digest.
     ///
-    /// The fast store is normally a `FilesystemStore`, while the slow store
-    /// may be one behind a `RefStore`. `Store::downcast_ref` follows those
-    /// references through `inner_store`, so callers can protect both local
-    /// eviction maps without depending on the configured wrapper stack.
+    /// The worker's fast store is normally a `FilesystemStore`, while the slow
+    /// store may be one behind a `RefStore`. `Store::downcast_ref` follows
+    /// wrappers that delegate `inner_store`; transforming wrappers intentionally
+    /// keep themselves visible because their digest-to-bytes mapping may differ,
+    /// so they are not recursively inspected here.
     pub fn get_filesystem_stores(&self) -> Vec<Arc<FilesystemStore>> {
         let mut stores = Vec::with_capacity(2);
         for store in [&self.fast_store, &self.slow_store] {

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -41,6 +41,8 @@ use parking_lot::Mutex;
 use tokio::sync::OnceCell;
 use tracing::{debug, info, trace, warn};
 
+use crate::filesystem_store::FilesystemStore;
+
 // TODO(palfrey) This store needs to be evaluated for more efficient memory usage,
 // there are many copies happening internally.
 
@@ -209,6 +211,31 @@ impl FastSlowStore {
 
     pub const fn slow_store(&self) -> &Store {
         &self.slow_store
+    }
+
+    /// Returns the filesystem-backed tiers that can evict a digest.
+    ///
+    /// The fast store is normally a `FilesystemStore`, while the slow store
+    /// may be one behind a `RefStore`. `Store::downcast_ref` follows those
+    /// references through `inner_store`, so callers can protect both local
+    /// eviction maps without depending on the configured wrapper stack.
+    pub fn get_filesystem_stores(&self) -> Vec<Arc<FilesystemStore>> {
+        let mut stores = Vec::with_capacity(2);
+        for store in [&self.fast_store, &self.slow_store] {
+            let Some(filesystem_store) = store
+                .downcast_ref::<FilesystemStore>(None)
+                .and_then(FilesystemStore::get_arc)
+            else {
+                continue;
+            };
+            if !stores
+                .iter()
+                .any(|existing| Arc::ptr_eq(existing, &filesystem_store))
+            {
+                stores.push(filesystem_store);
+            }
+        }
+        stores
     }
 
     pub fn get_arc(&self) -> Option<Arc<Self>> {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1270,13 +1270,6 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         self.evicting_map.lease_key(StoreKeyBorrow::from(key));
     }
 
-    /// Release one action-input lease and trim entries retained while the
-    /// lease was active.
-    pub async fn release_digest(&self, digest: &DigestInfo) {
-        let key: StoreKey<'static> = (*digest).into();
-        self.evicting_map.release_keys([&key]).await;
-    }
-
     /// Release a batch of action-input leases and trim retained entries once.
     pub async fn release_digests(&self, digests: &[DigestInfo]) {
         self.evicting_map

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1263,6 +1263,20 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
         self.weak_self.upgrade()
     }
 
+    /// Reserve a digest before it is populated so active action inputs cannot
+    /// be evicted while they are being materialized.
+    pub fn lease_digest(&self, digest: &DigestInfo) {
+        let key: StoreKey<'static> = (*digest).into();
+        self.evicting_map.lease_key(StoreKeyBorrow::from(key));
+    }
+
+    /// Release one action-input lease and trim entries retained while the
+    /// lease was active.
+    pub async fn release_digest(&self, digest: &DigestInfo) {
+        let key: StoreKey<'static> = (*digest).into();
+        self.evicting_map.release_key(&key).await;
+    }
+
     /// Path of the read-only executable (0o555) variant for `digest`.
     #[cfg(unix)]
     fn executable_variant_path(&self, digest: &DigestInfo) -> OsString {

--- a/nativelink-store/src/filesystem_store.rs
+++ b/nativelink-store/src/filesystem_store.rs
@@ -1274,7 +1274,14 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
     /// lease was active.
     pub async fn release_digest(&self, digest: &DigestInfo) {
         let key: StoreKey<'static> = (*digest).into();
-        self.evicting_map.release_key(&key).await;
+        self.evicting_map.release_keys([&key]).await;
+    }
+
+    /// Release a batch of action-input leases and trim retained entries once.
+    pub async fn release_digests(&self, digests: &[DigestInfo]) {
+        self.evicting_map
+            .release_keys(digests.iter().map(|digest| StoreKey::Digest(*digest)))
+            .await;
     }
 
     /// Path of the read-only executable (0o555) variant for `digest`.

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -145,10 +145,13 @@ impl<
     }
 
     /// Keep candidate recency aligned with a normal read from `lru`.
-    fn touch_evictable(&mut self, key: &Q) {
-        if !self.is_leased(key) {
-            self.evictable_lru.get(key);
+    /// Returns whether the key is leased so callers do not repeat the lookup.
+    fn touch_evictable(&mut self, key: &Q) -> bool {
+        if self.is_leased(key) {
+            return true;
         }
+        self.evictable_lru.get(key);
+        false
     }
 
     /// Add a newly written key to the candidate index unless it is reserved
@@ -423,8 +426,7 @@ where
     ) -> bool {
         let is_over_size = max_bytes != 0 && sum_store_size >= max_bytes;
 
-        let elapsed_seconds =
-            i32::try_from(self.anchor_time.elapsed().as_secs()).unwrap_or(i32::MAX);
+        let elapsed_seconds = self.elapsed_seconds();
         let evict_older_than_seconds = elapsed_seconds.saturating_sub(self.max_seconds);
         let old_item_exists =
             self.max_seconds != 0 && peek_entry.seconds_since_anchor < evict_older_than_seconds;
@@ -433,6 +435,10 @@ where
             self.max_count != 0 && u64::try_from(lru_len).unwrap_or(u64::MAX) > self.max_count;
 
         is_over_size || old_item_exists || is_over_count
+    }
+
+    fn elapsed_seconds(&self) -> i32 {
+        i32::try_from(self.anchor_time.elapsed().as_secs()).unwrap_or(i32::MAX)
     }
 
     // Gets a debugging snapshot of the state of the map. It's inevitably out of date by the time it gets sent to the user
@@ -547,10 +553,11 @@ where
             let mut data_to_unref = Vec::new();
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
-                let is_leased = state.is_leased(key.borrow());
-                if !peek {
-                    state.touch_evictable(key.borrow());
-                }
+                let is_leased = if peek {
+                    state.is_leased(key.borrow())
+                } else {
+                    state.touch_evictable(key.borrow())
+                };
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
                 } else {
@@ -573,9 +580,7 @@ where
                             }
                         } else {
                             if !peek {
-                                entry.seconds_since_anchor =
-                                    i32::try_from(self.anchor_time.elapsed().as_secs())
-                                        .unwrap_or(i32::MAX);
+                                entry.seconds_since_anchor = self.elapsed_seconds();
                             }
                             *result = Some(entry.data.len());
                         }
@@ -628,8 +633,7 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
-            let is_leased = state.is_leased(key.borrow());
-            state.touch_evictable(key.borrow());
+            let is_leased = state.touch_evictable(key.borrow());
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
@@ -643,8 +647,7 @@ where
                 let (data, futures) = state.remove(popped_key.borrow(), &eviction_item, false);
                 (None, Some(data), futures)
             } else {
-                entry.seconds_since_anchor =
-                    i32::try_from(self.anchor_time.elapsed().as_secs()).unwrap_or(i32::MAX);
+                entry.seconds_since_anchor = self.elapsed_seconds();
                 (Some(entry.data.clone()), None, Vec::new())
             }
         };
@@ -664,12 +667,8 @@ where
     where
         K: 'static,
     {
-        self.insert_with_time(
-            key,
-            data,
-            i32::try_from(self.anchor_time.elapsed().as_secs()).unwrap_or(i32::MAX),
-        )
-        .await
+        self.insert_with_time(key, data, self.elapsed_seconds())
+            .await
     }
 
     /// Returns the replaced item if any.
@@ -711,11 +710,7 @@ where
 
         let (items_to_unref, removal_futures) = {
             let mut state = self.state.lock();
-            self.inner_insert_many(
-                &mut state,
-                inserts,
-                i32::try_from(self.anchor_time.elapsed().as_secs()).unwrap_or(i32::MAX),
-            )
+            self.inner_insert_many(&mut state, inserts, self.elapsed_seconds())
         };
 
         let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -849,6 +849,9 @@ where
     {
         let (evicted_items, removal_futures, removed_item) = {
             let mut state = self.state.lock();
+            if !state.leases.contains_key(key.borrow()) {
+                state.evictable_lru.get(key.borrow());
+            }
             if let Some(entry) = state.lru.get(key.borrow()) {
                 if !cond(&entry.data) {
                     return false;

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -481,17 +481,14 @@ where
         // Pop the candidate index directly instead of collecting and cloning
         // all victim keys. Both indexes are protected by the same lock.
         loop {
-            let should_evict = match state.evictable_lru.peek_lru() {
-                Some((key, ())) => {
-                    let entry = state
-                        .lru
-                        .peek(key.borrow())
-                        .expect("Evictable LRU key must be resident in the main LRU");
-                    self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes)
-                }
-                None => false,
+            let Some((key, ())) = state.evictable_lru.peek_lru() else {
+                break;
             };
-            if !should_evict {
+            let entry = state
+                .lru
+                .peek(key.borrow())
+                .expect("Evictable LRU key must be resident in the main LRU");
+            if !self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes) {
                 break;
             }
 

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -115,9 +115,9 @@ struct State<
     leases: HashMap<K, u32>,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
-    #[metric(help = "Number of items currently leased and not evictable")]
+    #[metric(help = "Number of active lease keys (including keys not yet resident)")]
     leased_items: u64,
-    #[metric(help = "Number of bytes currently leased and not evictable")]
+    #[metric(help = "Number of resident bytes protected by active leases")]
     leased_bytes: u64,
 
     #[metric(help = "Number of bytes evicted from the store")]
@@ -200,8 +200,8 @@ impl<
         Some(leased_key)
     }
 
-    /// Re-enter a resident key as the newest eviction candidate. Its age is
-    /// intentionally preserved, so a long lease does not extend the TTL.
+    /// Re-enter a resident key as the newest eviction candidate without
+    /// changing its stored age.
     fn reinsert_evictable(&mut self, key: K) {
         if self.lru.peek(key.borrow()).is_some() {
             self.evictable_lru.put(key, ());
@@ -781,20 +781,42 @@ where
     {
         let (items_to_unref, removal_futures) = {
             let mut state = self.state.lock();
+            let mut items_to_unref = Vec::new();
+            let mut removal_futures = Vec::new();
+            let expired_before = (self.max_seconds != 0)
+                .then(|| self.elapsed_seconds().saturating_sub(self.max_seconds));
             let mut released_any = false;
             for key in keys {
                 if let Some(leased_key) = state.release_lease(key.borrow()) {
-                    // A released key re-enters as MRU, giving an actively used
-                    // input a fair chance to remain cached after its action.
-                    state.reinsert_evictable(leased_key);
+                    // A lease can keep an item past its TTL. Remove it now
+                    // instead of hiding it behind newer eviction candidates.
+                    let expired = expired_before.is_some_and(|expired_before| {
+                        state
+                            .lru
+                            .peek(leased_key.borrow())
+                            .is_some_and(|entry| entry.seconds_since_anchor < expired_before)
+                    });
+                    if expired {
+                        if let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
+                        {
+                            let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
+                            items_to_unref.push(data);
+                            removal_futures.extend(futures);
+                        }
+                    } else {
+                        // A released key re-enters as MRU, giving an actively
+                        // used input a fair chance to remain cached.
+                        state.reinsert_evictable(leased_key);
+                    }
                     released_any = true;
                 }
             }
             if released_any {
-                self.evict_items(&mut state)
-            } else {
-                (Vec::new(), Vec::new())
+                let (mut evicted, futures) = self.evict_items(&mut state);
+                items_to_unref.append(&mut evicted);
+                removal_futures.extend(futures);
             }
+            (items_to_unref, removal_futures)
         };
 
         let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -455,53 +455,50 @@ where
             return (Vec::new(), Vec::new());
         };
 
-        // Select all victims in one pass. The candidate index means leased
-        // entries are never scanned, and collecting keys first avoids
-        // restarting the LRU walk after each removal.
-        let keys_to_evict = {
-            let first_entry = state
-                .lru
-                .peek(first_key.borrow())
-                .expect("Evictable LRU key must be resident in the main LRU");
+        let first_entry = state
+            .lru
+            .peek(first_key.borrow())
+            .expect("Evictable LRU key must be resident in the main LRU");
 
-            // Preserve the configured low-watermark behavior: once pressure
-            // is detected, keep evicting until `evict_bytes` is reclaimed.
-            let max_bytes = if self.max_bytes != 0
-                && self.evict_bytes != 0
-                && self.should_evict(
-                    state.lru.len(),
-                    first_entry,
-                    state.sum_store_size,
-                    self.max_bytes,
-                ) {
-                self.max_bytes.saturating_sub(self.evict_bytes)
-            } else {
-                self.max_bytes
-            };
-
-            let mut keys_to_evict = Vec::new();
-            let mut lru_len = state.lru.len();
-            let mut sum_store_size = state.sum_store_size;
-
-            for (key, ()) in state.evictable_lru.iter().rev() {
-                let entry = state
-                    .lru
-                    .peek(key.borrow())
-                    .expect("Evictable LRU key must be resident in the main LRU");
-                if !self.should_evict(lru_len, entry, sum_store_size, max_bytes) {
-                    break;
-                }
-                keys_to_evict.push(key.clone());
-                lru_len -= 1;
-                sum_store_size -= entry.data.len();
-            }
-            keys_to_evict
+        // Preserve the configured low-watermark behavior: once pressure is
+        // detected, keep evicting until `evict_bytes` is reclaimed.
+        let max_bytes = if self.max_bytes != 0
+            && self.evict_bytes != 0
+            && self.should_evict(
+                state.lru.len(),
+                first_entry,
+                state.sum_store_size,
+                self.max_bytes,
+            ) {
+            self.max_bytes.saturating_sub(self.evict_bytes)
+        } else {
+            self.max_bytes
         };
 
         let mut items_to_unref = Vec::new();
         let mut removal_futures = Vec::new();
 
-        for key in keys_to_evict {
+        // Pop the candidate index directly instead of collecting and cloning
+        // all victim keys. Both indexes are protected by the same lock.
+        loop {
+            let should_evict = match state.evictable_lru.peek_lru() {
+                Some((key, ())) => {
+                    let entry = state
+                        .lru
+                        .peek(key.borrow())
+                        .expect("Evictable LRU key must be resident in the main LRU");
+                    self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes)
+                }
+                None => false,
+            };
+            if !should_evict {
+                break;
+            }
+
+            let (key, ()) = state
+                .evictable_lru
+                .pop_lru()
+                .expect("Evictable LRU key disappeared while state was locked");
             let eviction_item = state
                 .lru
                 .pop(key.borrow())

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -105,6 +105,10 @@ struct State<
 > {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
+    /// A mirror of `lru` that contains only currently unleased keys.
+    /// Keeping this index in LRU order lets eviction visit candidates without
+    /// scanning entries that an active operation has pinned.
+    evictable_lru: LruCache<K, ()>,
     /// Reference counts for keys that must not be evicted while an active
     /// operation is using them. A key can be leased before it is inserted,
     /// which closes the admission-to-insert race for cache populations.
@@ -144,12 +148,31 @@ impl<
         self.leases.contains_key(key)
     }
 
+    /// Keep candidate recency aligned with a normal read from `lru`.
+    /// Returns whether the key is leased so callers do not repeat the lookup.
+    fn touch_evictable(&mut self, key: &Q) -> bool {
+        if self.is_leased(key) {
+            return true;
+        }
+        self.evictable_lru.get(key);
+        false
+    }
+
+    /// Add a newly written key to the candidate index unless it is reserved
+    /// by a lease that was acquired before insertion.
+    fn insert_evictable(&mut self, key: K) {
+        if !self.is_leased(key.borrow()) {
+            self.evictable_lru.put(key, ());
+        }
+    }
+
     fn lease(&mut self, key: K) {
         if let Some(lease_count) = self.leases.get_mut(key.borrow()) {
             *lease_count = lease_count.checked_add(1).expect("lease count overflow");
             return;
         }
 
+        self.evictable_lru.pop(key.borrow());
         if let Some(entry) = self.lru.peek(key.borrow()) {
             self.leased_bytes += entry.data.len();
         }
@@ -177,6 +200,32 @@ impl<
         Some(leased_key)
     }
 
+    /// Re-enter a resident key as the newest eviction candidate without
+    /// changing its stored age.
+    fn reinsert_evictable(&mut self, key: K) {
+        if self.lru.peek(key.borrow()).is_some() {
+            self.evictable_lru.put(key, ());
+        }
+    }
+
+    fn peek_evictable(&self) -> Option<&EvictionItem<T>> {
+        let (key, ()) = self.evictable_lru.peek_lru()?;
+        Some(
+            self.lru
+                .peek(key.borrow())
+                .expect("Evictable LRU key must be resident in the main LRU"),
+        )
+    }
+
+    fn pop_evictable(&mut self) -> Option<(K, EvictionItem<T>)> {
+        let (candidate_key, ()) = self.evictable_lru.pop_lru()?;
+        let (key, entry) = self
+            .lru
+            .pop_entry(candidate_key.borrow())
+            .expect("Evictable LRU key must be resident in the main LRU");
+        Some((key, entry))
+    }
+
     /// Removes an item from the cache and returns the data for deferred cleanup.
     /// The caller is responsible for calling `unref()` on the returned data outside of the lock.
     #[must_use]
@@ -192,6 +241,8 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
+        // Keep every auxiliary resident index in sync with the main LRU.
+        self.evictable_lru.pop(key);
         if self.is_leased(key) {
             self.leased_bytes -= eviction_item.data.len();
         }
@@ -232,6 +283,9 @@ impl<
         if is_leased {
             self.leased_bytes += new_item_size;
         }
+        // `remove()` drops the old key from both indexes. Reinsert it after
+        // replacement so an unleased write is MRU in both LRU indexes.
+        self.insert_evictable(key.clone());
         if let Some(btree) = &mut self.btree {
             btree.insert(key.clone());
         }
@@ -332,6 +386,7 @@ where
             state: Mutex::new(State {
                 lru: LruCache::unbounded(),
                 btree: None,
+                evictable_lru: LruCache::unbounded(),
                 leases: HashMap::new(),
                 sum_store_size: 0,
                 leased_items: 0,
@@ -436,73 +491,49 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        // Select victims in one pass. This keeps eviction linear in the
-        // resident entries even when an active action has leased many keys.
-        let keys_to_evict = {
-            let mut unleased_entries = state
-                .lru
-                .iter()
-                .rev()
-                .filter(|(key, _)| !state.is_leased((*key).borrow()));
-            let Some((first_key, first_entry)) = unleased_entries.next() else {
-                if !state.lru.is_empty() {
-                    debug!(
-                        resident_items = state.lru.len(),
-                        lease_keys = state.leases.len(),
-                        leased_items = state.leased_items,
-                        leased_bytes = state.leased_bytes,
-                        resident_bytes = state.sum_store_size,
-                        "Eviction requested, but every resident entry is leased",
-                    );
-                }
-                return (Vec::new(), Vec::new());
-            };
-
-            // Preserve the configured low-watermark behavior: once pressure
-            // is detected, keep evicting until `evict_bytes` is reclaimed.
-            let max_bytes = if self.max_bytes != 0
-                && self.evict_bytes != 0
-                && self.should_evict(
-                    state.lru.len(),
-                    first_entry,
-                    state.sum_store_size,
-                    self.max_bytes,
-                ) {
-                self.max_bytes.saturating_sub(self.evict_bytes)
-            } else {
-                self.max_bytes
-            };
-
-            let mut keys_to_evict = Vec::new();
-            let mut lru_len = state.lru.len();
-            let mut sum_store_size = state.sum_store_size;
-            let mut consider_entry = |key: &K, entry: &EvictionItem<T>| {
-                if !self.should_evict(lru_len, entry, sum_store_size, max_bytes) {
-                    return false;
-                }
-                keys_to_evict.push(key.clone());
-                lru_len -= 1;
-                sum_store_size -= entry.data.len();
-                true
-            };
-
-            if consider_entry(first_key, first_entry) {
-                for (key, entry) in unleased_entries {
-                    if !consider_entry(key, entry) {
-                        break;
-                    }
-                }
+        let Some(first_entry) = state.peek_evictable() else {
+            if !state.lru.is_empty() {
+                debug!(
+                    resident_items = state.lru.len(),
+                    evictable_items = state.evictable_lru.len(),
+                    lease_keys = state.leases.len(),
+                    leased_items = state.leased_items,
+                    leased_bytes = state.leased_bytes,
+                    resident_bytes = state.sum_store_size,
+                    "Eviction requested, but every resident entry is leased",
+                );
             }
-            keys_to_evict
+            return (Vec::new(), Vec::new());
+        };
+
+        // Preserve the configured low-watermark behavior: once pressure is
+        // detected, keep evicting until `evict_bytes` is reclaimed.
+        let max_bytes = if self.max_bytes != 0
+            && self.evict_bytes != 0
+            && self.should_evict(
+                state.lru.len(),
+                first_entry,
+                state.sum_store_size,
+                self.max_bytes,
+            ) {
+            self.max_bytes.saturating_sub(self.evict_bytes)
+        } else {
+            self.max_bytes
         };
 
         let mut items_to_unref = Vec::new();
         let mut removal_futures = Vec::new();
-        for key in keys_to_evict {
-            let eviction_item = state
-                .lru
-                .pop(key.borrow())
-                .expect("Selected eviction key disappeared while state was locked");
+
+        // Pop the candidate index directly instead of collecting and cloning
+        // all victim keys. Both indexes are protected by the same lock.
+        while let Some(entry) = state.peek_evictable() {
+            if !self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes) {
+                break;
+            }
+
+            let (key, eviction_item) = state
+                .pop_evictable()
+                .expect("Evictable LRU key disappeared while state was locked");
             debug!(?key, "Evicting");
             let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
             items_to_unref.push(data);
@@ -545,7 +576,11 @@ where
             let mut data_to_unref = Vec::new();
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
-                let is_leased = state.is_leased(key.borrow());
+                let is_leased = if peek {
+                    state.is_leased(key.borrow())
+                } else {
+                    state.touch_evictable(key.borrow())
+                };
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
                 } else {
@@ -621,7 +656,7 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
-            let is_leased = state.is_leased(key.borrow());
+            let is_leased = state.touch_evictable(key.borrow());
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
@@ -761,12 +796,17 @@ where
                             .peek(leased_key.borrow())
                             .is_some_and(|entry| entry.seconds_since_anchor < expired_before)
                     });
-                    if expired
-                        && let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
-                    {
-                        let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
-                        items_to_unref.push(data);
-                        removal_futures.extend(futures);
+                    if expired {
+                        if let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
+                        {
+                            let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
+                            items_to_unref.push(data);
+                            removal_futures.extend(futures);
+                        }
+                    } else {
+                        // A released key re-enters as MRU, giving an actively
+                        // used input a fair chance to remain cached.
+                        state.reinsert_evictable(leased_key);
                     }
                     released_any = true;
                 }
@@ -872,6 +912,7 @@ where
     {
         let (evicted_items, removal_futures, removed_item) = {
             let mut state = self.state.lock();
+            state.touch_evictable(key.borrow());
             let Some(entry) = state.lru.get(key.borrow()) else {
                 return false;
             };

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -109,6 +109,10 @@ struct State<
     /// operation is using them. A key can be leased before it is inserted,
     /// which closes the admission-to-insert race for cache populations.
     leases: HashMap<K, u32>,
+    /// Number of resident entries that are not leased. This lets pressure
+    /// eviction return immediately while an active action has leased every
+    /// resident entry, instead of scanning the whole LRU for every insert.
+    unleased_entry_count: usize,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
 
@@ -151,6 +155,9 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
+        if !self.leases.contains_key(key) {
+            self.unleased_entry_count -= 1;
+        }
         self.sum_store_size -= eviction_item.data.len();
         if replaced {
             self.replaced_items.inc();
@@ -181,6 +188,9 @@ impl<
         // If we are maintaining a btree index, we need to update it.
         if let Some(btree) = &mut self.btree {
             btree.insert(key.clone());
+        }
+        if !self.leases.contains_key::<K>(key) {
+            self.unleased_entry_count += 1;
         }
         self.lru
             .put(key.clone(), eviction_item)
@@ -281,6 +291,7 @@ where
                 lru: LruCache::unbounded(),
                 btree: None,
                 leases: HashMap::new(),
+                unleased_entry_count: 0,
                 sum_store_size: 0,
                 evicted_bytes: Counter::default(),
                 evicted_items: CounterWithTime::default(),
@@ -379,6 +390,10 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
+        if state.unleased_entry_count == 0 {
+            return (Vec::new(), Vec::new());
+        }
+
         // Select all victims in one pass. Re-scanning the LRU from its tail
         // after every removal turns pressure eviction into O(n * victims)
         // when a large active action has leased many entries.
@@ -667,6 +682,11 @@ where
     /// eviction cannot race with the start of input materialization.
     pub fn lease_key(&self, key: K) {
         let mut state = self.state.lock();
+        let was_unleased = !state.leases.contains_key::<K>(&key);
+        let is_resident = state.lru.peek(key.borrow()).is_some();
+        if was_unleased && is_resident {
+            state.unleased_entry_count -= 1;
+        }
         let lease_count = state.leases.entry(key).or_default();
         *lease_count = lease_count.saturating_add(1);
     }
@@ -702,6 +722,9 @@ where
                 };
                 if remove_lease {
                     state.leases.remove(key.borrow());
+                    if state.lru.peek(key.borrow()).is_some() {
+                        state.unleased_entry_count += 1;
+                    }
                     released_any = true;
                 }
             }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -105,11 +105,9 @@ struct State<
 > {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
-    /// LRU index containing only entries that are currently eligible for
-    /// eviction. Normal writes and reads mirror the recency order of `lru`;
-    /// a final lease release intentionally re-enters a resident key as MRU.
-    /// Eviction can therefore inspect only candidates instead of scanning
-    /// leased entries.
+    /// A mirror of `lru` that contains only currently unleased keys.
+    /// Keeping this index in LRU order lets eviction visit candidates without
+    /// scanning entries that an active operation has pinned.
     evictable_lru: LruCache<K, ()>,
     /// Reference counts for keys that must not be evicted while an active
     /// operation is using them. A key can be leased before it is inserted,
@@ -142,6 +140,64 @@ impl<
     C: RemoveItemCallback<Q>,
 > State<K, Q, T, C>
 {
+    fn is_leased(&self, key: &Q) -> bool {
+        self.leases.contains_key(key)
+    }
+
+    /// Keep candidate recency aligned with a normal read from `lru`.
+    fn touch_evictable(&mut self, key: &Q) {
+        if !self.is_leased(key) {
+            self.evictable_lru.get(key);
+        }
+    }
+
+    /// Add a newly written key to the candidate index unless it is reserved
+    /// by a lease that was acquired before insertion.
+    fn insert_evictable(&mut self, key: K) {
+        if !self.is_leased(key.borrow()) {
+            self.evictable_lru.put(key, ());
+        }
+    }
+
+    fn lease(&mut self, key: K) {
+        if let Some(lease_count) = self.leases.get_mut(key.borrow()) {
+            *lease_count = lease_count.saturating_add(1);
+            return;
+        }
+
+        self.evictable_lru.pop(key.borrow());
+        self.leases.insert(key, 1);
+    }
+
+    /// Release one reference and return the owned key when the lease ends.
+    fn release_lease(&mut self, key: &Q) -> Option<K> {
+        let remove_lease = match self.leases.get_mut(key) {
+            Some(lease_count) if *lease_count > 1 => {
+                *lease_count -= 1;
+                false
+            }
+            Some(_) => true,
+            None => false,
+        };
+        if !remove_lease {
+            return None;
+        }
+
+        Some(
+            self.leases
+                .remove_entry(key)
+                .expect("Lease must exist when its final reference is released")
+                .0,
+        )
+    }
+
+    /// Re-enter a resident key as the newest eviction candidate.
+    fn reinsert_evictable(&mut self, key: K) {
+        if self.lru.peek(key.borrow()).is_some() {
+            self.evictable_lru.put(key, ());
+        }
+    }
+
     /// Removes an item from the cache and returns the data for deferred cleanup.
     /// The caller is responsible for calling `unref()` on the returned data outside of the lock.
     #[must_use]
@@ -157,9 +213,7 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
-        // `evictable_lru` intentionally has no entry for leased keys, but
-        // popping unconditionally keeps the two indexes self-healing if a
-        // caller removes a leased entry directly.
+        // Removal is the single place that clears every resident index.
         self.evictable_lru.pop(key);
         self.sum_store_size -= eviction_item.data.len();
         if replaced {
@@ -194,11 +248,8 @@ impl<
             .map(|old_item| self.remove(key.borrow(), &old_item, true));
 
         // `remove()` drops the old key from both indexes. Reinsert it after
-        // replacement so a write promotes an unleased key to MRU in both
-        // indexes and does not accidentally remove it from the B-tree.
-        if !self.leases.contains_key::<K>(key) {
-            self.evictable_lru.put(key.clone(), ());
-        }
+        // replacement so an unleased write is MRU in both LRU indexes.
+        self.insert_evictable(key.clone());
         if let Some(btree) = &mut self.btree {
             btree.insert(key.clone());
         }
@@ -399,20 +450,21 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        let Some((first_key, _)) = state.evictable_lru.peek_lru() else {
+        let Some((first_key, ())) = state.evictable_lru.peek_lru() else {
             return (Vec::new(), Vec::new());
         };
 
-        // Select all victims in one pass. The separate evictable LRU means
-        // leased entries are never scanned, while re-scanning the LRU from
-        // its tail after every removal is avoided when multiple victims are
-        // needed.
+        // Select all victims in one pass. The candidate index means leased
+        // entries are never scanned, and collecting keys first avoids
+        // restarting the LRU walk after each removal.
         let keys_to_evict = {
             let first_entry = state
                 .lru
                 .peek(first_key.borrow())
                 .expect("Evictable LRU key must be resident in the main LRU");
 
+            // Preserve the configured low-watermark behavior: once pressure
+            // is detected, keep evicting until `evict_bytes` is reclaimed.
             let max_bytes = if self.max_bytes != 0
                 && self.evict_bytes != 0
                 && self.should_evict(
@@ -429,26 +481,18 @@ where
             let mut keys_to_evict = Vec::new();
             let mut lru_len = state.lru.len();
             let mut sum_store_size = state.sum_store_size;
-            let mut consider_entry = |key: &K, entry: &EvictionItem<T>| {
+
+            for (key, ()) in state.evictable_lru.iter().rev() {
+                let entry = state
+                    .lru
+                    .peek(key.borrow())
+                    .expect("Evictable LRU key must be resident in the main LRU");
                 if !self.should_evict(lru_len, entry, sum_store_size, max_bytes) {
-                    return false;
+                    break;
                 }
                 keys_to_evict.push(key.clone());
                 lru_len -= 1;
                 sum_store_size -= entry.data.len();
-                true
-            };
-
-            if consider_entry(first_key, first_entry) {
-                for (key, _) in state.evictable_lru.iter().rev().skip(1) {
-                    let entry = state
-                        .lru
-                        .peek(key.borrow())
-                        .expect("Evictable LRU key must be resident in the main LRU");
-                    if !consider_entry(key, entry) {
-                        break;
-                    }
-                }
             }
             keys_to_evict
         };
@@ -503,9 +547,9 @@ where
             let mut data_to_unref = Vec::new();
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
-                let is_leased = state.leases.contains_key(key.borrow());
-                if !is_leased && !peek {
-                    state.evictable_lru.get(key.borrow());
+                let is_leased = state.is_leased(key.borrow());
+                if !peek {
+                    state.touch_evictable(key.borrow());
                 }
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
@@ -584,10 +628,8 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
-            let is_leased = state.leases.contains_key(key.borrow());
-            if !is_leased {
-                state.evictable_lru.get(key.borrow());
-            }
+            let is_leased = state.is_leased(key.borrow());
+            state.touch_evictable(key.borrow());
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
@@ -697,13 +739,7 @@ where
     /// reserve a digest before populating the fast tier, so insertion and
     /// eviction cannot race with the start of input materialization.
     pub fn lease_key(&self, key: K) {
-        let mut state = self.state.lock();
-        let was_unleased = !state.leases.contains_key::<K>(&key);
-        if was_unleased {
-            state.evictable_lru.pop(key.borrow());
-        }
-        let lease_count = state.leases.entry(key).or_default();
-        *lease_count = lease_count.saturating_add(1);
+        self.state.lock().lease(key);
     }
 
     /// Release one lease and trim any entries that were retained while the
@@ -727,25 +763,10 @@ where
             let mut state = self.state.lock();
             let mut released_any = false;
             for key in keys {
-                let remove_lease = match state.leases.get_mut(key.borrow()) {
-                    Some(lease_count) if *lease_count > 1 => {
-                        *lease_count -= 1;
-                        false
-                    }
-                    Some(_) => true,
-                    None => false,
-                };
-                if remove_lease {
-                    let (leased_key, _) = state
-                        .leases
-                        .remove_entry(key.borrow())
-                        .expect("Lease must exist when its final reference is released");
-                    if state.lru.peek(leased_key.borrow()).is_some() {
-                        // A released key re-enters as MRU. This gives an
-                        // actively used input a fair chance to remain cached
-                        // after its action completes.
-                        state.evictable_lru.put(leased_key, ());
-                    }
+                if let Some(leased_key) = state.release_lease(key.borrow()) {
+                    // A released key re-enters as MRU, giving an actively used
+                    // input a fair chance to remain cached after its action.
+                    state.reinsert_evictable(leased_key);
                     released_any = true;
                 }
             }
@@ -849,9 +870,7 @@ where
     {
         let (evicted_items, removal_futures, removed_item) = {
             let mut state = self.state.lock();
-            if !state.leases.contains_key(key.borrow()) {
-                state.evictable_lru.get(key.borrow());
-            }
+            state.touch_evictable(key.borrow());
             if let Some(entry) = state.lru.get(key.borrow()) {
                 if !cond(&entry.data) {
                     return false;

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -105,14 +105,16 @@ struct State<
 > {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
+    /// LRU index containing only entries that are currently eligible for
+    /// eviction. Normal writes and reads mirror the recency order of `lru`;
+    /// a final lease release intentionally re-enters a resident key as MRU.
+    /// Eviction can therefore inspect only candidates instead of scanning
+    /// leased entries.
+    evictable_lru: LruCache<K, ()>,
     /// Reference counts for keys that must not be evicted while an active
     /// operation is using them. A key can be leased before it is inserted,
     /// which closes the admission-to-insert race for cache populations.
     leases: HashMap<K, u32>,
-    /// Number of resident entries that are not leased. This lets pressure
-    /// eviction return immediately while an active action has leased every
-    /// resident entry, instead of scanning the whole LRU for every insert.
-    unleased_entry_count: usize,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
 
@@ -155,9 +157,10 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
-        if !self.leases.contains_key(key) {
-            self.unleased_entry_count -= 1;
-        }
+        // `evictable_lru` intentionally has no entry for leased keys, but
+        // popping unconditionally keeps the two indexes self-healing if a
+        // caller removes a leased entry directly.
+        self.evictable_lru.pop(key);
         self.sum_store_size -= eviction_item.data.len();
         if replaced {
             self.replaced_items.inc();
@@ -185,16 +188,22 @@ impl<
         K: Clone,
         T: Clone,
     {
-        // If we are maintaining a btree index, we need to update it.
+        let replaced_item = self
+            .lru
+            .put(key.clone(), eviction_item)
+            .map(|old_item| self.remove(key.borrow(), &old_item, true));
+
+        // `remove()` drops the old key from both indexes. Reinsert it after
+        // replacement so a write promotes an unleased key to MRU in both
+        // indexes and does not accidentally remove it from the B-tree.
+        if !self.leases.contains_key::<K>(key) {
+            self.evictable_lru.put(key.clone(), ());
+        }
         if let Some(btree) = &mut self.btree {
             btree.insert(key.clone());
         }
-        if !self.leases.contains_key::<K>(key) {
-            self.unleased_entry_count += 1;
-        }
-        self.lru
-            .put(key.clone(), eviction_item)
-            .map(|old_item| self.remove(key.borrow(), &old_item, true))
+
+        replaced_item
     }
 
     fn add_remove_callback(&mut self, callback: C) {
@@ -290,8 +299,8 @@ where
             state: Mutex::new(State {
                 lru: LruCache::unbounded(),
                 btree: None,
+                evictable_lru: LruCache::unbounded(),
                 leases: HashMap::new(),
-                unleased_entry_count: 0,
                 sum_store_size: 0,
                 evicted_bytes: Counter::default(),
                 evicted_items: CounterWithTime::default(),
@@ -390,22 +399,19 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        if state.unleased_entry_count == 0 {
+        let Some((first_key, _)) = state.evictable_lru.peek_lru() else {
             return (Vec::new(), Vec::new());
-        }
+        };
 
-        // Select all victims in one pass. Re-scanning the LRU from its tail
-        // after every removal turns pressure eviction into O(n * victims)
-        // when a large active action has leased many entries.
+        // Select all victims in one pass. The separate evictable LRU means
+        // leased entries are never scanned, while re-scanning the LRU from
+        // its tail after every removal is avoided when multiple victims are
+        // needed.
         let keys_to_evict = {
-            let mut unleased_entries = state
+            let first_entry = state
                 .lru
-                .iter()
-                .rev()
-                .filter(|(key, _)| !state.leases.contains_key::<K>(key));
-            let Some((first_key, first_entry)) = unleased_entries.next() else {
-                return (Vec::new(), Vec::new());
-            };
+                .peek(first_key.borrow())
+                .expect("Evictable LRU key must be resident in the main LRU");
 
             let max_bytes = if self.max_bytes != 0
                 && self.evict_bytes != 0
@@ -434,7 +440,11 @@ where
             };
 
             if consider_entry(first_key, first_entry) {
-                for (key, entry) in unleased_entries {
+                for (key, _) in state.evictable_lru.iter().rev().skip(1) {
+                    let entry = state
+                        .lru
+                        .peek(key.borrow())
+                        .expect("Evictable LRU key must be resident in the main LRU");
                     if !consider_entry(key, entry) {
                         break;
                     }
@@ -494,6 +504,9 @@ where
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
                 let is_leased = state.leases.contains_key(key.borrow());
+                if !is_leased && !peek {
+                    state.evictable_lru.get(key.borrow());
+                }
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
                 } else {
@@ -572,6 +585,9 @@ where
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
             let is_leased = state.leases.contains_key(key.borrow());
+            if !is_leased {
+                state.evictable_lru.get(key.borrow());
+            }
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
@@ -683,9 +699,8 @@ where
     pub fn lease_key(&self, key: K) {
         let mut state = self.state.lock();
         let was_unleased = !state.leases.contains_key::<K>(&key);
-        let is_resident = state.lru.peek(key.borrow()).is_some();
-        if was_unleased && is_resident {
-            state.unleased_entry_count -= 1;
+        if was_unleased {
+            state.evictable_lru.pop(key.borrow());
         }
         let lease_count = state.leases.entry(key).or_default();
         *lease_count = lease_count.saturating_add(1);
@@ -721,17 +736,24 @@ where
                     None => false,
                 };
                 if remove_lease {
-                    state.leases.remove(key.borrow());
-                    if state.lru.peek(key.borrow()).is_some() {
-                        state.unleased_entry_count += 1;
+                    let (leased_key, _) = state
+                        .leases
+                        .remove_entry(key.borrow())
+                        .expect("Lease must exist when its final reference is released");
+                    if state.lru.peek(leased_key.borrow()).is_some() {
+                        // A released key re-enters as MRU. This gives an
+                        // actively used input a fair chance to remain cached
+                        // after its action completes.
+                        state.evictable_lru.put(leased_key, ());
                     }
                     released_any = true;
                 }
             }
-            if !released_any {
-                return;
+            if released_any {
+                self.evict_items(&mut state)
+            } else {
+                (Vec::new(), Vec::new())
             }
-            self.evict_items(&mut state)
         };
 
         let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -188,7 +188,8 @@ impl<
         )
     }
 
-    /// Re-enter a resident key as the newest eviction candidate.
+    /// Re-enter a resident key as the newest eviction candidate. Its age is
+    /// intentionally preserved, so a long lease does not extend the TTL.
     fn reinsert_evictable(&mut self, key: K) {
         if self.lru.peek(key.borrow()).is_some() {
             self.evictable_lru.put(key, ());
@@ -722,11 +723,13 @@ where
             .await
     }
 
-    /// Lease a key so size, count, and expiry eviction cannot remove it.
+    /// Lease a key so automatic size, count, and expiry eviction cannot remove it.
     ///
     /// Leasing before the value is inserted is intentional: an action can
     /// reserve a digest before populating the fast tier, so insertion and
-    /// eviction cannot race with the start of input materialization.
+    /// eviction cannot race with the start of input materialization. Explicit
+    /// `remove` and `remove_if` calls still remove leased entries; those paths
+    /// are used for deliberate deletion and filesystem self-healing.
     pub fn lease_key(&self, key: K) {
         self.state.lock().lease(key);
     }

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -115,9 +115,9 @@ struct State<
     leases: HashMap<K, u32>,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
-    #[metric(help = "Number of active lease keys (including keys not yet resident)")]
+    #[metric(help = "Number of items currently leased and not evictable")]
     leased_items: u64,
-    #[metric(help = "Number of resident bytes protected by active leases")]
+    #[metric(help = "Number of bytes currently leased and not evictable")]
     leased_bytes: u64,
 
     #[metric(help = "Number of bytes evicted from the store")]
@@ -200,8 +200,8 @@ impl<
         Some(leased_key)
     }
 
-    /// Re-enter a resident key as the newest eviction candidate without
-    /// changing its stored age.
+    /// Re-enter a resident key as the newest eviction candidate. Its age is
+    /// intentionally preserved, so a long lease does not extend the TTL.
     fn reinsert_evictable(&mut self, key: K) {
         if self.lru.peek(key.borrow()).is_some() {
             self.evictable_lru.put(key, ());
@@ -781,42 +781,20 @@ where
     {
         let (items_to_unref, removal_futures) = {
             let mut state = self.state.lock();
-            let mut items_to_unref = Vec::new();
-            let mut removal_futures = Vec::new();
-            let expired_before = (self.max_seconds != 0)
-                .then(|| self.elapsed_seconds().saturating_sub(self.max_seconds));
             let mut released_any = false;
             for key in keys {
                 if let Some(leased_key) = state.release_lease(key.borrow()) {
-                    // A lease can keep an item past its TTL. Remove it now
-                    // instead of hiding it behind newer eviction candidates.
-                    let expired = expired_before.is_some_and(|expired_before| {
-                        state
-                            .lru
-                            .peek(leased_key.borrow())
-                            .is_some_and(|entry| entry.seconds_since_anchor < expired_before)
-                    });
-                    if expired {
-                        if let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
-                        {
-                            let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
-                            items_to_unref.push(data);
-                            removal_futures.extend(futures);
-                        }
-                    } else {
-                        // A released key re-enters as MRU, giving an actively
-                        // used input a fair chance to remain cached.
-                        state.reinsert_evictable(leased_key);
-                    }
+                    // A released key re-enters as MRU, giving an actively used
+                    // input a fair chance to remain cached after its action.
+                    state.reinsert_evictable(leased_key);
                     released_any = true;
                 }
             }
             if released_any {
-                let (mut evicted, futures) = self.evict_items(&mut state);
-                items_to_unref.append(&mut evicted);
-                removal_futures.extend(futures);
+                self.evict_items(&mut state)
+            } else {
+                (Vec::new(), Vec::new())
             }
-            (items_to_unref, removal_futures)
         };
 
         let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -115,6 +115,10 @@ struct State<
     leases: HashMap<K, u32>,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
+    #[metric(help = "Number of items currently leased and not evictable")]
+    leased_items: u64,
+    #[metric(help = "Number of bytes currently leased and not evictable")]
+    leased_bytes: u64,
 
     #[metric(help = "Number of bytes evicted from the store")]
     evicted_bytes: Counter,
@@ -169,6 +173,10 @@ impl<
         }
 
         self.evictable_lru.pop(key.borrow());
+        if let Some(entry) = self.lru.peek(key.borrow()) {
+            self.leased_bytes += entry.data.len();
+        }
+        self.leased_items += 1;
         self.leases.insert(key, 1);
     }
 
@@ -180,12 +188,16 @@ impl<
             return None;
         }
 
-        Some(
-            self.leases
-                .remove_entry(key)
-                .expect("Lease must exist when its final reference is released")
-                .0,
-        )
+        let leased_key = self
+            .leases
+            .remove_entry(key)
+            .expect("Lease must exist when its final reference is released")
+            .0;
+        self.leased_items -= 1;
+        if let Some(entry) = self.lru.peek(leased_key.borrow()) {
+            self.leased_bytes -= entry.data.len();
+        }
+        Some(leased_key)
     }
 
     /// Re-enter a resident key as the newest eviction candidate. Its age is
@@ -231,6 +243,9 @@ impl<
         }
         // Keep every auxiliary resident index in sync with the main LRU.
         self.evictable_lru.pop(key);
+        if self.is_leased(key) {
+            self.leased_bytes -= eviction_item.data.len();
+        }
         self.sum_store_size -= eviction_item.data.len();
         if replaced {
             self.replaced_items.inc();
@@ -258,11 +273,16 @@ impl<
         K: Clone,
         T: Clone,
     {
+        let is_leased = self.is_leased(key.borrow());
+        let new_item_size = eviction_item.data.len();
         let replaced_item = self
             .lru
             .put(key.clone(), eviction_item)
             .map(|old_item| self.remove(key.borrow(), &old_item, true));
 
+        if is_leased {
+            self.leased_bytes += new_item_size;
+        }
         // `remove()` drops the old key from both indexes. Reinsert it after
         // replacement so an unleased write is MRU in both LRU indexes.
         self.insert_evictable(key.clone());
@@ -369,6 +389,8 @@ where
                 evictable_lru: LruCache::unbounded(),
                 leases: HashMap::new(),
                 sum_store_size: 0,
+                leased_items: 0,
+                leased_bytes: 0,
                 evicted_bytes: Counter::default(),
                 evicted_items: CounterWithTime::default(),
                 replaced_bytes: Counter::default(),
@@ -470,6 +492,17 @@ where
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
         let Some(first_entry) = state.peek_evictable() else {
+            if !state.lru.is_empty() {
+                debug!(
+                    resident_items = state.lru.len(),
+                    evictable_items = state.evictable_lru.len(),
+                    lease_keys = state.leases.len(),
+                    leased_items = state.leased_items,
+                    leased_bytes = state.leased_bytes,
+                    resident_bytes = state.sum_store_size,
+                    "Eviction requested, but every resident entry is leased",
+                );
+            }
             return (Vec::new(), Vec::new());
         };
 

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -666,16 +666,40 @@ where
     /// Release one lease and trim any entries that were retained while the
     /// lease was active.
     pub async fn release_key(&self, key: &Q) {
+        self.release_keys([key]).await;
+    }
+
+    /// Release a batch of leases and trim retained entries once.
+    ///
+    /// Action input leases commonly contain thousands of digests. Batching
+    /// avoids rescanning the LRU and running deferred cleanup once per digest
+    /// during action teardown.
+    pub async fn release_keys<It, R>(&self, keys: It)
+    where
+        It: IntoIterator<Item = R> + Send,
+        <It as IntoIterator>::IntoIter: Send,
+        R: Borrow<Q> + Send,
+    {
         let (items_to_unref, removal_futures) = {
             let mut state = self.state.lock();
-            let Some(lease_count) = state.leases.get_mut(key) else {
-                return;
-            };
-            if *lease_count > 1 {
-                *lease_count -= 1;
+            let mut released_any = false;
+            for key in keys {
+                let remove_lease = match state.leases.get_mut(key.borrow()) {
+                    Some(lease_count) if *lease_count > 1 => {
+                        *lease_count -= 1;
+                        false
+                    }
+                    Some(_) => true,
+                    None => false,
+                };
+                if remove_lease {
+                    state.leases.remove(key.borrow());
+                    released_any = true;
+                }
+            }
+            if !released_any {
                 return;
             }
-            state.leases.remove(key);
             self.evict_items(&mut state)
         };
 

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -196,6 +196,24 @@ impl<
         }
     }
 
+    fn peek_evictable(&self) -> Option<&EvictionItem<T>> {
+        let (key, ()) = self.evictable_lru.peek_lru()?;
+        Some(
+            self.lru
+                .peek(key.borrow())
+                .expect("Evictable LRU key must be resident in the main LRU"),
+        )
+    }
+
+    fn pop_evictable(&mut self) -> Option<(K, EvictionItem<T>)> {
+        let (candidate_key, ()) = self.evictable_lru.pop_lru()?;
+        let (key, entry) = self
+            .lru
+            .pop_entry(candidate_key.borrow())
+            .expect("Evictable LRU key must be resident in the main LRU");
+        Some((key, entry))
+    }
+
     /// Removes an item from the cache and returns the data for deferred cleanup.
     /// The caller is responsible for calling `unref()` on the returned data outside of the lock.
     #[must_use]
@@ -451,14 +469,9 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        let Some((first_key, ())) = state.evictable_lru.peek_lru() else {
+        let Some(first_entry) = state.peek_evictable() else {
             return (Vec::new(), Vec::new());
         };
-
-        let first_entry = state
-            .lru
-            .peek(first_key.borrow())
-            .expect("Evictable LRU key must be resident in the main LRU");
 
         // Preserve the configured low-watermark behavior: once pressure is
         // detected, keep evicting until `evict_bytes` is reclaimed.
@@ -480,26 +493,14 @@ where
 
         // Pop the candidate index directly instead of collecting and cloning
         // all victim keys. Both indexes are protected by the same lock.
-        loop {
-            let Some((key, ())) = state.evictable_lru.peek_lru() else {
-                break;
-            };
-            let entry = state
-                .lru
-                .peek(key.borrow())
-                .expect("Evictable LRU key must be resident in the main LRU");
+        while let Some(entry) = state.peek_evictable() {
             if !self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes) {
                 break;
             }
 
-            let (key, ()) = state
-                .evictable_lru
-                .pop_lru()
+            let (key, eviction_item) = state
+                .pop_evictable()
                 .expect("Evictable LRU key disappeared while state was locked");
-            let eviction_item = state
-                .lru
-                .pop(key.borrow())
-                .expect("Selected eviction key disappeared while state was locked");
             debug!(?key, "Evicting");
             let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
             items_to_unref.push(data);
@@ -857,26 +858,26 @@ where
         let (evicted_items, removal_futures, removed_item) = {
             let mut state = self.state.lock();
             state.touch_evictable(key.borrow());
-            if let Some(entry) = state.lru.get(key.borrow()) {
-                if !cond(&entry.data) {
-                    return false;
-                }
-                // First perform eviction
-                let (evicted_items, mut removal_futures) = self.evict_items(&mut state);
-
-                // Then try to remove the requested item
-                let removed_item = if let Some(entry) = state.lru.pop(key.borrow()) {
-                    let (item, more_removal_futures) = state.remove(key, &entry, false);
-                    removal_futures.extend(more_removal_futures);
-                    Some(item)
-                } else {
-                    None
-                };
-
-                (evicted_items, removal_futures, removed_item)
-            } else {
-                (vec![], vec![].into_iter().collect(), None)
+            let Some(entry) = state.lru.get(key.borrow()) else {
+                return false;
+            };
+            if !cond(&entry.data) {
+                return false;
             }
+
+            // First perform eviction
+            let (evicted_items, mut removal_futures) = self.evict_items(&mut state);
+
+            // Then try to remove the requested item
+            let removed_item = if let Some(entry) = state.lru.pop(key.borrow()) {
+                let (item, more_removal_futures) = state.remove(key, &entry, false);
+                removal_futures.extend(more_removal_futures);
+                Some(item)
+            } else {
+                None
+            };
+
+            (evicted_items, removal_futures, removed_item)
         };
 
         // Perform the async callbacks outside of the lock

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -364,14 +364,6 @@ where
         is_over_size || old_item_exists || is_over_count
     }
 
-    fn oldest_unleased_key(state: &State<K, Q, T, C>) -> Option<K> {
-        state
-            .lru
-            .iter()
-            .rev()
-            .find_map(|(key, _)| (!state.leases.contains_key::<K>(key)).then(|| key.clone()))
-    }
-
     // Gets a debugging snapshot of the state of the map. It's inevitably out of date by the time it gets sent to the user
     // but does provide a momentary glimpse into possible issues e.g. if current_bytes is close to max_bytes
     pub fn get_snapshot(&self) -> EvictionSnapshot {
@@ -387,51 +379,67 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        let Some(first_key) = Self::oldest_unleased_key(state) else {
-            return (Vec::new(), Vec::new());
-        };
-        let Some(mut peek_entry) = state.lru.peek(first_key.borrow()) else {
-            return (Vec::new(), Vec::new());
-        };
+        // Select all victims in one pass. Re-scanning the LRU from its tail
+        // after every removal turns pressure eviction into O(n * victims)
+        // when a large active action has leased many entries.
+        let keys_to_evict = {
+            let mut unleased_entries = state
+                .lru
+                .iter()
+                .rev()
+                .filter(|(key, _)| !state.leases.contains_key::<K>(key));
+            let Some((first_key, first_entry)) = unleased_entries.next() else {
+                return (Vec::new(), Vec::new());
+            };
 
-        let max_bytes = if self.max_bytes != 0
-            && self.evict_bytes != 0
-            && self.should_evict(
-                state.lru.len(),
-                peek_entry,
-                state.sum_store_size,
-                self.max_bytes,
-            ) {
-            self.max_bytes.saturating_sub(self.evict_bytes)
-        } else {
-            self.max_bytes
+            let max_bytes = if self.max_bytes != 0
+                && self.evict_bytes != 0
+                && self.should_evict(
+                    state.lru.len(),
+                    first_entry,
+                    state.sum_store_size,
+                    self.max_bytes,
+                ) {
+                self.max_bytes.saturating_sub(self.evict_bytes)
+            } else {
+                self.max_bytes
+            };
+
+            let mut keys_to_evict = Vec::new();
+            let mut lru_len = state.lru.len();
+            let mut sum_store_size = state.sum_store_size;
+            let mut consider_entry = |key: &K, entry: &EvictionItem<T>| {
+                if !self.should_evict(lru_len, entry, sum_store_size, max_bytes) {
+                    return false;
+                }
+                keys_to_evict.push(key.clone());
+                lru_len -= 1;
+                sum_store_size -= entry.data.len();
+                true
+            };
+
+            if consider_entry(first_key, first_entry) {
+                for (key, entry) in unleased_entries {
+                    if !consider_entry(key, entry) {
+                        break;
+                    }
+                }
+            }
+            keys_to_evict
         };
 
         let mut items_to_unref = Vec::new();
         let mut removal_futures = Vec::new();
 
-        while self.should_evict(state.lru.len(), peek_entry, state.sum_store_size, max_bytes) {
-            let Some(key) = Self::oldest_unleased_key(state) else {
-                // Every remaining item is leased by an active operation. Keep
-                // the entries until those operations release their leases.
-                break;
-            };
-            let Some(eviction_item) = state.lru.pop(key.borrow()) else {
-                break;
-            };
+        for key in keys_to_evict {
+            let eviction_item = state
+                .lru
+                .pop(key.borrow())
+                .expect("Selected eviction key disappeared while state was locked");
             debug!(?key, "Evicting");
             let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
             items_to_unref.push(data);
             removal_futures.extend(futures);
-
-            peek_entry = if let Some(next_key) = Self::oldest_unleased_key(state) {
-                let Some(entry) = state.lru.peek(next_key.borrow()) else {
-                    break;
-                };
-                entry
-            } else {
-                break;
-            };
         }
 
         (items_to_unref, removal_futures)

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -164,7 +164,7 @@ impl<
 
     fn lease(&mut self, key: K) {
         if let Some(lease_count) = self.leases.get_mut(key.borrow()) {
-            *lease_count = lease_count.saturating_add(1);
+            *lease_count = lease_count.checked_add(1).expect("lease count overflow");
             return;
         }
 
@@ -174,15 +174,9 @@ impl<
 
     /// Release one reference and return the owned key when the lease ends.
     fn release_lease(&mut self, key: &Q) -> Option<K> {
-        let remove_lease = match self.leases.get_mut(key) {
-            Some(lease_count) if *lease_count > 1 => {
-                *lease_count -= 1;
-                false
-            }
-            Some(_) => true,
-            None => false,
-        };
-        if !remove_lease {
+        let lease_count = self.leases.get_mut(key)?;
+        if *lease_count > 1 {
+            *lease_count -= 1;
             return None;
         }
 
@@ -216,7 +210,7 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
-        // Removal is the single place that clears every resident index.
+        // Keep every auxiliary resident index in sync with the main LRU.
         self.evictable_lru.pop(key);
         self.sum_store_size -= eviction_item.data.len();
         if replaced {

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -20,7 +20,7 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::RangeBounds;
 use core::pin::Pin;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -105,6 +105,10 @@ struct State<
 > {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
+    /// Reference counts for keys that must not be evicted while an active
+    /// operation is using them. A key can be leased before it is inserted,
+    /// which closes the admission-to-insert race for cache populations.
+    leases: HashMap<K, u32>,
     #[metric(help = "Total size of all items in the store")]
     sum_store_size: u64,
 
@@ -276,6 +280,7 @@ where
             state: Mutex::new(State {
                 lru: LruCache::unbounded(),
                 btree: None,
+                leases: HashMap::new(),
                 sum_store_size: 0,
                 evicted_bytes: Counter::default(),
                 evicted_items: CounterWithTime::default(),
@@ -359,6 +364,14 @@ where
         is_over_size || old_item_exists || is_over_count
     }
 
+    fn oldest_unleased_key(state: &State<K, Q, T, C>) -> Option<K> {
+        state
+            .lru
+            .iter()
+            .rev()
+            .find_map(|(key, _)| (!state.leases.contains_key::<K>(key)).then(|| key.clone()))
+    }
+
     // Gets a debugging snapshot of the state of the map. It's inevitably out of date by the time it gets sent to the user
     // but does provide a momentary glimpse into possible issues e.g. if current_bytes is close to max_bytes
     pub fn get_snapshot(&self) -> EvictionSnapshot {
@@ -374,7 +387,10 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        let Some((_, mut peek_entry)) = state.lru.peek_lru() else {
+        let Some(first_key) = Self::oldest_unleased_key(state) else {
+            return (Vec::new(), Vec::new());
+        };
+        let Some(mut peek_entry) = state.lru.peek(first_key.borrow()) else {
             return (Vec::new(), Vec::new());
         };
 
@@ -395,16 +411,23 @@ where
         let mut removal_futures = Vec::new();
 
         while self.should_evict(state.lru.len(), peek_entry, state.sum_store_size, max_bytes) {
-            let (key, eviction_item) = state
-                .lru
-                .pop_lru()
-                .expect("Tried to peek() then pop() but failed");
+            let Some(key) = Self::oldest_unleased_key(state) else {
+                // Every remaining item is leased by an active operation. Keep
+                // the entries until those operations release their leases.
+                break;
+            };
+            let Some(eviction_item) = state.lru.pop(key.borrow()) else {
+                break;
+            };
             debug!(?key, "Evicting");
             let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
             items_to_unref.push(data);
             removal_futures.extend(futures);
 
-            peek_entry = if let Some((_, entry)) = state.lru.peek_lru() {
+            peek_entry = if let Some(next_key) = Self::oldest_unleased_key(state) {
+                let Some(entry) = state.lru.peek(next_key.borrow()) else {
+                    break;
+                };
                 entry
             } else {
                 break;
@@ -447,6 +470,7 @@ where
             let mut data_to_unref = Vec::new();
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
+                let is_leased = state.leases.contains_key(key.borrow());
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
                 } else {
@@ -457,7 +481,7 @@ where
                         // Note: We need to check eviction because the item might be expired
                         // based on the current time. In such case, we remove the item while
                         // we are here.
-                        if self.should_evict(lru_len, entry, 0, u64::MAX) {
+                        if !is_leased && self.should_evict(lru_len, entry, 0, u64::MAX) {
                             *result = None;
                             if let Some((key, eviction_item)) = state.lru.pop_entry(key.borrow()) {
                                 info!(?key, "Item expired, evicting");
@@ -524,11 +548,12 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
+            let is_leased = state.leases.contains_key(key.borrow());
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
             // Mirrors the per-key reap path in `sizes_for_keys`.
-            if self.should_evict(lru_len, entry, 0, u64::MAX) {
+            if !is_leased && self.should_evict(lru_len, entry, 0, u64::MAX) {
                 let (popped_key, eviction_item) = state
                     .lru
                     .pop_entry(key.borrow())
@@ -625,6 +650,40 @@ where
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()
             .await
+    }
+
+    /// Lease a key so size, count, and expiry eviction cannot remove it.
+    ///
+    /// Leasing before the value is inserted is intentional: an action can
+    /// reserve a digest before populating the fast tier, so insertion and
+    /// eviction cannot race with the start of input materialization.
+    pub fn lease_key(&self, key: K) {
+        let mut state = self.state.lock();
+        let lease_count = state.leases.entry(key).or_default();
+        *lease_count = lease_count.saturating_add(1);
+    }
+
+    /// Release one lease and trim any entries that were retained while the
+    /// lease was active.
+    pub async fn release_key(&self, key: &Q) {
+        let (items_to_unref, removal_futures) = {
+            let mut state = self.state.lock();
+            let Some(lease_count) = state.leases.get_mut(key) else {
+                return;
+            };
+            if *lease_count > 1 {
+                *lease_count -= 1;
+                return;
+            }
+            state.leases.remove(key);
+            self.evict_items(&mut state)
+        };
+
+        let mut futures: FuturesUnordered<_> = removal_futures.into_iter().collect();
+        while futures.next().await.is_some() {}
+
+        let mut futures: FuturesUnordered<_> = items_to_unref.iter().map(LenEntry::unref).collect();
+        while futures.next().await.is_some() {}
     }
 
     fn inner_insert_many<It>(

--- a/nativelink-util/src/evicting_map.rs
+++ b/nativelink-util/src/evicting_map.rs
@@ -105,10 +105,6 @@ struct State<
 > {
     lru: LruCache<K, EvictionItem<T>>,
     btree: Option<BTreeSet<K>>,
-    /// A mirror of `lru` that contains only currently unleased keys.
-    /// Keeping this index in LRU order lets eviction visit candidates without
-    /// scanning entries that an active operation has pinned.
-    evictable_lru: LruCache<K, ()>,
     /// Reference counts for keys that must not be evicted while an active
     /// operation is using them. A key can be leased before it is inserted,
     /// which closes the admission-to-insert race for cache populations.
@@ -148,31 +144,12 @@ impl<
         self.leases.contains_key(key)
     }
 
-    /// Keep candidate recency aligned with a normal read from `lru`.
-    /// Returns whether the key is leased so callers do not repeat the lookup.
-    fn touch_evictable(&mut self, key: &Q) -> bool {
-        if self.is_leased(key) {
-            return true;
-        }
-        self.evictable_lru.get(key);
-        false
-    }
-
-    /// Add a newly written key to the candidate index unless it is reserved
-    /// by a lease that was acquired before insertion.
-    fn insert_evictable(&mut self, key: K) {
-        if !self.is_leased(key.borrow()) {
-            self.evictable_lru.put(key, ());
-        }
-    }
-
     fn lease(&mut self, key: K) {
         if let Some(lease_count) = self.leases.get_mut(key.borrow()) {
             *lease_count = lease_count.checked_add(1).expect("lease count overflow");
             return;
         }
 
-        self.evictable_lru.pop(key.borrow());
         if let Some(entry) = self.lru.peek(key.borrow()) {
             self.leased_bytes += entry.data.len();
         }
@@ -200,32 +177,6 @@ impl<
         Some(leased_key)
     }
 
-    /// Re-enter a resident key as the newest eviction candidate without
-    /// changing its stored age.
-    fn reinsert_evictable(&mut self, key: K) {
-        if self.lru.peek(key.borrow()).is_some() {
-            self.evictable_lru.put(key, ());
-        }
-    }
-
-    fn peek_evictable(&self) -> Option<&EvictionItem<T>> {
-        let (key, ()) = self.evictable_lru.peek_lru()?;
-        Some(
-            self.lru
-                .peek(key.borrow())
-                .expect("Evictable LRU key must be resident in the main LRU"),
-        )
-    }
-
-    fn pop_evictable(&mut self) -> Option<(K, EvictionItem<T>)> {
-        let (candidate_key, ()) = self.evictable_lru.pop_lru()?;
-        let (key, entry) = self
-            .lru
-            .pop_entry(candidate_key.borrow())
-            .expect("Evictable LRU key must be resident in the main LRU");
-        Some((key, entry))
-    }
-
     /// Removes an item from the cache and returns the data for deferred cleanup.
     /// The caller is responsible for calling `unref()` on the returned data outside of the lock.
     #[must_use]
@@ -241,8 +192,6 @@ impl<
         if let Some(btree) = &mut self.btree {
             btree.remove(key);
         }
-        // Keep every auxiliary resident index in sync with the main LRU.
-        self.evictable_lru.pop(key);
         if self.is_leased(key) {
             self.leased_bytes -= eviction_item.data.len();
         }
@@ -283,9 +232,6 @@ impl<
         if is_leased {
             self.leased_bytes += new_item_size;
         }
-        // `remove()` drops the old key from both indexes. Reinsert it after
-        // replacement so an unleased write is MRU in both LRU indexes.
-        self.insert_evictable(key.clone());
         if let Some(btree) = &mut self.btree {
             btree.insert(key.clone());
         }
@@ -386,7 +332,6 @@ where
             state: Mutex::new(State {
                 lru: LruCache::unbounded(),
                 btree: None,
-                evictable_lru: LruCache::unbounded(),
                 leases: HashMap::new(),
                 sum_store_size: 0,
                 leased_items: 0,
@@ -491,49 +436,73 @@ where
 
     #[must_use]
     fn evict_items(&self, state: &mut State<K, Q, T, C>) -> (Vec<T>, Vec<RemoveFuture>) {
-        let Some(first_entry) = state.peek_evictable() else {
-            if !state.lru.is_empty() {
-                debug!(
-                    resident_items = state.lru.len(),
-                    evictable_items = state.evictable_lru.len(),
-                    lease_keys = state.leases.len(),
-                    leased_items = state.leased_items,
-                    leased_bytes = state.leased_bytes,
-                    resident_bytes = state.sum_store_size,
-                    "Eviction requested, but every resident entry is leased",
-                );
-            }
-            return (Vec::new(), Vec::new());
-        };
+        // Select victims in one pass. This keeps eviction linear in the
+        // resident entries even when an active action has leased many keys.
+        let keys_to_evict = {
+            let mut unleased_entries = state
+                .lru
+                .iter()
+                .rev()
+                .filter(|(key, _)| !state.is_leased((*key).borrow()));
+            let Some((first_key, first_entry)) = unleased_entries.next() else {
+                if !state.lru.is_empty() {
+                    debug!(
+                        resident_items = state.lru.len(),
+                        lease_keys = state.leases.len(),
+                        leased_items = state.leased_items,
+                        leased_bytes = state.leased_bytes,
+                        resident_bytes = state.sum_store_size,
+                        "Eviction requested, but every resident entry is leased",
+                    );
+                }
+                return (Vec::new(), Vec::new());
+            };
 
-        // Preserve the configured low-watermark behavior: once pressure is
-        // detected, keep evicting until `evict_bytes` is reclaimed.
-        let max_bytes = if self.max_bytes != 0
-            && self.evict_bytes != 0
-            && self.should_evict(
-                state.lru.len(),
-                first_entry,
-                state.sum_store_size,
-                self.max_bytes,
-            ) {
-            self.max_bytes.saturating_sub(self.evict_bytes)
-        } else {
-            self.max_bytes
+            // Preserve the configured low-watermark behavior: once pressure
+            // is detected, keep evicting until `evict_bytes` is reclaimed.
+            let max_bytes = if self.max_bytes != 0
+                && self.evict_bytes != 0
+                && self.should_evict(
+                    state.lru.len(),
+                    first_entry,
+                    state.sum_store_size,
+                    self.max_bytes,
+                ) {
+                self.max_bytes.saturating_sub(self.evict_bytes)
+            } else {
+                self.max_bytes
+            };
+
+            let mut keys_to_evict = Vec::new();
+            let mut lru_len = state.lru.len();
+            let mut sum_store_size = state.sum_store_size;
+            let mut consider_entry = |key: &K, entry: &EvictionItem<T>| {
+                if !self.should_evict(lru_len, entry, sum_store_size, max_bytes) {
+                    return false;
+                }
+                keys_to_evict.push(key.clone());
+                lru_len -= 1;
+                sum_store_size -= entry.data.len();
+                true
+            };
+
+            if consider_entry(first_key, first_entry) {
+                for (key, entry) in unleased_entries {
+                    if !consider_entry(key, entry) {
+                        break;
+                    }
+                }
+            }
+            keys_to_evict
         };
 
         let mut items_to_unref = Vec::new();
         let mut removal_futures = Vec::new();
-
-        // Pop the candidate index directly instead of collecting and cloning
-        // all victim keys. Both indexes are protected by the same lock.
-        while let Some(entry) = state.peek_evictable() {
-            if !self.should_evict(state.lru.len(), entry, state.sum_store_size, max_bytes) {
-                break;
-            }
-
-            let (key, eviction_item) = state
-                .pop_evictable()
-                .expect("Evictable LRU key disappeared while state was locked");
+        for key in keys_to_evict {
+            let eviction_item = state
+                .lru
+                .pop(key.borrow())
+                .expect("Selected eviction key disappeared while state was locked");
             debug!(?key, "Evicting");
             let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
             items_to_unref.push(data);
@@ -576,11 +545,7 @@ where
             let mut data_to_unref = Vec::new();
             let mut removal_futures = Vec::new();
             for (key, result) in keys.into_iter().zip(results.iter_mut()) {
-                let is_leased = if peek {
-                    state.is_leased(key.borrow())
-                } else {
-                    state.touch_evictable(key.borrow())
-                };
+                let is_leased = state.is_leased(key.borrow());
                 let maybe_entry = if peek {
                     state.lru.peek_mut(key.borrow())
                 } else {
@@ -656,7 +621,7 @@ where
         let (data, expired_data, removal_futures) = {
             let mut state = self.state.lock();
             let lru_len = state.lru.len();
-            let is_leased = state.touch_evictable(key.borrow());
+            let is_leased = state.is_leased(key.borrow());
             let entry = state.lru.get_mut(key.borrow())?;
             // Pass `sum_store_size=0` and `max_bytes=u64::MAX` so we only
             // consult TTL / count predicates — never the global byte budget.
@@ -796,17 +761,12 @@ where
                             .peek(leased_key.borrow())
                             .is_some_and(|entry| entry.seconds_since_anchor < expired_before)
                     });
-                    if expired {
-                        if let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
-                        {
-                            let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
-                            items_to_unref.push(data);
-                            removal_futures.extend(futures);
-                        }
-                    } else {
-                        // A released key re-enters as MRU, giving an actively
-                        // used input a fair chance to remain cached.
-                        state.reinsert_evictable(leased_key);
+                    if expired
+                        && let Some((key, eviction_item)) = state.lru.pop_entry(leased_key.borrow())
+                    {
+                        let (data, futures) = state.remove(key.borrow(), &eviction_item, false);
+                        items_to_unref.push(data);
+                        removal_futures.extend(futures);
                     }
                     released_any = true;
                 }
@@ -912,7 +872,6 @@ where
     {
         let (evicted_items, removal_futures, removed_item) = {
             let mut state = self.state.lock();
-            state.touch_evictable(key.borrow());
             let Some(entry) = state.lru.get(key.borrow()) else {
                 return false;
             };

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -560,44 +560,6 @@ async fn leased_key_survives_ttl_until_released() -> Result<(), Error> {
 }
 
 #[nativelink_test]
-async fn released_expired_key_is_not_hidden_by_fresh_entry() -> Result<(), Error> {
-    const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-        &EvictionPolicy {
-            max_count: 0,
-            max_seconds: 5,
-            max_bytes: 0,
-            evict_bytes: 0,
-        },
-        MockInstantWrapped::default(),
-    );
-    let leased_key = DigestInfo::try_new(HASH1, 0)?;
-    let fresh_key = DigestInfo::try_new(HASH2, 0)?;
-
-    evicting_map.lease_key(leased_key);
-    evicting_map
-        .insert(leased_key, Bytes::from(DATA).into())
-        .await;
-    MockClock::advance(Duration::from_secs(10));
-    evicting_map
-        .insert(fresh_key, Bytes::from(DATA).into())
-        .await;
-
-    evicting_map.release_key(&leased_key).await;
-
-    // Releasing an expired key must remove it immediately. Otherwise the
-    // fresh entry can become the LRU head and hide the expired key from
-    // eviction until a later insert.
-    assert_eq!(evicting_map.len_for_test(), 1);
-    assert_eq!(
-        evicting_map.size_for_key(&fresh_key).await,
-        Some(DATA.len() as u64)
-    );
-
-    Ok(())
-}
-
-#[nativelink_test]
 async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -216,6 +216,49 @@ async fn leased_key_survives_fast_tier_pressure_until_released() -> Result<(), E
 }
 
 #[nativelink_test]
+async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 1,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let first_key = DigestInfo::try_new(HASH1, 0)?;
+    let second_key = DigestInfo::try_new(HASH2, 0)?;
+
+    // With no unleased victim, pressure insertion must not repeatedly scan
+    // and evict active inputs just to satisfy max_count.
+    evicting_map.lease_key(first_key);
+    evicting_map.lease_key(second_key);
+    evicting_map
+        .insert(first_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(second_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(evicting_map.len_for_test(), 2);
+
+    // Releasing one lease makes the retained entry an ordinary victim again.
+    evicting_map.release_key(&first_key).await;
+    assert_eq!(
+        evicting_map.size_for_key(&first_key).await,
+        None,
+        "released entry should be trimmed once an unleased victim exists",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&second_key).await,
+        Some(DATA.len() as u64),
+        "the still-leased entry must remain available",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn leased_key_batch_release_preserves_reference_counts() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -560,6 +560,44 @@ async fn leased_key_survives_ttl_until_released() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn released_expired_key_is_not_hidden_by_fresh_entry() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 5,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let leased_key = DigestInfo::try_new(HASH1, 0)?;
+    let fresh_key = DigestInfo::try_new(HASH2, 0)?;
+
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(10));
+    evicting_map
+        .insert(fresh_key, Bytes::from(DATA).into())
+        .await;
+
+    evicting_map.release_key(&leased_key).await;
+
+    // Releasing an expired key must remove it immediately. Otherwise the
+    // fresh entry can become the LRU head and hide the expired key from
+    // eviction until a later insert.
+    assert_eq!(evicting_map.len_for_test(), 1);
+    assert_eq!(
+        evicting_map.size_for_key(&fresh_key).await,
+        Some(DATA.len() as u64)
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -216,6 +216,58 @@ async fn leased_key_survives_fast_tier_pressure_until_released() -> Result<(), E
 }
 
 #[nativelink_test]
+async fn leased_key_batch_release_preserves_reference_counts() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 1,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let leased_key = DigestInfo::try_new(HASH1, 0)?;
+    let other_key = DigestInfo::try_new(HASH2, 0)?;
+
+    // Three references let the batch release exercise both duplicate keys and
+    // the remaining reference-counted lease.
+    evicting_map.lease_key(leased_key);
+    evicting_map.lease_key(leased_key);
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map.release_keys([&leased_key, &leased_key]).await;
+
+    evicting_map
+        .insert(other_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "one remaining lease must keep the input available",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&other_key).await,
+        None,
+        "unleased pressure entry should be evicted first",
+    );
+
+    evicting_map.release_keys([&leased_key]).await;
+    evicting_map
+        .insert(other_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        None,
+        "the final release must re-enable normal eviction",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn leased_key_survives_ttl_until_released() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -317,6 +317,48 @@ async fn evictable_lru_tracks_unleased_access() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn remove_if_tracks_unleased_access() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 3,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let first_key = DigestInfo::try_new(HASH1, 0)?;
+    let second_key = DigestInfo::try_new(HASH2, 0)?;
+    let third_key = DigestInfo::try_new(HASH3, 0)?;
+    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
+
+    for key in [first_key, second_key, third_key] {
+        evicting_map.insert(key, Bytes::from(DATA).into()).await;
+    }
+    assert!(
+        !evicting_map.remove_if(&first_key, |_| false).await,
+        "the conditional removal should leave the entry resident",
+    );
+    evicting_map
+        .insert(fourth_key, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map.size_for_key(&first_key).await,
+        Some(DATA.len() as u64),
+        "remove_if must promote the evictable LRU with the resident LRU",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&second_key).await,
+        None,
+        "the least-recently used unleased entry should be evicted",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn released_lease_reenters_evictable_lru_as_mru() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -216,7 +216,7 @@ async fn leased_key_survives_fast_tier_pressure_until_released() -> Result<(), E
 }
 
 #[nativelink_test]
-async fn all_leased_entries_are_retained_under_pressure() -> Result<(), Error> {
+async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
@@ -306,6 +306,159 @@ async fn removing_leased_key_preserves_lease_until_release() -> Result<(), Error
     assert_eq!(
         evicting_map.size_for_key(&other_key).await,
         Some(DATA.len() as u64),
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn evictable_lru_tracks_unleased_access() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 3,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let first_key = DigestInfo::try_new(HASH1, 0)?;
+    let leased_key = DigestInfo::try_new(HASH2, 0)?;
+    let third_key = DigestInfo::try_new(HASH3, 0)?;
+    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
+
+    evicting_map
+        .insert(first_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(third_key, Bytes::from(DATA).into())
+        .await;
+
+    // Removing a key from the evictable index must not make the next
+    // unleased insertion scan or evict the active input.
+    evicting_map.lease_key(leased_key);
+    // A normal read promotes both indexes. If only the resident LRU were
+    // updated, `first_key` would be selected instead of `third_key`.
+    assert_eq!(
+        evicting_map.get(&first_key).await,
+        Some(Bytes::from(DATA).into())
+    );
+    evicting_map
+        .insert(fourth_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&first_key).await,
+        Some(DATA.len() as u64),
+        "an unleased read must promote the evictable LRU as well",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&third_key).await,
+        None,
+        "the least-recently used unleased entry should be evicted",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "leased entries are never eviction candidates",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn remove_if_tracks_unleased_access() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 3,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let first_key = DigestInfo::try_new(HASH1, 0)?;
+    let second_key = DigestInfo::try_new(HASH2, 0)?;
+    let third_key = DigestInfo::try_new(HASH3, 0)?;
+    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
+
+    for key in [first_key, second_key, third_key] {
+        evicting_map.insert(key, Bytes::from(DATA).into()).await;
+    }
+    assert!(
+        !evicting_map.remove_if(&first_key, |_| false).await,
+        "the conditional removal should leave the entry resident",
+    );
+    evicting_map
+        .insert(fourth_key, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map.size_for_key(&first_key).await,
+        Some(DATA.len() as u64),
+        "remove_if must promote the evictable LRU with the resident LRU",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&second_key).await,
+        None,
+        "the least-recently used unleased entry should be evicted",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn released_lease_reenters_evictable_lru_as_mru() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 2,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let older_key = DigestInfo::try_new(HASH1, 0)?;
+    let leased_key = DigestInfo::try_new(HASH2, 0)?;
+    let resident_key = DigestInfo::try_new(HASH3, 0)?;
+
+    evicting_map
+        .insert(older_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(resident_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&older_key).await,
+        None,
+        "the ordinary unleased entry should be evicted while the lease is active",
+    );
+
+    // Releasing a resident key re-enters the candidate index as MRU. The
+    // existing unleased `resident_key` is therefore evicted before the just-released
+    // key when another item creates pressure.
+    evicting_map.release_key(&leased_key).await;
+    evicting_map
+        .insert(older_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "a released key should re-enter as MRU",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&resident_key).await,
+        None,
+        "older unleased entries should be evicted before a just-released key",
     );
 
     Ok(())
@@ -940,6 +1093,30 @@ async fn range_multiple_items_test() -> Result<(), Error> {
         let found_values = get_map_range(&evicting_map, KEY2.to_string()..KEY3.to_string()).await;
         assert_eq!(expected_values, found_values);
     }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn replacing_entry_keeps_filter_index_consistent() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy::default(),
+        MockInstantWrapped::default(),
+    );
+    let key = DigestInfo::try_new(HASH1, 0)?;
+    let first_value = BytesWrapper(Bytes::from_static(b"first"));
+    let second_value = BytesWrapper(Bytes::from_static(b"second"));
+
+    evicting_map.enable_filtering().await;
+    evicting_map.insert(key, first_value).await;
+    evicting_map.insert(key, second_value.clone()).await;
+
+    let mut values = Vec::new();
+    evicting_map.range(.., |_, value| {
+        values.push(value.clone());
+        true
+    });
+    assert_eq!(values, vec![second_value]);
 
     Ok(())
 }

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -216,7 +216,7 @@ async fn leased_key_survives_fast_tier_pressure_until_released() -> Result<(), E
 }
 
 #[nativelink_test]
-async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Error> {
+async fn all_leased_entries_are_retained_under_pressure() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
         &EvictionPolicy {
@@ -306,159 +306,6 @@ async fn removing_leased_key_preserves_lease_until_release() -> Result<(), Error
     assert_eq!(
         evicting_map.size_for_key(&other_key).await,
         Some(DATA.len() as u64),
-    );
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn evictable_lru_tracks_unleased_access() -> Result<(), Error> {
-    const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-        &EvictionPolicy {
-            max_count: 3,
-            max_seconds: 0,
-            max_bytes: 0,
-            evict_bytes: 0,
-        },
-        MockInstantWrapped::default(),
-    );
-    let first_key = DigestInfo::try_new(HASH1, 0)?;
-    let leased_key = DigestInfo::try_new(HASH2, 0)?;
-    let third_key = DigestInfo::try_new(HASH3, 0)?;
-    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
-
-    evicting_map
-        .insert(first_key, Bytes::from(DATA).into())
-        .await;
-    evicting_map
-        .insert(leased_key, Bytes::from(DATA).into())
-        .await;
-    evicting_map
-        .insert(third_key, Bytes::from(DATA).into())
-        .await;
-
-    // Removing a key from the evictable index must not make the next
-    // unleased insertion scan or evict the active input.
-    evicting_map.lease_key(leased_key);
-    // A normal read promotes both indexes. If only the resident LRU were
-    // updated, `first_key` would be selected instead of `third_key`.
-    assert_eq!(
-        evicting_map.get(&first_key).await,
-        Some(Bytes::from(DATA).into())
-    );
-    evicting_map
-        .insert(fourth_key, Bytes::from(DATA).into())
-        .await;
-    assert_eq!(
-        evicting_map.size_for_key(&first_key).await,
-        Some(DATA.len() as u64),
-        "an unleased read must promote the evictable LRU as well",
-    );
-    assert_eq!(
-        evicting_map.size_for_key(&third_key).await,
-        None,
-        "the least-recently used unleased entry should be evicted",
-    );
-    assert_eq!(
-        evicting_map.size_for_key(&leased_key).await,
-        Some(DATA.len() as u64),
-        "leased entries are never eviction candidates",
-    );
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn remove_if_tracks_unleased_access() -> Result<(), Error> {
-    const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-        &EvictionPolicy {
-            max_count: 3,
-            max_seconds: 0,
-            max_bytes: 0,
-            evict_bytes: 0,
-        },
-        MockInstantWrapped::default(),
-    );
-    let first_key = DigestInfo::try_new(HASH1, 0)?;
-    let second_key = DigestInfo::try_new(HASH2, 0)?;
-    let third_key = DigestInfo::try_new(HASH3, 0)?;
-    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
-
-    for key in [first_key, second_key, third_key] {
-        evicting_map.insert(key, Bytes::from(DATA).into()).await;
-    }
-    assert!(
-        !evicting_map.remove_if(&first_key, |_| false).await,
-        "the conditional removal should leave the entry resident",
-    );
-    evicting_map
-        .insert(fourth_key, Bytes::from(DATA).into())
-        .await;
-
-    assert_eq!(
-        evicting_map.size_for_key(&first_key).await,
-        Some(DATA.len() as u64),
-        "remove_if must promote the evictable LRU with the resident LRU",
-    );
-    assert_eq!(
-        evicting_map.size_for_key(&second_key).await,
-        None,
-        "the least-recently used unleased entry should be evicted",
-    );
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn released_lease_reenters_evictable_lru_as_mru() -> Result<(), Error> {
-    const DATA: &str = "12345678";
-    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-        &EvictionPolicy {
-            max_count: 2,
-            max_seconds: 0,
-            max_bytes: 0,
-            evict_bytes: 0,
-        },
-        MockInstantWrapped::default(),
-    );
-    let older_key = DigestInfo::try_new(HASH1, 0)?;
-    let leased_key = DigestInfo::try_new(HASH2, 0)?;
-    let resident_key = DigestInfo::try_new(HASH3, 0)?;
-
-    evicting_map
-        .insert(older_key, Bytes::from(DATA).into())
-        .await;
-    evicting_map.lease_key(leased_key);
-    evicting_map
-        .insert(leased_key, Bytes::from(DATA).into())
-        .await;
-    evicting_map
-        .insert(resident_key, Bytes::from(DATA).into())
-        .await;
-    assert_eq!(
-        evicting_map.size_for_key(&older_key).await,
-        None,
-        "the ordinary unleased entry should be evicted while the lease is active",
-    );
-
-    // Releasing a resident key re-enters the candidate index as MRU. The
-    // existing unleased `resident_key` is therefore evicted before the just-released
-    // key when another item creates pressure.
-    evicting_map.release_key(&leased_key).await;
-    evicting_map
-        .insert(older_key, Bytes::from(DATA).into())
-        .await;
-    assert_eq!(
-        evicting_map.size_for_key(&leased_key).await,
-        Some(DATA.len() as u64),
-        "a released key should re-enter as MRU",
-    );
-    assert_eq!(
-        evicting_map.size_for_key(&resident_key).await,
-        None,
-        "older unleased entries should be evicted before a just-released key",
     );
 
     Ok(())
@@ -1093,30 +940,6 @@ async fn range_multiple_items_test() -> Result<(), Error> {
         let found_values = get_map_range(&evicting_map, KEY2.to_string()..KEY3.to_string()).await;
         assert_eq!(expected_values, found_values);
     }
-
-    Ok(())
-}
-
-#[nativelink_test]
-async fn replacing_entry_keeps_filter_index_consistent() -> Result<(), Error> {
-    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
-        &EvictionPolicy::default(),
-        MockInstantWrapped::default(),
-    );
-    let key = DigestInfo::try_new(HASH1, 0)?;
-    let first_value = BytesWrapper(Bytes::from_static(b"first"));
-    let second_value = BytesWrapper(Bytes::from_static(b"second"));
-
-    evicting_map.enable_filtering().await;
-    evicting_map.insert(key, first_value).await;
-    evicting_map.insert(key, second_value.clone()).await;
-
-    let mut values = Vec::new();
-    evicting_map.range(.., |_, value| {
-        values.push(value.clone());
-        true
-    });
-    assert_eq!(values, vec![second_value]);
 
     Ok(())
 }

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -167,6 +167,98 @@ async fn insert_purges_at_max_bytes() -> Result<(), Error> {
 }
 
 #[nativelink_test]
+async fn leased_key_survives_fast_tier_pressure_until_released() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 1,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let leased_key = DigestInfo::try_new(HASH1, 0)?;
+    let other_key = DigestInfo::try_new(HASH2, 0)?;
+
+    // Reserve the key before it is populated. This is the ordering used by an
+    // action input lease and is the race the regression test protects.
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(other_key, Bytes::from(DATA).into())
+        .await;
+
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "leased input must remain available while another blob is inserted",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&other_key).await,
+        None,
+        "unleased blob should be the eviction candidate",
+    );
+
+    evicting_map.release_key(&leased_key).await;
+    evicting_map
+        .insert(other_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        None,
+        "released input may be evicted after its action completes",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn leased_key_survives_ttl_until_released() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 0,
+            max_seconds: 5,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let leased_key = DigestInfo::try_new(HASH1, 0)?;
+
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    MockClock::advance(Duration::from_secs(10));
+
+    let mut result = [None];
+    evicting_map
+        .sizes_for_keys([&leased_key], &mut result, true)
+        .await;
+    assert_eq!(
+        result[0],
+        Some(DATA.len() as u64),
+        "TTL expiry must not remove a leased input",
+    );
+
+    evicting_map.release_key(&leased_key).await;
+    result[0] = None;
+    evicting_map
+        .sizes_for_keys([&leased_key], &mut result, true)
+        .await;
+    assert_eq!(
+        result[0], None,
+        "expired input may be reaped after its lease is released",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
 async fn insert_purges_to_low_watermark_at_max_bytes() -> Result<(), Error> {
     const DATA: &str = "12345678";
     let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -241,6 +241,9 @@ async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Erro
         .insert(second_key, Bytes::from(DATA).into())
         .await;
     assert_eq!(evicting_map.len_for_test(), 2);
+    assert!(logs_contain(
+        "Eviction requested, but every resident entry is leased"
+    ));
 
     // Releasing one lease makes the retained entry an ordinary victim again.
     evicting_map.release_key(&first_key).await;
@@ -253,6 +256,56 @@ async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Erro
         evicting_map.size_for_key(&second_key).await,
         Some(DATA.len() as u64),
         "the still-leased entry must remain available",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn removing_leased_key_preserves_lease_until_release() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 1,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let leased_key = DigestInfo::try_new(HASH1, 0)?;
+    let other_key = DigestInfo::try_new(HASH2, 0)?;
+
+    // Explicit removal deletes the resident value but intentionally leaves
+    // the lease active so a subsequent population cannot race with eviction.
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    assert!(evicting_map.remove(&leased_key).await);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "reinserted leased value must remain resident",
+    );
+
+    // The final release must clear the lease even when the key was removed
+    // and repopulated while the lease was active.
+    evicting_map.release_key(&leased_key).await;
+    evicting_map
+        .insert(other_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        None,
+        "reinserted value should become evictable after release",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&other_key).await,
+        Some(DATA.len() as u64),
     );
 
     Ok(())

--- a/nativelink-util/tests/evicting_map_test.rs
+++ b/nativelink-util/tests/evicting_map_test.rs
@@ -230,8 +230,8 @@ async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Erro
     let first_key = DigestInfo::try_new(HASH1, 0)?;
     let second_key = DigestInfo::try_new(HASH2, 0)?;
 
-    // With no unleased victim, pressure insertion must not repeatedly scan
-    // and evict active inputs just to satisfy max_count.
+    // With no evictable victim, pressure insertion must not evict active
+    // inputs just to satisfy max_count.
     evicting_map.lease_key(first_key);
     evicting_map.lease_key(second_key);
     evicting_map
@@ -253,6 +253,117 @@ async fn all_leased_entries_can_temporarily_exceed_capacity() -> Result<(), Erro
         evicting_map.size_for_key(&second_key).await,
         Some(DATA.len() as u64),
         "the still-leased entry must remain available",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn evictable_lru_tracks_unleased_access() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 3,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let first_key = DigestInfo::try_new(HASH1, 0)?;
+    let leased_key = DigestInfo::try_new(HASH2, 0)?;
+    let third_key = DigestInfo::try_new(HASH3, 0)?;
+    let fourth_key = DigestInfo::try_new(HASH4, 0)?;
+
+    evicting_map
+        .insert(first_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(third_key, Bytes::from(DATA).into())
+        .await;
+
+    // Removing a key from the evictable index must not make the next
+    // unleased insertion scan or evict the active input.
+    evicting_map.lease_key(leased_key);
+    // A normal read promotes both indexes. If only the resident LRU were
+    // updated, `first_key` would be selected instead of `third_key`.
+    assert_eq!(
+        evicting_map.get(&first_key).await,
+        Some(Bytes::from(DATA).into())
+    );
+    evicting_map
+        .insert(fourth_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&first_key).await,
+        Some(DATA.len() as u64),
+        "an unleased read must promote the evictable LRU as well",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&third_key).await,
+        None,
+        "the least-recently used unleased entry should be evicted",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "leased entries are never eviction candidates",
+    );
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn released_lease_reenters_evictable_lru_as_mru() -> Result<(), Error> {
+    const DATA: &str = "12345678";
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy {
+            max_count: 2,
+            max_seconds: 0,
+            max_bytes: 0,
+            evict_bytes: 0,
+        },
+        MockInstantWrapped::default(),
+    );
+    let older_key = DigestInfo::try_new(HASH1, 0)?;
+    let leased_key = DigestInfo::try_new(HASH2, 0)?;
+    let resident_key = DigestInfo::try_new(HASH3, 0)?;
+
+    evicting_map
+        .insert(older_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map.lease_key(leased_key);
+    evicting_map
+        .insert(leased_key, Bytes::from(DATA).into())
+        .await;
+    evicting_map
+        .insert(resident_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&older_key).await,
+        None,
+        "the ordinary unleased entry should be evicted while the lease is active",
+    );
+
+    // Releasing a resident key re-enters the candidate index as MRU. The
+    // existing unleased `resident_key` is therefore evicted before the just-released
+    // key when another item creates pressure.
+    evicting_map.release_key(&leased_key).await;
+    evicting_map
+        .insert(older_key, Bytes::from(DATA).into())
+        .await;
+    assert_eq!(
+        evicting_map.size_for_key(&leased_key).await,
+        Some(DATA.len() as u64),
+        "a released key should re-enter as MRU",
+    );
+    assert_eq!(
+        evicting_map.size_for_key(&resident_key).await,
+        None,
+        "older unleased entries should be evicted before a just-released key",
     );
 
     Ok(())
@@ -849,6 +960,30 @@ async fn range_multiple_items_test() -> Result<(), Error> {
         let found_values = get_map_range(&evicting_map, KEY2.to_string()..KEY3.to_string()).await;
         assert_eq!(expected_values, found_values);
     }
+
+    Ok(())
+}
+
+#[nativelink_test]
+async fn replacing_entry_keeps_filter_index_consistent() -> Result<(), Error> {
+    let evicting_map = EvictingMap::<DigestInfo, DigestInfo, BytesWrapper, MockInstantWrapped>::new(
+        &EvictionPolicy::default(),
+        MockInstantWrapped::default(),
+    );
+    let key = DigestInfo::try_new(HASH1, 0)?;
+    let first_value = BytesWrapper(Bytes::from_static(b"first"));
+    let second_value = BytesWrapper(Bytes::from_static(b"second"));
+
+    evicting_map.enable_filtering().await;
+    evicting_map.insert(key, first_value).await;
+    evicting_map.insert(key, second_value.clone()).await;
+
+    let mut values = Vec::new();
+    evicting_map.range(.., |_, value| {
+        values.push(value.clone());
+        true
+    });
+    assert_eq!(values, vec![second_value]);
 
     Ok(())
 }

--- a/nativelink-worker/src/directory_cache.rs
+++ b/nativelink-worker/src/directory_cache.rs
@@ -898,7 +898,8 @@ impl DirectoryCache {
     ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>> {
         Box::pin(async move {
             debug!(?digest, ?dest_path, "Constructing directory");
-            acquire_digest(lease, &digest);
+            // The root is reserved by `get_or_create_entry`; child digests are
+            // reserved before their recursive futures are queued below.
 
             // Use the prefetched proto when available; otherwise fetch it
             // (permit held only for the fetch). A prefetch-map miss (e.g.

--- a/nativelink-worker/src/directory_cache.rs
+++ b/nativelink-worker/src/directory_cache.rs
@@ -115,6 +115,12 @@ pub trait DigestLease: Send + Sync {
     fn acquire(&self, digest: &DigestInfo);
 }
 
+fn acquire_digest(lease: Option<&dyn DigestLease>, digest: &DigestInfo) {
+    if let Some(lease) = lease {
+        lease.acquire(digest);
+    }
+}
+
 impl Default for DirectoryCacheConfig {
     fn default() -> Self {
         Self {
@@ -457,9 +463,7 @@ impl DirectoryCache {
         lease: Option<&dyn DigestLease>,
     ) -> Result<(bool, u64), Error> {
         self.maybe_log_summary();
-        if let Some(lease) = lease {
-            lease.acquire(&digest);
-        }
+        acquire_digest(lease, &digest);
 
         // Fast path: serve from an existing entry.
         if let Some(size) = self.try_materialize_from_cache(&digest, dest_path).await {
@@ -894,9 +898,7 @@ impl DirectoryCache {
     ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>> {
         Box::pin(async move {
             debug!(?digest, ?dest_path, "Constructing directory");
-            if let Some(lease) = lease {
-                lease.acquire(&digest);
-            }
+            acquire_digest(lease, &digest);
 
             // Use the prefetched proto when available; otherwise fetch it
             // (permit held only for the fetch). A prefetch-map miss (e.g.
@@ -921,10 +923,8 @@ impl DirectoryCache {
                 if let Some(file_digest) = &file.digest {
                     // size_bytes is non-negative; clamp defensively.
                     total_size += u64::try_from(file_digest.size_bytes).unwrap_or(0);
-                    if let Some(lease) = lease
-                        && let Ok(file_digest) = DigestInfo::try_from(file_digest)
-                    {
-                        lease.acquire(&file_digest);
+                    if let Ok(file_digest) = DigestInfo::try_from(file_digest) {
+                        acquire_digest(lease, &file_digest);
                     }
                 }
             }
@@ -946,11 +946,10 @@ impl DirectoryCache {
                 }));
             }
             for dir_node in &directory.directories {
-                if let Some(lease) = lease
-                    && let Some(dir_digest) = &dir_node.digest
+                if let Some(dir_digest) = &dir_node.digest
                     && let Ok(dir_digest) = DigestInfo::try_from(dir_digest)
                 {
-                    lease.acquire(&dir_digest);
+                    acquire_digest(lease, &dir_digest);
                 }
                 node_futures.push(Box::pin(
                     self.create_subdirectory(dest_path, dir_node, protos, lease),

--- a/nativelink-worker/src/directory_cache.rs
+++ b/nativelink-worker/src/directory_cache.rs
@@ -108,6 +108,13 @@ pub struct DirectoryCacheConfig {
     pub experimental_get_tree_prefetch: bool,
 }
 
+/// Receives every CAS digest before the directory cache starts materializing
+/// that node. Action workers use this hook to keep the digest pinned in their
+/// local eviction-managed CAS tiers for the duration of the action.
+pub trait DigestLease: Send + Sync {
+    fn acquire(&self, digest: &DigestInfo);
+}
+
 impl Default for DirectoryCacheConfig {
     fn default() -> Self {
         Self {
@@ -405,8 +412,25 @@ impl DirectoryCache {
     /// * `Ok(false)` - Cache miss (directory was constructed)
     /// * `Err` - Error during construction or hardlinking
     pub async fn get_or_create(&self, digest: DigestInfo, dest_path: &Path) -> Result<bool, Error> {
+        self.get_or_create_with_lease(digest, dest_path, None).await
+    }
+
+    /// Gets or creates a cached directory while optionally reserving each CAS
+    /// digest used by a construction.
+    ///
+    /// Existing cache hits only hardlink from the already-materialized cache
+    /// entry, whose own pin protects the source tree. On a miss, the lease is
+    /// called before the root, file, and child-directory digests are fetched
+    /// or populated, closing the admission-to-eviction race for active
+    /// actions.
+    pub async fn get_or_create_with_lease(
+        &self,
+        digest: DigestInfo,
+        dest_path: &Path,
+        lease: Option<&dyn DigestLease>,
+    ) -> Result<bool, Error> {
         let (hit, _size) = self
-            .get_or_create_entry(digest, dest_path, None, true)
+            .get_or_create_entry(digest, dest_path, None, true, lease)
             .await?;
         Ok(hit)
     }
@@ -430,8 +454,12 @@ impl DirectoryCache {
         dest_path: &Path,
         protos: Option<&HashMap<DigestInfo, ProtoDirectory>>,
         prefetch_on_miss: bool,
+        lease: Option<&dyn DigestLease>,
     ) -> Result<(bool, u64), Error> {
         self.maybe_log_summary();
+        if let Some(lease) = lease {
+            lease.acquire(&digest);
+        }
 
         // Fast path: serve from an existing entry.
         if let Some(size) = self.try_materialize_from_cache(&digest, dest_path).await {
@@ -464,7 +492,7 @@ impl DirectoryCache {
         // held until the end of this function — `forget_construction_lock`
         // only unmaps the Arc; any waiter already cloned it before blocking.
         let result = self
-            .construct_and_materialize(digest, dest_path, protos, prefetch_on_miss)
+            .construct_and_materialize(digest, dest_path, protos, prefetch_on_miss, lease)
             .await;
         self.forget_construction_lock(&digest).await;
         result
@@ -526,6 +554,7 @@ impl DirectoryCache {
         dest_path: &Path,
         protos: Option<&HashMap<DigestInfo, ProtoDirectory>>,
         prefetch_on_miss: bool,
+        lease: Option<&dyn DigestLease>,
     ) -> Result<(bool, u64), Error> {
         // Re-check: another task may have just constructed this digest while
         // we waited on the construction lock. If the entry turns out to be
@@ -567,7 +596,10 @@ impl DirectoryCache {
         let protos = prefetched.as_ref().or(protos);
         let temp_path = self.allocate_scratch_path(TEMP_PREFIX);
         let mut temp_guard = ScratchGuard::new(temp_path.clone());
-        let size = match self.construct_directory(digest, &temp_path, protos).await {
+        let size = match self
+            .construct_directory(digest, &temp_path, protos, lease)
+            .await
+        {
             Ok(size) => size,
             Err(e) => {
                 temp_guard.disarm();
@@ -858,9 +890,13 @@ impl DirectoryCache {
         digest: DigestInfo,
         dest_path: &'a Path,
         protos: Option<&'a HashMap<DigestInfo, ProtoDirectory>>,
+        lease: Option<&'a dyn DigestLease>,
     ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>> {
         Box::pin(async move {
             debug!(?digest, ?dest_path, "Constructing directory");
+            if let Some(lease) = lease {
+                lease.acquire(&digest);
+            }
 
             // Use the prefetched proto when available; otherwise fetch it
             // (permit held only for the fetch). A prefetch-map miss (e.g.
@@ -885,6 +921,11 @@ impl DirectoryCache {
                 if let Some(file_digest) = &file.digest {
                     // size_bytes is non-negative; clamp defensively.
                     total_size += u64::try_from(file_digest.size_bytes).unwrap_or(0);
+                    if let Some(lease) = lease
+                        && let Ok(file_digest) = DigestInfo::try_from(file_digest)
+                    {
+                        lease.acquire(&file_digest);
+                    }
                 }
             }
 
@@ -905,8 +946,14 @@ impl DirectoryCache {
                 }));
             }
             for dir_node in &directory.directories {
+                if let Some(lease) = lease
+                    && let Some(dir_digest) = &dir_node.digest
+                    && let Ok(dir_digest) = DigestInfo::try_from(dir_digest)
+                {
+                    lease.acquire(&dir_digest);
+                }
                 node_futures.push(Box::pin(
-                    self.create_subdirectory(dest_path, dir_node, protos),
+                    self.create_subdirectory(dest_path, dir_node, protos, lease),
                 ));
             }
             for symlink in &directory.symlinks {
@@ -1111,6 +1158,7 @@ impl DirectoryCache {
         parent: &Path,
         dir_node: &DirectoryNode,
         protos: Option<&HashMap<DigestInfo, ProtoDirectory>>,
+        lease: Option<&dyn DigestLease>,
     ) -> Result<u64, Error> {
         let dir_path = parent.join(&dir_node.name);
         let digest =
@@ -1130,7 +1178,7 @@ impl DirectoryCache {
             // through this method, so nested subtrees get their own entries
             // too (leaf-level reuse).
             let (hit, _size) = self
-                .get_or_create_entry(digest, &dir_path, protos, false)
+                .get_or_create_entry(digest, &dir_path, protos, false, lease)
                 .await?;
             let counter = if hit {
                 &self.subtree_hits
@@ -1150,7 +1198,8 @@ impl DirectoryCache {
         }
 
         // Recursively construct subdirectory
-        self.construct_directory(digest, &dir_path, protos).await
+        self.construct_directory(digest, &dir_path, protos, lease)
+            .await
     }
 
     /// Creates a symlink from a `SymlinkNode`

--- a/nativelink-worker/src/local_worker.rs
+++ b/nativelink-worker/src/local_worker.rs
@@ -709,6 +709,7 @@ pub async fn new_local_worker(
             max_cleanup_backoff,
             timeout_handled_externally: config.timeout_handled_externally,
             directory_cache,
+            active_input_leases: config.experimental_active_input_leases,
             #[cfg(target_os = "linux")]
             use_namespaces,
         })?);

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1262,7 +1262,9 @@ pub struct RunningActionImpl {
     action_directory: String,
     work_directory: String,
     action_info: ActionInfo,
-    input_lease: Arc<ActionInputLease>,
+    /// `Some` only when the manager was configured with
+    /// `experimental_active_input_leases`; `None` leaves eviction untouched.
+    input_lease: Option<Arc<ActionInputLease>>,
     timeout: Duration,
     running_actions_manager: Arc<RunningActionsManagerImpl>,
     state: Mutex<RunningActionImplState>,
@@ -1280,11 +1282,13 @@ impl RunningActionImpl {
         running_actions_manager: Arc<RunningActionsManagerImpl>,
     ) -> Self {
         let work_directory = format!("{}/{}", action_directory, "work");
-        let input_lease = ActionInputLease::new(
-            running_actions_manager.cas_store.as_ref(),
-            action_info.command_digest,
-            action_info.input_root_digest,
-        );
+        let input_lease = running_actions_manager.active_input_leases.then(|| {
+            ActionInputLease::new(
+                running_actions_manager.cas_store.as_ref(),
+                action_info.command_digest,
+                action_info.input_root_digest,
+            )
+        });
         let (kill_channel_tx, kill_channel_rx) = oneshot::channel();
         Self {
             operation_id,
@@ -1362,7 +1366,7 @@ impl RunningActionImpl {
                         filesystem_store_pin,
                         &self.action_info.input_root_digest,
                         &self.work_directory,
-                        Some(self.input_lease.clone()),
+                        self.input_lease.clone(),
                     ))
                     .await
             })
@@ -2333,11 +2337,12 @@ impl Drop for RunningActionImpl {
                         .cleanup_action(&self.operation_id),
                 );
             }
-            let input_lease = self.input_lease.clone();
-            background_spawn!(
-                "running_action_impl_release_input_lease",
-                input_lease.release()
-            );
+            if let Some(input_lease) = self.input_lease.clone() {
+                background_spawn!(
+                    "running_action_impl_release_input_lease",
+                    input_lease.release()
+                );
+            }
             return;
         }
         let operation_id = self.operation_id.clone();
@@ -2351,7 +2356,9 @@ impl Drop for RunningActionImpl {
         background_spawn!("running_action_impl_drop", async move {
             let cleanup_result =
                 do_cleanup(&running_actions_manager, &operation_id, &action_directory).await;
-            input_lease.release().await;
+            if let Some(input_lease) = input_lease {
+                input_lease.release().await;
+            }
             if let Err(err) = cleanup_result {
                 error!(
                     %operation_id,
@@ -2463,7 +2470,9 @@ impl RunningAction for RunningActionImpl {
                 // lease is released. If this future is cancelled while the
                 // release task is finishing, Drop still observes a completed
                 // cleanup and cannot strand the action in the manager.
-                self.input_lease.clone().release().await;
+                if let Some(input_lease) = self.input_lease.clone() {
+                    input_lease.release().await;
+                }
                 result.map(move |()| self)
             })
             .await;
@@ -2819,6 +2828,11 @@ pub struct RunningActionsManagerArgs<'a> {
     pub max_cleanup_backoff: Duration,
     pub timeout_handled_externally: bool,
     pub directory_cache: Option<Arc<crate::directory_cache::DirectoryCache>>,
+    /// When true, every digest in an active action's input Merkle closure is
+    /// leased in the locally eviction-managed CAS tiers until the action's
+    /// cleanup completes. While leases are held, those tiers may temporarily
+    /// exceed their configured `max_bytes` / `max_count` eviction limits.
+    pub active_input_leases: bool,
     #[cfg(target_os = "linux")]
     pub use_namespaces: UseNamespaces,
 }
@@ -2872,6 +2886,9 @@ pub struct RunningActionsManagerImpl {
     /// Optional directory cache for improving performance by caching reconstructed
     /// input directories and using hardlinks.
     directory_cache: Option<Arc<crate::directory_cache::DirectoryCache>>,
+    /// Whether active action inputs are leased against eviction in the local
+    /// CAS tiers (opt-in via `experimental_active_input_leases`).
+    active_input_leases: bool,
     persistent_worker_pool: PersistentWorkerPool,
 }
 
@@ -2917,6 +2934,7 @@ impl RunningActionsManagerImpl {
             max_cleanup_backoff: args.max_cleanup_backoff,
             cleanup_complete_notify: Arc::new(Notify::new()),
             directory_cache: args.directory_cache,
+            active_input_leases: args.active_input_leases,
             persistent_worker_pool: PersistentWorkerPool::default(),
             #[cfg(target_os = "linux")]
             use_namespaces: args.use_namespaces,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -333,16 +333,23 @@ impl ActionInputLease {
         Some((self.filesystem_stores.clone(), digests))
     }
 
+    fn spawn_release(&self) -> Option<tokio::task::JoinHandle<()>> {
+        let (filesystem_stores, digests) = self.take_release_work()?;
+        Some(background_spawn!(
+            "action_input_lease_release",
+            async move {
+                release_filesystem_stores(filesystem_stores, digests).await;
+            }
+        ))
+    }
+
     async fn release(&self) {
-        let Some((filesystem_stores, digests)) = self.take_release_work() else {
+        let Some(handle) = self.spawn_release() else {
             return;
         };
         // Detach the actual release before awaiting it so cancellation of the
         // action cleanup future cannot strand leases in a later filesystem
         // tier.
-        let handle = background_spawn!("action_input_lease_release", async move {
-            release_filesystem_stores(filesystem_stores, digests).await;
-        });
         let _result = handle.await;
     }
 }
@@ -355,12 +362,7 @@ impl crate::directory_cache::DigestLease for ActionInputLease {
 
 impl Drop for ActionInputLease {
     fn drop(&mut self) {
-        let Some((filesystem_stores, digests)) = self.take_release_work() else {
-            return;
-        };
-        background_spawn!("action_input_lease_drop", async move {
-            release_filesystem_stores(filesystem_stores, digests).await;
-        });
+        drop(self.spawn_release());
     }
 }
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -370,7 +370,7 @@ async fn release_filesystem_stores(
 ) {
     join_all(
         filesystem_stores
-            .into_iter()
+            .iter()
             .map(|filesystem_store| filesystem_store.release_digests(&digests)),
     )
     .await;

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -302,7 +302,7 @@ struct ActionInputLease {
 
 impl ActionInputLease {
     fn new(
-        cas_store: Arc<FastSlowStore>,
+        cas_store: &FastSlowStore,
         command_digest: DigestInfo,
         input_root_digest: DigestInfo,
     ) -> Arc<Self> {
@@ -332,11 +332,11 @@ impl ActionInputLease {
         if self.released.swap(true, Ordering::AcqRel) {
             return;
         }
-        let digests = std::mem::take(&mut *self.digests.lock());
-        for digest in digests {
-            for filesystem_store in &self.filesystem_stores {
-                filesystem_store.release_digest(&digest).await;
-            }
+        let digests: Vec<_> = core::mem::take(&mut *self.digests.lock())
+            .into_iter()
+            .collect();
+        for filesystem_store in &self.filesystem_stores {
+            filesystem_store.release_digests(&digests).await;
         }
     }
 }
@@ -347,12 +347,12 @@ impl Drop for ActionInputLease {
             return;
         }
         let filesystem_stores = self.filesystem_stores.clone();
-        let digests = std::mem::take(&mut *self.digests.lock());
+        let digests: Vec<_> = core::mem::take(&mut *self.digests.lock())
+            .into_iter()
+            .collect();
         background_spawn!("action_input_lease_drop", async move {
-            for digest in digests {
-                for filesystem_store in &filesystem_stores {
-                    filesystem_store.release_digest(&digest).await;
-                }
+            for filesystem_store in &filesystem_stores {
+                filesystem_store.release_digests(&digests).await;
             }
         });
     }
@@ -556,6 +556,13 @@ fn download_to_directory_with_lease<'a>(
                 .try_into()
                 .err_tip(|| "In Directory::file::digest")?;
             let new_directory_path = format!("{}/{}", current_directory, directory.name);
+            if let Some(input_lease) = &input_lease {
+                // Reserve queued child directories before their futures are
+                // polled. Without this, a large parent can leave later
+                // directory digests exposed to slow-tier eviction while the
+                // first batch of children is being materialized.
+                input_lease.acquire(&digest);
+            }
             let input_lease = input_lease.clone();
             futures.push(
                 async move {
@@ -1182,7 +1189,7 @@ impl RunningActionImpl {
     ) -> Self {
         let work_directory = format!("{}/{}", action_directory, "work");
         let input_lease = ActionInputLease::new(
-            running_actions_manager.cas_store.clone(),
+            running_actions_manager.cas_store.as_ref(),
             action_info.command_digest,
             action_info.input_root_digest,
         );

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -291,10 +291,10 @@ const DOWNLOAD_TO_DIRECTORY_CONCURRENCY: usize = 64;
 /// A lease is registered before a digest is populated. This is important for
 /// blobs that are not yet in the fast tier: reserving the key first prevents
 /// the insertion that follows from immediately evicting the blob under pressure.
-/// Both filesystem tiers of the worker's `FastSlowStore` are leased when
-/// present, so a slow CAS eviction cannot remove a queued input before the
-/// worker reaches it. The reference count also lets concurrent actions share a
-/// digest safely.
+/// Every directly discoverable filesystem tier of the worker's
+/// `FastSlowStore` is leased when present (including a `RefStore` target).
+/// Transforming wrappers remain opaque by design. The reference count lets
+/// concurrent actions share a digest safely.
 #[derive(Debug)]
 struct ActionInputLease {
     filesystem_stores: Vec<Arc<FilesystemStore>>,

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -2385,9 +2385,13 @@ impl RunningAction for RunningActionImpl {
                     &self.action_directory,
                 )
                 .await;
-                self.input_lease.release().await;
                 self.has_manager_entry.store(false, Ordering::Release);
                 self.did_cleanup.store(true, Ordering::Release);
+                // The work directory and manager entry are gone before the
+                // lease is released. If this future is cancelled while the
+                // release task is finishing, Drop still observes a completed
+                // cleanup and cannot strand the action in the manager.
+                self.input_lease.release().await;
                 result.map(move |()| self)
             })
             .await;

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -283,6 +283,81 @@ fn persistent_worker_request_arguments(argv: &[String]) -> Vec<String> {
 /// overhead.
 const DOWNLOAD_TO_DIRECTORY_CONCURRENCY: usize = 64;
 
+/// Keeps every digest used by an action present in locally eviction-managed
+/// CAS tiers.
+///
+/// A lease is registered before a digest is populated. This is important for
+/// blobs that are not yet in the fast tier: reserving the key first prevents
+/// the insertion that follows from immediately evicting the blob under pressure.
+/// Both filesystem tiers of the worker's `FastSlowStore` are leased when
+/// present, so a slow CAS eviction cannot remove a queued input before the
+/// worker reaches it. The reference count also lets concurrent actions share a
+/// digest safely.
+#[derive(Debug)]
+struct ActionInputLease {
+    filesystem_stores: Vec<Arc<FilesystemStore>>,
+    digests: Mutex<HashSet<DigestInfo>>,
+    released: AtomicBool,
+}
+
+impl ActionInputLease {
+    fn new(
+        cas_store: Arc<FastSlowStore>,
+        command_digest: DigestInfo,
+        input_root_digest: DigestInfo,
+    ) -> Arc<Self> {
+        let lease = Arc::new(Self {
+            filesystem_stores: cas_store.get_filesystem_stores(),
+            digests: Mutex::new(HashSet::new()),
+            released: AtomicBool::new(false),
+        });
+        lease.acquire(&command_digest);
+        lease.acquire(&input_root_digest);
+        lease
+    }
+
+    fn acquire(&self, digest: &DigestInfo) {
+        let mut digests = self.digests.lock();
+        if self.released.load(Ordering::Acquire) {
+            return;
+        }
+        if digests.insert(*digest) {
+            for filesystem_store in &self.filesystem_stores {
+                filesystem_store.lease_digest(digest);
+            }
+        }
+    }
+
+    async fn release(&self) {
+        if self.released.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let digests = std::mem::take(&mut *self.digests.lock());
+        for digest in digests {
+            for filesystem_store in &self.filesystem_stores {
+                filesystem_store.release_digest(&digest).await;
+            }
+        }
+    }
+}
+
+impl Drop for ActionInputLease {
+    fn drop(&mut self) {
+        if self.released.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let filesystem_stores = self.filesystem_stores.clone();
+        let digests = std::mem::take(&mut *self.digests.lock());
+        background_spawn!("action_input_lease_drop", async move {
+            for digest in digests {
+                for filesystem_store in &filesystem_stores {
+                    filesystem_store.release_digest(&digest).await;
+                }
+            }
+        });
+    }
+}
+
 /// Aggressively download the digests of files and make a local folder from it. This function
 /// gates each directory level to at most `DOWNLOAD_TO_DIRECTORY_CONCURRENCY`
 /// concurrent in-flight materialization futures.
@@ -299,7 +374,20 @@ pub fn download_to_directory<'a>(
     digest: &'a DigestInfo,
     current_directory: &'a str,
 ) -> BoxFuture<'a, Result<(), Error>> {
+    download_to_directory_with_lease(cas_store, filesystem_store, digest, current_directory, None)
+}
+
+fn download_to_directory_with_lease<'a>(
+    cas_store: &'a FastSlowStore,
+    filesystem_store: Pin<&'a FilesystemStore>,
+    digest: &'a DigestInfo,
+    current_directory: &'a str,
+    input_lease: Option<Arc<ActionInputLease>>,
+) -> BoxFuture<'a, Result<(), Error>> {
     async move {
+        if let Some(input_lease) = &input_lease {
+            input_lease.acquire(digest);
+        }
         let directory = get_and_decode_digest::<ProtoDirectory>(cas_store, digest.into())
             .await
             .err_tip(|| "Converting digest to Directory")?;
@@ -317,6 +405,9 @@ pub fn download_to_directory<'a>(
                 Some(properties) => (properties.mtime, properties.unix_mode),
                 None => (None, None),
             };
+            if let Some(input_lease) = &input_lease {
+                input_lease.acquire(&digest);
+            }
             futures.push(
                 cas_store
                     .populate_fast_store(digest.into())
@@ -465,16 +556,18 @@ pub fn download_to_directory<'a>(
                 .try_into()
                 .err_tip(|| "In Directory::file::digest")?;
             let new_directory_path = format!("{}/{}", current_directory, directory.name);
+            let input_lease = input_lease.clone();
             futures.push(
                 async move {
                     fs::create_dir(&new_directory_path)
                         .await
                         .err_tip(|| format!("Could not create directory {new_directory_path}"))?;
-                    download_to_directory(
+                    download_to_directory_with_lease(
                         cas_store,
                         filesystem_store,
                         &digest,
                         &new_directory_path,
+                        input_lease,
                     )
                     .await
                     .err_tip(|| format!("in download_to_directory : {new_directory_path}"))?;
@@ -534,8 +627,34 @@ pub async fn prepare_action_inputs(
     digest: &DigestInfo,
     work_directory: &str,
 ) -> Result<(), Error> {
+    prepare_action_inputs_with_lease(
+        directory_cache,
+        cas_store,
+        filesystem_store,
+        digest,
+        work_directory,
+        None,
+    )
+    .await
+}
+
+async fn prepare_action_inputs_with_lease(
+    directory_cache: &Option<Arc<crate::directory_cache::DirectoryCache>>,
+    cas_store: &FastSlowStore,
+    filesystem_store: Pin<&FilesystemStore>,
+    digest: &DigestInfo,
+    work_directory: &str,
+    input_lease: Option<Arc<ActionInputLease>>,
+) -> Result<(), Error> {
     // Try cache first if available
-    if let Some(cache) = directory_cache {
+    //
+    // A directory-cache hit does not visit the individual CAS digests, so an
+    // action input lease cannot protect the underlying fast-tier entries on
+    // that path. Use the normal traversal while a lease is active; it
+    // reserves each directory and file digest before fetching it.
+    if input_lease.is_none()
+        && let Some(cache) = directory_cache
+    {
         // `clonefile(2)` and `hardlink_directory_tree` both require the
         // destination to not exist. Remove the empty directory the caller
         // pre-created; without this the cache fails its precondition on every
@@ -584,7 +703,14 @@ pub async fn prepare_action_inputs(
     }
 
     // Traditional path (cache disabled or failed)
-    download_to_directory(cas_store, filesystem_store, digest, work_directory).await
+    download_to_directory_with_lease(
+        cas_store,
+        filesystem_store,
+        digest,
+        work_directory,
+        input_lease,
+    )
+    .await
 }
 
 #[cfg(target_family = "windows")]
@@ -1037,6 +1163,7 @@ pub struct RunningActionImpl {
     action_directory: String,
     work_directory: String,
     action_info: ActionInfo,
+    input_lease: Arc<ActionInputLease>,
     timeout: Duration,
     running_actions_manager: Arc<RunningActionsManagerImpl>,
     state: Mutex<RunningActionImplState>,
@@ -1054,12 +1181,18 @@ impl RunningActionImpl {
         running_actions_manager: Arc<RunningActionsManagerImpl>,
     ) -> Self {
         let work_directory = format!("{}/{}", action_directory, "work");
+        let input_lease = ActionInputLease::new(
+            running_actions_manager.cas_store.clone(),
+            action_info.command_digest,
+            action_info.input_root_digest,
+        );
         let (kill_channel_tx, kill_channel_rx) = oneshot::channel();
         Self {
             operation_id,
             action_directory,
             work_directory,
             action_info,
+            input_lease,
             timeout,
             running_actions_manager,
             state: Mutex::new(RunningActionImplState {
@@ -1122,12 +1255,13 @@ impl RunningActionImpl {
                 // Use directory cache if available for better performance.
                 self.metrics()
                     .download_to_directory
-                    .wrap(prepare_action_inputs(
+                    .wrap(prepare_action_inputs_with_lease(
                         &self.running_actions_manager.directory_cache,
                         &self.running_actions_manager.cas_store,
                         filesystem_store_pin,
                         &self.action_info.input_root_digest,
                         &self.work_directory,
+                        Some(self.input_lease.clone()),
                     ))
                     .await
             })
@@ -2092,6 +2226,10 @@ impl Drop for RunningActionImpl {
                         .cleanup_action(&self.operation_id),
                 );
             }
+            let input_lease = self.input_lease.clone();
+            background_spawn!("running_action_impl_release_input_lease", async move {
+                input_lease.release().await;
+            });
             return;
         }
         let operation_id = self.operation_id.clone();
@@ -2101,18 +2239,19 @@ impl Drop for RunningActionImpl {
         );
         let running_actions_manager = self.running_actions_manager.clone();
         let action_directory = self.action_directory.clone();
+        let input_lease = self.input_lease.clone();
         background_spawn!("running_action_impl_drop", async move {
-            let Err(err) =
-                do_cleanup(&running_actions_manager, &operation_id, &action_directory).await
-            else {
-                return;
-            };
-            error!(
-                %operation_id,
-                ?action_directory,
-                ?err,
-                "Error cleaning up action"
-            );
+            let cleanup_result =
+                do_cleanup(&running_actions_manager, &operation_id, &action_directory).await;
+            input_lease.release().await;
+            if let Err(err) = cleanup_result {
+                error!(
+                    %operation_id,
+                    ?action_directory,
+                    ?err,
+                    "Error cleaning up action"
+                );
+            }
         });
     }
 }
@@ -2210,6 +2349,7 @@ impl RunningAction for RunningActionImpl {
                     &self.action_directory,
                 )
                 .await;
+                self.input_lease.release().await;
                 self.has_manager_entry.store(false, Ordering::Release);
                 self.did_cleanup.store(true, Ordering::Release);
                 result.map(move |()| self)

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -35,7 +35,9 @@ use std::time::SystemTime;
 use bytes::{Bytes, BytesMut};
 use filetime::{FileTime, set_file_mtime};
 use formatx::Template;
-use futures::future::{BoxFuture, Future, FutureExt, TryFutureExt, try_join, try_join_all};
+use futures::future::{
+    BoxFuture, Future, FutureExt, TryFutureExt, join_all, try_join, try_join_all,
+};
 use futures::stream::{FuturesUnordered, StreamExt, TryStreamExt};
 use nativelink_config::cas_server::{
     EnvironmentSource, UploadActionResultConfig, UploadCacheResultsStrategy,
@@ -296,8 +298,7 @@ const DOWNLOAD_TO_DIRECTORY_CONCURRENCY: usize = 64;
 #[derive(Debug)]
 struct ActionInputLease {
     filesystem_stores: Vec<Arc<FilesystemStore>>,
-    digests: Mutex<HashSet<DigestInfo>>,
-    released: AtomicBool,
+    digests: Mutex<Option<HashSet<DigestInfo>>>,
 }
 
 impl ActionInputLease {
@@ -308,8 +309,7 @@ impl ActionInputLease {
     ) -> Arc<Self> {
         let lease = Arc::new(Self {
             filesystem_stores: cas_store.get_filesystem_stores(),
-            digests: Mutex::new(HashSet::new()),
-            released: AtomicBool::new(false),
+            digests: Mutex::new(Some(HashSet::new())),
         });
         lease.acquire(&command_digest);
         lease.acquire(&input_root_digest);
@@ -318,9 +318,9 @@ impl ActionInputLease {
 
     fn acquire(&self, digest: &DigestInfo) {
         let mut digests = self.digests.lock();
-        if self.released.load(Ordering::Acquire) {
+        let Some(digests) = digests.as_mut() else {
             return;
-        }
+        };
         if digests.insert(*digest) {
             for filesystem_store in &self.filesystem_stores {
                 filesystem_store.lease_digest(digest);
@@ -329,12 +329,7 @@ impl ActionInputLease {
     }
 
     fn take_release_work(&self) -> Option<(Vec<Arc<FilesystemStore>>, Vec<DigestInfo>)> {
-        if self.released.swap(true, Ordering::AcqRel) {
-            return None;
-        }
-        let digests = core::mem::take(&mut *self.digests.lock())
-            .into_iter()
-            .collect();
+        let digests = self.digests.lock().take()?.into_iter().collect();
         Some((self.filesystem_stores.clone(), digests))
     }
 
@@ -346,9 +341,15 @@ impl ActionInputLease {
         // action cleanup future cannot strand leases in a later filesystem
         // tier.
         let handle = background_spawn!("action_input_lease_release", async move {
-            release_filesystem_stores(filesystem_stores, &digests).await;
+            release_filesystem_stores(filesystem_stores, digests).await;
         });
         let _result = handle.await;
+    }
+}
+
+impl crate::directory_cache::DigestLease for ActionInputLease {
+    fn acquire(&self, digest: &DigestInfo) {
+        ActionInputLease::acquire(self, digest);
     }
 }
 
@@ -358,18 +359,21 @@ impl Drop for ActionInputLease {
             return;
         };
         background_spawn!("action_input_lease_drop", async move {
-            release_filesystem_stores(filesystem_stores, &digests).await;
+            release_filesystem_stores(filesystem_stores, digests).await;
         });
     }
 }
 
 async fn release_filesystem_stores(
     filesystem_stores: Vec<Arc<FilesystemStore>>,
-    digests: &[DigestInfo],
+    digests: Vec<DigestInfo>,
 ) {
-    for filesystem_store in &filesystem_stores {
-        filesystem_store.release_digests(digests).await;
-    }
+    join_all(
+        filesystem_stores
+            .iter()
+            .map(|filesystem_store| filesystem_store.release_digests(&digests)),
+    )
+    .await;
 }
 
 /// Aggressively download the digests of files and make a local folder from it. This function
@@ -667,15 +671,12 @@ async fn prepare_action_inputs_with_lease(
     work_directory: &str,
     input_lease: Option<Arc<ActionInputLease>>,
 ) -> Result<(), Error> {
-    // Try cache first if available
-    //
-    // A directory-cache hit does not visit the individual CAS digests, so an
-    // action input lease cannot protect the underlying fast-tier entries on
-    // that path. Use the normal traversal while a lease is active; it
-    // reserves each directory and file digest before fetching it.
-    if input_lease.is_none()
-        && let Some(cache) = directory_cache
-    {
+    // Try cache first if available. Cache hits are safe while an action lease
+    // is active because the directory cache pins its own materialized tree
+    // across the hardlink operation. On a miss, pass the action lease into
+    // cache construction so every CAS digest is reserved before it is
+    // fetched/populated.
+    if let Some(cache) = directory_cache {
         // `clonefile(2)` and `hardlink_directory_tree` both require the
         // destination to not exist. Remove the empty directory the caller
         // pre-created; without this the cache fails its precondition on every
@@ -683,10 +684,20 @@ async fn prepare_action_inputs_with_lease(
         fs::remove_dir(work_directory)
             .await
             .err_tip(|| format!("Failed to clear pre-created work directory {work_directory}"))?;
-        match cache
-            .get_or_create(*digest, Path::new(work_directory))
-            .await
-        {
+        let cache_result = if let Some(input_lease) = &input_lease {
+            cache
+                .get_or_create_with_lease(
+                    *digest,
+                    Path::new(work_directory),
+                    Some(input_lease.as_ref()),
+                )
+                .await
+        } else {
+            cache
+                .get_or_create(*digest, Path::new(work_directory))
+                .await
+        };
+        match cache_result {
             Ok(cache_hit) => {
                 // The materialized tree is already usable. The directory
                 // cache locks each entry down with `set_readonly_recursive`,
@@ -1226,8 +1237,10 @@ impl RunningActionImpl {
                 execution_metadata,
                 error: None,
             }),
-            // Always need to ensure that we're removed from the manager on Drop.
-            has_manager_entry: AtomicBool::new(true),
+            // Set to true only after the action is inserted into the manager.
+            // The constructor can fail the operation-id uniqueness check
+            // immediately after this object is created.
+            has_manager_entry: AtomicBool::new(false),
             // Only needs to be cleaned up after a prepare_action call, set there.
             did_cleanup: AtomicBool::new(true),
         }
@@ -2857,6 +2870,20 @@ impl RunningActionsManagerImpl {
             };
 
             if !should_wait {
+                let action_is_running = self
+                    .running_actions
+                    .lock()
+                    .get(operation_id)
+                    .and_then(Weak::upgrade)
+                    .is_some();
+                if action_is_running {
+                    return Err(make_err!(
+                        Code::AlreadyExists,
+                        "Action with operation_id {} is already running",
+                        operation_id
+                    ));
+                }
+
                 let dir_path =
                     PathBuf::from(&self.root_action_directory).join(operation_id.to_string());
 
@@ -3097,6 +3124,9 @@ impl RunningActionsManager for RunningActionsManagerImpl {
                             ));
                     }
                     running_actions.insert(operation_id, Arc::downgrade(&running_action));
+                    running_action
+                        .has_manager_entry
+                        .store(true, Ordering::Release);
                 }
                 Ok(running_action)
             })

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -311,12 +311,12 @@ impl ActionInputLease {
             filesystem_stores: cas_store.get_filesystem_stores(),
             digests: Mutex::new(Some(HashSet::new())),
         });
-        lease.acquire(&command_digest);
-        lease.acquire(&input_root_digest);
+        lease.lease_digest(&command_digest);
+        lease.lease_digest(&input_root_digest);
         lease
     }
 
-    fn acquire(&self, digest: &DigestInfo) {
+    fn lease_digest(&self, digest: &DigestInfo) {
         let mut digests = self.digests.lock();
         let Some(digests) = digests.as_mut() else {
             return;
@@ -356,7 +356,7 @@ impl ActionInputLease {
 
 impl crate::directory_cache::DigestLease for ActionInputLease {
     fn acquire(&self, digest: &DigestInfo) {
-        Self::acquire(self, digest);
+        self.lease_digest(digest);
     }
 }
 
@@ -406,7 +406,7 @@ fn download_to_directory_with_lease<'a>(
 ) -> BoxFuture<'a, Result<(), Error>> {
     async move {
         if let Some(input_lease) = &input_lease {
-            input_lease.acquire(digest);
+            input_lease.lease_digest(digest);
         }
         let directory = get_and_decode_digest::<ProtoDirectory>(cas_store, digest.into())
             .await
@@ -426,7 +426,7 @@ fn download_to_directory_with_lease<'a>(
                 None => (None, None),
             };
             if let Some(input_lease) = &input_lease {
-                input_lease.acquire(&digest);
+                input_lease.lease_digest(&digest);
             }
             futures.push(
                 cas_store
@@ -581,7 +581,7 @@ fn download_to_directory_with_lease<'a>(
                 // polled. Without this, a large parent can leave later
                 // directory digests exposed to slow-tier eviction while the
                 // first batch of children is being materialized.
-                input_lease.acquire(&digest);
+                input_lease.lease_digest(&digest);
             }
             let input_lease = input_lease.clone();
             futures.push(

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -328,33 +328,47 @@ impl ActionInputLease {
         }
     }
 
-    async fn release(&self) {
+    fn take_release_work(&self) -> Option<(Vec<Arc<FilesystemStore>>, Vec<DigestInfo>)> {
         if self.released.swap(true, Ordering::AcqRel) {
-            return;
+            return None;
         }
-        let digests: Vec<_> = core::mem::take(&mut *self.digests.lock())
+        let digests = core::mem::take(&mut *self.digests.lock())
             .into_iter()
             .collect();
-        for filesystem_store in &self.filesystem_stores {
-            filesystem_store.release_digests(&digests).await;
-        }
+        Some((self.filesystem_stores.clone(), digests))
+    }
+
+    async fn release(&self) {
+        let Some((filesystem_stores, digests)) = self.take_release_work() else {
+            return;
+        };
+        // Detach the actual release before awaiting it so cancellation of the
+        // action cleanup future cannot strand leases in a later filesystem
+        // tier.
+        let handle = background_spawn!("action_input_lease_release", async move {
+            release_filesystem_stores(filesystem_stores, &digests).await;
+        });
+        let _result = handle.await;
     }
 }
 
 impl Drop for ActionInputLease {
     fn drop(&mut self) {
-        if self.released.swap(true, Ordering::AcqRel) {
+        let Some((filesystem_stores, digests)) = self.take_release_work() else {
             return;
-        }
-        let filesystem_stores = self.filesystem_stores.clone();
-        let digests: Vec<_> = core::mem::take(&mut *self.digests.lock())
-            .into_iter()
-            .collect();
+        };
         background_spawn!("action_input_lease_drop", async move {
-            for filesystem_store in &filesystem_stores {
-                filesystem_store.release_digests(&digests).await;
-            }
+            release_filesystem_stores(filesystem_stores, &digests).await;
         });
+    }
+}
+
+async fn release_filesystem_stores(
+    filesystem_stores: Vec<Arc<FilesystemStore>>,
+    digests: &[DigestInfo],
+) {
+    for filesystem_store in &filesystem_stores {
+        filesystem_store.release_digests(digests).await;
     }
 }
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -349,7 +349,7 @@ impl ActionInputLease {
 
 impl crate::directory_cache::DigestLease for ActionInputLease {
     fn acquire(&self, digest: &DigestInfo) {
-        ActionInputLease::acquire(self, digest);
+        Self::acquire(self, digest);
     }
 }
 

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -337,13 +337,11 @@ impl ActionInputLease {
         let (filesystem_stores, digests) = self.take_release_work()?;
         Some(background_spawn!(
             "action_input_lease_release",
-            async move {
-                release_filesystem_stores(filesystem_stores, digests).await;
-            }
+            release_filesystem_stores(filesystem_stores, digests)
         ))
     }
 
-    async fn release(&self) {
+    async fn release(self: Arc<Self>) {
         let Some(handle) = self.spawn_release() else {
             return;
         };
@@ -372,7 +370,7 @@ async fn release_filesystem_stores(
 ) {
     join_all(
         filesystem_stores
-            .iter()
+            .into_iter()
             .map(|filesystem_store| filesystem_store.release_digests(&digests)),
     )
     .await;
@@ -2263,9 +2261,10 @@ impl Drop for RunningActionImpl {
                 );
             }
             let input_lease = self.input_lease.clone();
-            background_spawn!("running_action_impl_release_input_lease", async move {
-                input_lease.release().await;
-            });
+            background_spawn!(
+                "running_action_impl_release_input_lease",
+                input_lease.release()
+            );
             return;
         }
         let operation_id = self.operation_id.clone();
@@ -2391,7 +2390,7 @@ impl RunningAction for RunningActionImpl {
                 // lease is released. If this future is cancelled while the
                 // release task is finishing, Drop still observes a completed
                 // cleanup and cannot strand the action in the manager.
-                self.input_lease.release().await;
+                self.input_lease.clone().release().await;
                 result.map(move |()| self)
             })
             .await;

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -1736,7 +1736,7 @@ mod tests {
             b"hello-from-outside".len()
         );
         // Verify the blob actually landed in CAS by re-reading it.
-        let key: nativelink_util::store_trait::StoreKey<'_> = uploaded.digest.into();
+        let key: StoreKey<'_> = uploaded.digest.into();
         let blob = slow_store.as_ref().get_part_unchunked(key, 0, None).await?;
         assert_eq!(blob.as_ref(), b"hello-from-outside");
         Ok(())
@@ -1898,7 +1898,7 @@ mod tests {
             .clone()
             .expect("inner.txt must have a digest")
             .try_into()?;
-        let key: nativelink_util::store_trait::StoreKey<'_> = inner_digest.into();
+        let key: StoreKey<'_> = inner_digest.into();
         let blob = slow_store.as_ref().get_part_unchunked(key, 0, None).await?;
         assert_eq!(blob.as_ref(), b"inner-payload");
         Ok(())

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -379,9 +379,9 @@ mod tests {
             .await?;
         assert!(
             fast_store
-                .get_evicting_map()
-                .size_for_key(&StoreKey::Digest(file_digest))
-                .await
+                .as_ref()
+                .has(StoreKey::Digest(file_digest))
+                .await?
                 .is_some(),
             "an active action input must survive fast-tier pressure",
         );
@@ -416,9 +416,9 @@ mod tests {
             .await?;
         assert_eq!(
             fast_store
-                .get_evicting_map()
-                .size_for_key(&StoreKey::Digest(file_digest))
-                .await,
+                .as_ref()
+                .has(StoreKey::Digest(file_digest))
+                .await?,
             None,
             "released action inputs must become ordinary eviction candidates",
         );

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -37,7 +37,7 @@ mod tests {
         EnvironmentSource, UploadActionResultConfig, UploadCacheResultsStrategy,
     };
     use nativelink_config::stores::{
-        FastSlowSpec, FilesystemSpec, MemorySpec, StoreDirection, StoreSpec,
+        EvictionPolicy, FastSlowSpec, FilesystemSpec, MemorySpec, StoreDirection, StoreSpec,
     };
     use nativelink_error::{Code, Error, ResultExt, make_input_err};
     use nativelink_macro::nativelink_test;
@@ -67,7 +67,8 @@ mod tests {
     };
     use nativelink_util::common::{DigestInfo, fs, make_temp_path};
     use nativelink_util::digest_hasher::{DigestHasher, DigestHasherFunc};
-    use nativelink_util::store_trait::{Store, StoreLike};
+    use nativelink_util::store_trait::{Store, StoreKey, StoreLike};
+    use nativelink_worker::directory_cache::{DirectoryCache, DirectoryCacheConfig};
     #[cfg(target_os = "linux")]
     use nativelink_worker::namespace_utils;
     use nativelink_worker::running_actions_manager::{
@@ -103,10 +104,24 @@ mod tests {
         ),
         Error,
     > {
+        setup_stores_with_eviction_policy(None).await
+    }
+
+    async fn setup_stores_with_eviction_policy(
+        eviction_policy: Option<EvictionPolicy>,
+    ) -> Result<
+        (
+            Arc<FilesystemStore>,
+            Arc<MemoryStore>,
+            Arc<FastSlowStore>,
+            Arc<MemoryStore>,
+        ),
+        Error,
+    > {
         let fast_config = FilesystemSpec {
             content_path: make_temp_path("content_path"),
             temp_path: make_temp_path("temp_path"),
-            eviction_policy: None,
+            eviction_policy,
             ..Default::default()
         };
         let slow_config = MemorySpec::default();
@@ -255,6 +270,160 @@ mod tests {
                 FILE2_MTIME
             );
         }
+        Ok(())
+    }
+
+    #[nativelink_test]
+    async fn active_action_input_lease_survives_fast_store_pressure()
+    -> Result<(), Box<dyn core::error::Error>> {
+        const FILE_CONTENT: &[u8] = b"leased input";
+        const PRESSURE_CONTENT: &[u8] = b"pressure";
+
+        let (fast_store, slow_store, cas_store, _ac_store) =
+            setup_stores_with_eviction_policy(Some(EvictionPolicy {
+                max_count: 1,
+                ..Default::default()
+            }))
+            .await?;
+
+        let file_digest = DigestInfo::new([7u8; 32], FILE_CONTENT.len() as u64);
+        slow_store
+            .as_ref()
+            .update_oneshot(file_digest, FILE_CONTENT.into())
+            .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                files: vec![FileNode {
+                    name: "input.txt".to_string(),
+                    digest: Some(file_digest.into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let command_digest = serialize_and_upload_message(
+            &Command::default(),
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action_digest = serialize_and_upload_message(
+            &Action {
+                command_digest: Some(command_digest.into()),
+                input_root_digest: Some(input_root_digest.into()),
+                ..Default::default()
+            },
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let operation_id = OperationId::default().to_string();
+
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
+        let directory_cache = Arc::new(
+            DirectoryCache::new(
+                DirectoryCacheConfig {
+                    cache_root: make_temp_path("directory_cache").into(),
+                    ..Default::default()
+                },
+                cas_store.clone(),
+            )
+            .await?,
+        );
+        let running_actions_manager =
+            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+                root_action_directory,
+                execution_configuration: ExecutionConfiguration::default(),
+                cas_store: cas_store.clone(),
+                ac_store: None,
+                historical_store: Store::new(cas_store.clone()),
+                upload_action_result_config: &UploadActionResultConfig {
+                    upload_ac_results_strategy: UploadCacheResultsStrategy::Never,
+                    ..Default::default()
+                },
+                max_action_timeout: Duration::from_secs(600),
+                max_upload_timeout: Duration::from_secs(DEFAULT_MAX_UPLOAD_TIMEOUT),
+                max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
+                max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
+                timeout_handled_externally: false,
+                directory_cache: Some(directory_cache),
+                #[cfg(target_os = "linux")]
+                use_namespaces: use_namespaces(),
+            })?);
+
+        let action = running_actions_manager
+            .create_and_add_action(
+                "test-worker".to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    operation_id: operation_id.clone(),
+                    ..Default::default()
+                },
+            )
+            .await?
+            .prepare_action()
+            .await?;
+
+        let pressure_digest = DigestInfo::new([8u8; 32], PRESSURE_CONTENT.len() as u64);
+        fast_store
+            .as_ref()
+            .update_oneshot(pressure_digest, PRESSURE_CONTENT.into())
+            .await?;
+        assert!(
+            fast_store
+                .as_ref()
+                .has(StoreKey::Digest(file_digest))
+                .await?
+                .is_some(),
+            "an active action input must survive fast-tier pressure",
+        );
+
+        let duplicate_result = running_actions_manager
+            .create_and_add_action(
+                "test-worker".to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    operation_id,
+                    ..Default::default()
+                },
+            )
+            .await;
+        let duplicate_error =
+            duplicate_result.expect_err("a duplicate operation id must be rejected");
+        assert_eq!(duplicate_error.code, Code::AlreadyExists);
+        assert!(
+            fs::metadata(action.get_work_directory()).await.is_ok(),
+            "a duplicate operation must not remove the active action directory",
+        );
+
+        let action = action.cleanup().await?;
+        let second_pressure_digest = DigestInfo::new([9u8; 32], PRESSURE_CONTENT.len() as u64);
+        fast_store
+            .as_ref()
+            .update_oneshot(second_pressure_digest, PRESSURE_CONTENT.into())
+            .await?;
+        assert_eq!(
+            fast_store
+                .as_ref()
+                .has(StoreKey::Digest(file_digest))
+                .await?,
+            None,
+            "released action inputs must become ordinary eviction candidates",
+        );
+
+        drop(action);
         Ok(())
     }
 

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -379,9 +379,9 @@ mod tests {
             .await?;
         assert!(
             fast_store
-                .as_ref()
-                .has(StoreKey::Digest(file_digest))
-                .await?
+                .get_evicting_map()
+                .size_for_key(&StoreKey::Digest(file_digest))
+                .await
                 .is_some(),
             "an active action input must survive fast-tier pressure",
         );
@@ -416,9 +416,9 @@ mod tests {
             .await?;
         assert_eq!(
             fast_store
-                .as_ref()
-                .has(StoreKey::Digest(file_digest))
-                .await?,
+                .get_evicting_map()
+                .size_for_key(&StoreKey::Digest(file_digest))
+                .await,
             None,
             "released action inputs must become ordinary eviction candidates",
         );

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -350,6 +350,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: true,
                 directory_cache: Some(directory_cache),
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -423,6 +424,133 @@ mod tests {
             "released action inputs must become ordinary eviction candidates",
         );
 
+        drop(action);
+        Ok(())
+    }
+
+    #[nativelink_test]
+    async fn action_inputs_stay_evictable_when_leases_disabled()
+    -> Result<(), Box<dyn core::error::Error>> {
+        const FILE_CONTENT: &[u8] = b"unleased input";
+        const PRESSURE_CONTENT: &[u8] = b"pressure";
+        // High enough that action preparation never triggers eviction; the
+        // pressure loop below inserts this many fresh digests so every entry
+        // that predates it is evicted.
+        const MAX_COUNT: u64 = 10;
+
+        let (fast_store, slow_store, cas_store, _ac_store) =
+            setup_stores_with_eviction_policy(Some(EvictionPolicy {
+                max_count: MAX_COUNT,
+                ..Default::default()
+            }))
+            .await?;
+
+        let file_digest = DigestInfo::new([7u8; 32], FILE_CONTENT.len() as u64);
+        slow_store
+            .as_ref()
+            .update_oneshot(file_digest, FILE_CONTENT.into())
+            .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory {
+                files: vec![FileNode {
+                    name: "input.txt".to_string(),
+                    digest: Some(file_digest.into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let command_digest = serialize_and_upload_message(
+            &Command::default(),
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action_digest = serialize_and_upload_message(
+            &Action {
+                command_digest: Some(command_digest.into()),
+                input_root_digest: Some(input_root_digest.into()),
+                ..Default::default()
+            },
+            slow_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
+        let directory_cache = Arc::new(
+            DirectoryCache::new(
+                DirectoryCacheConfig {
+                    cache_root: make_temp_path("directory_cache").into(),
+                    ..Default::default()
+                },
+                cas_store.clone(),
+            )
+            .await?,
+        );
+        let running_actions_manager =
+            Arc::new(RunningActionsManagerImpl::new(RunningActionsManagerArgs {
+                root_action_directory,
+                execution_configuration: ExecutionConfiguration::default(),
+                cas_store: cas_store.clone(),
+                ac_store: None,
+                historical_store: Store::new(cas_store.clone()),
+                upload_action_result_config: &UploadActionResultConfig {
+                    upload_ac_results_strategy: UploadCacheResultsStrategy::Never,
+                    ..Default::default()
+                },
+                max_action_timeout: Duration::from_mins(10),
+                max_upload_timeout: Duration::from_secs(DEFAULT_MAX_UPLOAD_TIMEOUT),
+                max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
+                max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
+                timeout_handled_externally: false,
+                active_input_leases: false,
+                directory_cache: Some(directory_cache),
+                #[cfg(target_os = "linux")]
+                use_namespaces: use_namespaces(),
+            })?);
+
+        let action = running_actions_manager
+            .create_and_add_action(
+                "test-worker".to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        digest_function: ProtoDigestFunction::Sha256.into(),
+                        ..Default::default()
+                    }),
+                    operation_id: OperationId::default().to_string(),
+                    ..Default::default()
+                },
+            )
+            .await?
+            .prepare_action()
+            .await?;
+
+        for pressure_index in 0..MAX_COUNT {
+            let pressure_digest = DigestInfo::new(
+                [0x80 + u8::try_from(pressure_index)?; 32],
+                PRESSURE_CONTENT.len() as u64,
+            );
+            fast_store
+                .as_ref()
+                .update_oneshot(pressure_digest, PRESSURE_CONTENT.into())
+                .await?;
+        }
+        assert_eq!(
+            fast_store
+                .as_ref()
+                .has(StoreKey::Digest(file_digest))
+                .await?,
+            None,
+            "with active input leases disabled, the fast tier must honor its eviction limits even while an action is running",
+        );
+
+        let action = action.cleanup().await?;
         drop(action);
         Ok(())
     }
@@ -755,6 +883,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -882,6 +1011,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1011,6 +1141,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1195,6 +1326,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1381,6 +1513,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1636,6 +1769,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1789,6 +1923,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -1933,6 +2068,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2072,6 +2208,7 @@ mod tests {
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2279,6 +2416,7 @@ exit 0
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2459,6 +2597,7 @@ exit 0
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2633,6 +2772,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2724,6 +2864,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2802,6 +2943,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2887,6 +3029,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -2993,6 +3136,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3043,6 +3187,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3114,6 +3259,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3236,6 +3382,7 @@ exit 1
                     max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                     max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                     timeout_handled_externally: false,
+                    active_input_leases: false,
                     directory_cache: None,
                     #[cfg(target_os = "linux")]
                     use_namespaces: use_namespaces(),
@@ -3327,6 +3474,7 @@ exit 1
                     max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                     max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                     timeout_handled_externally: false,
+                    active_input_leases: false,
                     directory_cache: None,
                     #[cfg(target_os = "linux")]
                     use_namespaces: use_namespaces(),
@@ -3418,6 +3566,7 @@ exit 1
                     max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                     max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                     timeout_handled_externally: false,
+                    active_input_leases: false,
                     directory_cache: None,
                     #[cfg(target_os = "linux")]
                     use_namespaces: use_namespaces(),
@@ -3506,6 +3655,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3658,6 +3808,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3827,6 +3978,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -3940,6 +4092,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 // Pin namespaces off so this exercises the no-pre_exec/posix_spawn
                 // path regardless of what the host kernel supports.
@@ -4054,6 +4207,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4263,6 +4417,7 @@ exit 1
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4362,6 +4517,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4546,6 +4702,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4670,6 +4827,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4815,6 +4973,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -4927,6 +5086,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -5070,6 +5230,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -5244,6 +5405,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),
@@ -5402,6 +5564,7 @@ done
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
                 timeout_handled_externally: false,
+                active_input_leases: false,
                 directory_cache: None,
                 #[cfg(target_os = "linux")]
                 use_namespaces: use_namespaces(),

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -345,7 +345,7 @@ mod tests {
                     upload_ac_results_strategy: UploadCacheResultsStrategy::Never,
                     ..Default::default()
                 },
-                max_action_timeout: Duration::from_secs(600),
+                max_action_timeout: Duration::from_mins(10),
                 max_upload_timeout: Duration::from_secs(DEFAULT_MAX_UPLOAD_TIMEOUT),
                 max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
                 max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),


### PR DESCRIPTION
## 🚀 What

Keep every digest in an active action's input Merkle closure available in locally eviction-managed CAS tiers until the action has finished cleanup. This prevents `Lost inputs no longer available remotely` failures caused by local fast-tier eviction during input materialization.

## 🤔 Why

Under fast-tier pressure, an input could be evicted after an action began but before the worker materialized or hard-linked it. The resulting missing input caused remote execution failures such as `Lost inputs no longer available remotely` (see #2129).

## 🔧 How

- Add reference-counted, pre-admission leases to `EvictingMap`. A digest is leased before its value is inserted, so insertion cannot race with eviction. Leased keys are excluded from size, count, and TTL eviction.
- Keep a dedicated LRU of unleased entries synchronized with the resident LRU, so pressure eviction never selects leased inputs. If every resident entry is leased, defer eviction and emit diagnostic lease metrics/logging.
- Expose filesystem-backed tiers from `FastSlowStore`, including a filesystem store behind a `RefStore`, so the worker can protect every applicable local CAS tier.
- Lease the command and input-root digests immediately, then lease every file and directory digest before fetching or populating it. Child-directory leases are registered before their materialization futures are polled, closing the bounded-concurrency admission race.
- Make `DirectoryCache` lease-aware. Cache hits pin the materialized entry across hardlinking; cache misses reserve every CAS digest before construction. The directory-cache pin and CAS lease protect different resources and are released independently.
- Release leases after work-directory cleanup. Batch release performs one eviction pass for the whole Merkle closure, and detached release work keeps cleanup cancellation-safe. Duplicate operation IDs are rejected without deleting an active action directory.

## 💥 Breaking Changes

If every eviction candidate is leased, a local filesystem tier may temporarily exceed its configured capacity; normal eviction resumes after leases are released. Scheduler backpressure for this state is intentionally left to a follow-up. Lease discovery covers the filesystem-backed tiers used by the worker; remote and non-eviction stores remain unchanged.

## 🧪 Validation

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p nativelink-util --test evicting_map_test` (24 passed)
- `nix develop -c cargo test -p nativelink-worker --test running_actions_manager_test active_action_input_lease_survives_fast_store_pressure -- --nocapture` (1 passed)
- `nix develop -c cargo check -p nativelink-worker`

## 🔗 Related

Fixes the active-input eviction class described in #2129.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2675)
<!-- Reviewable:end -->


