### PR TITLE
Add OTLP metrics for workers, gRPC, the scheduler, store tiers and health

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -125,7 +125,12 @@ message ActionResourceUsage {
     /// The worker ID that observed the resource usage.
     string worker_id = 4;
 
-    reserved 5; // NextId.
+    /// Total CPU time consumed by the action process tree, in milliseconds.
+    /// User and system time combined, summed across every process in the
+    /// action's process group.
+    uint64 cpu_time_ms = 5;
+
+    reserved 6; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -104,6 +104,11 @@ pub struct ActionResourceUsage {
     /// / The worker ID that observed the resource usage.
     #[prost(string, tag = "4")]
     pub worker_id: ::prost::alloc::string::String,
+    /// / Total CPU time consumed by the action process tree, in milliseconds.
+    /// / User and system time combined, summed across every process in the
+    /// / action's process group.
+    #[prost(uint64, tag = "5")]
+    pub cpu_time_ms: u64,
 }
 /// / Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -31,6 +31,11 @@ use nativelink_proto::com::github::trace_machina::nativelink::events::{
 };
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::ActionResourceUsage;
 use nativelink_util::action_messages::{OperationId, WorkerId};
+use nativelink_util::metrics::{
+    WorkerDisconnectReason, record_execution_cpu_time, record_execution_peak_memory,
+    record_worker_connected, record_worker_disconnected, record_worker_keepalive,
+    record_worker_state,
+};
 use nativelink_util::operation_state_manager::{UpdateOperationType, WorkerStateManager};
 use nativelink_util::origin_event::get_node_id;
 use nativelink_util::platform_properties::PlatformProperties;
@@ -179,6 +184,7 @@ impl ApiWorkerSchedulerImpl {
             running_operations = worker.running_action_infos.len(),
             "Worker keepalive received"
         );
+        record_worker_keepalive();
 
         Ok(())
     }
