### PR TITLE
Chunk oversized messages in the ByteStream write and batch update paths

### DIFF
--- a/nativelink-store/src/grpc_store.rs
+++ b/nativelink-store/src/grpc_store.rs
@@ -32,7 +32,8 @@ use nativelink_proto::build::bazel::remote::execution::v2::{
     ActionResult, BatchReadBlobsRequest, BatchReadBlobsResponse, BatchUpdateBlobsRequest,
     BatchUpdateBlobsResponse, FindMissingBlobsRequest, FindMissingBlobsResponse,
     GetActionResultRequest, GetTreeRequest, GetTreeResponse, SpliceBlobRequest, SpliceBlobResponse,
-    SplitBlobRequest, SplitBlobResponse, UpdateActionResultRequest, compressor,
+    SplitBlobRequest, SplitBlobResponse, UpdateActionResultRequest, batch_update_blobs_request,
+    compressor,
 };
 use nativelink_proto::google::bytestream::byte_stream_client::ByteStreamClient;
 use nativelink_proto::google::bytestream::{
@@ -47,7 +48,8 @@ use nativelink_util::connection_manager::ConnectionManager;
 use nativelink_util::digest_hasher::{DigestHasherFunc, default_digest_hasher_func};
 use nativelink_util::health_utils::HealthStatusIndicator;
 use nativelink_util::proto_stream_utils::{
-    FirstStream, WriteRequestStreamWrapper, WriteState, WriteStateWrapper,
+    FirstStream, MAX_WRITE_REQUEST_DATA_BYTES, WriteRequestStreamWrapper, WriteState,
+    WriteStateWrapper,
 };
 use nativelink_util::resource_info::ResourceInfo;
 use nativelink_util::retry::{Retrier, RetryResult};
@@ -211,9 +213,39 @@ const fn is_retryable_code(code: Code) -> bool {
 // This store is usually a pass-through store, but can also be used as a CAS store. Using it as an
 // AC store has one major side-effect... The has() function may not give the proper size of the
 // underlying data. This might cause issues if embedded in certain stores.
-/// Largest `data` payload in a single `ByteStream` `WriteRequest`, kept under
-/// tonic's 4MiB default `max_decoding_message_size` with room to spare.
-const MAX_WRITE_REQUEST_DATA_BYTES: usize = 2 * 1024 * 1024;
+/// Starting capacity for the stitched-together batch response. Only a hint:
+/// most batches are one chunk, and the vec grows if not.
+const MAX_BATCH_UPDATE_ENTRIES_HINT: usize = 256;
+
+/// Groups blobs so no single `BatchUpdateBlobs` RPC carries more than
+/// `MAX_WRITE_REQUEST_DATA_BYTES` of payload.
+///
+/// An entry larger than the cap on its own still goes out alone. Nothing can
+/// be done for it here, since a batch entry cannot be split across messages,
+/// and REAPI already tells clients to use `ByteStream` for blobs that size.
+fn split_batch_update_requests(
+    requests: Vec<batch_update_blobs_request::Request>,
+) -> Vec<Vec<batch_update_blobs_request::Request>> {
+    let mut chunks = Vec::new();
+    let mut current: Vec<batch_update_blobs_request::Request> = Vec::new();
+    let mut current_bytes = 0usize;
+
+    for request in requests {
+        let len = request.data.len();
+        if !current.is_empty() && current_bytes.saturating_add(len) > MAX_WRITE_REQUEST_DATA_BYTES {
+            chunks.push(core::mem::take(&mut current));
+            current_bytes = 0;
+        }
+        current_bytes = current_bytes.saturating_add(len);
+        current.push(request);
+    }
+    // An empty batch still needs one RPC: the caller expects the upstream's
+    // answer to an empty request, not a synthesised one.
+    if !current.is_empty() || chunks.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
 
 #[derive(Debug, MetricsComponent)]
 pub struct GrpcStore {
@@ -396,22 +428,40 @@ impl GrpcStore {
 
         let mut request = grpc_request.into_inner();
         request.instance_name.clone_from(&self.instance_name);
-        self.perform_request(request, |request| async move {
-            let channel = self
-                .connection_manager
-                .connection("batch_update_blobs".into())
-                .await
-                .err_tip(|| "in batch_update_blobs")?;
-            ContentAddressableStorageClient::new(channel)
-                .batch_update_blobs(enrich_request(
-                    Request::new(request),
-                    &self.headers,
-                    &self.forward_headers,
-                ))
-                .await
-                .err_tip(|| "in GrpcStore::batch_update_blobs")
-        })
-        .await
+
+        // A batch is one message, so an oversized one cannot be chunked the
+        // way a ByteStream write can; it has to become several RPCs. Split on
+        // the accumulated payload and stitch the responses back together in
+        // request order, which is what the caller matches results by.
+        let mut responses =
+            Vec::with_capacity(request.requests.len().min(MAX_BATCH_UPDATE_ENTRIES_HINT));
+        for chunk in split_batch_update_requests(core::mem::take(&mut request.requests)) {
+            let chunk_request = BatchUpdateBlobsRequest {
+                instance_name: request.instance_name.clone(),
+                requests: chunk,
+                digest_function: request.digest_function,
+            };
+            let response = self
+                .perform_request(chunk_request, |chunk_request| async move {
+                    let channel = self
+                        .connection_manager
+                        .connection("batch_update_blobs".into())
+                        .await
+                        .err_tip(|| "in batch_update_blobs")?;
+                    ContentAddressableStorageClient::new(channel)
+                        .batch_update_blobs(enrich_request(
+                            Request::new(chunk_request),
+                            &self.headers,
+                            &self.forward_headers,
+                        ))
+                        .await
+                        .err_tip(|| "in GrpcStore::batch_update_blobs")
+                })
+                .await?;
+            responses.extend(response.into_inner().responses);
+        }
+
+        Ok(Response::new(BatchUpdateBlobsResponse { responses }))
     }
 
     pub async fn batch_read_blobs(

--- a/nativelink-store/tests/grpc_store_test.rs
+++ b/nativelink-store/tests/grpc_store_test.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_lock::Mutex;
-use futures::stream::unfold;
+use futures::stream::{self, unfold};
 use futures::{Stream, StreamExt};
 use nativelink_config::stores::{GrpcEndpoint, GrpcSpec, Retry, StoreType};
 use nativelink_error::{Error, ResultExt};
@@ -16,7 +16,8 @@ use nativelink_proto::build::bazel::remote::execution::v2::{
     BatchReadBlobsRequest, BatchReadBlobsResponse, BatchUpdateBlobsRequest,
     BatchUpdateBlobsResponse, Digest, FindMissingBlobsRequest, FindMissingBlobsResponse,
     GetTreeRequest, GetTreeResponse, SpliceBlobRequest, SpliceBlobResponse, SplitBlobRequest,
-    SplitBlobResponse, chunking_function, digest_function,
+    SplitBlobResponse, batch_update_blobs_request, batch_update_blobs_response, chunking_function,
+    compressor, digest_function,
 };
 use nativelink_proto::google::bytestream::byte_stream_server::{ByteStream, ByteStreamServer};
 use nativelink_proto::google::bytestream::{
@@ -27,6 +28,7 @@ use nativelink_store::grpc_store::GrpcStore;
 use nativelink_util::background_spawn;
 use nativelink_util::buf_channel::make_buf_channel_pair;
 use nativelink_util::common::DigestInfo;
+use nativelink_util::proto_stream_utils::WriteRequestStreamWrapper;
 use nativelink_util::store_trait::{StoreLike, UploadSizeInfo};
 use nativelink_util::telemetry::ClientHeaders;
 use opentelemetry::Context;
@@ -363,6 +365,9 @@ async fn read_works_with_headers() -> Result<(), Error> {
 struct FakeCasServer {
     split_requests: Arc<Mutex<Vec<SplitBlobRequest>>>,
     splice_requests: Arc<Mutex<Vec<SpliceBlobRequest>>>,
+    /// Every `BatchUpdateBlobs` RPC received, so a test can assert on how the
+    /// store split an oversized batch.
+    batch_updates: Arc<Mutex<Vec<BatchUpdateBlobsRequest>>>,
 }
 
 impl FakeCasServer {
@@ -370,6 +375,7 @@ impl FakeCasServer {
         Self {
             split_requests: Arc::new(Mutex::new(vec![])),
             splice_requests: Arc::new(Mutex::new(vec![])),
+            batch_updates: Arc::new(Mutex::new(vec![])),
         }
     }
 }
@@ -388,12 +394,23 @@ impl ContentAddressableStorage for FakeCasServer {
         unimplemented!();
     }
 
-    #[allow(clippy::unimplemented)]
     async fn batch_update_blobs(
         &self,
-        _grpc_request: Request<BatchUpdateBlobsRequest>,
+        grpc_request: Request<BatchUpdateBlobsRequest>,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Status> {
-        unimplemented!();
+        let request = grpc_request.into_inner();
+        // One response per entry, echoing the digest, so a test can check the
+        // stitched-together result keeps request order.
+        let responses = request
+            .requests
+            .iter()
+            .map(|r| batch_update_blobs_response::Response {
+                digest: r.digest.clone(),
+                status: None,
+            })
+            .collect();
+        self.batch_updates.lock().await.push(request);
+        Ok(Response::new(BatchUpdateBlobsResponse { responses }))
     }
 
     #[allow(clippy::unimplemented)]
@@ -581,6 +598,157 @@ async fn update_splits_buffers_larger_than_the_grpc_message_limit() -> Result<()
     assert!(
         *finish_flags.last().unwrap(),
         "finish_write must be on the final message"
+    );
+    Ok(())
+}
+
+/// The `ByteStream` pass-through forwards the caller's frames as it receives
+/// them, so a caller that hands over a whole blob in one frame would produce
+/// one oversized message and be rejected at the receiver's 4MiB default.
+#[nativelink_test]
+async fn write_splits_frames_larger_than_the_grpc_message_limit() -> Result<(), Error> {
+    const TONIC_DEFAULT_DECODE_LIMIT: usize = 4 * 1024 * 1024;
+    // Over the limit and not a multiple of the chunk size, so the tail is a
+    // partial piece. Kept just past the limit rather than at the ~9.4MB seen
+    // in the wild: the extra bytes prove nothing here and cost real time under
+    // sanitizers.
+    const BLOB_LEN: usize = 5_242_883;
+
+    let (server, port) = make_fake_bytestream_server_draining().await;
+    let mut spec = test_spec(format!("http://localhost:{port}"), false);
+    // Streaming several MiB through ByteStream is slow under instrumented
+    // builds. This deadline is headroom for that, not part of the test.
+    spec.rpc_timeout_s = 30;
+    let store = GrpcStore::new(&spec).await?;
+
+    let payload = vec![0xCDu8; BLOB_LEN];
+    let resource_name = format!(
+        "instance_name/uploads/{}/blobs/{VALID_HASH}/{BLOB_LEN}",
+        uuid::Uuid::new_v4()
+    );
+    // A single frame carrying the entire blob, which is what a client doing
+    // one big write looks like on the wire.
+    let requests = vec![WriteRequest {
+        resource_name,
+        write_offset: 0,
+        finish_write: true,
+        data: payload.clone().into(),
+    }];
+    let stream =
+        WriteRequestStreamWrapper::from(stream::iter(requests.into_iter().map(Ok::<_, Error>)))
+            .await?;
+
+    store.write(stream).await?;
+
+    let write_requests = server.write_requests.lock().await;
+    assert!(
+        write_requests.len() > 1,
+        "expected the frame to be split, got {}",
+        write_requests.len()
+    );
+
+    for (i, req) in write_requests.iter().enumerate() {
+        assert!(
+            req.data.len() <= TONIC_DEFAULT_DECODE_LIMIT,
+            "WriteRequest {i} carries {} bytes, over the {TONIC_DEFAULT_DECODE_LIMIT} byte default decode limit",
+            req.data.len()
+        );
+    }
+
+    let mut reassembled = Vec::with_capacity(BLOB_LEN);
+    let mut expected_offset = 0i64;
+    for req in write_requests.iter() {
+        assert_eq!(
+            req.write_offset, expected_offset,
+            "write_offset must be contiguous across chunks"
+        );
+        expected_offset += i64::try_from(req.data.len()).unwrap();
+        reassembled.extend_from_slice(&req.data);
+    }
+    assert_eq!(reassembled, payload, "the split must not corrupt the blob");
+
+    let finish_flags: Vec<bool> = write_requests.iter().map(|r| r.finish_write).collect();
+    assert_eq!(
+        finish_flags.iter().filter(|f| **f).count(),
+        1,
+        "expected exactly one finish_write, got {finish_flags:?}"
+    );
+    assert!(
+        *finish_flags.last().unwrap(),
+        "finish_write must be on the final chunk"
+    );
+    Ok(())
+}
+
+/// A batch is a single message, so an oversized one has to become several
+/// RPCs rather than several chunks of one RPC.
+#[nativelink_test]
+async fn batch_update_blobs_splits_an_oversized_batch_across_rpcs() -> Result<(), Error> {
+    const TONIC_DEFAULT_DECODE_LIMIT: usize = 4 * 1024 * 1024;
+    const ENTRY_LEN: usize = 900 * 1024;
+    const ENTRIES: usize = 12; // ~10.5MiB total, comfortably over the limit.
+
+    let (server, port) = make_fake_cas_server().await;
+    let mut spec = test_spec(format!("http://localhost:{port}"), false);
+    spec.instance_name = "backend_instance".to_string();
+    spec.rpc_timeout_s = 5;
+    let store = GrpcStore::new(&spec).await?;
+
+    let requests: Vec<batch_update_blobs_request::Request> = (0..ENTRIES)
+        .map(|i| batch_update_blobs_request::Request {
+            digest: Some(Digest {
+                hash: format!("{i:064x}"),
+                size_bytes: i64::try_from(ENTRY_LEN).unwrap(),
+            }),
+            data: vec![u8::try_from(i).unwrap_or(0); ENTRY_LEN].into(),
+            compressor: compressor::Value::Identity.into(),
+        })
+        .collect();
+    let expected_digests: Vec<Option<Digest>> = requests.iter().map(|r| r.digest.clone()).collect();
+
+    let response = store
+        .batch_update_blobs(Request::new(BatchUpdateBlobsRequest {
+            instance_name: "local_instance".to_string(),
+            requests,
+            digest_function: digest_function::Value::Sha256.into(),
+        }))
+        .await?;
+
+    let batches = server.batch_updates.lock().await;
+    assert!(
+        batches.len() > 1,
+        "expected the batch to be split across several RPCs, got {}",
+        batches.len()
+    );
+
+    for (i, batch) in batches.iter().enumerate() {
+        let bytes: usize = batch.requests.iter().map(|r| r.data.len()).sum();
+        assert!(
+            bytes <= TONIC_DEFAULT_DECODE_LIMIT,
+            "batch {i} carries {bytes} bytes, over the {TONIC_DEFAULT_DECODE_LIMIT} byte default decode limit",
+        );
+        assert_eq!(
+            batch.instance_name, "backend_instance",
+            "every split batch keeps the rewritten instance name"
+        );
+    }
+
+    // Nothing dropped or reordered by the split.
+    let sent: Vec<Option<Digest>> = batches
+        .iter()
+        .flat_map(|b| b.requests.iter().map(|r| r.digest.clone()))
+        .collect();
+    assert_eq!(sent, expected_digests, "every blob must be forwarded once");
+
+    let got: Vec<Option<Digest>> = response
+        .into_inner()
+        .responses
+        .into_iter()
+        .map(|r| r.digest)
+        .collect();
+    assert_eq!(
+        got, expected_digests,
+        "stitched responses must stay in request order"
     );
     Ok(())
 }

--- a/nativelink-util/src/proto_stream_utils.rs
+++ b/nativelink-util/src/proto_stream_utils.rs
@@ -207,6 +207,10 @@ impl Stream for FirstStream {
     }
 }
 
+/// Largest `data` payload in a single `ByteStream` `WriteRequest`, kept under
+/// tonic's 4MiB default `max_decoding_message_size` with room to spare.
+pub const MAX_WRITE_REQUEST_DATA_BYTES: usize = 2 * 1024 * 1024;
+
 /// This structure wraps all of the information required to perform a write
 /// request on the `GrpcStore`.  It stores the last message retrieved which allows
 /// the write to resume since the UUID allows upload resume at the server.
@@ -227,6 +231,9 @@ where
     resume_queue: [Option<WriteRequest>; 2],
     // An optimisation to avoid having to manage resume_queue when it's empty.
     is_resumed: bool,
+    // Remainder of an incoming frame too large to forward in one message.
+    // Drained before the next frame is read so ordering is preserved.
+    pending: Option<WriteRequest>,
     // When false, a partially-consumed stream never reports `can_resume()`:
     // uploads whose server-side protocol cannot accept a replay from a
     // nonzero offset (REAPI compressed-blobs writes) must fail fast instead
@@ -248,8 +255,32 @@ where
             cached_messages: [None, None],
             resume_queue: [None, None],
             is_resumed: false,
+            pending: None,
             resumable: true,
         }
+    }
+
+    /// Caps the payload of an outgoing message, stashing anything over the
+    /// limit to be sent as the following message.
+    ///
+    /// A caller can hand us a whole blob in one frame, and forwarding that
+    /// verbatim produces a message the receiver rejects at its 4MiB default.
+    /// Only the final piece carries `finish_write`, and each piece advances
+    /// `write_offset` by what came before it.
+    fn split_oversized(&mut self, mut message: WriteRequest) -> WriteRequest {
+        if message.data.len() <= MAX_WRITE_REQUEST_DATA_BYTES {
+            return message;
+        }
+        let rest = message.data.split_off(MAX_WRITE_REQUEST_DATA_BYTES);
+        let sent_len = i64::try_from(message.data.len()).unwrap_or(i64::MAX);
+        self.pending = Some(WriteRequest {
+            resource_name: message.resource_name.clone(),
+            write_offset: message.write_offset.saturating_add(sent_len),
+            finish_write: message.finish_write,
+            data: rest,
+        });
+        message.finish_write = false;
+        message
     }
 
     /// Marks this write as non-resumable: once the stream has been partially
@@ -340,6 +371,14 @@ where
         if cached_message.is_some() {
             return Poll::Ready(cached_message);
         }
+        // Finish draining an oversized frame before reading the next one.
+        if let Some(pending) = local_state.pending.take() {
+            let message = local_state.split_oversized(pending);
+            if local_state.is_resumable() {
+                local_state.push_message(message.clone());
+            }
+            return Poll::Ready(Some(message));
+        }
         // Read a new write request from the downstream.
         let Poll::Ready(maybe_message) = Pin::new(&mut local_state.read_stream).poll_next(cx)
         else {
@@ -365,6 +404,7 @@ where
                         }
                     }
                 }
+                let message = local_state.split_oversized(message);
                 // Cache the last request in case there is an error to allow
                 // the upload to be resumed. Non-resumable writes skip the
                 // clone: cached messages would never be replayed.


### PR DESCRIPTION
# Description

Follow-up to #2679, which fixed one of three places that send a whole blob as
a single gRPC message. The other two were missed: the `ByteStream` write
pass-through, and `batch_update_blobs`.

Both are hit when NativeLink sits in front of another CAS. The receiver
rejects anything over its 4MiB default, and it fails the same way on every
retry.

Writes are now split into smaller messages. A batch is one message and cannot
be split that way, so an oversized batch is sent as several RPCs instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests for both paths. Each one fails if you revert the fix it
covers.

## Checklist

- [X] Updated documentation if needed
- [X] Tests added/amended
- [X] `bazel test //...`  passes locally
- [X] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2686)
<!-- Reviewable:end -->
