### PR TITLE
Increase RPC timeout to 5-second deadline

### DIFF
--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -512,7 +512,11 @@ async fn update_splits_buffers_larger_than_the_grpc_message_limit() -> Result<()
     const BLOB_LEN: usize = 9_869_079;
 
     let (server, port) = make_fake_bytestream_server_draining().await;
-    let spec = test_spec(format!("http://localhost:{port}"), false);
+    let mut spec = test_spec(format!("http://localhost:{port}"), false);
+    // This test moves and reassembles almost 10 MiB under instrumented builds.
+    // Keep the RPC deadline comfortably above sanitizer overhead; timeout
+    // behavior is not what this test exercises.
+    spec.rpc_timeout_s = 5;
     let store = GrpcStore::new(&spec).await?;
     let digest = DigestInfo::try_new(VALID_HASH, BLOB_LEN).unwrap();
 


### PR DESCRIPTION
# Description

Previously, integration tests used a shared 1-second deadline. This PR increases an RPC deadline to 5 second due to frequent timeouts of large asset transfers. We may need to revisit it to tighten the hung-loop associated with that deadline. It should pass in just a couple seconds. 

Fixes #2682 

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2683)
<!-- Reviewable:end -->