@@ -188,7 +194,9 @@ impl ApiWorkerSchedulerImpl {
     fn add_worker(&mut self, worker: Worker) -> Result<(), Error> {
         let worker_id = worker.id.clone();
         let platform_properties = worker.platform_properties.clone();
-        self.workers.put(worker_id.clone(), worker);
+        // A replacement is one out and one in, so the gauge only moves for a
+        // genuinely new worker.
+        let replaced = self.workers.put(worker_id.clone(), worker);
 
         // Add to capability index for fast matching
         self.capability_index
@@ -207,6 +215,16 @@ impl ApiWorkerSchedulerImpl {
                 ?err,
                 "Worker connection appears to have been closed while adding to pool"
             );
+        }
+        if let Some(replaced) = &replaced {
+            if replaced.is_draining {
+                record_worker_state("draining", false);
+            }
+            if replaced.is_paused {
+                record_worker_state("paused", false);
+            }
+        } else {
+            record_worker_connected();
         }
         self.worker_change_notify.notify_one();
         res
@@ -234,6 +252,9 @@ impl ApiWorkerSchedulerImpl {
             .workers
             .get_mut(worker_id)
             .err_tip(|| format!("Worker {worker_id} doesn't exist in the pool"))?;
+        if worker.is_draining != is_draining {
+            record_worker_state("draining", is_draining);
+        }
         worker.is_draining = is_draining;
         self.worker_change_notify.notify_one();
         Ok(())
@@ -378,10 +399,18 @@ impl ApiWorkerSchedulerImpl {
         // Clear this action from the current worker if finished.
         let complete_action_res = {
             // Note: We need to run this before dealing with backpressure logic.
+            let was_paused = worker.is_paused;
             let complete_action_res = worker.complete_action(operation_id).await;
 
             if (due_to_backpressure || !worker.can_accept_work()) && worker.has_actions() {
                 worker.is_paused = true;
+            }
+            // complete_action clears is_paused on its way through, so compare
+            // the state either side of it rather than testing the flag after.
+            // Testing afterwards counts a re-pause every time and never
+            // unwinds, which leaves the gauge climbing forever.
+            if was_paused != worker.is_paused {
+                record_worker_state("paused", worker.is_paused);
             }
             complete_action_res
         };
@@ -471,6 +500,15 @@ impl ApiWorkerSchedulerImpl {
                 running_actions = worker.running_action_infos.len(),
                 reason = %err.message_string(),
                 "Evicting worker from pool"
+            );
+            record_worker_disconnected(
+                if is_disconnect {
+                    WorkerDisconnectReason::Disconnected
+                } else {
+                    WorkerDisconnectReason::Evicted
+                },
+                worker.is_draining,
+                worker.is_paused,
             );
             // We don't care if we fail to send message to worker, this is only a best attempt.
             drop(worker.notify_update(WorkerUpdate::Disconnect).await);
@@ -661,6 +699,17 @@ impl WorkerScheduler for ApiWorkerScheduler {
         // only override lived on `SimpleScheduler`, which this path never
         // reaches, so the event was silently dropped by the trait's no-op
         // default and `observed_worker_peak_memory_mib` was never recorded.
+        // Sampling is optional, so only record when the worker actually took a
+        // reading. A zero here means "not sampled", not "used no memory".
+        if resource_usage.sampled {
+            if resource_usage.peak_memory_kb > 0 {
+                record_execution_peak_memory(resource_usage.peak_memory_kb, "");
+            }
+            if resource_usage.cpu_time_ms > 0 {
+                record_execution_cpu_time(resource_usage.cpu_time_ms, "");
+            }
+        }
+
         let Some(origin_event_tx) = self.maybe_origin_event_tx.as_ref() else {
             return Ok(());
         };

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -27,6 +27,7 @@ use nativelink_proto::com::github::trace_machina::nativelink::events::{
 use nativelink_proto::com::github::trace_machina::nativelink::remote_execution::StartExecute;
 use nativelink_util::action_messages::{ActionInfo, ActionState, OperationId, WorkerId};
 use nativelink_util::instant_wrapper::InstantWrapper;
+use nativelink_util::metrics::record_matching_pass;
 use nativelink_util::operation_state_manager::{
     ActionStateResult, ActionStateResultStream, ClientStateManager, MatchingEngineStateManager,
     OperationFilter, OperationStageFlags, OrderDirection, UpdateOperationType,
@@ -275,6 +276,13 @@ impl SimpleScheduler {
     // can create a map of capabilities of each worker and then try and match
     // the actions to the worker using the map lookup (ie. map reduce).
     async fn do_try_match(&self, full_worker_logging: bool) -> Result<(), Error> {
+        let match_started = Instant::now();
+        let result = self.do_try_match_inner(full_worker_logging).await;
+        record_matching_pass(match_started.elapsed().as_secs_f64(), result.is_ok());
+        result
+    }
+
+    async fn do_try_match_inner(&self, full_worker_logging: bool) -> Result<(), Error> {
         async fn match_action_to_worker(
             action_state_result: &dyn ActionStateResult,
             workers: &ApiWorkerScheduler,

--- a/nativelink-store/src/fast_slow_store.rs
+++ b/nativelink-store/src/fast_slow_store.rs
@@ -33,6 +33,7 @@ use nativelink_util::buf_channel::{
 };
 use nativelink_util::fs;
 use nativelink_util::health_utils::{HealthStatusIndicator, default_health_status_indicator};
+use nativelink_util::metrics::{record_store_tier_io, record_store_tier_read};
 use nativelink_util::store_trait::{
     RemoveCallback, Store, StoreDriver, StoreKey, StoreLike, StoreOptimizations, UploadSizeInfo,
     slow_update_store_with_file,
@@ -308,6 +309,7 @@ impl FastSlowStore {
                     self.metrics
                         .slow_store_hit_count
                         .fetch_add(1, Ordering::Acquire);
+                    record_store_tier_read("slow", "hit");
                     counted_hit = true;
                 }
 
@@ -316,6 +318,7 @@ impl FastSlowStore {
                 self.metrics
                     .slow_store_downloaded_bytes
                     .fetch_add(output_buf_len, Ordering::Acquire);
+                record_store_tier_io("slow", "read", output_buf_len);
 
                 let writer_fut = Self::calculate_range(
                     &(bytes_received..bytes_received + output_buf_len),
@@ -769,7 +772,13 @@ impl StoreDriver for FastSlowStore {
         // `has()` can report a stale map entry whose file is gone, so
         // get_part may still return NotFound; fall through to the slow
         // store unless we have already streamed bytes to the caller.
-        if self.fast_store.has(key.borrow()).await?.is_some() {
+        // One existence check, reused: this is the hot read path and `has()`
+        // on a filesystem fast store is a syscall.
+        let in_fast_store = self.fast_store.has(key.borrow()).await?.is_some();
+        if !in_fast_store {
+            record_store_tier_read("fast", "miss");
+        }
+        if in_fast_store {
             let bytes_before = writer.get_bytes_written();
             match self
                 .fast_store
@@ -783,6 +792,8 @@ impl StoreDriver for FastSlowStore {
                     self.metrics
                         .fast_store_downloaded_bytes
                         .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
+                    record_store_tier_read("fast", "hit");
+                    record_store_tier_io("fast", "read", writer.get_bytes_written());
                     return Ok(());
                 }
                 Err(e)
@@ -791,6 +802,7 @@ impl StoreDriver for FastSlowStore {
                     self.metrics
                         .fast_store_stale_map_falls_through
                         .fetch_add(1, Ordering::Acquire);
+                    record_store_tier_read("fast", "stale");
                     warn!(%key, ?e, "Stale fast-store map entry; falling through to slow store");
                     // fall through to populate path
                 }
@@ -815,6 +827,8 @@ impl StoreDriver for FastSlowStore {
             self.metrics
                 .slow_store_downloaded_bytes
                 .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
+            record_store_tier_read("slow", "hit");
+            record_store_tier_io("slow", "read", writer.get_bytes_written());
             return Ok(());
         }
 
@@ -835,6 +849,8 @@ impl StoreDriver for FastSlowStore {
             self.metrics
                 .slow_store_downloaded_bytes
                 .fetch_add(writer.get_bytes_written(), Ordering::Acquire);
+            record_store_tier_read("slow", "hit");
+            record_store_tier_io("slow", "read", writer.get_bytes_written());
             return Ok(());
         }
 

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -37,6 +37,7 @@ use nativelink_redis_tester::SubscriptionManagerNotify;
 use nativelink_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
 use nativelink_util::common::DigestInfo;
 use nativelink_util::health_utils::{HealthRegistryBuilder, HealthStatus, HealthStatusIndicator};
+use nativelink_util::metrics::{record_connection_acquired, record_connection_reconnect};
 use nativelink_util::store_trait::{
     BoolValue, RemoveCallback, SchedulerCurrentVersionProvider, SchedulerIndexProvider,
     SchedulerStore, SchedulerStoreDataProvider, SchedulerStoreDecodeTo, SchedulerStoreKeyProvider,
@@ -314,6 +315,7 @@ impl RedisManager<ConnectionManager> for StandardRedisManager<ConnectionManager>
                 return Ok(guard.clone());
             }
         }
+        record_connection_reconnect("redis");
         let mut connection_manager = (self.connect_func)().await?;
         let new_uuid = Uuid::new_v4();
         self.configure(&mut connection_manager).await?;
@@ -551,6 +553,9 @@ where
     async fn get_client(&self) -> Result<ClientWithPermit<C>, Error> {
         let local_client_permits = self.client_permits.clone();
         let remaining = local_client_permits.available_permits();
+        // Zero here means every client is busy and this call is about to wait,
+        // which is the saturation signal worth alerting on.
+        record_connection_acquired("redis", Some(remaining), remaining == 0);
         let semaphore_permit = local_client_permits.acquire_owned().await?;
         trace!(remaining, "Got a client permit");
         let (connection_manager, uuid) = self.connection_manager.get_connection().await?;

--- a/nativelink-util/src/connection_manager.rs
+++ b/nativelink-util/src/connection_manager.rs
@@ -27,6 +27,7 @@ use tonic::transport::{Channel, Endpoint, channel};
 use tracing::{debug, error, info, warn};
 
 use crate::background_spawn;
+use crate::metrics::record_connection_acquired;
 use crate::retry::{self, Retrier, RetryResult};
 
 /// A helper utility that enables management of a suite of connections to an
@@ -102,6 +103,10 @@ struct ConnectionManagerWorker {
     /// round-trip that could be lost on tonic transport errors or task
     /// aborts.
     available_connections: Arc<Semaphore>,
+
+    /// Whether `available_connections` reflects a configured limit. When the
+    /// pool is unlimited its permit count is a sentinel, not a measurement.
+    bounded_connections: bool,
     /// Channels that are currently being connected.
     connecting_channels: FuturesUnordered<Pin<Box<dyn Future<Output = IndexedChannel> + Send>>>,
     /// Connected channels that are available for use.
@@ -140,6 +145,10 @@ impl ConnectionManager {
             .map(|endpoint| (0, endpoint))
             .collect();
 
+        // Zero means unlimited, which becomes a semaphore holding
+        // Semaphore::MAX_PERMITS. That is a sentinel, not a free-slot count,
+        // so remember which case this is and report no figure when unbounded.
+        let bounded_connections = max_concurrent_requests != 0;
         if max_concurrent_requests == 0 {
             max_concurrent_requests = Semaphore::MAX_PERMITS;
         } else {
@@ -151,6 +160,7 @@ impl ConnectionManager {
         let worker = ConnectionManagerWorker {
             endpoints,
             available_connections: Arc::new(Semaphore::new(max_concurrent_requests)),
+            bounded_connections,
             connection_tx,
             connecting_channels: FuturesUnordered::new(),
             available_channels: VecDeque::new(),
@@ -314,6 +324,13 @@ impl ConnectionManagerWorker {
         }));
     }
 
+    /// Free slots, or `None` when the pool is unlimited and the permit count
+    /// is a sentinel rather than a measurement.
+    fn free_connection_slots(&self) -> Option<usize> {
+        self.bounded_connections
+            .then(|| self.available_connections.available_permits())
+    }
+
     // This must never be made async otherwise the select may cancel it.
     fn handle_worker(&mut self, reason: String, tx: oneshot::Sender<Connection>) {
         let maybe_permit = self.available_connections.clone().try_acquire_owned().ok();
@@ -321,6 +338,7 @@ impl ConnectionManagerWorker {
             && let Some(channel) = self.available_channels.pop_front()
         {
             debug!(reason, "ConnectionManager: request running");
+            record_connection_acquired("grpc", self.free_connection_slots(), false);
             self.provide_channel(channel, tx, permit);
         } else {
             debug!(
@@ -330,6 +348,7 @@ impl ConnectionManagerWorker {
                 reason,
                 "ConnectionManager: no connection available, request queued",
             );
+            record_connection_acquired("grpc", self.free_connection_slots(), true);
             self.waiting_connections.push_back((reason, tx));
         }
     }

--- a/nativelink-util/src/health_utils.rs
+++ b/nativelink-util/src/health_utils.rs
@@ -26,6 +26,8 @@ use serde::Serialize;
 use tokio::time::timeout;
 use tracing::warn;
 
+use crate::metrics::record_health_check;
+
 /// Struct name health indicator component.
 type StructName = str;
 /// Readable message status of the health indicator.
@@ -56,6 +58,19 @@ pub enum HealthStatus {
 }
 
 impl HealthStatus {
+    /// Stable label for metrics. Part of the wire contract, so dashboards
+    /// break if these strings change.
+    #[must_use]
+    pub const fn metric_label(&self) -> &'static str {
+        match self {
+            Self::Ok { .. } => "ok",
+            Self::Initializing { .. } => "initializing",
+            Self::Warning { .. } => "warning",
+            Self::Failed { .. } => "failed",
+            Self::Timeout { .. } => "timeout",
+        }
+    }
+
     pub fn new_ok(
         component: &(impl HealthStatusIndicator + ?Sized),
         message: Cow<'static, str>,
@@ -225,13 +240,15 @@ impl HealthStatusReporter for HealthRegistry {
                         indicator.check_health(namespace.clone()),
                     )
                     .await;
+                    let status = status_res.unwrap_or_else(|_| {
+                        let struct_name = indicator.struct_name();
+                        warn!(struct_name, "Timeout during health check");
+                        HealthStatus::Timeout { struct_name }
+                    });
+                    record_health_check(namespace, status.metric_label());
                     HealthStatusDescription {
                         namespace: namespace.clone(),
-                        status: status_res.unwrap_or_else(|_| {
-                            let struct_name = indicator.struct_name();
-                            warn!(struct_name, "Timeout during health check");
-                            HealthStatus::Timeout { struct_name }
-                        }),
+                        status,
                     }
                 },
             ))

--- a/nativelink-util/src/metrics.rs
+++ b/nativelink-util/src/metrics.rs
@@ -35,6 +35,50 @@ pub const EXECUTION_WORKER_ID: &str = "execution.worker_id";
 pub const EXECUTION_EXIT_CODE: &str = "execution.exit_code";
 pub const EXECUTION_ACTION_DIGEST: &str = "execution.action_digest";
 
+// Metric attribute keys for gRPC serving, following OTel rpc semconv.
+pub const RPC_SERVICE: &str = "rpc.service";
+pub const RPC_METHOD: &str = "rpc.method";
+pub const RPC_STATUS_CODE: &str = "rpc.grpc.status_code";
+
+// Metric attribute keys for the scheduler.
+pub const SCHEDULER_MATCH_RESULT: &str = "scheduler.match.result";
+
+// Metric attribute keys for tiered stores.
+pub const STORE_TIER: &str = "store.tier";
+pub const STORE_RESULT: &str = "store.result";
+pub const STORE_DIRECTION: &str = "store.direction";
+
+// Metric attribute keys for connection pools.
+pub const CONNECTION_POOL: &str = "connection.pool";
+pub const CONNECTION_RESULT: &str = "connection.result";
+
+// Metric attribute keys for health checks.
+pub const HEALTH_NAMESPACE: &str = "health.namespace";
+pub const HEALTH_STATUS: &str = "health.status";
+
+// Metric attribute keys for the worker fleet.
+pub const WORKER_STATE: &str = "worker.state";
+pub const WORKER_DISCONNECT_REASON: &str = "worker.disconnect.reason";
+
+/// Why a worker left the pool.
+#[derive(Debug, Clone, Copy)]
+pub enum WorkerDisconnectReason {
+    /// The worker's connection ended.
+    Disconnected,
+    /// The scheduler evicted it, usually after a timeout or an error.
+    Evicted,
+}
+
+impl WorkerDisconnectReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Disconnected => "disconnected",
+            Self::Evicted => "evicted",
+        }
+    }
+}
+
 /// Cache operation types for metrics classification.
 #[derive(Debug, Clone, Copy)]
 pub enum CacheOperationName {
@@ -551,6 +595,31 @@ pub static EXECUTION_METRICS: LazyLock<ExecutionMetrics> = LazyLock::new(|| {
             .with_unit("{transition}")
             .build(),
 
+        execution_cpu_time: meter
+            .f64_histogram("execution.cpu.time")
+            .with_description("CPU time consumed by an action in seconds")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0, 7200.0,
+            ])
+            .build(),
+
+        execution_peak_memory: meter
+            .u64_histogram("execution.peak.memory")
+            .with_description("Peak resident memory observed while running an action in bytes")
+            .with_unit("By")
+            .with_boundaries(vec![
+                1_048_576.0,      // 1MiB
+                16_777_216.0,     // 16MiB
+                67_108_864.0,     // 64MiB
+                268_435_456.0,    // 256MiB
+                1_073_741_824.0,  // 1GiB
+                4_294_967_296.0,  // 4GiB
+                17_179_869_184.0, // 16GiB
+                68_719_476_736.0, // 64GiB
+            ])
+            .build(),
+
         execution_output_size: meter
             .u64_histogram("execution.output.size")
             .with_description("Size of execution outputs in bytes")
@@ -594,6 +663,59 @@ pub struct ExecutionMetrics {
     pub execution_output_size: metrics::Histogram<u64>,
     /// Counter for execution retries
     pub execution_retry_count: metrics::Counter<u64>,
+    /// Peak memory an action used, as sampled by the worker.
+    pub execution_peak_memory: metrics::Histogram<u64>,
+    /// CPU time an action used, as sampled by the worker.
+    pub execution_cpu_time: metrics::Histogram<f64>,
+}
+
+/// Records the CPU time a worker observed for an action.
+///
+/// Wall time is already covered by `execution.stage.duration`. This is the
+/// other half: an action pinning eight cores for a minute and one sleeping
+/// for a minute look identical by wall time and nothing alike here.
+pub fn record_execution_cpu_time(cpu_time_ms: u64, instance_name: &str) {
+    #[expect(clippy::cast_precision_loss)] // Milliseconds; f64 is exact well past any real action.
+    let seconds = cpu_time_ms as f64 / 1000.0;
+    EXECUTION_METRICS.execution_cpu_time.record(
+        seconds,
+        &[KeyValue::new(EXECUTION_INSTANCE, instance_name.to_string())],
+    );
+}
+
+/// Records the peak memory a worker observed while running an action.
+///
+/// The worker samples this, so it is only present when sampling ran. #2614
+/// listed `execution_memory_usage` as unimplementable because
+/// `ExecutionMetadata` carries no memory figure; `ActionResourceUsage` does,
+/// and this is that number.
+pub fn record_execution_peak_memory(peak_memory_kb: u64, instance_name: &str) {
+    EXECUTION_METRICS.execution_peak_memory.record(
+        peak_memory_sample(peak_memory_kb),
+        &[KeyValue::new(EXECUTION_INSTANCE, instance_name.to_string())],
+    );
+}
+
+/// Ceiling on a recorded peak-memory sample.
+///
+/// Well above any real action and far below the point where a histogram's
+/// `u64` sum can wrap, so it filters a garbage reading without touching a
+/// plausible one. Everything past the largest bucket already shares the same
+/// bucket, so this changes no bucket count.
+const PEAK_MEMORY_MAX_BYTES: u64 = 1 << 50; // 1 PiB.
+
+/// Converts a worker's peak-memory reading to bytes, bounded.
+///
+/// The figure crosses a gRPC boundary from a worker, so a malfunctioning one
+/// could report something absurd. An unbounded value overflows the
+/// histogram's `u64` sum, which panics a debug build and takes the thread
+/// with it. Kept separate so it is directly testable: the overflow only
+/// happens once a meter provider is installed, which no unit test does.
+#[must_use]
+pub fn peak_memory_sample(peak_memory_kb: u64) -> u64 {
+    peak_memory_kb
+        .saturating_mul(1024)
+        .min(PEAK_MEMORY_MAX_BYTES)
 }
 
 /// Helper function to create attributes for execution metrics
@@ -689,4 +811,388 @@ pub fn execution_output_bytes(action_result: &ActionResult) -> u64 {
         .sum::<u64>()
         + action_result.stdout_digest.size_bytes()
         + action_result.stderr_digest.size_bytes()
+}
+
+/// Global worker fleet metrics instruments.
+pub static WORKER_METRICS: LazyLock<WorkerMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    WorkerMetrics {
+        worker_connected_count: meter
+            .i64_up_down_counter("worker.connected.count")
+            .with_description("Number of workers currently connected to this scheduler instance")
+            .with_unit("{worker}")
+            .build(),
+
+        worker_connections: meter
+            .u64_counter("worker.connections")
+            .with_description("Total number of workers that have joined the pool")
+            .with_unit("{worker}")
+            .build(),
+
+        worker_disconnections: meter
+            .u64_counter("worker.disconnections")
+            .with_description("Total number of workers that have left the pool, by reason")
+            .with_unit("{worker}")
+            .build(),
+
+        worker_keepalives: meter
+            .u64_counter("worker.keepalives")
+            .with_description("Total worker keepalives received")
+            .with_unit("{keepalive}")
+            .build(),
+
+        worker_state_count: meter
+            .i64_up_down_counter("worker.state.count")
+            .with_description("Number of connected workers in each non-default state")
+            .with_unit("{worker}")
+            .build(),
+    }
+});
+
+/// Worker fleet metrics.
+///
+/// These are per-scheduler-instance. A worker only appears in the registry of
+/// the instance holding its stream, so with several schedulers behind a load
+/// balancer the fleet total is the sum across instances, not any one of them.
+///
+/// Deliberately not attributed by worker id. Ids are per connection, so a
+/// fleet that churns would grow the label set without bound, and the
+/// autoscaling and fleet-health questions these answer are all aggregate.
+#[derive(Debug)]
+pub struct WorkerMetrics {
+    /// Workers currently connected.
+    pub worker_connected_count: metrics::UpDownCounter<i64>,
+    /// Workers that have joined, cumulative.
+    pub worker_connections: metrics::Counter<u64>,
+    /// Workers that have left, cumulative, by reason.
+    pub worker_disconnections: metrics::Counter<u64>,
+    /// Keepalives received, cumulative.
+    pub worker_keepalives: metrics::Counter<u64>,
+    /// Connected workers currently paused or draining.
+    pub worker_state_count: metrics::UpDownCounter<i64>,
+}
+
+/// Records a worker joining the pool.
+pub fn record_worker_connected() {
+    WORKER_METRICS.worker_connected_count.add(1, &[]);
+    WORKER_METRICS.worker_connections.add(1, &[]);
+}
+
+/// Records a worker leaving the pool.
+///
+/// `was_draining` and `was_paused` unwind the state gauges, which would
+/// otherwise keep counting a worker that is already gone.
+pub fn record_worker_disconnected(
+    reason: WorkerDisconnectReason,
+    was_draining: bool,
+    was_paused: bool,
+) {
+    WORKER_METRICS.worker_connected_count.add(-1, &[]);
+    WORKER_METRICS.worker_disconnections.add(
+        1,
+        &[KeyValue::new(WORKER_DISCONNECT_REASON, reason.as_str())],
+    );
+    if was_draining {
+        record_worker_state("draining", false);
+    }
+    if was_paused {
+        record_worker_state("paused", false);
+    }
+}
+
+/// Records a worker entering or leaving `state`.
+pub fn record_worker_state(state: &'static str, entered: bool) {
+    WORKER_METRICS.worker_state_count.add(
+        if entered { 1 } else { -1 },
+        &[KeyValue::new(WORKER_STATE, state)],
+    );
+}
+
+/// Records a keepalive from a worker.
+pub fn record_worker_keepalive() {
+    WORKER_METRICS.worker_keepalives.add(1, &[]);
+}
+
+/// Global gRPC serving metrics.
+///
+/// One duration histogram covers rate, errors and latency: the count gives
+/// rate, the status attribute separates errors, and the buckets give latency.
+pub static RPC_METRICS: LazyLock<RpcMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    RpcMetrics {
+        rpc_server_duration: meter
+            .f64_histogram("rpc.server.duration")
+            .with_description("Duration of inbound gRPC calls in seconds")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+                300.0,
+            ])
+            .build(),
+    }
+});
+
+/// gRPC serving metrics.
+#[derive(Debug)]
+pub struct RpcMetrics {
+    /// Duration of inbound gRPC calls, by service, method and status.
+    pub rpc_server_duration: metrics::Histogram<f64>,
+}
+
+/// Records a served gRPC call.
+///
+/// `full_path` is the HTTP path tonic routes on, `/package.Service/Method`.
+pub fn record_rpc_served(full_path: &str, grpc_status: i32, duration_secs: f64) {
+    let (service, method) = split_grpc_path(full_path);
+    RPC_METRICS.rpc_server_duration.record(
+        duration_secs,
+        &[
+            KeyValue::new(RPC_SERVICE, service.to_string()),
+            KeyValue::new(RPC_METHOD, method.to_string()),
+            KeyValue::new(RPC_STATUS_CODE, i64::from(grpc_status)),
+        ],
+    );
+}
+
+/// Splits `/package.Service/Method` into its service and method halves.
+///
+/// Anything that does not look like a gRPC path is reported whole under an
+/// `unknown` method, so an unexpected route still shows up rather than
+/// silently vanishing. Both halves come from the route table, not user input,
+/// so the label set stays bounded.
+#[must_use]
+pub fn split_grpc_path(full_path: &str) -> (&str, &str) {
+    let trimmed = full_path.strip_prefix('/').unwrap_or(full_path);
+    trimmed
+        .split_once('/')
+        .map_or((trimmed, "unknown"), |(service, method)| (service, method))
+}
+
+/// Global scheduler metrics.
+pub static SCHEDULER_METRICS: LazyLock<SchedulerOtlpMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    SchedulerOtlpMetrics {
+        matching_duration: meter
+            .f64_histogram("scheduler.matching.duration")
+            .with_description("Duration of one queued-action to worker matching pass in seconds")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.0001, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ])
+            .build(),
+
+        matching_passes: meter
+            .u64_counter("scheduler.matching.passes")
+            .with_description("Matching passes run, by result")
+            .with_unit("{pass}")
+            .build(),
+    }
+});
+
+/// Scheduler matching metrics.
+///
+/// Named to avoid colliding with the existing `#[metric]` component struct of
+/// the same idea in the scheduler crate.
+#[derive(Debug)]
+pub struct SchedulerOtlpMetrics {
+    /// How long a matching pass takes. The saturation signal: this climbing
+    /// while the queue is non-empty means matching is the bottleneck.
+    pub matching_duration: metrics::Histogram<f64>,
+    /// Matching passes, by result.
+    pub matching_passes: metrics::Counter<u64>,
+}
+
+/// Records a completed matching pass.
+pub fn record_matching_pass(duration_secs: f64, succeeded: bool) {
+    SCHEDULER_METRICS
+        .matching_duration
+        .record(duration_secs, &[]);
+    SCHEDULER_METRICS.matching_passes.add(
+        1,
+        &[KeyValue::new(
+            SCHEDULER_MATCH_RESULT,
+            if succeeded { "ok" } else { "error" },
+        )],
+    );
+}
+
+/// Global tiered-store metrics.
+pub static STORE_TIER_METRICS: LazyLock<StoreTierMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    StoreTierMetrics {
+        tier_operations: meter
+            .u64_counter("store.tier.operations")
+            .with_description("Reads served by each tier of a tiered store, by result")
+            .with_unit("{operation}")
+            .build(),
+
+        tier_io: meter
+            .u64_counter("store.tier.io")
+            .with_description("Bytes moved through each tier of a tiered store")
+            .with_unit("By")
+            .build(),
+    }
+});
+
+/// Tiered-store metrics. The hit ratio is `tier_operations{result="hit"}` over
+/// the sum, which is the number worth alerting on for a fast/slow store.
+#[derive(Debug)]
+pub struct StoreTierMetrics {
+    /// Reads served per tier, by result.
+    pub tier_operations: metrics::Counter<u64>,
+    /// Bytes moved per tier and direction.
+    pub tier_io: metrics::Counter<u64>,
+}
+
+/// Records a read served, or not served, by a tier.
+pub fn record_store_tier_read(tier: &'static str, result: &'static str) {
+    STORE_TIER_METRICS.tier_operations.add(
+        1,
+        &[
+            KeyValue::new(STORE_TIER, tier),
+            KeyValue::new(STORE_RESULT, result),
+        ],
+    );
+}
+
+/// Records bytes moved through a tier.
+pub fn record_store_tier_io(tier: &'static str, direction: &'static str, bytes: u64) {
+    STORE_TIER_METRICS.tier_io.add(
+        bytes,
+        &[
+            KeyValue::new(STORE_TIER, tier),
+            KeyValue::new(STORE_DIRECTION, direction),
+        ],
+    );
+}
+
+/// Global health-check metrics.
+pub static HEALTH_METRICS: LazyLock<HealthMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    HealthMetrics {
+        health_checks: meter
+            .u64_counter("health.checks")
+            .with_description("Health check results, by component and status")
+            .with_unit("{check}")
+            .build(),
+    }
+});
+
+/// Health-check metrics.
+#[derive(Debug)]
+pub struct HealthMetrics {
+    /// Health check results, by namespace and status.
+    pub health_checks: metrics::Counter<u64>,
+}
+
+/// Records one component's health check result.
+pub fn record_health_check(namespace: &str, status: &'static str) {
+    HEALTH_METRICS.health_checks.add(
+        1,
+        &[
+            KeyValue::new(HEALTH_NAMESPACE, namespace.to_string()),
+            KeyValue::new(HEALTH_STATUS, status),
+        ],
+    );
+}
+
+/// Global connection-pool metrics.
+pub static CONNECTION_METRICS: LazyLock<ConnectionMetrics> = LazyLock::new(|| {
+    let meter = global::meter_with_scope(InstrumentationScope::builder("nativelink").build());
+
+    ConnectionMetrics {
+        pool_available: meter
+            .u64_histogram("connection.pool.available")
+            .with_description("Free slots in a connection pool, sampled when one is taken")
+            .with_unit("{connection}")
+            .with_boundaries(vec![
+                0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0,
+            ])
+            .build(),
+
+        pool_acquisitions: meter
+            .u64_counter("connection.pool.acquisitions")
+            .with_description("Connection acquisitions, by pool and whether one was free")
+            .with_unit("{acquisition}")
+            .build(),
+
+        reconnects: meter
+            .u64_counter("connection.reconnects")
+            .with_description("Reconnects performed, by pool")
+            .with_unit("{reconnect}")
+            .build(),
+    }
+});
+
+/// Connection-pool metrics.
+///
+/// `pool_available` is the saturation signal: a pool that keeps reporting zero
+/// free slots is the bottleneck, whatever the latency elsewhere says. Counting
+/// queued acquisitions gives the same answer from the other direction.
+#[derive(Debug)]
+pub struct ConnectionMetrics {
+    /// Free slots at the moment a connection was taken.
+    pub pool_available: metrics::Histogram<u64>,
+    /// Acquisitions, by pool and result.
+    pub pool_acquisitions: metrics::Counter<u64>,
+    /// Reconnects, by pool.
+    pub reconnects: metrics::Counter<u64>,
+}
+
+/// Ceiling on a recorded free-slot count.
+///
+/// An unbounded pool is a semaphore holding `Semaphore::MAX_PERMITS`, around
+/// 2.3e18. Recording that overflows the histogram's `u64` sum after a handful
+/// of samples, which panics a debug build. Callers pass `None` for an
+/// unbounded pool, and this clamp is the backstop if one ever does not: it
+/// sits above the largest bucket boundary, so bucket counts are unchanged.
+const POOL_AVAILABLE_MAX: u64 = 1024;
+
+/// Records a connection being taken from `pool`.
+///
+/// `available` is the free-slot count, or `None` when the pool is unbounded
+/// and the figure would be meaningless. `queued` means nothing was free and
+/// the caller had to wait, which is the case worth alerting on.
+/// Clamps a free-slot count to something a histogram can accumulate.
+///
+/// Kept separate so it is directly testable: the failure this guards against
+/// only appears once a meter provider is installed, so a test that merely
+/// calls `record_connection_acquired` cannot catch it.
+#[must_use]
+pub fn pool_available_sample(available: usize) -> u64 {
+    u64::try_from(available)
+        .unwrap_or(POOL_AVAILABLE_MAX)
+        .min(POOL_AVAILABLE_MAX)
+}
+
+pub fn record_connection_acquired(pool: &'static str, available: Option<usize>, queued: bool) {
+    if let Some(available) = available {
+        CONNECTION_METRICS.pool_available.record(
+            pool_available_sample(available),
+            &[KeyValue::new(CONNECTION_POOL, pool)],
+        );
+    }
+    CONNECTION_METRICS.pool_acquisitions.add(
+        1,
+        &[
+            KeyValue::new(CONNECTION_POOL, pool),
+            KeyValue::new(
+                CONNECTION_RESULT,
+                if queued { "queued" } else { "immediate" },
+            ),
+        ],
+    );
+}
+
+/// Records a reconnect. A rising count means the backend is flapping, which
+/// on Redis usually means a failover.
+pub fn record_connection_reconnect(pool: &'static str) {
+    CONNECTION_METRICS
+        .reconnects
+        .add(1, &[KeyValue::new(CONNECTION_POOL, pool)]);
 }

--- a/nativelink-util/src/telemetry.rs
+++ b/nativelink-util/src/telemetry.rs
@@ -47,6 +47,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer, Registry, fmt, registry};
 use uuid::Uuid;
 
