### PR TITLE
Rework the PR template and check that it is filled in

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ that, and it is better at it than either of us. -->
 If there is an issue, link it as "Fixes #123" so it closes on merge. If there
 isn't, say what prompted the change. -->
 
-## How this was verified
+## How was this verified?
 
 <!-- What you ran, on what, and what you saw. Beyond CI.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,36 @@
-# Description
+<!-- Thanks for contributing to NativeLink.
 
-Please include a summary of the changes and the related issue. Please also
-include relevant motivation and context.
+Everything outside an HTML comment becomes part of the permanent record, so
+replace the prompts below with your own words. The comments themselves are
+invisible once posted; leaving them in is fine.
 
-Fixes # (issue)
+You do not need to confirm that tests, formatting or lints pass. CI checks
+that, and it is better at it than either of us. -->
 
-## Type of change
+## What and why
 
-Please delete options that aren't relevant.
+<!-- What this changes, and what problem it solves. Two or three sentences.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to
-  not work as expected)
-- [ ] This change requires a documentation update
+If there is an issue, link it as "Fixes #123" so it closes on merge. If there
+isn't, say what prompted the change. -->
 
-## How Has This Been Tested?
+## How this was verified
 
-Please also list any relevant details for your test configuration
+<!-- What you ran, on what, and what you saw. Beyond CI.
 
-## Checklist
+"Added unit tests" on its own does not help a reviewer. Say what they cover,
+and how you know they fail without the change. If you tested against a real
+deployment, say which one and what you observed. If you could not verify part
+of it, say that too: an honest gap is far more useful than a confident
+guess. -->
 
-- [ ] Updated documentation if needed
-- [ ] Tests added/amended
-- [ ] `bazel test //...`  passes locally
-- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
+## Risk
+
+<!-- What breaks if this is wrong, and who notices first.
+
+Worth calling out: changed config defaults, data that gets deleted or
+migrated, wire formats, public API, anything on a hot path, and anything that
+behaves differently on an existing deployment than on a fresh one.
+
+"Low. Pure refactor, covered by existing tests." is a fine answer when it is
+true. -->

