### PR TITLE
Never notify the action-done channel while holding the running-actions mutex

### DIFF
--- a/nativelink-worker/src/running_actions_manager.rs
+++ b/nativelink-worker/src/running_actions_manager.rs
@@ -3331,10 +3331,20 @@ impl RunningActionsManagerImpl {
     }
 
     fn cleanup_action(&self, operation_id: &OperationId) -> Result<(), Error> {
-        let mut running_actions = self.running_actions.lock();
-        let result = running_actions.remove(operation_id).err_tip(|| {
-            format!("Expected operation id '{operation_id}' to exist in RunningActionsManagerImpl")
-        });
+        // The guard must be dropped before notifying: `send_modify` takes
+        // the watch channel's internal lock, and a `wait_for` closure that
+        // takes `running_actions` runs while holding that same lock, so
+        // notifying while holding `running_actions` is an ABBA deadlock
+        // (issue #2672). There is no lost wakeup in the gap: the removal
+        // happens-before the notify.
+        let result = {
+            let mut running_actions = self.running_actions.lock();
+            running_actions.remove(operation_id).err_tip(|| {
+                format!(
+                    "Expected operation id '{operation_id}' to exist in RunningActionsManagerImpl"
+                )
+            })
+        };
         // No need to copy anything, we just are telling the receivers an event happened.
         self.action_done_tx.send_modify(|()| {});
         result.map(|_| ())
@@ -3495,15 +3505,24 @@ impl RunningActionsManager for RunningActionsManagerImpl {
                 while kill_futures.next().await.is_some() {}
             })
             .await;
-        // Ignore error. If error happens it means there's no sender, which is not a problem.
-        // Note: Sanity check this API will always check current value then future values:
-        // https://play.rust-lang.org/?version=stable&edition=2021&gist=23103652cc1276a97e5f9938da87fdb2
-        drop(
-            self.action_done_tx
-                .subscribe()
-                .wait_for(|()| self.running_actions.lock().is_empty())
-                .await,
-        );
+        // Wait for the running actions to drain. Deliberately NOT
+        // `wait_for(|()| ...)`: that closure runs while the watch channel's
+        // internal lock is held, so taking `running_actions` inside it
+        // deadlocks with anyone notifying the channel while holding
+        // `running_actions` (issue #2672). Checking outside the channel's
+        // lock loses no wakeup: `changed()` reports any version bump since
+        // the last check, and `cleanup_action` removes before it notifies.
+        let mut action_done_rx = self.action_done_tx.subscribe();
+        loop {
+            if self.running_actions.lock().is_empty() {
+                break;
+            }
+            // The only sender lives on `self`, so this cannot error; if it
+            // ever did, giving up the wait is still the safe answer.
+            if action_done_rx.changed().await.is_err() {
+                break;
+            }
+        }
     }
 
     #[inline]

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -4157,6 +4157,123 @@ exit 1
         Ok(())
     }
 
