### PR TITLE
Label execution resource samples with the action mnemonic

### DIFF
--- a/nativelink-scheduler/src/api_worker_scheduler.rs
+++ b/nativelink-scheduler/src/api_worker_scheduler.rs
@@ -766,19 +766,27 @@ impl WorkerScheduler for ApiWorkerScheduler {
         // default and `observed_worker_peak_memory_mib` was never recorded.
         // Sampling is optional, so only record when the worker actually took a
         // reading. A zero here means "not sampled", not "used no memory".
+        let maybe_action_info = self.running_action_info(worker_id, operation_id).await;
+        let action_mnemonic = maybe_action_info
+            .as_ref()
+            .and_then(|action_info| action_info.origin_metadata.bazel_metadata.as_ref())
+            .map_or_else(String::new, |bazel_metadata| {
+                bazel_metadata.action_mnemonic.clone()
+            });
+
         if resource_usage.sampled {
             if resource_usage.peak_memory_kb > 0 {
-                record_execution_peak_memory(resource_usage.peak_memory_kb, "");
+                record_execution_peak_memory(resource_usage.peak_memory_kb, "", &action_mnemonic);
             }
             if resource_usage.cpu_time_ms > 0 {
-                record_execution_cpu_time(resource_usage.cpu_time_ms, "");
+                record_execution_cpu_time(resource_usage.cpu_time_ms, "", &action_mnemonic);
             }
         }
 
         let Some(origin_event_tx) = self.maybe_origin_event_tx.as_ref() else {
             return Ok(());
         };
-        let Some(action_info) = self.running_action_info(worker_id, operation_id).await else {
+        let Some(action_info) = maybe_action_info else {
             return Ok(());
         };
 

--- a/nativelink-util/src/metrics.rs
+++ b/nativelink-util/src/metrics.rs
@@ -32,6 +32,7 @@ pub const EXECUTION_RESULT: &str = "execution.result";
 pub const EXECUTION_INSTANCE: &str = "execution.instance";
 pub const EXECUTION_PRIORITY: &str = "execution.priority";
 pub const EXECUTION_WORKER_ID: &str = "execution.worker_id";
+pub const EXECUTION_ACTION_MNEMONIC: &str = "execution.action_mnemonic";
 pub const EXECUTION_EXIT_CODE: &str = "execution.exit_code";
 pub const EXECUTION_ACTION_DIGEST: &str = "execution.action_digest";
 
@@ -674,12 +675,12 @@ pub struct ExecutionMetrics {
 /// Wall time is already covered by `execution.stage.duration`. This is the
 /// other half: an action pinning eight cores for a minute and one sleeping
 /// for a minute look identical by wall time and nothing alike here.
-pub fn record_execution_cpu_time(cpu_time_ms: u64, instance_name: &str) {
+pub fn record_execution_cpu_time(cpu_time_ms: u64, instance_name: &str, action_mnemonic: &str) {
     #[expect(clippy::cast_precision_loss)] // Milliseconds; f64 is exact well past any real action.
     let seconds = cpu_time_ms as f64 / 1000.0;
     EXECUTION_METRICS.execution_cpu_time.record(
         seconds,
-        &[KeyValue::new(EXECUTION_INSTANCE, instance_name.to_string())],
+        &execution_sample_attributes(instance_name, action_mnemonic),
     );
 }
 
@@ -689,11 +690,29 @@ pub fn record_execution_cpu_time(cpu_time_ms: u64, instance_name: &str) {
 /// listed `execution_memory_usage` as unimplementable because
 /// `ExecutionMetadata` carries no memory figure; `ActionResourceUsage` does,
 /// and this is that number.
-pub fn record_execution_peak_memory(peak_memory_kb: u64, instance_name: &str) {
+pub fn record_execution_peak_memory(
+    peak_memory_kb: u64,
+    instance_name: &str,
+    action_mnemonic: &str,
+) {
     EXECUTION_METRICS.execution_peak_memory.record(
         peak_memory_sample(peak_memory_kb),
-        &[KeyValue::new(EXECUTION_INSTANCE, instance_name.to_string())],
+        &execution_sample_attributes(instance_name, action_mnemonic),
     );
+}
+
+/// Attributes for a per-action resource sample. The mnemonic is attached only
+/// when known: an empty value on every sample from an unattributed client
+/// would read as a real mnemonic named "".
+fn execution_sample_attributes(instance_name: &str, action_mnemonic: &str) -> Vec<KeyValue> {
+    let mut attrs = vec![KeyValue::new(EXECUTION_INSTANCE, instance_name.to_string())];
+    if !action_mnemonic.is_empty() {
+        attrs.push(KeyValue::new(
+            EXECUTION_ACTION_MNEMONIC,
+            action_mnemonic.to_string(),
+        ));
+    }
+    attrs
 }
 
 /// Ceiling on a recorded peak-memory sample.

--- a/nativelink-util/tests/metrics_test.rs
+++ b/nativelink-util/tests/metrics_test.rs
@@ -348,8 +348,8 @@ fn test_new_metric_helpers_are_callable() {
     record_store_tier_read("slow", "hit");
     record_store_tier_io("fast", "read", 4096);
     record_health_check("store", "ok");
-    record_execution_peak_memory(512 * 1024, "main");
-    record_execution_cpu_time(90_000, "main");
+    record_execution_peak_memory(512 * 1024, "main", "CppCompile");
+    record_execution_cpu_time(90_000, "main", "CppCompile");
     record_connection_acquired("grpc", Some(12), false);
     record_connection_acquired("redis", Some(0), true);
     record_connection_acquired("grpc", None, false);


### PR DESCRIPTION

## What and why

Adds `execution.action_mnemonic` to `execution.peak.memory` and `execution.cpu.time`.  

## How was this verified?

Tested this locally with the unit tests and verified the results in a live environment.

## Risk

Low risk. Adds a metric so no change to the build performance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2712)
<!-- Reviewable:end -->
