### PR TITLE
Don't let one scheduler instance time out another's in-flight actions

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
+++ b/nativelink-scheduler/src/awaited_action_db/awaited_action.rs
@@ -211,7 +211,7 @@ impl AwaitedAction {
     }
 
     /// Sets the worker id that is currently processing this action.
-    pub(crate) fn set_worker_id(&mut self, new_maybe_worker_id: Option<WorkerId>, now: SystemTime) {
+    pub fn set_worker_id(&mut self, new_maybe_worker_id: Option<WorkerId>, now: SystemTime) {
         if self.worker_id != new_maybe_worker_id {
             self.worker_id = new_maybe_worker_id;
             self.worker_keep_alive(now);

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -41,7 +41,7 @@ use tracing::{debug, info, trace, warn};
 use super::awaited_action_db::{
     AwaitedAction, AwaitedActionDb, AwaitedActionSubscriber, SortedAwaitedActionState,
 };
-use crate::worker_registry::SharedWorkerRegistry;
+use crate::worker_registry::{SharedWorkerRegistry, WorkerLiveness};
 
 /// Maximum number of times an update to the database
 /// can fail before giving up.
@@ -367,34 +367,42 @@ where
             }
         }
 
-        let registry_alive = if let Some(ref worker_registry) = self.worker_registry {
-            if let Some(worker_id) = awaited_action.worker_id() {
+        let liveness = match (&self.worker_registry, awaited_action.worker_id()) {
+            (Some(worker_registry), Some(worker_id)) => {
                 worker_registry
-                    .is_worker_alive(worker_id, self.no_event_action_timeout, now)
+                    .check_liveness(worker_id, self.no_event_action_timeout, now)
                     .await
-            } else {
-                false
             }
-        } else {
-            false
+            // No registry, or not assigned yet: fall back to the
+            // timestamp-only check.
+            _ => WorkerLiveness::Stale,
         };
 
-        if registry_alive {
-            if self.max_executing_timeout > Duration::ZERO {
-                let last_update = awaited_action.last_worker_updated_timestamp();
-                if let Ok(elapsed) = now.duration_since(last_update) {
-                    return elapsed > self.max_executing_timeout;
+        match liveness {
+            // Unknown means "not registered here", which with several
+            // schedulers on shared state is usually a peer's healthy worker.
+            // We never see its heartbeats, so only the stuck-but-alive ceiling
+            // can judge it; that also backstops a genuine orphan.
+            WorkerLiveness::Alive | WorkerLiveness::Unknown => {
+                if self.max_executing_timeout > Duration::ZERO {
+                    let last_update = awaited_action.last_worker_updated_timestamp();
+                    if let Ok(elapsed) = now.duration_since(last_update) {
+                        return elapsed > self.max_executing_timeout;
+                    }
                 }
+                false
             }
-            return false;
+
+            // Registered here and gone quiet: ours, and it looks dead.
+            WorkerLiveness::Stale => {
+                let worker_should_update_before = awaited_action
+                    .last_worker_updated_timestamp()
+                    .checked_add(self.no_event_action_timeout)
+                    .unwrap_or(now);
+
+                worker_should_update_before < now
+            }
         }
-
-        let worker_should_update_before = awaited_action
-            .last_worker_updated_timestamp()
-            .checked_add(self.no_event_action_timeout)
-            .unwrap_or(now);
-
-        worker_should_update_before < now
     }
 
     async fn apply_filter_predicate(
@@ -571,41 +579,13 @@ where
             .await
             .err_tip(|| "In SimpleSchedulerStateManager::timeout_operation_id")?;
 
-        // If the action is not executing, we should not timeout the action.
-        if !matches!(awaited_action.state().stage, ActionStage::Executing) {
-            return Ok(());
-        }
-
-        let now = (self.now_fn)().now();
-
-        // Check worker liveness via registry if available.
-        let registry_alive = if let Some(ref worker_registry) = self.worker_registry {
-            if let Some(worker_id) = awaited_action.worker_id() {
-                worker_registry
-                    .is_worker_alive(worker_id, self.no_event_action_timeout, now)
-                    .await
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
-        let timestamp_alive = {
-            let worker_should_update_before = awaited_action
-                .last_worker_updated_timestamp()
-                .checked_add(self.no_event_action_timeout)
-                .unwrap_or(now);
-            worker_should_update_before >= now
-        };
-
-        if registry_alive || timestamp_alive {
+        // Re-check under the lock against freshly loaded state, and delegate
+        // rather than re-deriving the rule: the two copies had drifted.
+        if !self.should_timeout_operation(&awaited_action).await {
             trace!(
                 %operation_id,
                 worker_id = ?awaited_action.worker_id(),
-                registry_alive,
-                timestamp_alive,
-                "Worker is alive, operation not timed out"
+                "Operation no longer needs timing out, skipping"
             );
             return Ok(());
         }
@@ -613,9 +593,7 @@ where
         warn!(
             %operation_id,
             worker_id = ?awaited_action.worker_id(),
-            registry_alive,
-            timestamp_alive,
-            "Worker not alive via registry or timestamp, timing out operation"
+            "Timing out operation"
         );
 
         self.assign_operation(

--- a/nativelink-scheduler/src/worker_registry.rs
+++ b/nativelink-scheduler/src/worker_registry.rs
@@ -21,7 +21,27 @@ use async_lock::RwLock;
 use nativelink_util::action_messages::WorkerId;
 use tracing::{debug, trace};
 
+/// What this scheduler instance knows about a worker's liveness.
+///
+/// A worker only appears in the registry of the instance holding its
+/// `connect_worker` stream, so `Unknown` means "not mine to judge", not
+/// "dead".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerLiveness {
+    /// Registered here and has heartbeat within the timeout.
+    Alive,
+    /// Registered here, but has not been heard from within the timeout.
+    Stale,
+    /// Not registered here at all. Either connected to a different scheduler
+    /// instance, or already evicted (in which case its actions were requeued
+    /// at eviction time and no longer reference it).
+    Unknown,
+}
+
 /// In-memory worker registry that tracks worker liveness.
+///
+/// Per-process: fed by the `connect_worker` streams this instance owns, not a
+/// view of every worker in the deployment.
 #[derive(Debug)]
 pub struct WorkerRegistry {
     workers: RwLock<HashMap<WorkerId, SystemTime>>,
@@ -60,30 +80,44 @@ impl WorkerRegistry {
         debug!(?worker_id, "FLOW: Worker removed from registry");
     }
 
+    /// Liveness as far as THIS instance can tell. Callers acting on "dead"
+    /// must handle `Unknown` separately.
+    pub async fn check_liveness(
+        &self,
+        worker_id: &WorkerId,
+        timeout: Duration,
+        now: SystemTime,
+    ) -> WorkerLiveness {
+        let workers = self.workers.read().await;
+
+        let Some(last_seen) = workers.get(worker_id) else {
+            trace!(?worker_id, "FLOW: Worker not registered on this instance");
+            return WorkerLiveness::Unknown;
+        };
+
+        // An overflowing deadline can only be clock skew; treat as alive.
+        let liveness = match last_seen.checked_add(timeout) {
+            Some(deadline) if deadline > now => WorkerLiveness::Alive,
+            Some(_) => WorkerLiveness::Stale,
+            None => WorkerLiveness::Alive,
+        };
+        trace!(
+            ?worker_id,
+            last_seen = %humantime::format_rfc3339(*last_seen),
+            ?timeout,
+            ?liveness,
+            "FLOW: Worker liveness check"
+        );
+        liveness
+    }
+
     pub async fn is_worker_alive(
         &self,
         worker_id: &WorkerId,
         timeout: Duration,
         now: SystemTime,
     ) -> bool {
-        let workers = self.workers.read().await;
-
-        if let Some(last_seen) = workers.get(worker_id)
-            && let Some(deadline) = last_seen.checked_add(timeout)
-        {
-            let is_alive = deadline > now;
-            trace!(
-                ?worker_id,
-                last_seen = %humantime::format_rfc3339(*last_seen),
-                ?timeout,
-                is_alive,
-                "FLOW: Worker liveness check"
-            );
-            return is_alive;
-        }
-
-        trace!(?worker_id, "FLOW: Worker not found or timed out");
-        false
+        self.check_liveness(worker_id, timeout, now).await == WorkerLiveness::Alive
     }
 
     pub async fn get_worker_last_seen(&self, worker_id: &WorkerId) -> Option<SystemTime> {
@@ -135,6 +169,42 @@ mod tests {
             registry
                 .is_worker_alive(&worker_id, Duration::from_secs(5), future)
                 .await
+        );
+    }
+
+    #[nativelink_test]
+    async fn test_check_liveness_distinguishes_stale_from_unknown() {
+        let registry = WorkerRegistry::new();
+        let mine = WorkerId::from(String::from("mine"));
+        let theirs = WorkerId::from(String::from("belongs-to-another-instance"));
+        let now = SystemTime::now();
+        let timeout = Duration::from_secs(5);
+
+        // Never registered here. This is the case that must NOT read as dead:
+        // with several schedulers on shared state it is a peer's worker.
+        assert_eq!(
+            registry.check_liveness(&theirs, timeout, now).await,
+            WorkerLiveness::Unknown
+        );
+
+        registry.register_worker(&mine, now).await;
+        assert_eq!(
+            registry.check_liveness(&mine, timeout, now).await,
+            WorkerLiveness::Alive
+        );
+
+        // Registered here but gone quiet: genuinely ours and genuinely dead.
+        let later = now.checked_add(Duration::from_secs(10)).unwrap();
+        assert_eq!(
+            registry.check_liveness(&mine, timeout, later).await,
+            WorkerLiveness::Stale
+        );
+
+        // Eviction takes it back to Unknown, not Stale.
+        registry.remove_worker(&mine).await;
+        assert_eq!(
+            registry.check_liveness(&mine, timeout, later).await,
+            WorkerLiveness::Unknown
         );
     }
 

--- a/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
@@ -1,12 +1,21 @@
 use core::time::Duration;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use mock_instant::thread_local::MockClock;
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
+use nativelink_scheduler::awaited_action_db::AwaitedAction;
 use nativelink_scheduler::default_scheduler_factory::memory_awaited_action_db_factory;
 use nativelink_scheduler::simple_scheduler_state_manager::SimpleSchedulerStateManager;
-use nativelink_util::action_messages::{OperationId, WorkerId};
+use nativelink_scheduler::worker_registry::WorkerRegistry;
+use nativelink_util::action_messages::{
+    ActionInfo, ActionStage, ActionState, ActionUniqueKey, ActionUniqueQualifier, OperationId,
+    WorkerId,
+};
+use nativelink_util::common::DigestInfo;
+use nativelink_util::digest_hasher::DigestHasherFunc;
 use nativelink_util::instant_wrapper::MockInstantWrapped;
 use nativelink_util::operation_state_manager::{UpdateOperationType, WorkerStateManager};
 use tokio::sync::Notify;
@@ -42,5 +51,175 @@ async fn drops_missing_actions() -> Result<(), Error> {
     assert!(logs_contain(
         "Unable to update action due to it being missing, probably dropped operation_id=c458c1f4-136e-486d-b9cd-cea07460cde4"
     ));
+    Ok(())
+}
+
+const NOW_TIME: u64 = 10_000;
+const WORKER_TIMEOUT: Duration = Duration::from_mins(2);
+const MAX_EXECUTING: Duration = Duration::from_mins(15);
+
+fn make_system_time(add_time: u64) -> SystemTime {
+    SystemTime::UNIX_EPOCH
+        .checked_add(Duration::from_secs(NOW_TIME + add_time))
+        .unwrap()
+}
+
+/// An action already assigned to `worker_id` and executing since `started`.
+fn executing_action(worker_id: &WorkerId, started: SystemTime) -> AwaitedAction {
+    let action_digest = DigestInfo::zero_digest();
+    let action_info = ActionInfo {
+        command_digest: action_digest,
+        input_root_digest: action_digest,
+        timeout: Duration::ZERO,
+        platform_properties: HashMap::default(),
+        priority: 0,
+        load_timestamp: SystemTime::UNIX_EPOCH,
+        insert_timestamp: started,
+        unique_qualifier: ActionUniqueQualifier::Uncacheable(ActionUniqueKey {
+            instance_name: "main".to_string(),
+            digest_function: DigestHasherFunc::Sha256,
+            digest: action_digest,
+        }),
+    };
+    let operation_id = OperationId::default();
+    let mut action = AwaitedAction::new(operation_id.clone(), Arc::new(action_info), started);
+    action.worker_set_state(
+        Arc::new(ActionState {
+            stage: ActionStage::Executing,
+            client_operation_id: operation_id,
+            action_digest,
+            last_transition_timestamp: started,
+        }),
+        started,
+    );
+    action.set_worker_id(Some(worker_id.clone()), started);
+    action
+}
+
+fn state_manager(
+    registry: Arc<WorkerRegistry>,
+) -> Arc<
+    SimpleSchedulerStateManager<
+        impl nativelink_scheduler::awaited_action_db::AwaitedActionDb,
+        MockInstantWrapped,
+        fn() -> MockInstantWrapped,
+    >,
+> {
+    let task_change_notify = Arc::new(Notify::new());
+    SimpleSchedulerStateManager::new(
+        5,
+        WORKER_TIMEOUT,
+        Duration::from_mins(5),
+        MAX_EXECUTING,
+        memory_awaited_action_db_factory(0, &task_change_notify, MockInstantWrapped::default),
+        MockInstantWrapped::default,
+        Some(registry),
+    )
+}
+
+/// An action on a worker connected to a DIFFERENT scheduler instance must not
+/// be timed out here. This instance never sees that worker's heartbeats, so
+/// the action's timestamp looks frozen however healthy it is.
+#[nativelink_test]
+async fn does_not_time_out_a_peer_instances_worker() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    // Deliberately not registered here: it belongs to another instance.
+    let action = executing_action(
+        &WorkerId::from(String::from("owned-by-another-scheduler")),
+        make_system_time(0),
+    );
+    let state_mgr = state_manager(Arc::new(WorkerRegistry::new()));
+
+    MockClock::advance(WORKER_TIMEOUT + Duration::from_mins(1));
+    assert!(
+        !state_mgr.should_timeout_operation(&action).await,
+        "must not time out an action on a peer instance's worker"
+    );
+    Ok(())
+}
+
+/// A worker registered here that stopped heartbeating is ours and looks dead,
+/// so the short timeout must still fire.
+#[nativelink_test]
+async fn still_times_out_our_own_dead_worker() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from(String::from("connected-to-us"));
+    let action = executing_action(&worker_id, make_system_time(0));
+
+    let registry = Arc::new(WorkerRegistry::new());
+    registry
+        .register_worker(&worker_id, make_system_time(0))
+        .await;
+    let state_mgr = state_manager(registry);
+
+    MockClock::advance(WORKER_TIMEOUT + Duration::from_mins(1));
+    assert!(
+        state_mgr.should_timeout_operation(&action).await,
+        "a registered worker that stopped heartbeating must time out"
+    );
+    Ok(())
+}
+
+/// A registered, heartbeating worker is bounded only by the executing ceiling.
+#[nativelink_test]
+async fn does_not_time_out_a_live_worker_mid_action() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from(String::from("connected-to-us"));
+    let action = executing_action(&worker_id, make_system_time(0));
+
+    let elapsed = WORKER_TIMEOUT + Duration::from_mins(1);
+    let registry = Arc::new(WorkerRegistry::new());
+    registry
+        .update_worker_heartbeat(&worker_id, make_system_time(elapsed.as_secs()))
+        .await;
+    let state_mgr = state_manager(registry);
+
+    MockClock::advance(elapsed);
+    assert!(
+        !state_mgr.should_timeout_operation(&action).await,
+        "a heartbeating worker's action must survive past worker_timeout_s"
+    );
+    Ok(())
+}
+
+/// A heartbeating worker stuck on one action past the executing ceiling must
+/// still be timed out, which is what `max_action_executing_timeout_s` is for.
+#[nativelink_test]
+async fn times_out_a_live_but_stuck_worker() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from(String::from("alive-but-wedged"));
+    let action = executing_action(&worker_id, make_system_time(0));
+
+    let elapsed = MAX_EXECUTING + Duration::from_mins(1);
+    let registry = Arc::new(WorkerRegistry::new());
+    registry
+        .update_worker_heartbeat(&worker_id, make_system_time(elapsed.as_secs()))
+        .await;
+    let state_mgr = state_manager(registry);
+
+    MockClock::advance(elapsed);
+    assert!(
+        state_mgr.should_timeout_operation(&action).await,
+        "a worker stuck past max_action_executing_timeout_s must time out"
+    );
+    Ok(())
+}
+
+/// An orphan whose owning instance died permanently still gets reaped, on the
+/// longer ceiling.
+#[nativelink_test]
+async fn eventually_times_out_an_orphan() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let action = executing_action(
+        &WorkerId::from(String::from("owner-died-permanently")),
+        make_system_time(0),
+    );
+    let state_mgr = state_manager(Arc::new(WorkerRegistry::new()));
+
+    MockClock::advance(MAX_EXECUTING + Duration::from_mins(1));
+    assert!(
+        state_mgr.should_timeout_operation(&action).await,
+        "an orphaned action must still be reaped on max_action_executing_timeout_s"
+    );
     Ok(())
 }

--- a/nativelink-scheduler/tests/worker_registry_test.rs
+++ b/nativelink-scheduler/tests/worker_registry_test.rs
@@ -30,8 +30,11 @@ async fn is_worker_alive_logging() -> Result<(), Error> {
             .is_worker_alive(&worker_id, Duration::from_secs(10), SystemTime::UNIX_EPOCH)
             .await
     );
+    // `liveness` replaced the old `is_alive` bool: a two-state field could not
+    // express "not registered on this instance", which is what made
+    // multi-scheduler deployments time each other's actions out.
     assert!(logs_contain(
-        "FLOW: Worker liveness check worker_id=foo last_seen=1970-01-01T00:00:00Z timeout=10s is_alive=true"
+        "FLOW: Worker liveness check worker_id=foo last_seen=1970-01-01T00:00:00Z timeout=10s liveness=Alive"
     ));
     Ok(())
 }


### PR DESCRIPTION
# Description

This issue is wrt to the HPA where one scheduler instance times out the other's in-flight actions, resulting in CAS pod crashes or builds stalling. 

Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests. 

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2680)
<!-- Reviewable:end -->