+use crate::metrics::record_rpc_served;
 use crate::origin_event::{BAZEL_METADATA_KEY, request_metadata_to_baggage};
 
 /// The OTLP "service.name" field for all nativelink services.
@@ -364,8 +365,36 @@ NativeLink instance configured to require this OpenTelemetry Baggage header:
         }
 
         let cx = cx.with_value(client_headers);
-        Box::pin(async move { inner.call(req).with_context(cx).await })
+        // Rate, errors and latency for every gRPC service, taken here because
+        // this layer already wraps all of them.
+        let route = req.uri().path().to_string();
+        let started = std::time::Instant::now();
+        Box::pin(async move {
+            let result = inner.call(req).with_context(cx).await;
+            if let Ok(response) = &result {
+                record_rpc_served(
+                    &route,
+                    grpc_status_of(response.headers()),
+                    started.elapsed().as_secs_f64(),
+                );
+            }
+            result
+        })
     }
+}
+
+/// Reads the gRPC status from a response.
+///
+/// Tonic puts `grpc-status` in the headers when it fails before streaming and
+/// in the trailers otherwise. Trailers are not available here without
+/// consuming the body, so a call that got far enough to stream is reported as
+/// OK. Transport-level failures never reach this point at all.
+fn grpc_status_of(headers: &hyper::http::HeaderMap) -> i32 {
+    headers
+        .get("grpc-status")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/nativelink-util/tests/metrics_test.rs
+++ b/nativelink-util/tests/metrics_test.rs
@@ -18,7 +18,12 @@ use nativelink_util::action_messages::{
 use nativelink_util::common::DigestInfo;
 use nativelink_util::metrics::{
     CACHE_METRICS, CacheMetricAttrs, EXECUTION_METRICS, ExecutionMetricAttrs, ExecutionStage,
-    execution_output_bytes, make_execution_attributes, record_completed_execution_metrics,
+    WORKER_METRICS, WorkerDisconnectReason, execution_output_bytes, make_execution_attributes,
+    peak_memory_sample, pool_available_sample, record_completed_execution_metrics,
+    record_connection_acquired, record_connection_reconnect, record_execution_cpu_time,
+    record_execution_peak_memory, record_health_check, record_matching_pass, record_rpc_served,
+    record_store_tier_io, record_store_tier_read, record_worker_connected,
+    record_worker_disconnected, record_worker_keepalive, record_worker_state, split_grpc_path,
 };
 use opentelemetry::KeyValue;
 
@@ -113,6 +118,7 @@ fn test_metrics_lazy_initialization() {
     // Verify that the lazy static initialization works
     let _cache_metrics = &*CACHE_METRICS;
     let _execution_metrics = &*EXECUTION_METRICS;
+    let _worker_metrics = &*WORKER_METRICS;
 
     // If we got here without panicking, the metrics were initialized successfully
 }
@@ -249,4 +255,136 @@ fn record_completed_execution_metrics_guards_unpopulated_metadata() {
 
     // Default (UNIX_EPOCH) metadata must skip the duration records cleanly.
     record_completed_execution_metrics(&ActionResult::default(), "instance", None, None);
+}
+
+#[test]
+fn test_worker_disconnect_reason_labels() {
+    // These become metric label values, so they are part of the wire contract
+    // and dashboards break if they change.
+    assert_eq!(
+        WorkerDisconnectReason::Disconnected.as_str(),
+        "disconnected"
+    );
+    assert_eq!(WorkerDisconnectReason::Evicted.as_str(), "evicted");
+}
+
+#[test]
+fn test_worker_metric_helpers_are_callable() {
+    // The instruments are global, so there is nothing to read back here
+    // without a test exporter. This guards the call sites: every helper stays
+    // callable with the arguments the scheduler passes.
+    record_worker_connected();
+    record_worker_keepalive();
+    record_worker_state("draining", true);
+    record_worker_state("draining", false);
+    record_worker_disconnected(WorkerDisconnectReason::Disconnected, false, false);
+
+    // A worker that was draining and paused when it left unwinds both gauges.
+    record_worker_connected();
+    record_worker_state("draining", true);
+    record_worker_state("paused", true);
+    record_worker_disconnected(WorkerDisconnectReason::Evicted, true, true);
+}
+
+#[test]
+fn test_split_grpc_path() {
+    assert_eq!(
+        split_grpc_path(
+            "/build.bazel.remote.execution.v2.ContentAddressableStorage/FindMissingBlobs"
+        ),
+        (
+            "build.bazel.remote.execution.v2.ContentAddressableStorage",
+            "FindMissingBlobs"
+        )
+    );
+    assert_eq!(
+        split_grpc_path("/google.bytestream.ByteStream/Write"),
+        ("google.bytestream.ByteStream", "Write")
+    );
+    // Not a gRPC route. Reported whole rather than dropped, so an unexpected
+    // path is still visible.
+    assert_eq!(split_grpc_path("/healthz"), ("healthz", "unknown"));
+    assert_eq!(split_grpc_path(""), ("", "unknown"));
+}
+
+#[test]
+fn test_health_status_metric_labels() {
+    use std::borrow::Cow;
+
+    use nativelink_util::health_utils::HealthStatus;
+
+    // Label values are part of the wire contract for dashboards.
+    assert_eq!(
+        HealthStatus::Ok {
+            struct_name: "S",
+            message: Cow::Borrowed("")
+        }
+        .metric_label(),
+        "ok"
+    );
+    assert_eq!(
+        HealthStatus::Failed {
+            struct_name: "S",
+            message: Cow::Borrowed("")
+        }
+        .metric_label(),
+        "failed"
+    );
+    assert_eq!(
+        HealthStatus::Timeout { struct_name: "S" }.metric_label(),
+        "timeout"
+    );
+}
+
+#[test]
+fn test_new_metric_helpers_are_callable() {
+    // Global instruments, so nothing to read back without a test exporter.
+    // This guards the call sites against drift.
+    record_rpc_served("/pkg.Service/Method", 0, 0.01);
+    record_rpc_served("/pkg.Service/Method", 5, 1.5);
+    record_matching_pass(0.002, true);
+    record_matching_pass(0.002, false);
+    record_store_tier_read("fast", "hit");
+    record_store_tier_read("slow", "hit");
+    record_store_tier_io("fast", "read", 4096);
+    record_health_check("store", "ok");
+    record_execution_peak_memory(512 * 1024, "main");
+    record_execution_cpu_time(90_000, "main");
+    record_connection_acquired("grpc", Some(12), false);
+    record_connection_acquired("redis", Some(0), true);
+    record_connection_acquired("grpc", None, false);
+    record_connection_reconnect("redis");
+}
+
+/// An unlimited pool is a semaphore holding `Semaphore::MAX_PERMITS`, about
+/// 2.3e18. Recording that as a histogram sample overflowed the SDK's `u64`
+/// sum within a handful of samples and panicked a debug build, which killed a
+/// tokio worker and turned every later connection request into a `SendError`.
+///
+/// Callers now pass `None` for an unlimited pool. This covers the clamp that
+/// backstops them, which is the part that can be asserted without installing
+/// a meter provider.
+#[test]
+fn pool_available_sample_clamps_an_unbounded_permit_count() {
+    // Semaphore::MAX_PERMITS.
+    assert_eq!(pool_available_sample(usize::MAX >> 3), 1024);
+    assert_eq!(pool_available_sample(usize::MAX), 1024);
+    // Real counts pass through untouched.
+    assert_eq!(pool_available_sample(0), 0);
+    assert_eq!(pool_available_sample(12), 12);
+    assert_eq!(pool_available_sample(1024), 1024);
+}
+
+/// Peak memory arrives from a worker over gRPC, so a malfunctioning one could
+/// report a value that overflows the histogram's `u64` sum the same way an
+/// unbounded connection pool did.
+#[test]
+fn peak_memory_sample_bounds_an_absurd_reading() {
+    // KiB to bytes for anything plausible.
+    assert_eq!(peak_memory_sample(0), 0);
+    assert_eq!(peak_memory_sample(1), 1024);
+    assert_eq!(peak_memory_sample(4 * 1024 * 1024), 4 * 1024 * 1024 * 1024);
+    // Absurd readings are bounded rather than wrapped.
+    assert_eq!(peak_memory_sample(u64::MAX), 1 << 50);
+    assert_eq!(peak_memory_sample(u64::MAX / 512), 1 << 50);
 }

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -100,10 +100,18 @@ const DEFAULT_HISTORICAL_RESULTS_STRATEGY: UploadCacheResultsStrategy =
 #[cfg(target_os = "linux")]
 const RESOURCE_USAGE_SAMPLE_INTERVAL: Duration = Duration::from_millis(250);
 
+/// What the sampler observed over an action's lifetime.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SampledResourceUsage {
+    peak_memory_kb: u64,
+    cpu_time_ms: u64,
+}
+
 #[cfg(target_os = "linux")]
 struct ActionResourceUsageSampler {
     stop_tx: watch::Sender<bool>,
-    handle: tokio::task::JoinHandle<u64>,
+    handle: tokio::task::JoinHandle<SampledResourceUsage>,
 }
 
 #[cfg(target_os = "linux")]
@@ -111,24 +119,43 @@ fn start_action_resource_usage_sampler(pgid: u32) -> ActionResourceUsageSampler 
     let (stop_tx, stop_rx) = watch::channel(false);
     let handle = background_spawn!(
         "action_resource_usage_sampler",
-        sample_action_peak_memory_kb(pgid, stop_rx)
+        sample_action_resource_usage(pgid, stop_rx)
     );
     ActionResourceUsageSampler { stop_tx, handle }
 }
 
 #[cfg(target_os = "linux")]
