### PR TITLE
Limit local uploads to trusted lanes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -126,4 +126,10 @@ jobs:
         tags: trace_machina/nativelink:latest
 
     - name: Run tests
+      env:
+        # Merges to main are a trusted upload lane; PRs are not (keeps the
+        # repo-wide --remote_upload_local_results=false anti-poisoning default
+        # in force for PRs). Upload-dependent integration tests
+        # (chunking_cache_test, simple_cache_test) self-skip unless this is 1.
+        NL_LOCAL_UPLOADS: ${{ github.event_name == 'push' && '1' || '0' }}
       run: ./run_integration_tests.sh

--- a/.github/workflows/nativelink-cloud-canary.yaml
+++ b/.github/workflows/nativelink-cloud-canary.yaml
@@ -129,3 +129,40 @@ jobs:
             echo "FAIL: BEP is missing the expected GitHub run metadata" >&2
             exit 1
           fi
+
+  # Daily safety net for integration tests that must upload locally-built
+  # results to the cache (chunking_cache_test, simple_cache_test). The repo-wide
+  # --remote_upload_local_results=false keeps PR/developer lanes read-only, so
+  # these tests self-skip unless NL_LOCAL_UPLOADS=1 -- set here (and on merges to
+  # main in main.yaml). Never runs on PRs: no upload lane, keeps the canary's PR
+  # leg light.
+  upload-integration-tests:
+    name: Upload-dependent integration tests
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: >- # v6.0.2
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Docker Buildx
+        uses: >- # v3.9.0
+          docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+
+      - name: Build image
+        uses: >- # v6.13.0
+          docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
+        with:
+          context: .
+          file: ./deployment-examples/docker-compose/Dockerfile
+          build-args: |
+            OPT_LEVEL=fastbuild
+            ADDITIONAL_BAZEL_FLAGS=--extra_toolchains=@rust_toolchains//:all
+          load: true # Brings the image into `docker images` for docker-compose.
+          tags: trace_machina/nativelink:latest
+
+      - name: Run upload-dependent integration tests
+        env:
+          NL_LOCAL_UPLOADS: '1'
+        run: ./run_integration_tests.sh chunking_cache_test.sh simple_cache_test.sh

--- a/integration_tests/chunking_cache_test.sh
+++ b/integration_tests/chunking_cache_test.sh
@@ -22,6 +22,17 @@ if [[ $UNDER_TEST_RUNNER -ne 1 ]]; then
     echo "This script should be run under run_integration_tests.sh"
     exit 1
 fi
+
+# This test uploads a locally-built output to exercise the chunked write path
+# (see CHUNKING_FLAGS below), which the repo-wide
+# --remote_upload_local_results=false disables. To keep that anti-poisoning
+# default intact for PR/developer lanes, this test runs only where local
+# uploads are explicitly enabled: merges to main and the scheduled canary set
+# NL_LOCAL_UPLOADS=1 (see main.yaml / nativelink-cloud-canary.yaml).
+if [[ ${NL_LOCAL_UPLOADS:-0} != "1" ]]; then
+    echo "Skipping $(basename "$0"): requires local cache uploads (main/canary lanes only)."
+    exit 0
+fi
 set -x
 
 # Bazel uploads cache entries in the background by default

--- a/integration_tests/simple_cache_test.sh
+++ b/integration_tests/simple_cache_test.sh
@@ -19,10 +19,27 @@ if [[ $UNDER_TEST_RUNNER -ne 1 ]]; then
     echo "This script should be run under run_integration_tests.sh"
     exit 1
 fi
+
+# This test uploads a locally-run test result to the cache and asserts the
+# re-run is a cache hit, so it needs --remote_upload_local_results=true.
+# nativelink.bazelrc sets that false repo-wide to stop PR/developer lanes from
+# writing to the *shared* cache (cache-poisoning guard). Uploads here target
+# only the ephemeral, per-run docker-compose cache, so they are safe -- but to
+# keep the anti-poisoning default intact this test runs only where local
+# uploads are explicitly enabled: merges to main and the scheduled canary set
+# NL_LOCAL_UPLOADS=1 (see main.yaml / nativelink-cloud-canary.yaml).
+if [[ ${NL_LOCAL_UPLOADS:-0} != "1" ]]; then
+    echo "Skipping $(basename "$0"): requires local cache uploads (main/canary lanes only)."
+    exit 0
+fi
 set -x
 
+# A command-line flag overrides the repo-wide --remote_upload_local_results
+# =false so this test can populate the cache it then asserts on.
+TEST_FLAGS=(--config self_test --remote_upload_local_results=true)
+
 # First run our test under bazel. It should not be cached.
-OUTPUT=$(bazel --output_base="$BAZEL_CACHE_DIR" test --config self_test //:dummy_test)
+OUTPUT=$(bazel --output_base="$BAZEL_CACHE_DIR" test "${TEST_FLAGS[@]}" //:dummy_test)
 if [[ $OUTPUT =~ .*'(cached)'.* ]]; then
     echo "Expected first bazel run to not have test cached."
     echo "STDOUT:"
@@ -34,7 +51,7 @@ fi
 bazel --output_base="$BAZEL_CACHE_DIR" clean
 
 # Now run it under bazel again. This time the remote cache should have it.
-OUTPUT=$(bazel --output_base="$BAZEL_CACHE_DIR" test --config self_test //:dummy_test)
+OUTPUT=$(bazel --output_base="$BAZEL_CACHE_DIR" test "${TEST_FLAGS[@]}" //:dummy_test)
 if [[ ! $OUTPUT =~ .*'(cached)'.* ]]; then
     echo "Expected second bazel run to have test cached."
     echo "STDOUT:"


### PR DESCRIPTION
# Description

#2674 Introduced flakiness because of a reliance on local uploads that were shifted to disallowed to completely prevent cache poisoning. This PR restricts local upload checks to trusted lanes.

| Test | Upload-dependent? | Why |
|---|---|---|
| `chunking_cache_test.sh` | **Yes** | asserts a chunk layout appears after a local upload |
| `simple_cache_test.sh` | **Yes** | asserts `(cached)` on re-run after a local build |
| `simple_remote_execution_test.sh` | No | asserts remote *execution strategy*; `--nocache_test_results` |
| `simple_tls_test.sh` | No | curl TLS health check, no cache |


## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

`bazel test //...`

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2677)
<!-- Reviewable:end -->
