### PR TITLE
Sample CPU time for actions and report it with resource usage

### DIFF
--- a/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
+++ b/nativelink-proto/com/github/trace_machina/nativelink/remote_execution/worker_api.proto
@@ -125,7 +125,12 @@ message ActionResourceUsage {
     /// The worker ID that observed the resource usage.
     string worker_id = 4;
 
-    reserved 5; // NextId.
+    /// Total CPU time consumed by the action process tree, in milliseconds.
+    /// User and system time combined, summed across every process in the
+    /// action's process group.
+    uint64 cpu_time_ms = 5;
+
+    reserved 6; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
+++ b/nativelink-proto/genproto/com.github.trace_machina.nativelink.remote_execution.pb.rs
@@ -104,6 +104,11 @@ pub struct ActionResourceUsage {
     /// / The worker ID that observed the resource usage.
     #[prost(string, tag = "4")]
     pub worker_id: ::prost::alloc::string::String,
+    /// / Total CPU time consumed by the action process tree, in milliseconds.
+    /// / User and system time combined, summed across every process in the
+    /// / action's process group.
+    #[prost(uint64, tag = "5")]
+    pub cpu_time_ms: u64,
 }
 /// / Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -100,10 +100,18 @@ const DEFAULT_HISTORICAL_RESULTS_STRATEGY: UploadCacheResultsStrategy =
 #[cfg(target_os = "linux")]
 const RESOURCE_USAGE_SAMPLE_INTERVAL: Duration = Duration::from_millis(250);
 
+/// What the sampler observed over an action's lifetime.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SampledResourceUsage {
+    peak_memory_kb: u64,
+    cpu_time_ms: u64,
+}
+
 #[cfg(target_os = "linux")]
 struct ActionResourceUsageSampler {
     stop_tx: watch::Sender<bool>,
-    handle: tokio::task::JoinHandle<u64>,
+    handle: tokio::task::JoinHandle<SampledResourceUsage>,
 }
 
 #[cfg(target_os = "linux")]
@@ -111,24 +119,43 @@ fn start_action_resource_usage_sampler(pgid: u32) -> ActionResourceUsageSampler 
     let (stop_tx, stop_rx) = watch::channel(false);
     let handle = background_spawn!(
         "action_resource_usage_sampler",
-        sample_action_peak_memory_kb(pgid, stop_rx)
+        sample_action_resource_usage(pgid, stop_rx)
     );
     ActionResourceUsageSampler { stop_tx, handle }
 }
 
 #[cfg(target_os = "linux")]
