### PR TITLE
Upgrade curl to 8.5.0-2ubuntu10.13

### DIFF
--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=builder /root/nativelink-bin /usr/local/bin/nativelink
 ARG ADDITIONAL_SETUP_WORKER_CMD
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.12 \
+    && apt-get install -y --no-install-recommends curl=8.5.0-2ubuntu10.13 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && bash -ueo pipefail -c "${ADDITIONAL_SETUP_WORKER_CMD}" \


### PR DESCRIPTION
## What and why

This upgrades curl in the deployment examples to 8.5.0-2ubuntu10.13 to fix the integration tests

## How was this verified?

`docker build -f ./deployment-examples/docker-compose/Dockerfile .`

## Risk

Low. A curl patch version upgrade is pretty safe!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2717)
<!-- Reviewable:end -->
