### PR TITLE
Collapse the PR template comment once the description is fixed

### DIFF
--- a/.github/workflows/pr-template-check.yaml
+++ b/.github/workflows/pr-template-check.yaml
@@ -56,31 +56,54 @@ jobs:
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           cat result.md
 
-      - name: Leave a comment saying what is missing
-        if: steps.check.outputs.exit_code != '0'
+      - name: Leave a comment saying what is missing, or mark as resolved
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         # One comment, edited in place, so a few rounds of fixing the
         # description does not bury the discussion.
+        #
+        # Once the description is fixed, the comment is collapsed.
         run: |
           marker="<!-- pr-template-check -->"
+
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+            --jq "[.comments[] | select(.body | startswith(\"$marker\"))] | first // {}" \
+            > existing.json
+          comment_id=$(jq -r '.id // empty' existing.json)
+          minimized=$(jq -r '.isMinimized // false' existing.json)
+
+          if [ "${{ steps.check.outputs.exit_code }}" = '0' ]; then
+            if [ -n "$comment_id" ] && [ "$minimized" = 'false' ]; then
+              gh api graphql -f id="$comment_id" -f query='
+                mutation($id: ID!) {
+                  minimizeComment(input: {subjectId: $id, classifier: RESOLVED}) {
+                    minimizedComment { isMinimized }
+                  }
+                }' > /dev/null
+            fi
+            exit 0
+          fi
+
           printf '%s\n\n' "$marker" > comment.md
           cat result.md >> comment.md
 
-          existing=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json comments \
-            --jq ".comments[] | select(.body | startswith(\"$marker\")) | .url" \
-            | head -n 1)
-
-          if [ -n "$existing" ]; then
-            gh api --method PATCH \
-              "repos/$GITHUB_REPOSITORY/issues/comments/${existing##*-}" \
-              -f body="$(cat comment.md)" > /dev/null
-          else
+          if [ -z "$comment_id" ]; then
             gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
               --body-file comment.md
+            exit 0
           fi
+
+          gh api graphql -f id="$comment_id" -F body="@comment.md" \
+            -F minimized="$minimized" -f query='
+            mutation($id: ID!, $body: String!, $minimized: Boolean!) {
+              updateIssueComment(input: {id: $id, body: $body}) {
+                issueComment { url }
+              }
+              unminimizeComment(input: {subjectId: $id}) @include(if: $minimized) {
+                unminimizedComment { isMinimized }
+              }
+            }' > /dev/null
 
       - name: Fail if the description is incomplete
         if: steps.check.outputs.exit_code != '0'


### PR DESCRIPTION
<!-- Thanks for contributing to NativeLink.

Everything outside an HTML comment becomes part of the permanent record, so
replace the prompts below with your own words. The comments themselves are
invisible once posted; leaving them in is fine.

You do not need to confirm that tests, formatting or lints pass. CI checks
that, and it is better at it than either of us. -->

## What and why

<!-- What this changes, and what problem it solves. Two or three sentences.

If there is an issue, link it as "Fixes #123" so it closes on merge. If there
isn't, say what prompted the change. -->

If a comment ever gets posted in response to an inadequately filled out PR template, it stays in that state even once fixed, unlike e.g. the CLA comment, which updates.

## How was this verified?

<!-- What you ran, on what, and what you saw. Beyond CI.

"Added unit tests" on its own does not help a reviewer. Say what they cover,
and how you know they fail without the change. If you tested against a real
deployment, say which one and what you observed. If you could not verify part
of it, say that too: an honest gap is far more useful than a confident
guess. -->

Ran the shell code against a stub `gh` to check each combination of comment state and check outcome

## Risk

<!-- What breaks if this is wrong, and who notices first.

Worth calling out: changed config defaults, data that gets deleted or
migrated, wire formats, public API, anything on a hot path, and anything that
behaves differently on an existing deployment than on a fresh one.

"Low. Pure refactor, covered by existing tests." is a fine answer when it is
true. -->

Breaking the PR template check job; no functional risk.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2703)
<!-- Reviewable:end -->
