### PR TITLE
Reap orphaned actions when the executing timeout is disabled

### DIFF
--- a/nativelink-scheduler/src/awaited_action_db/mod.rs
+++ b/nativelink-scheduler/src/awaited_action_db/mod.rs
@@ -24,6 +24,8 @@ use nativelink_metric::MetricsComponent;
 use nativelink_util::action_messages::{ActionInfo, ActionStage, OperationId};
 use serde::{Deserialize, Serialize};
 
+use crate::worker_registry::SharedWorkerRegistry;
+
 mod awaited_action;
 
 /// Duration to wait before sending client keep alive messages.
@@ -188,4 +190,9 @@ pub trait AwaitedActionDb: Send + Sync + MetricsComponent + Unpin + 'static {
         action_info: Arc<ActionInfo>,
         no_event_action_timeout: Duration,
     ) -> impl Future<Output = Result<Self::Subscriber, Error>> + Send;
+
+    /// Lets an implementation judge worker liveness before deciding an
+    /// executing action was abandoned. Only shared-state implementations
+    /// need it, so the default ignores the registry.
+    fn set_worker_registry(&mut self, _worker_registry: SharedWorkerRegistry) {}
 }

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -468,7 +468,7 @@ impl SimpleScheduler {
         NowFn: Fn() -> I + Clone + Send + Unpin + Sync + 'static,
     >(
         spec: &SimpleSpec,
-        awaited_action_db: A,
+        mut awaited_action_db: A,
         on_matching_engine_run: F,
         task_change_notify: Arc<Notify>,
         now_fn: NowFn,
@@ -509,6 +509,10 @@ impl SimpleScheduler {
 
         // Create shared worker registry for single heartbeat per worker.
         let worker_registry = Arc::new(WorkerRegistry::new());
+
+        // The db decides on its own whether an executing action was abandoned,
+        // so it needs the same liveness view the state manager uses.
+        awaited_action_db.set_worker_registry(worker_registry.clone());
 
         let state_manager = SimpleSchedulerStateManager::new(
             max_job_retries,

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -41,7 +41,7 @@ use tracing::{debug, info, trace, warn};
 use super::awaited_action_db::{
     AwaitedAction, AwaitedActionDb, AwaitedActionSubscriber, SortedAwaitedActionState,
 };
-use crate::worker_registry::{SharedWorkerRegistry, WorkerLiveness};
+use crate::worker_registry::{ORPHANED_ACTION_TIMEOUT, SharedWorkerRegistry, WorkerLiveness};
 
 /// Maximum number of times an update to the database
 /// can fail before giving up.
@@ -379,11 +379,9 @@ where
         };
 
         match liveness {
-            // Unknown means "not registered here", which with several
-            // schedulers on shared state is usually a peer's healthy worker.
-            // We never see its heartbeats, so only the stuck-but-alive ceiling
-            // can judge it; that also backstops a genuine orphan.
-            WorkerLiveness::Alive | WorkerLiveness::Unknown => {
+            // Ours and heartbeating: only the stuck-but-alive ceiling applies,
+            // and disabling that means no ceiling on a live worker.
+            WorkerLiveness::Alive => {
                 if self.max_executing_timeout > Duration::ZERO {
                     let last_update = awaited_action.last_worker_updated_timestamp();
                     if let Ok(elapsed) = now.duration_since(last_update) {
@@ -391,6 +389,23 @@ where
                     }
                 }
                 false
+            }
+
+            // Usually a peer's healthy worker, so worker_timeout_s must not
+            // apply. It can also be an orphan no instance will ever reap, and
+            // max_action_executing_timeout_s defaults to disabled, so fall
+            // back to a ceiling rather than never timing out.
+            WorkerLiveness::Unknown => {
+                let ceiling = if self.max_executing_timeout > Duration::ZERO {
+                    self.max_executing_timeout
+                } else {
+                    ORPHANED_ACTION_TIMEOUT
+                };
+                let last_update = awaited_action.last_worker_updated_timestamp();
+                match now.duration_since(last_update) {
+                    Ok(elapsed) => elapsed > ceiling,
+                    Err(_) => false,
+                }
             }
 
             // Registered here and gone quiet: ours, and it looks dead.

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -18,7 +18,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use core::time::Duration;
 use std::borrow::Cow;
 use std::sync::{Arc, Weak};
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
@@ -42,6 +42,7 @@ use crate::awaited_action_db::{
     AwaitedAction, AwaitedActionDb, AwaitedActionSubscriber, CLIENT_KEEPALIVE_DURATION,
     SortedAwaitedAction, SortedAwaitedActionState,
 };
+use crate::worker_registry::{ORPHANED_ACTION_TIMEOUT, SharedWorkerRegistry, WorkerLiveness};
 
 type ClientOperationId = OperationId;
 
@@ -136,9 +137,8 @@ where
         }
 
         // Helper to convert SystemTime to unix timestamp
-        let to_unix_ts = |t: std::time::SystemTime| -> u64 {
-            t.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs())
-        };
+        let to_unix_ts =
+            |t: SystemTime| -> u64 { t.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs()) };
 
         // Check the separate keepalive key for the most recent timestamp.
         let keepalive_ts = if USE_SEPARATE_CLIENT_KEEPALIVE_KEY {
@@ -630,6 +630,7 @@ where
     operation_id_creator: F,
     _pull_task_change_subscriber_spawn: JoinHandleDropGuard<()>,
     retain_completed_for: Duration,
+    worker_registry: Option<SharedWorkerRegistry>,
 }
 
 impl<S, F, I, NowFn> StoreAwaitedActionDb<S, F, I, NowFn>
@@ -681,7 +682,53 @@ where
             operation_id_creator,
             _pull_task_change_subscriber_spawn: pull_task_change_subscriber,
             retain_completed_for: Duration::from_secs(retain_completed_for_s.into()),
+            worker_registry: None,
         })
