### PR TITLE
Release NativeLink v1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.6](https://github.com/TraceMachina/nativelink/compare/v1.6.5..v1.6.6) - 2026-08-21
+
+### ⛰️  Features
+
+- Tell workers to kill operations the scheduler no longer has executing on them ([#2693](https://github.com/TraceMachina/nativelink/issues/2693)) - ([a851147](https://github.com/TraceMachina/nativelink/commit/a85114732ac6a20f16fcaa93c0c3ef5c2ef3fca7))
+
+### 📚 Documentation
+
+- *(config-reference)* regenerate for NativeLink ([#2700](https://github.com/TraceMachina/nativelink/issues/2700)) - ([aa4ca31](https://github.com/TraceMachina/nativelink/commit/aa4ca31f4a87185f2e0d46163b0156c3840aacd4))
+- *(config-reference)* regenerate for NativeLink v1.6.5 ([#2697](https://github.com/TraceMachina/nativelink/issues/2697)) - ([712f321](https://github.com/TraceMachina/nativelink/commit/712f32154c3b3087cdbcbdb2ef4f681b77ad05ae))
+- rewrite the open-source documentation site for v1.6.5 ([#2698](https://github.com/TraceMachina/nativelink/issues/2698)) - ([8ae3317](https://github.com/TraceMachina/nativelink/commit/8ae33172a598687291b672d1ef2a1c7a2d1e967c))
+- generate the metrics reference and bring the config reference to v1.6.5 ([#2701](https://github.com/TraceMachina/nativelink/issues/2701)) - ([8f86dab](https://github.com/TraceMachina/nativelink/commit/8f86dab48a7602b5d6b07efb86678f65c77ce8a9))
+- add the journey components, page templates, lint scripts and the llms.txt generator ([#2699](https://github.com/TraceMachina/nativelink/issues/2699)) - ([b6bf4d0](https://github.com/TraceMachina/nativelink/commit/b6bf4d00210f65447d3eba4c00283b4d873662bb))
+
+### 🧪 Testing & CI
+
+- Never notify the action-done channel while holding the running-actions mutex ([#2706](https://github.com/TraceMachina/nativelink/issues/2706)) - ([4eb2d07](https://github.com/TraceMachina/nativelink/commit/4eb2d0749363e02a2b7a32ad9a23865c95d54587))
+- Fix a crash from scheduler/worker disconnect [1.6-patch-2] ([#2643](https://github.com/TraceMachina/nativelink/issues/2643)) - ([64f0fbc](https://github.com/TraceMachina/nativelink/commit/64f0fbce0adff40c592782a000d3c38717105006))
+
+### ⚙️ Miscellaneous
+
+- Evict a worker that never acknowledges a kill ([#2707](https://github.com/TraceMachina/nativelink/issues/2707)) - ([4ae820a](https://github.com/TraceMachina/nativelink/commit/4ae820a8e9a86471af25f8691ce6ca97fac9cc0c))
+- Match undeclared platform properties dynamically instead of rejecting them ([#2705](https://github.com/TraceMachina/nativelink/issues/2705)) - ([2978a1d](https://github.com/TraceMachina/nativelink/commit/2978a1dbd496971e7ca77198b8de53ff26164e21))
+- Collapse the PR template comment once the description is fixed ([#2703](https://github.com/TraceMachina/nativelink/issues/2703)) - ([5f028d9](https://github.com/TraceMachina/nativelink/commit/5f028d97cda960db057f2875558d838e6a9b9603))
+- Batch input staging syscalls ([#2695](https://github.com/TraceMachina/nativelink/issues/2695)) - ([1444869](https://github.com/TraceMachina/nativelink/commit/144486944a1542081daa74e0fd6ba25318cc8527))
+- fix log dupe at cmd completion ([#2694](https://github.com/TraceMachina/nativelink/issues/2694)) - ([cbcdf64](https://github.com/TraceMachina/nativelink/commit/cbcdf64f1ae80ca928a22429f6e3de27fc4d786f))
+
+### ⬆️ Bumps & Version Updates
+
+- Update Rust crate lru to 0.18.0 [SECURITY] ([#2681](https://github.com/TraceMachina/nativelink/issues/2681)) - ([5d29f82](https://github.com/TraceMachina/nativelink/commit/5d29f8266c836872a9bb278787063548ee1d1bd8))
+- Bump the pinned curl to 8.5.0-2ubuntu10.12 ([#2702](https://github.com/TraceMachina/nativelink/issues/2702)) - ([888ea82](https://github.com/TraceMachina/nativelink/commit/888ea82496dd7ef490f1681df2d6ea2abb7de205))
+
 ## [1.6.5](https://github.com/TraceMachina/nativelink/compare/v1.6.4..v1.6.5) - 2026-08-18
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "axum",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "base64 0.22.1",
  "mongodb",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.93.1"
-version = "1.6.5"
+version = "1.6.6"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.6.5",
+    version = "1.6.6",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.6.5"
+version = "1.6.6"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.6.5"
+version = "1.6.6"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.6.5"
+version = "1.6.6"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-test/fuzz/Cargo.lock
+++ b/nativelink-test/fuzz/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "base64",
  "mongodb",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "derive_more",
  "prost",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.6.5"
+version = "1.6.6"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.6.5"
+version = "1.6.6"
 
 [features]
 nix = []


### PR DESCRIPTION
## What and why

Releases a new version of the Nativelink v1.6.6

## How was this verified?

Standard Unit tests and CI runs green. No additional tests needed.

## Risk

Low risk, since the PR is simply a Nativelink version update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2708)
<!-- Reviewable:end -->
