### PR TITLE
web: point Media kit Download at the shared Drive folder

### DIFF
--- a/web/apps/web/app/company/page.tsx
+++ b/web/apps/web/app/company/page.tsx
@@ -35,7 +35,10 @@ const contactCards = [
   {
     title: "Media kit",
     body: "Logos, branding guidelines, and approved press resources.",
-    cta: { label: "Download", href: "https://drive.google.com/drive/folders/" },
+    cta: {
+      label: "Download",
+      href: "https://drive.google.com/drive/folders/1fNmr4IpIaaiej6yKr1t0ispbXOaCVVTa?usp=sharing",
+    },
     variant: "outline" as const,
   },
   {


### PR DESCRIPTION
The company CTA was an incomplete folders/ URL and 404ed. Restore the folder id from the previous company page so Download opens the kit.

## What and why

URL was broken for the media kit. We need to bring back the pre-existing folder id so that viewers and agents can access our Media kit in the future without needing us to go retrieve them.

## How was this verified?

Tested at different viewports in cursor cloud agent

## Risk

It was already broken so this is an upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2722)
<!-- Reviewable:end -->
