### PR TITLE
Upgrade scorecard action to 2.4.4

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -29,8 +29,8 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: >- # v2.4.0
-          ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
+        uses: >- # v2.4.4
+          ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## What and why

Upgrades the scorecard action to 2.4.4 because [apparently it can't pull it's own images anymore](https://github.com/TraceMachina/nativelink/actions/runs/33771505578/job/100703360483). https://github.com/ossf/scorecard-action/pull/1453 and https://github.com/ossf/scorecard-action/pull/1478 which is in this release fixes this.

## How was this verified?

https://github.com/TraceMachina/nativelink/actions/runs/33772472933/job/100705905138?pr=2725 successfully pulled which is more than main, but doesn't work because of lack of tokens.

## Risk

Low. It currently doesn't work at all!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2725)
<!-- Reviewable:end -->
