### PR TITLE
Bump the pinned curl to 8.5.0-2ubuntu10.12

### DIFF
--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=builder /root/nativelink-bin /usr/local/bin/nativelink
 ARG ADDITIONAL_SETUP_WORKER_CMD
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.11 \
+    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.12 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && bash -ueo pipefail -c "${ADDITIONAL_SETUP_WORKER_CMD}" \


### PR DESCRIPTION
## What and why

Pins the curl version for docker to `8.5.0-2ubuntu10.12`. All the recent CI builds for integration tests were failing, so this should fix these CI failures. 

## How was this verified?

Tested it locally with docker environment, however a CI run should provide the definitive answer. 

## Risk

Low risk PR since this is a simple update to the Dockerfile, and should not affect existing builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2702)
<!-- Reviewable:end -->