+    }
+
+    /// Whether an executing action looks abandoned and should be recreated
+    /// rather than joined.
+    ///
+    /// `last_worker_updated_timestamp` lives in the shared store and
+    /// heartbeats never refresh it, so on its own it goes stale on any action
+    /// outliving `worker_timeout_s` and a healthy worker looks abandoned.
+    /// Consult the registry first and only fall back to the timestamp for
+    /// workers this instance owns.
+    #[expect(clippy::future_not_send)] // TODO(jhpratt) remove this
+    async fn executing_action_is_abandoned(
+        &self,
+        awaited_action: &AwaitedAction,
+        no_event_action_timeout: Duration,
+        now: SystemTime,
+    ) -> bool {
+        if awaited_action.state().stage != ActionStage::Executing {
+            return false;
+        }
+
+        let liveness = match (&self.worker_registry, awaited_action.worker_id()) {
+            (Some(worker_registry), Some(worker_id)) => {
+                worker_registry
+                    .check_liveness(worker_id, no_event_action_timeout, now)
+                    .await
+            }
+            // No registry, or not assigned yet: timestamp only, as before.
+            _ => WorkerLiveness::Stale,
+        };
+
+        let ceiling = match liveness {
+            // Ours and heartbeating. Never recreate: that forks a second
+            // execution of work already running.
+            WorkerLiveness::Alive => return false,
+            // Ours and gone quiet.
+            WorkerLiveness::Stale => no_event_action_timeout,
+            // A peer's worker, or an orphan nobody owns.
+            WorkerLiveness::Unknown => ORPHANED_ACTION_TIMEOUT,
+        };
+
+        awaited_action
+            .last_worker_updated_timestamp()
+            .checked_add(ceiling)
+            .is_some_and(|deadline| deadline < now)
     }
 
     // `pub` so integration tests in `tests/` can drive this directly;
@@ -731,17 +778,14 @@ where
                 // If the existing job failed then we need to set back to queued or we get
                 // a version mismatch.  Equally we need to check the timeout as the job
                 // may be abandoned in the store.