--- a/.github/scripts/check_pr_body.py
+++ b/.github/scripts/check_pr_body.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check that a pull request body has the template's sections filled in.
+
+Shape only. Whether a section is empty is something a script can know;
+whether it is honest is not, so nothing here tries to judge the content.
+
+Usage: check_pr_body.py <path-to-body-file>
+
+Exits 0 when the body is usable, 1 otherwise, printing what is missing in
+markdown suitable for posting as a comment.
+"""
+
+import re
+import sys
+
+# Each section a reviewer cannot reconstruct from the diff or from CI.
+REQUIRED_SECTIONS = ("What and why", "How this was verified", "Risk")
+
+# Long enough to rule out "n/a" and "see title", short enough that one real
+# sentence clears it.
+MIN_SECTION_CHARS = 40
+
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def section_body(body: str, heading: str) -> str | None:
+    """Returns the text under `heading`, or None if the heading is absent."""
+    pattern = re.compile(
+        rf"^\#{{1,6}}\s*{re.escape(heading)}\s*$(.*?)(?=^\#{{1,6}}\s|\Z)",
+        re.DOTALL | re.MULTILINE | re.IGNORECASE,
+    )
+    match = pattern.search(body)
+    if match is None:
+        return None
+    # Comments are invisible to a reader, so they do not count as content.
+    return HTML_COMMENT.sub("", match.group(1)).strip()
+
+
+def check(body: str) -> list[str]:
+    if not body.strip():
+        return ["The description is empty. Please fill in the template."]
+
+    problems = []
+    for heading in REQUIRED_SECTIONS:
+        content = section_body(body, heading)
+        if content is None:
+            problems.append(
+                f"**{heading}** is missing. Please keep the template's headings."
+            )
+        elif len(content) < MIN_SECTION_CHARS:
+            problems.append(
+                f"**{heading}** needs a bit more detail "
+                f"({len(content)} characters, {MIN_SECTION_CHARS} expected)."
+            )
+    return problems
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check_pr_body.py <path-to-body-file>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        body = handle.read()
+
+    problems = check(body)
+    if not problems:
+        print("Pull request description looks complete.")
+        return 0
+
+    print("Some of the pull request description still needs filling in:\n")
+    for problem in problems:
+        print(f"- {problem}")
+    print(
+        "\nEdit the description and this check re-runs on its own. "
+        "The sections exist because they are the parts a reviewer cannot get "
+        "from the diff: why the change is needed, how you know it works, and "
+        "what breaks if it is wrong."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_pr_body.py
+++ b/.github/scripts/check_pr_body.py
@@ -14,7 +14,7 @@ import re
 import sys
 
 # Each section a reviewer cannot reconstruct from the diff or from CI.
-REQUIRED_SECTIONS = ("What and why", "How this was verified", "Risk")
+REQUIRED_SECTIONS = ("What and why", "How was this verified?", "Risk")
 
 # Long enough to rule out "n/a" and "see title", short enough that one real
 # sentence clears it.

--- a/.github/workflows/pr-template-check.yaml
+++ b/.github/workflows/pr-template-check.yaml
@@ -1,0 +1,87 @@
+---
+name: PR template
+
+# `pull_request_target` so the comment can be posted on pull requests from
+# forks, which is where a first-time contributor is most likely to need it.
+# Nothing from the pull request is checked out or executed: the checkout below
+# is the base branch, and the body is only ever read from a file.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    # Bots never fill in a template, and a maintainer can wave through a
+    # one-line fix with the skip-pr-template label.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-pr-template')
+    steps:
+      - name: Checkout
+        uses: >- # v6.0.2
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Read the pull request description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Written to a file rather than an env var so the description is never
+        # interpolated into a shell command.
+        run: |
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > pr-body.md
+
+      - name: Check the description
+        id: check
+        run: |
+          set +e
+          python3 .github/scripts/check_pr_body.py pr-body.md > result.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat result.md
+
+      - name: Leave a comment saying what is missing
+        if: steps.check.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # One comment, edited in place, so a few rounds of fixing the
+        # description does not bury the discussion.
+        run: |
+          marker="<!-- pr-template-check -->"
+          printf '%s\n\n' "$marker" > comment.md
+          cat result.md >> comment.md
+
+          existing=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json comments \
+            --jq ".comments[] | select(.body | startswith(\"$marker\")) | .url" \
+            | head -n 1)
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/${existing##*-}" \
+              -f body="$(cat comment.md)" > /dev/null
+          else
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body-file comment.md
+          fi
+
+      - name: Fail if the description is incomplete
+        if: steps.check.outputs.exit_code != '0'
+        run: exit 1


### PR DESCRIPTION
## What and why

The PR template asks for things CI already proves and not much a reviewer actually needs, so it gets filled in as ceremony. Measured across the last 33 merged PRs that used it:

- 29/33 tick "`bazel test //...` passes locally". Nobody runs the full suite before every PR, so the box carries no information.
- 17/33 tick every box, including all four mutually exclusive "Type of change" options.
- 15/33 leave "Please delete options that aren't relevant" in the body.
- 14/33 have an effectively empty "How Has This Been Tested?", which is the one section a reviewer cannot get from the diff.
- 6/33 leave "Fixes # (issue)" verbatim.

Several of those are mine. This replaces it with three sections that each ask for something only the author knows: what problem this solves, how it was actually verified, and what breaks if it is wrong. All guidance moved into HTML comments so it cannot leak into the permanent record.

The checklist is gone. `bazel test //...`, formatting and lints are already CI jobs and pre-commit hooks, which enforce them properly rather than on the honour system.

## How this was verified

Ran the checker against real inputs: a filled-in body passes, the unedited template fails on all three sections, a body with no headings fails, an empty body fails, and a body with "n/a" under a heading fails on that heading only. Also ran it against #2683, an existing PR using the old template, and confirmed it reports the headings as missing rather than crashing.

Workflow YAML parses and the triggers resolve as intended. I could not exercise the workflow end to end, since that only happens once it is on the default branch.

## Risk

This is a process change, so it needs agreement rather than just review.

The check fails PRs whose description is thin, which is the point, but two details keep it from being hostile:

- It skips bots and honours a `skip-pr-template` label, which a maintainer will need to create.
- It comments saying exactly which section is short and re-runs on `edited`, so it goes green as soon as the author fixes it. A red X with no explanation is how you lose a drive-by contributor.

Open PRs written against the old template will fail this check the next time they are edited or pushed to. The label is the escape hatch, or hold the merge until the queue drains.

It runs on `pull_request_target` so it can comment on fork PRs, where a first-time contributor most needs the hint. Nothing from the PR is checked out or executed: the checkout is the base branch, and the description is only ever read from a file, never interpolated into a shell command.

No new third-party action; it reuses the `actions/checkout` pin already trusted in this repo and the preinstalled `gh` CLI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2689)
<!-- Reviewable:end -->