-async fn finish_action_resource_usage_sampler(sampler: ActionResourceUsageSampler) -> Option<u64> {
+async fn finish_action_resource_usage_sampler(
+    sampler: ActionResourceUsageSampler,
+) -> Option<SampledResourceUsage> {
     let _ = sampler.stop_tx.send(true);
     sampler.handle.await.ok()
 }
 
 #[cfg(target_os = "linux")]
-async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bool>) -> u64 {
+async fn sample_action_resource_usage(
+    pgid: u32,
+    mut stop_rx: watch::Receiver<bool>,
+) -> SampledResourceUsage {
     let mut peak_memory_kb = 0;
+    // CPU time is cumulative per process and a process that exits stops
+    // appearing, so summing the live group at the end would lose everything
+    // short-lived. Keep the last figure seen for each pid and total them at
+    // the end instead.
+    let mut cpu_ticks_by_pid = HashMap::new();
+
+    let sample = |peak_memory_kb: &mut u64, cpu_ticks_by_pid: &mut HashMap<u32, u64>| {
+        let observed = sample_process_group(pgid, cpu_ticks_by_pid);
+        if let Some(memory_kb) = observed {
+            *peak_memory_kb = (*peak_memory_kb).max(memory_kb);
+        }
+        observed
+    };
+
     loop {
-        if let Some(memory_kb) = sample_process_group_memory_kb(pgid) {
-            peak_memory_kb = peak_memory_kb.max(memory_kb);
-        } else if !Path::new(&format!("/proc/{pgid}")).exists() {
+        if sample(&mut peak_memory_kb, &mut cpu_ticks_by_pid).is_none()
+            && !Path::new(&format!("/proc/{pgid}")).exists()
+        {
             // The group leader has been reaped and no member process remains,
             // so the action is finished.
             break;
@@ -141,16 +168,31 @@ async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bo
         tokio::select! {
             changed = stop_rx.changed() => {
                 if changed.is_ok() && *stop_rx.borrow() {
-                    if let Some(memory_kb) = sample_process_group_memory_kb(pgid) {
-                        peak_memory_kb = peak_memory_kb.max(memory_kb);
-                    }
+                    sample(&mut peak_memory_kb, &mut cpu_ticks_by_pid);
                     break;
                 }
             }
             () = tokio::time::sleep(RESOURCE_USAGE_SAMPLE_INTERVAL) => {}
         }
     }
-    peak_memory_kb
+
+    SampledResourceUsage {
+        peak_memory_kb,
+        cpu_time_ms: ticks_to_millis(cpu_ticks_by_pid.values().sum()),
+    }
+}
+
+/// Converts clock ticks from `/proc` into milliseconds.
+///
+/// `_SC_CLK_TCK` is 100 on every Linux we run on, but it is queryable so ask
+/// rather than assume, and fall back to 100 if the query fails.
+#[cfg(target_os = "linux")]
+fn ticks_to_millis(ticks: u64) -> u64 {
+    // SAFETY: `sysconf` takes an int and returns a long, with no memory
+    // safety considerations.
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    ticks.saturating_mul(1_000) / hz
 }
 
 /// Sums the resident memory of every process in the action's process group.
@@ -165,7 +207,7 @@ async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bo
 /// inherited and survives reparenting, and excludes the worker's own group.
 /// Returns `None` when no member process can be read (the group is empty).
 #[cfg(target_os = "linux")]
-fn sample_process_group_memory_kb(pgid: u32) -> Option<u64> {
+fn sample_process_group(pgid: u32, cpu_ticks_by_pid: &mut HashMap<u32, u64>) -> Option<u64> {
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return None;
     };
@@ -176,8 +218,17 @@ fn sample_process_group_memory_kb(pgid: u32) -> Option<u64> {
         let Ok(member_pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
             continue;
         };
-        if read_process_pgid(member_pid) != Some(pgid) {
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{member_pid}/stat")) else {
             continue;
+        };
+        if parse_pgid_from_stat(&stat) != Some(pgid) {
+            continue;
+        }
+        if let Some(ticks) = parse_cpu_ticks_from_stat(&stat) {
+            // Monotonic per process, but a pid could in principle be reused
+            // within one action, so never let the figure go backwards.
+            let entry = cpu_ticks_by_pid.entry(member_pid).or_insert(0);
+            *entry = (*entry).max(ticks);
         }
         if let Some(memory_kb) = read_process_rss_kb(member_pid) {
             total_kb += memory_kb;
@@ -197,12 +248,6 @@ fn read_process_rss_kb(pid: u32) -> Option<u64> {
     })
 }
 
-/// Reads a process's group id (`pgrp`) from `/proc/<pid>/stat`.
-#[cfg(target_os = "linux")]
-fn read_process_pgid(pid: u32) -> Option<u32> {
-    parse_pgid_from_stat(&std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?)
-}
-
 /// Parses the process group id (`pgrp`, field 5) from the contents of a
 /// `/proc/<pid>/stat` line.
 ///
@@ -214,6 +259,28 @@ pub fn parse_pgid_from_stat(stat: &str) -> Option<u32> {
     let after_comm = stat.rsplit_once(')')?.1;
     // Fields after the final ')': state(0) ppid(1) pgrp(2) ...
     after_comm.split_whitespace().nth(2)?.parse().ok()
+}
+
+/// Sums user and system CPU ticks (`utime` + `stime`, fields 14 and 15) from
+/// the contents of a `/proc/<pid>/stat` line.
+///
+/// Parsed relative to the final `)` for the same reason as the pgid above:
+/// `comm` can contain spaces and parentheses. Returns `None` when the line is
+/// malformed.
+///
+/// `cutime`/`cstime` are deliberately not included. They only cover children
+/// this process has already reaped, so adding them here would double count
+/// every child that is still its own entry in the group.
+#[cfg(target_os = "linux")]
+pub fn parse_cpu_ticks_from_stat(stat: &str) -> Option<u64> {
+    let after_comm = stat.rsplit_once(')')?.1;
+    let mut fields = after_comm.split_whitespace();
+    // Fields after the final ')': state(0) ppid(1) pgrp(2) session(3) tty(4)
+    // tpgid(5) flags(6) minflt(7) cminflt(8) majflt(9) cmajflt(10)
+    // utime(11) stime(12) ...
+    let utime: u64 = fields.nth(11)?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+    Some(utime.saturating_add(stime))
 }
 
 /// Valid string reasons for a failure.
@@ -1643,13 +1710,19 @@ impl RunningActionImpl {
                     let resource_usage = match maybe_resource_usage_sampler.take() {
                         Some(sampler) => finish_action_resource_usage_sampler(sampler)
                             .await
-                            .and_then(|peak_memory_kb| {
-                                (peak_memory_kb > 0).then_some(ActionResourceUsage {
-                                    peak_memory_kb,
-                                    sampled: true,
-                                    operation_id: String::new(),
-                                    worker_id: String::new(),
-                                })
+                            .and_then(|usage| {
+                                // An action too short to catch a sample leaves
+                                // both at zero; report nothing rather than a
+                                // misleading zero.
+                                (usage.peak_memory_kb > 0 || usage.cpu_time_ms > 0).then_some(
+                                    ActionResourceUsage {
+                                        peak_memory_kb: usage.peak_memory_kb,
+                                        cpu_time_ms: usage.cpu_time_ms,
+                                        sampled: true,
+                                        operation_id: String::new(),
+                                        worker_id: String::new(),
+                                    },
+                                )
                             }),
                         None => None,
                     };

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -5141,6 +5141,48 @@ done
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn parse_cpu_ticks_from_stat_sums_user_and_system_time() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        // Fields after the final ')': state ppid pgrp session tty tpgid flags
+        // minflt cminflt majflt cmajflt utime stime ...
+        // utime = 120, stime = 34, so 154 ticks.
+        assert_eq!(
+            parse_cpu_ticks_from_stat(
+                "315 (perl) S 1 60 60 0 -1 0 100 0 200 0 120 34 7 9 20 0 1 0"
+            ),
+            Some(154)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cpu_ticks_from_stat_handles_comm_with_spaces_and_parens() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        // Same trap as the pgid parser: a `comm` containing ')' would shift
+        // every field if parsed from the left.
+        assert_eq!(
+            parse_cpu_ticks_from_stat(
+                "1234 (weird )( name) R 1 777 777 0 -1 0 1 2 3 4 11 22 0 0 0 0"
+            ),
+            Some(33)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cpu_ticks_from_stat_rejects_malformed_input() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        assert_eq!(parse_cpu_ticks_from_stat("no parenthesis here"), None);
+        // Truncated before utime.
+        assert_eq!(
+            parse_cpu_ticks_from_stat("123 (only) S 1 60 60 0 -1 0"),
+            None
+        );
+        assert_eq!(parse_cpu_ticks_from_stat(""), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn parse_pgid_from_stat_rejects_malformed_input() {
         use nativelink_worker::running_actions_manager::parse_pgid_from_stat;
         assert_eq!(parse_pgid_from_stat("no parenthesis here"), None);


### PR DESCRIPTION
## What and why

Fixes #2614. NativeLink had OTLP metrics for cache and execution only. Everything else lived in the older `#[metric]` system or nowhere.

Adds the missing categories: workers (connected, connects, disconnects, keepalives, paused/draining), gRPC (one duration histogram by service, method and status, giving rate, errors and latency together), scheduler matching duration, fast/slow store tier hits and bytes, and health check results.

Also the two execution metrics dropped in #2599 for want of a data source. Memory comes from `ActionResourceUsage.peak_memory_kb`, which the worker already reported. CPU time is new: the worker samples `/proc/<pid>/stat` for the process group every 250ms already, so it now reads `utime`/`stime` from the same line and reports it as `cpu_time_ms`.

Connection pools are covered too: free slots at acquisition, whether a caller had to queue, and Redis reconnects. A pool that keeps reporting zero free slots is the bottleneck whatever the latency elsewhere says.

Nothing is labelled by worker id or action digest; both grow without bound.

## How this was verified

Unit tests for the metric helpers, the gRPC path splitter, the health status labels, and the `/proc/<pid>/stat` CPU parser.

## Risk

Moderate, mostly in accounting rather than behaviour.

CPU time is cumulative per process and a process that exits disappears from `/proc`, so the sampler keeps the last value per pid and totals them at the end rather than summing the live group. `cutime`/`cstime` are excluded, since they only cover reaped children and would double count.

Worker counts are per scheduler instance; with several schedulers the fleet total is the sum. They are exact by construction: unbounded LRU so nothing is silently evicted, one removal path, and re-adding an id does not double count.

gRPC status comes from response headers. Tonic puts it in trailers when a call fails mid-stream, and trailers are not reachable from that layer without consuming the body, so error rate undercounts mid-stream failures. Rate and latency are exact.

The proto gains `cpu_time_ms` at tag 5, a new optional field, so an old worker reports zero.

Nothing from #2614 is left out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2687)
<!-- Reviewable:end -->
