### PR TITLE
Release NativeLink v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.5](https://github.com/TraceMachina/nativelink/compare/v1.6.4..v1.6.5) - 2026-08-18
+
+### ⛰️  Features
+
+- Add OTLP metrics for workers, gRPC, the scheduler, store tiers and health ([#2687](https://github.com/TraceMachina/nativelink/issues/2687)) - ([9172cec](https://github.com/TraceMachina/nativelink/commit/9172cec1afd1556f8d9a7a8892e5d24cfb744405))
+- Add an optional TTL for keys a redis store writes ([#2688](https://github.com/TraceMachina/nativelink/issues/2688)) - ([5c1a042](https://github.com/TraceMachina/nativelink/commit/5c1a042b7b46f47ea2753f10f6a21e144744937d))
+- Add support for multi arch container on docker compose examples ([#2653](https://github.com/TraceMachina/nativelink/issues/2653)) - ([ed56f95](https://github.com/TraceMachina/nativelink/commit/ed56f9514d89d712ae6360324e5b6b7b60948a0b))
+
+### 🐛 Bug Fixes
+
+- Fix wildcard retry match so new error codes can't silently retry ([#2673](https://github.com/TraceMachina/nativelink/issues/2673)) - ([b669f2c](https://github.com/TraceMachina/nativelink/commit/b669f2cbe9f8ed7ca511d149683449fd776f59a3))
+
+### 📚 Documentation
+
+- *(config-reference)* regenerate for NativeLink v1.6.4 ([#2666](https://github.com/TraceMachina/nativelink/issues/2666)) - ([aa94763](https://github.com/TraceMachina/nativelink/commit/aa947638cd342c358b250dca11f3d88daa86fb51))
+
+### 🧪 Testing & CI
+
+- *(worker)* 🐛 lease active action inputs across eviction ([#2675](https://github.com/TraceMachina/nativelink/issues/2675)) - ([df7de0d](https://github.com/TraceMachina/nativelink/commit/df7de0dca26a025064740283a8d8dc3718d7e89d))
+- Chunk oversized messages in the bytestream write and batch update paths ([#2686](https://github.com/TraceMachina/nativelink/issues/2686)) - ([36a7b08](https://github.com/TraceMachina/nativelink/commit/36a7b083e660259901de87a7211a93585aaa5264))
+- Upgrade rules_rs and hermetic_llvm ([#2674](https://github.com/TraceMachina/nativelink/issues/2674)) - ([e9033a9](https://github.com/TraceMachina/nativelink/commit/e9033a9110360fb6755178da8d1dcef248cdcc7c))
+- Enable remote execution in CI ([#2671](https://github.com/TraceMachina/nativelink/issues/2671)) - ([0af8592](https://github.com/TraceMachina/nativelink/commit/0af8592777e59a2f18ec3a9e05b6fc7feb3ea9f4))
+
+### ⚙️ Miscellaneous
+
+- Rework the PR template and check that it is filled in ([#2689](https://github.com/TraceMachina/nativelink/issues/2689)) - ([b76af1c](https://github.com/TraceMachina/nativelink/commit/b76af1c374e33771f7e8e1b120453377058d07b1))
+- Retry the final key TTL after a failover ([#2691](https://github.com/TraceMachina/nativelink/issues/2691)) - ([3f1fb5d](https://github.com/TraceMachina/nativelink/commit/3f1fb5d66c20f3e0559f3cc1c201b17506fe451b))
+- Reap orphaned actions and check worker liveness before recreating one ([#2685](https://github.com/TraceMachina/nativelink/issues/2685)) - ([a50385e](https://github.com/TraceMachina/nativelink/commit/a50385e27a2bee3ab7618fe64b27f30c7b24c9fb))
+- Don't let one scheduler instance time out another's in-flight actions ([#2680](https://github.com/TraceMachina/nativelink/issues/2680)) - ([d4fa6af](https://github.com/TraceMachina/nativelink/commit/d4fa6af626d6be6657dbf775bea5592e79cb7c24))
+- Chunk ByteStream writes instead of sending a whole blob as one message ([#2679](https://github.com/TraceMachina/nativelink/issues/2679)) - ([93b679b](https://github.com/TraceMachina/nativelink/commit/93b679b7377943a85ecc7bce33891444c9eacb39))
+- CAS eviction mid-build is recoverable ([#2678](https://github.com/TraceMachina/nativelink/issues/2678)) - ([9565f46](https://github.com/TraceMachina/nativelink/commit/9565f46e18e69e6c592c40cf23e7e654555f0ea8))
+- Limit local uploads to trusted lanes ([#2677](https://github.com/TraceMachina/nativelink/issues/2677)) - ([efc21cf](https://github.com/TraceMachina/nativelink/commit/efc21cf3701e857a06062c49f20816235f8620bf))
+- Harden the compressed GrpcStore download path ([#2640](https://github.com/TraceMachina/nativelink/issues/2640)) - ([aba6718](https://github.com/TraceMachina/nativelink/commit/aba67183b065e09d68911f0193cbe8a984af584b))
+
+### ⬆️ Bumps & Version Updates
+
+- Update copyright year to 2026 ([#2676](https://github.com/TraceMachina/nativelink/issues/2676)) - ([492fa50](https://github.com/TraceMachina/nativelink/commit/492fa50374485aec9426c74826360563a030fc9a))
+- increase RPC timeout to 30-second deadline ([#2683](https://github.com/TraceMachina/nativelink/issues/2683)) - ([02dd21d](https://github.com/TraceMachina/nativelink/commit/02dd21d9ad6da760db50b3ad8d66c9ff21489f23))
+- Update CONTRIBUTING.MD instructions template from v0.x.y to v1.x.y ([#2667](https://github.com/TraceMachina/nativelink/issues/2667)) - ([624420d](https://github.com/TraceMachina/nativelink/commit/624420d63aa95d3e3976034cd9a0ca283bc0afd8))
+- Amend release steps in CONTRIBUTING.md ([#2665](https://github.com/TraceMachina/nativelink/issues/2665)) - ([364fd2e](https://github.com/TraceMachina/nativelink/commit/364fd2e1bd02b0406c2b77d760b204d1c76e112f))
+
 ## [1.6.4](https://github.com/TraceMachina/nativelink/compare/v1.6.3..1.6.4) - 2026-08-04
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "axum",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "base64 0.22.1",
  "mongodb",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.6.4"
+version = "1.6.5"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.6.4",
+    version = "1.6.5",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.6.4"
+version = "1.6.5"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.6.4"
+version = "1.6.5"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.6.4"
+version = "1.6.5"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-test/fuzz/Cargo.lock
+++ b/nativelink-test/fuzz/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "base64",
  "mongodb",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "derive_more",
  "prost",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.6.4"
+version = "1.6.5"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.6.4"
+version = "1.6.5"
 
 [features]
 nix = []


### PR DESCRIPTION
## What and why

Releases Nativelink v1.6.5. This commit is the version bump and changelog only; every change in it landed and was reviewed in its own PR.

Focuses on multi-replica scheduler correctness and large-blob handling. Two scheduler fixes stop replicas timing out each other's in-flight actions and stop orphaned actions leaking on the default configuration, and the remaining ByteStream paths now chunk oversized messages instead of failing them outright. Also adds full OTLP metric coverage for workers, gRPC, the scheduler, store tiers and health, and an optional TTL for Redis store keys. Anyone running more than one CAS replica, or proxying to another CAS, should upgrade.


## How was this verified?

 Each change was verified in its own PR: unit tests throughout. And the environment was tested in a live cluster with positive results. 

## Risk

Moderate, and concentrated in two behaviour changes rather than in the release mechanics.                                                                                                                    

- Orphaned actions now get reaped. On a deployment leaving `max_action_executing_timeout_s` at its default of 0, an action whose scheduler disappeared previously hung until the client gave up; it is now cleaned up after an hour.
- Duplicate Execute now joins instead of recreating. 
- Wire framing changed for ByteStream pass-through. 
- The Redis key TTL defaults to 0 (no expiry), so it does nothing unless configured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2696)
<!-- Reviewable:end -->
