### PR TITLE
Retry the final key TTL after a failover

### DIFF
--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1223,19 +1223,41 @@ where
             }
         }
 
-        // Expire the final key, not the temp one: RENAME would carry a TTL
-        // over, but setting it here keeps the window where the key exists
-        // without one down to a single round trip and keeps the intent
-        // obvious. A failure here is a real error rather than something to
-        // swallow, since a key that silently never expires is the bug this
-        // option exists to prevent.
+        // The rename carries the temp key's TTL across, so the key is never
+        // unprotected. Re-setting it here restarts the window at completion
+        // rather than at the first byte, which matters for a large blob whose
+        // upload takes a noticeable slice of the TTL. Reconnect once on a
+        // transient failover error, the same as the rename above: a key that
+        // silently never expires is the bug this option exists to prevent.
         if let Some(key_ttl) = self.key_ttl {
-            let ttl_secs = i64::try_from(key_ttl.as_secs()).unwrap_or(i64::MAX);
-            client
+            let ttl_secs = ttl_seconds(key_ttl);
+            match client
                 .connection_manager
                 .expire::<_, ()>(final_key.as_ref(), ttl_secs)
                 .await
-                .err_tip(|| format!("While setting TTL on {final_key} in RedisStore::update()"))?;
+            {
+                Ok(()) => {}
+                Err(err) if is_retryable_redis_error(&err) => {
+                    let (connection_manager, uuid) =
+                        self.connection_manager.reconnect(client.uuid).await?;
+                    client.connection_manager = connection_manager;
+                    client.uuid = uuid;
+                    client
+                        .connection_manager
+                        .expire::<_, ()>(final_key.as_ref(), ttl_secs)
+                        .await
+                        .err_tip(|| {
+                            format!(
+                                "While setting TTL on {final_key} (after reconnect) in RedisStore::update()"
+                            )
+                        })?;
+                }
+                Err(err) => {
+                    return Err(Error::from(err).append(format!(
+                        "While setting TTL on {final_key} in RedisStore::update()"
+                    )));
+                }
+            }
         }
 
         // If we have a publish channel configured, send a notice that the key has been set.

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -2688,6 +2688,62 @@ async fn update_sets_a_ttl_when_configured() -> Result<(), Error> {
     Ok(())
 }
 
+/// A failover between the rename and the expire must not leave the key
+/// without a TTL. Every other step in `update` reconnects and retries once on
+/// a transient error; this one did not, which review caught after it merged.
+#[nativelink_test]
+async fn update_retries_the_ttl_after_a_failover() -> Result<(), Error> {
+    const TTL_SECONDS: u64 = 7 * 24 * 60 * 60;
+    let data = Bytes::from_static(b"14");
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let packed_hash_hex = format!("{digest}");
+    let temp_key = make_temp_key(&packed_hash_hex);
+    let real_key = packed_hash_hex;
+    let ttl_arg = i64::try_from(TTL_SECONDS).unwrap();
+
+    let store = make_mock_store_with_ttl(
+        vec![
+            MockCmd::new(
+                redis::cmd("SETRANGE")
+                    .arg(&temp_key)
+                    .arg(0)
+                    .arg(data.to_vec()),
+                Ok(Value::Int(0)),
+            ),
+            MockCmd::new(
+                redis::cmd("EXPIRE").arg(&temp_key).arg(ttl_arg),
+                Ok(Value::Int(1)),
+            ),
+            MockCmd::new(
+                redis::cmd("STRLEN").arg(&temp_key),
+                Ok(Value::Int(data.len().try_into().unwrap_or(i64::MAX))),
+            ),
+            MockCmd::new(
+                redis::cmd("RENAME").arg(&temp_key).arg(&real_key),
+                Ok(Value::Nil),
+            ),
+            // The master goes away right as we set the retention window.
+            MockCmd::new(
+                redis::cmd("EXPIRE").arg(&real_key).arg(ttl_arg),
+                Err::<Value, _>(RedisError::from(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "connection reset by peer",
+                ))),
+            ),
+            // After re-resolving the master the TTL is set on the new one.
+            MockCmd::new(
+                redis::cmd("EXPIRE").arg(&real_key).arg(ttl_arg),
+                Ok(Value::Int(1)),
+            ),
+        ],
+        Duration::from_secs(TTL_SECONDS),
+    )
+    .await;
+
+    store.update_oneshot(digest, data).await?;
+    Ok(())
+}
+
 /// The default must stay off. The same store type backs the CAS fast tier and
 /// the scheduler, and expiring scheduler state would drop in-flight actions.
 ///


### PR DESCRIPTION
## What and why

Follow-up to #2688. @corcillo asked for the reconnect-and-retry on both
`EXPIRE` calls; only the temp-key one got it and I mistakenly reported both as
done. The final-key `EXPIRE` still failed outright on a transient failover,
while every other step in `update` reconnects and retries once.

Same change routes it through `ttl_seconds()`, so the clamp to at least one
second now covers both sites rather than just the temp key. Not reachable
today since config rejects zero, but it was meant to be defence in depth at
both.

Also corrected the comment above it, which still described the pre-review
design where only the final key carried a TTL.

## How this was verified

Added `update_retries_the_ttl_after_a_failover`: the mock returns a connection
reset on the first `EXPIRE` of the real key and succeeds on the retry. It
fails with the retry arm removed, with the error the reviewer predicted:

```
Error { code: Unavailable, messages: ["Io: connection reset by peer",
  "While setting TTL on 3031...30-2 in RedisStore::update()"] }
```

Full store suite (30 binaries) and clippy are clean.

## Risk

Low. One more round trip only on a failover that would previously have failed
the write.

The retry is bounded to a single attempt, matching the rename directly above
it, so a persistently unreachable master still surfaces an error rather than
looping.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2691)
<!-- Reviewable:end -->