+    /// Regression test for issue #2672: `cleanup_action` used to notify the
+    /// action-done watch channel while holding the `running_actions` mutex,
+    /// and `kill_all` used to take that mutex inside a `wait_for` closure,
+    /// which runs while the channel's internal lock is held. On a
+    /// multi-threaded runtime the two parked each other's threads forever.
+    /// This races many concurrent cleanups against `kill_all`; a
+    /// reintroduction shows up as the timeout firing rather than a wedge.
+    #[nativelink_test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kill_all_does_not_deadlock_with_concurrent_cleanups()
+    -> Result<(), Box<dyn core::error::Error>> {
+        const WORKER_ID: &str = "foo_worker_id";
+
+        fn test_monotonic_clock() -> SystemTime {
+            static CLOCK: AtomicU64 = AtomicU64::new(0);
+            monotonic_clock(&CLOCK)
+        }
+
+        let root_action_directory = make_temp_path("root_action_directory");
+        fs::create_dir_all(&root_action_directory).await?;
+
+        let (_, _, cas_store, ac_store) = setup_stores().await?;
+        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+            RunningActionsManagerArgs {
+                root_action_directory: root_action_directory.clone(),
+                execution_configuration: ExecutionConfiguration::default(),
+                cas_store: cas_store.clone(),
+                ac_store: Some(Store::new(ac_store.clone())),
+                historical_store: Store::new(cas_store.clone()),
+                upload_action_result_config: &UploadActionResultConfig {
+                    upload_ac_results_strategy: UploadCacheResultsStrategy::Never,
+                    ..Default::default()
+                },
+                max_action_timeout: Duration::MAX,
+                max_upload_timeout: Duration::from_secs(DEFAULT_MAX_UPLOAD_TIMEOUT),
+                max_cleanup_wait: Duration::from_secs(DEFAULT_MAX_CLEANUP_WAIT),
+                max_cleanup_backoff: Duration::from_millis(DEFAULT_MAX_CLEANUP_BACKOFF),
+                timeout_handled_externally: false,
+                active_input_leases: false,
+                directory_cache: None,
+                #[cfg(target_os = "linux")]
+                use_namespaces: use_namespaces(),
+            },
+            Callbacks {
+                now_fn: test_monotonic_clock,
+                sleep_fn: |_duration| Box::pin(future::pending()),
+            },
+        )?);
+
+        let command = Command {
+            arguments: vec!["true".to_string()],
+            output_paths: vec![],
+            working_directory: ".".to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(
+            &command,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let input_root_digest = serialize_and_upload_message(
+            &Directory::default(),
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(
+            &action,
+            cas_store.as_pin(),
+            &mut DigestHasherFunc::Sha256.hasher(),
+        )
+        .await?;
+
+        for iteration in 0..50 {
+            let mut actions = Vec::new();
+            for i in 0..4 {
+                let execute_request = ExecuteRequest {
+                    action_digest: Some(action_digest.into()),
+                    digest_function: ProtoDigestFunction::Sha256.into(),
+                    ..Default::default()
+                };
+                let running_action = running_actions_manager
+                    .create_and_add_action(
+                        WORKER_ID.to_string(),
+                        StartExecute {
+                            execute_request: Some(execute_request),
+                            operation_id: format!("kill-race-{iteration}-{i}"),
+                            queued_timestamp: Some(make_system_time(1000).into()),
+                            platform: action.platform.clone(),
+                            worker_id: WORKER_ID.to_string(),
+                        },
+                    )
+                    .await?;
+                actions.push(running_action);
+            }
+            // Cleanups notify the action-done channel while kill_all waits
+            // on it; running them concurrently is the racing window.
+            let cleanups: Vec<_> = actions
+                .into_iter()
+                .map(|running_action| tokio::spawn(running_action.cleanup()))
+                .collect();
+            tokio::time::timeout(Duration::from_secs(60), running_actions_manager.kill_all())
+                .await
+                .expect("kill_all deadlocked against concurrent cleanup_action (issue #2672)");
+            for cleanup in cleanups {
+                drop(cleanup.await??);
+            }
+        }
+
+        Ok(())
+    }
+
     /// Regression Test for Issue #675
     #[cfg(target_family = "unix")]
     #[nativelink_test]

--- a/nativelink-worker/tests/running_actions_manager_test.rs
+++ b/nativelink-worker/tests/running_actions_manager_test.rs
@@ -4263,7 +4263,7 @@ exit 1
                 .into_iter()
                 .map(|running_action| tokio::spawn(running_action.cleanup()))
                 .collect();
-            tokio::time::timeout(Duration::from_secs(60), running_actions_manager.kill_all())
+            tokio::time::timeout(Duration::from_mins(1), running_actions_manager.kill_all())
                 .await
                 .expect("kill_all deadlocked against concurrent cleanup_action (issue #2672)");
             for cleanup in cleanups {


### PR DESCRIPTION
## What and why

`cleanup_action` notified the action-done watch channel while holding the running-actions mutex, and `kill_all` took that mutex inside a `wait_for` closure, which runs under the channel's internal lock. On a disconnect-triggered `kill_all` racing the killed actions' cleanups, the two parked each other's runtime threads forever (#2672). The worker kept keepalives up while doing nothing. The mutex is now released before any notify, and the drain wait checks the map outside the channel's lock.

## How was this verified?

New multi-thread regression test racing concurrent cleanups against `kill_all`: it deadlocks on the previous code and passes in under a second with the fix. All existing worker tests pass, including the one pinning kill_all's wait-for-drain semantics.

## Risk

Low: same semantics, narrower critical sections; the only behavioral surface is the drain wait, covered by existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2706)
<!-- Reviewable:end -->