-                let worker_should_update_before = (awaited_action.state().stage
-                    == ActionStage::Executing)
-                    .then_some(())
-                    .map(|()| awaited_action.last_worker_updated_timestamp())
-                    .and_then(|last_worker_updated| {
-                        last_worker_updated.checked_add(no_event_action_timeout)
-                    });
-                let awaited_action = if awaited_action.state().stage.is_finished()
-                    || worker_should_update_before
-                        .is_some_and(|timestamp| timestamp < (self.now_fn)().now())
-                {
+                let abandoned = self
+                    .executing_action_is_abandoned(
+                        &awaited_action,
+                        no_event_action_timeout,
+                        (self.now_fn)().now(),
+                    )
+                    .await;
+                let awaited_action = if awaited_action.state().stage.is_finished() || abandoned {
                     tracing::debug!(
                         "Recreating action {:?} for operation {client_operation_id}",
                         awaited_action.action_info().digest()
@@ -950,6 +994,10 @@ where
                 self.retain_completed_for,
             ));
         }
+    }
+
+    fn set_worker_registry(&mut self, worker_registry: SharedWorkerRegistry) {
+        self.worker_registry = Some(worker_registry);
     }
 
     async fn get_range_of_actions(

--- a/nativelink-scheduler/src/worker_registry.rs
+++ b/nativelink-scheduler/src/worker_registry.rs
@@ -21,6 +21,12 @@ use async_lock::RwLock;
 use nativelink_util::action_messages::WorkerId;
 use tracing::{debug, trace};
 
+/// Ceiling for an action whose worker no instance here recognises. Long on
+/// purpose: heartbeats never reach the shared state, so a healthy hour-long
+/// action and an abandoned one look identical from here, and acting early
+/// costs live work.
+pub const ORPHANED_ACTION_TIMEOUT: Duration = Duration::from_hours(1);
+
 /// What this scheduler instance knows about a worker's liveness.
 ///
 /// A worker only appears in the registry of the instance holding its

--- a/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
@@ -117,6 +117,63 @@ fn state_manager(
     )
 }
 
+/// Same as above but with `max_action_executing_timeout_s` disabled, which is
+/// its default.
+fn state_manager_no_executing_ceiling(
+    registry: Arc<WorkerRegistry>,
+) -> Arc<
+    SimpleSchedulerStateManager<
+        impl nativelink_scheduler::awaited_action_db::AwaitedActionDb,
+        MockInstantWrapped,
+        fn() -> MockInstantWrapped,
+    >,
+> {
+    let task_change_notify = Arc::new(Notify::new());
+    SimpleSchedulerStateManager::new(
+        5,
+        WORKER_TIMEOUT,
+        Duration::from_mins(5),
+        Duration::ZERO,
+        memory_awaited_action_db_factory(0, &task_change_notify, MockInstantWrapped::default),
+        MockInstantWrapped::default,
+        Some(registry),
+    )
+}
+
+/// An orphan must still be reaped when `max_action_executing_timeout_s` is
+/// disabled, which is its default.
+///
+/// An HPA scaling a replica down leaves its workers' actions Executing in
+/// shared state, naming worker ids no surviving instance recognises. If the
+/// only ceiling for Unknown were the executing timeout, the default config
+/// would never reap them and every scale-down would leak actions until the
+/// client gave up.
+#[nativelink_test]
+async fn reaps_an_orphan_even_with_the_executing_ceiling_disabled() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let action = executing_action(
+        &WorkerId::from(String::from("owner-was-scaled-down")),
+        make_system_time(0),
+    );
+    let state_mgr = state_manager_no_executing_ceiling(Arc::new(WorkerRegistry::new()));
+
+    // Past worker_timeout_s: still must not fire, this could be a healthy
+    // action on a peer's worker.
+    MockClock::advance(WORKER_TIMEOUT + Duration::from_mins(1));
+    assert!(
+        !state_mgr.should_timeout_operation(&action).await,
+        "must not reap at worker_timeout_s just because the ceiling is disabled"
+    );
+
+    // Past the orphan backstop: now it has to go, or it never will.
+    MockClock::advance(Duration::from_mins(61));
+    assert!(
+        state_mgr.should_timeout_operation(&action).await,
+        "an orphan must be reaped by the backstop when no ceiling is configured"
+    );
+    Ok(())
+}
+
 /// An action on a worker connected to a DIFFERENT scheduler instance must not
 /// be timed out here. This instance never sees that worker's heartbeats, so
 /// the action's timestamp looks frozen however healthy it is.

