### PR TITLE
fix log dupe at cmd completion

### DIFF
--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1902,11 +1902,7 @@ impl RunningActionImpl {
                     let resource_usage = None;
 
                     // log something useful instead of repeating same ?arg
-                    if let Some(ru) = &resource_usage {
-                        info!(exit_code, ru.peak_memory_kb, ru.cpu_time_ms, "Command complete");
-                    } else {
-                        info!("Command complete");
-                    }
+                    info!(?exit_code, "Command complete");
 
                     let maybe_error_override = if let Some(side_channel_file) = maybe_side_channel_file {
                         process_side_channel_file(side_channel_file.clone(), &args, requested_timeout).await

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1904,6 +1904,8 @@ impl RunningActionImpl {
                     // log something useful instead of repeating same ?arg
                     if let Some(ru) = &resource_usage {
                         info!(exit_code, ru.peak_memory_kb, ru.cpu_time_ms, "Command complete");
+                    } else {
+                        info!("Command complete");
                     }
 
                     let maybe_error_override = if let Some(side_channel_file) = maybe_side_channel_file {

--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -1901,7 +1901,10 @@ impl RunningActionImpl {
                     #[cfg(not(target_os = "linux"))]
                     let resource_usage = None;
 
-                    info!(?args, "Command complete");
+                    // log something useful instead of repeating same ?arg
+                    if let Some(ru) = &resource_usage {
+                        info!(exit_code, ru.peak_memory_kb, ru.cpu_time_ms, "Command complete");
+                    }
 
                     let maybe_error_override = if let Some(side_channel_file) = maybe_side_channel_file {
                         process_side_channel_file(side_channel_file.clone(), &args, requested_timeout).await

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -3762,7 +3762,7 @@ exit 1
         let command = "[\"cmd\", \"/C\", \"ping -n 99999 127.0.0.1\"]";
 
         assert!(logs_contain(&format!("Executing command args={command}")));
-        assert!(logs_contain(&format!("Command complete exit_code=")));
+        assert!(logs_contain("Command complete exit_code="));
 
         assert!(!logs_contain(
             "Child process was not cleaned up before dropping the call to execute(), killing in background spawn"

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -3762,7 +3762,7 @@ exit 1
         let command = "[\"cmd\", \"/C\", \"ping -n 99999 127.0.0.1\"]";
 
         assert!(logs_contain(&format!("Executing command args={command}")));
-        assert!(logs_contain(&format!("Command complete args={command}")));
+        assert!(logs_contain(&format!("Command complete exit_code=")));
 
         assert!(!logs_contain(
             "Child process was not cleaned up before dropping the call to execute(), killing in background spawn"


### PR DESCRIPTION
<!-- Thanks for contributing to NativeLink.

Everything outside an HTML comment becomes part of the permanent record, so
replace the prompts below with your own words. The comments themselves are
invisible once posted; leaving them in is fine.

You do not need to confirm that tests, formatting or lints pass. CI checks
that, and it is better at it than either of us. -->

## What and why

<!-- What this changes, and what problem it solves. Two or three sentences.

If there is an issue, link it as "Fixes #123" so it closes on merge. If there
isn't, say what prompted the change. -->
At the default RUST_LOG=info level, every action is logging its complete argv twice -
once at running_actions_manager.rs:1487 ("Executing command") and 
again at running_actions_manager.rs:1904 ("Command complete"). 
The 1st time is deliberate looking at the TODO explaining why it is not a debug! instead - 'we often rely on this to figure out toolchain misconfiguration issues'. However, the 2nd time has no such justification and seems to be a duplication. When this line executes, the action is completed but we do not see any useful info which is in context like exit_code. so instead of repeating what is already known it would be helpful to log something useful to correlate. Also this reduces total log size by omitting line duplication.

## How was this verified?

<!-- What you ran, on what, and what you saw. Beyond CI.

"Added unit tests" on its own does not help a reviewer. Say what they cover,
and how you know they fail without the change. If you tested against a real
deployment, say which one and what you observed. If you could not verify part
of it, say that too: an honest gap is far more useful than a confident
guess. -->

the cargo test `worker_times_out` asserts the info! log statement.
this was run locally to verify that the test case is passing -
$ cargo test -- worker_times_out
running 1 test
test tests::worker_times_out ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 0.03s

## Risk
<!-- What breaks if this is wrong, and who notices first.

Worth calling out: changed config defaults, data that gets deleted or
migrated, wire formats, public API, anything on a hot path, and anything that
behaves differently on an existing deployment than on a fresh one.

"Low. Pure refactor, covered by existing tests." is a fine answer when it is
true. -->

Severity: low (log operability)
Resulting logs for an action might appear different in terms of debugging prespective from earlier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2694)
<!-- Reviewable:end -->