-async fn finish_action_resource_usage_sampler(sampler: ActionResourceUsageSampler) -> Option<u64> {
+async fn finish_action_resource_usage_sampler(
+    sampler: ActionResourceUsageSampler,
+) -> Option<SampledResourceUsage> {
     let _ = sampler.stop_tx.send(true);
     sampler.handle.await.ok()
 }
 
 #[cfg(target_os = "linux")]
-async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bool>) -> u64 {
+async fn sample_action_resource_usage(
+    pgid: u32,
+    mut stop_rx: watch::Receiver<bool>,
+) -> SampledResourceUsage {
     let mut peak_memory_kb = 0;
+    // CPU time is cumulative per process and a process that exits stops
+    // appearing, so summing the live group at the end would lose everything
+    // short-lived. Keep the last figure seen for each pid and total them at
+    // the end instead.
+    let mut cpu_ticks_by_pid = HashMap::new();
+
+    let mut sample = |peak_memory_kb: &mut u64, cpu_ticks_by_pid: &mut HashMap<u32, u64>| {
+        let observed = sample_process_group(pgid, cpu_ticks_by_pid);
+        if let Some(memory_kb) = observed {
+            *peak_memory_kb = (*peak_memory_kb).max(memory_kb);
+        }
+        observed
+    };
+
     loop {
-        if let Some(memory_kb) = sample_process_group_memory_kb(pgid) {
-            peak_memory_kb = peak_memory_kb.max(memory_kb);
-        } else if !Path::new(&format!("/proc/{pgid}")).exists() {
+        if sample(&mut peak_memory_kb, &mut cpu_ticks_by_pid).is_none()
+            && !Path::new(&format!("/proc/{pgid}")).exists()
+        {
             // The group leader has been reaped and no member process remains,
             // so the action is finished.
             break;
@@ -141,16 +168,31 @@ async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bo
         tokio::select! {
             changed = stop_rx.changed() => {
                 if changed.is_ok() && *stop_rx.borrow() {
-                    if let Some(memory_kb) = sample_process_group_memory_kb(pgid) {
-                        peak_memory_kb = peak_memory_kb.max(memory_kb);
-                    }
+                    sample(&mut peak_memory_kb, &mut cpu_ticks_by_pid);
                     break;
                 }
             }
             () = tokio::time::sleep(RESOURCE_USAGE_SAMPLE_INTERVAL) => {}
         }
     }
-    peak_memory_kb
+
+    SampledResourceUsage {
+        peak_memory_kb,
+        cpu_time_ms: ticks_to_millis(cpu_ticks_by_pid.values().sum()),
+    }
+}
+
+/// Converts clock ticks from `/proc` into milliseconds.
+///
+/// `_SC_CLK_TCK` is 100 on every Linux we run on, but it is queryable so ask
+/// rather than assume, and fall back to 100 if the query fails.
+#[cfg(target_os = "linux")]
+fn ticks_to_millis(ticks: u64) -> u64 {
+    // SAFETY: `sysconf` takes an int and returns a long, with no memory
+    // safety considerations.
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    ticks.saturating_mul(1_000) / hz
 }
 
 /// Sums the resident memory of every process in the action's process group.
@@ -165,7 +207,7 @@ async fn sample_action_peak_memory_kb(pgid: u32, mut stop_rx: watch::Receiver<bo
 /// inherited and survives reparenting, and excludes the worker's own group.
 /// Returns `None` when no member process can be read (the group is empty).
 #[cfg(target_os = "linux")]
-fn sample_process_group_memory_kb(pgid: u32) -> Option<u64> {
+fn sample_process_group(pgid: u32, cpu_ticks_by_pid: &mut HashMap<u32, u64>) -> Option<u64> {
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return None;
     };
@@ -176,8 +218,17 @@ fn sample_process_group_memory_kb(pgid: u32) -> Option<u64> {
         let Ok(member_pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
             continue;
         };
-        if read_process_pgid(member_pid) != Some(pgid) {
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{member_pid}/stat")) else {
             continue;
+        };
+        if parse_pgid_from_stat(&stat) != Some(pgid) {
+            continue;
+        }
+        if let Some(ticks) = parse_cpu_ticks_from_stat(&stat) {
+            // Monotonic per process, but a pid could in principle be reused
+            // within one action, so never let the figure go backwards.
+            let entry = cpu_ticks_by_pid.entry(member_pid).or_insert(0);
+            *entry = (*entry).max(ticks);
         }
         if let Some(memory_kb) = read_process_rss_kb(member_pid) {
             total_kb += memory_kb;
@@ -214,6 +265,28 @@ pub fn parse_pgid_from_stat(stat: &str) -> Option<u32> {
     let after_comm = stat.rsplit_once(')')?.1;
     // Fields after the final ')': state(0) ppid(1) pgrp(2) ...
     after_comm.split_whitespace().nth(2)?.parse().ok()
+}
+
+/// Sums user and system CPU ticks (`utime` + `stime`, fields 14 and 15) from
+/// the contents of a `/proc/<pid>/stat` line.
+///
+/// Parsed relative to the final `)` for the same reason as the pgid above:
+/// `comm` can contain spaces and parentheses. Returns `None` when the line is
+/// malformed.
+///
+/// `cutime`/`cstime` are deliberately not included. They only cover children
+/// this process has already reaped, so adding them here would double count
+/// every child that is still its own entry in the group.
+#[cfg(target_os = "linux")]
+pub fn parse_cpu_ticks_from_stat(stat: &str) -> Option<u64> {
+    let after_comm = stat.rsplit_once(')')?.1;
+    let mut fields = after_comm.split_whitespace();
+    // Fields after the final ')': state(0) ppid(1) pgrp(2) session(3) tty(4)
+    // tpgid(5) flags(6) minflt(7) cminflt(8) majflt(9) cmajflt(10)
+    // utime(11) stime(12) ...
+    let utime: u64 = fields.nth(11)?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+    Some(utime.saturating_add(stime))
 }
 
 /// Valid string reasons for a failure.
@@ -1643,13 +1716,19 @@ impl RunningActionImpl {
                     let resource_usage = match maybe_resource_usage_sampler.take() {
                         Some(sampler) => finish_action_resource_usage_sampler(sampler)
                             .await
-                            .and_then(|peak_memory_kb| {
-                                (peak_memory_kb > 0).then_some(ActionResourceUsage {
-                                    peak_memory_kb,
-                                    sampled: true,
-                                    operation_id: String::new(),
-                                    worker_id: String::new(),
-                                })
+                            .and_then(|usage| {
+                                // An action too short to catch a sample leaves
+                                // both at zero; report nothing rather than a
+                                // misleading zero.
+                                (usage.peak_memory_kb > 0 || usage.cpu_time_ms > 0).then_some(
+                                    ActionResourceUsage {
+                                        peak_memory_kb: usage.peak_memory_kb,
+                                        cpu_time_ms: usage.cpu_time_ms,
+                                        sampled: true,
+                                        operation_id: String::new(),
+                                        worker_id: String::new(),
+                                    },
+                                )
                             }),
                         None => None,
                     };

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -5141,6 +5141,48 @@ done
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn parse_cpu_ticks_from_stat_sums_user_and_system_time() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        // Fields after the final ')': state ppid pgrp session tty tpgid flags
+        // minflt cminflt majflt cmajflt utime stime ...
+        // utime = 120, stime = 34, so 154 ticks.
+        assert_eq!(
+            parse_cpu_ticks_from_stat(
+                "315 (perl) S 1 60 60 0 -1 0 100 0 200 0 120 34 7 9 20 0 1 0"
+            ),
+            Some(154)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cpu_ticks_from_stat_handles_comm_with_spaces_and_parens() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        // Same trap as the pgid parser: a `comm` containing ')' would shift
+        // every field if parsed from the left.
+        assert_eq!(
+            parse_cpu_ticks_from_stat(
+                "1234 (weird )( name) R 1 777 777 0 -1 0 1 2 3 4 11 22 0 0 0 0"
+            ),
+            Some(33)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cpu_ticks_from_stat_rejects_malformed_input() {
+        use nativelink_worker::running_actions_manager::parse_cpu_ticks_from_stat;
+        assert_eq!(parse_cpu_ticks_from_stat("no parenthesis here"), None);
+        // Truncated before utime.
+        assert_eq!(
+            parse_cpu_ticks_from_stat("123 (only) S 1 60 60 0 -1 0"),
+            None
+        );
+        assert_eq!(parse_cpu_ticks_from_stat(""), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn parse_pgid_from_stat_rejects_malformed_input() {
         use nativelink_worker::running_actions_manager::parse_pgid_from_stat;
         assert_eq!(parse_pgid_from_stat("no parenthesis here"), None);


### PR DESCRIPTION
## What and why

Part of #2614 (Separating the PR out, since this feature is getting quite big). `execution_cpu_time` was removed in #2599 because nothing reported CPU time.

The worker already samples the action's process group every 250ms for peak memory, reading `/proc/<pid>/stat` for the process group id. `utime` and `stime` are in that same line, so this reads them while it is already there and reports the total as `cpu_time_ms` on `ActionResourceUsage`.

That message already flows to the scheduler and out as an origin event, so the value reaches the BEP pipeline with no further plumbing.

## How this was verified

Added unit tests for the parser.

## Risk

Low, and confined to Linux workers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2690)
<!-- Reviewable:end -->