--- a/nativelink-scheduler/tests/store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/store_awaited_action_db_test.rs
@@ -8,15 +8,16 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 use futures::{Stream, stream};
-use mock_instant::thread_local::SystemTime as MockSystemTime;
+use mock_instant::thread_local::{MockClock, SystemTime as MockSystemTime};
 use nativelink_error::Error;
 use nativelink_macro::nativelink_test;
-use nativelink_scheduler::awaited_action_db::AwaitedAction;
+use nativelink_scheduler::awaited_action_db::{AwaitedAction, AwaitedActionDb};
 use nativelink_scheduler::store_awaited_action_db::{
     StoreAwaitedActionDb, inner_update_awaited_action,
 };
+use nativelink_scheduler::worker_registry::{ORPHANED_ACTION_TIMEOUT, WorkerRegistry};
 use nativelink_util::action_messages::{
-    ActionInfo, ActionUniqueKey, ActionUniqueQualifier, OperationId,
+    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier, OperationId, WorkerId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -386,6 +387,173 @@ async fn try_subscribe_skips_lookup_for_uncacheable_qualifier() -> Result<(), Er
         counter.load(Ordering::SeqCst),
         0,
         "uncacheable qualifier must short-circuit before any lookup",
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `try_subscribe` abandonment check.
+//
+// The stage/timestamp pair lives in the shared store and heartbeats never
+// refresh it, so without a liveness check a healthy long-running action looks
+// abandoned and a duplicate Execute forks a second execution of it.
+// ---------------------------------------------------------------------------
+
+const WORKER_TIMEOUT: Duration = Duration::from_mins(2);
+const NOW_TIME: u64 = 10_000;
+
+/// `MockInstantWrapped::now` reads `MockClock::time`, so timestamps have to be
+/// built from the same clock or nothing lines up.
+fn mock_now() -> SystemTime {
+    SystemTime::UNIX_EPOCH + MockClock::time()
+}
+
+fn make_executing_awaited_action(worker_id: &WorkerId) -> AwaitedAction {
+    let now = mock_now();
+    let mut action = AwaitedAction::new(
+        OperationId::from("existing-operation"),
+        make_cacheable_action_info(),
+        now,
+    );
+    action.set_worker_id(Some(worker_id.clone()), now);
+    let mut state = action.state().as_ref().clone();
+    state.stage = ActionStage::Executing;
+    action.worker_set_state(Arc::new(state), now);
+    action
+}
+
+/// Runs `try_subscribe` against an executing action owned by `worker_id`,
+/// after `elapsed` has passed, and reports whether the action was recreated
+/// rather than joined.
+async fn recreated_after(
+    registry: Option<Arc<WorkerRegistry>>,
+    worker_id: &WorkerId,
+    elapsed: Duration,
+) -> Result<bool, Error> {
+    let action = make_executing_awaited_action(worker_id);
+    let qualifier = action.action_info().unique_qualifier.clone();
+    let store = Arc::new(EventuallyVisibleStore::new(
+        /* empty_for = */ 0, &action,
+    ));
+    let mut db = build_db(store).await;
+    if let Some(registry) = registry {
+        db.set_worker_registry(registry);
+    }
+
+    MockClock::advance(elapsed);
+
+    let result = db
+        .try_subscribe(
+            &OperationId::from("client-abandon"),
+            &qualifier,
+            WORKER_TIMEOUT,
+            0,
+        )
+        .await?
+        .expect("the action is visible, so try_subscribe must return it");
+
+    Ok(*result.operation_id() == OperationId::from("new-operation"))
+}
+
+#[nativelink_test]
+async fn joins_an_executing_action_whose_worker_is_ours_and_alive() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from("worker-alive".to_string());
+    let registry = Arc::new(WorkerRegistry::new());
+
+    // Heartbeats keep the registry current even though the shared timestamp
+    // on the action does not move.
+    let action = make_executing_awaited_action(&worker_id);
+    let qualifier = action.action_info().unique_qualifier.clone();
+    let store = Arc::new(EventuallyVisibleStore::new(
+        /* empty_for = */ 0, &action,
+    ));
+    let mut db = build_db(store).await;
+    db.set_worker_registry(registry.clone());
+
+    // The action's shared timestamp stays put while the worker keeps
+    // heartbeating, which is exactly the case that used to look abandoned.
+    MockClock::advance(WORKER_TIMEOUT * 3);
+    registry
+        .update_worker_heartbeat(&worker_id, mock_now())
+        .await;
+
+    let result = db
+        .try_subscribe(
+            &OperationId::from("client-alive"),
+            &qualifier,
+            WORKER_TIMEOUT,
+            0,
+        )
+        .await?
+        .expect("action is visible");
+    let recreated = *result.operation_id() == OperationId::from("new-operation");
+
+    assert!(
+        !recreated,
+        "a worker we can see heartbeating owns this action; recreating it would run the work twice",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn recreates_an_executing_action_whose_worker_went_quiet() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from("worker-stale".to_string());
+    let registry = Arc::new(WorkerRegistry::new());
+    registry.register_worker(&worker_id, mock_now()).await;
+
+    let recreated = recreated_after(Some(registry), &worker_id, WORKER_TIMEOUT * 2).await?;
+
+    assert!(
+        recreated,
+        "the worker is registered here and has stopped reporting, so the action is genuinely abandoned",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn joins_an_executing_action_on_a_peers_worker() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from("worker-elsewhere".to_string());
+    // Empty registry: the worker belongs to another scheduler instance.
+    let registry = Arc::new(WorkerRegistry::new());
+
+    let recreated = recreated_after(Some(registry), &worker_id, WORKER_TIMEOUT * 5).await?;
+
+    assert!(
+        !recreated,
+        "worker_timeout_s must not apply to a worker this instance never sees heartbeats for",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn recreates_an_orphan_once_past_the_backstop() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from("worker-orphaned".to_string());
+    let registry = Arc::new(WorkerRegistry::new());
+
+    let recreated =
+        recreated_after(Some(registry), &worker_id, ORPHANED_ACTION_TIMEOUT * 2).await?;
+
+    assert!(
+        recreated,
+        "an action nobody claims still has to be reaped eventually or it leaks forever",
+    );
+    Ok(())
+}
+
+#[nativelink_test]
+async fn falls_back_to_the_timestamp_when_there_is_no_registry() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let worker_id = WorkerId::from("worker-no-registry".to_string());
+
+    let recreated = recreated_after(None, &worker_id, WORKER_TIMEOUT * 2).await?;
+
+    assert!(
+        recreated,
+        "without a registry there is nothing better than the timestamp, so behaviour is unchanged",
     );
     Ok(())
 }


### PR DESCRIPTION
# Description

Follow-up to #2680. Two places still decide an action is abandoned by reading
a timestamp in the shared store that worker heartbeats never update.

One leaks: on the default config `max_action_executing_timeout_s` is 0, so an
action whose scheduler went away is never cleaned up. The other duplicates
work: `try_subscribe` recreates an action that is still running instead of
joining it, so the same build step executes twice.

Both now check worker liveness first, and an unrecognised worker gets a long
backstop instead of nothing.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests. Each one fails if you revert the fix it covers.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2685)
<!-- Reviewable:end -->
