### PR TITLE
Retire queued actions no client is waiting on

### DIFF
--- a/nativelink-redis-tester/src/dynamic_fake_redis.rs
+++ b/nativelink-redis-tester/src/dynamic_fake_redis.rs
@@ -53,7 +53,7 @@ impl<S: SubscriptionManagerNotify> fmt::Debug for FakeRedisBackend<S> {
     }
 }
 
-const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
+const FAKE_SCRIPT_SHA: &str = "d89e3573a1f9689c22115e8a41bd332d0c7c2643";
 
 impl<S: SubscriptionManagerNotify + Send + 'static + Sync> FakeRedisBackend<S> {
     pub fn new() -> Self {

--- a/nativelink-redis-tester/src/read_only_redis.rs
+++ b/nativelink-redis-tester/src/read_only_redis.rs
@@ -27,7 +27,7 @@ use tracing::info;
 
 use crate::fake_redis::{arg_as_string, fake_redis_internal};
 
-const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
+const FAKE_SCRIPT_SHA: &str = "d89e3573a1f9689c22115e8a41bd332d0c7c2643";
 
 #[derive(Clone, Debug)]
 pub struct ReadOnlyRedis {

--- a/nativelink-scheduler/src/default_scheduler_factory.rs
+++ b/nativelink-scheduler/src/default_scheduler_factory.rs
@@ -167,6 +167,14 @@ async fn simple_scheduler_factory(
                 now_fn,
                 Default::default,
                 spec.retain_completed_for_s,
+                // Same normalisation SimpleScheduler applies, so the
+                // keepalive stops being kept exactly when the timeout that
+                // reads it comes due.
+                if spec.client_action_timeout_s == 0 {
+                    crate::simple_scheduler::DEFAULT_CLIENT_ACTION_TIMEOUT_S
+                } else {
+                    spec.client_action_timeout_s
+                },
             )
             .await
             .err_tip(|| "In state_manager_factory::redis_state_manager")?;

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -151,6 +151,10 @@ pub struct SimpleScheduler {
     /// is dropped the spawn will be cancelled as well.
     task_worker_matching_spawn: JoinHandleDropGuard<()>,
 
+    /// Background task that retires queued actions nobody is waiting on.
+    /// Dropped with the struct, like the matching task.
+    task_abandoned_sweep_spawn: JoinHandleDropGuard<()>,
+
     /// Every duration, do logging of worker matching
     /// e.g. "worker busy", "can't find any worker"
     /// Set to None to disable. This is quite noisy, so we limit it
@@ -166,6 +170,10 @@ impl core::fmt::Debug for SimpleScheduler {
             .field(
                 "task_worker_matching_spawn",
                 &self.task_worker_matching_spawn,
+            )
+            .field(
+                "task_abandoned_sweep_spawn",
+                &self.task_abandoned_sweep_spawn,
             )
             .finish_non_exhaustive()
     }
@@ -560,6 +568,28 @@ impl SimpleScheduler {
             secs => Some(Duration::from_secs(secs.unsigned_abs())),
         };
 
+        // Retiring abandoned queued actions is its own task rather than part
+        // of the matching pass. The matching pass is exactly what stops
+        // running when they pile up, so making the cleanup depend on it
+        // means the cleanup stops precisely when it is needed. Sweeping on
+        // the client timeout bounds how long one can sit there to roughly
+        // twice that.
+        let sweep_interval = Duration::from_secs(client_action_timeout_s);
+        let sweep_state_manager = Arc::downgrade(&state_manager);
+        let task_abandoned_sweep_spawn =
+            spawn!("simple_scheduler_task_abandoned_sweep", async move {
+                loop {
+                    tokio::time::sleep(sweep_interval).await;
+                    // Weak, so the sweep stops when the scheduler goes away.
+                    let Some(state_manager) = sweep_state_manager.upgrade() else {
+                        return;
+                    };
+                    if let Err(err) = state_manager.sweep_abandoned_queued_actions().await {
+                        error!(?err, "Error while sweeping abandoned queued actions");
+                    }
+                }
+            });
+
         let action_scheduler = Arc::new_cyclic(move |weak_self| -> Self {
             let weak_inner = weak_self.clone();
             let task_worker_matching_spawn =
@@ -713,6 +743,7 @@ impl SimpleScheduler {
                 platform_property_manager,
                 maybe_origin_event_tx,
                 task_worker_matching_spawn,
+                task_abandoned_sweep_spawn,
                 worker_match_logging_interval,
             }
         });

--- a/nativelink-scheduler/src/simple_scheduler.rs
+++ b/nativelink-scheduler/src/simple_scheduler.rs
@@ -65,7 +65,7 @@ const DEFAULT_UNACKNOWLEDGED_KILL_TIMEOUT_S: u64 = 60;
 /// Mark operations as completed with error if no client has updated them
 /// within this duration.
 /// If this changes, remember to change the documentation in the config.
-const DEFAULT_CLIENT_ACTION_TIMEOUT_S: u64 = 60;
+pub(crate) const DEFAULT_CLIENT_ACTION_TIMEOUT_S: u64 = 60;
 
 /// Default times a job can retry before failing.
 /// If this changes, remember to change the documentation in the config.

--- a/nativelink-scheduler/src/simple_scheduler_state_manager.rs
+++ b/nativelink-scheduler/src/simple_scheduler_state_manager.rs
@@ -346,6 +346,93 @@ where
         })
     }
 
+    /// Retires queued actions whose client has stopped listening.
+    ///
+    /// A queued action has no worker, so neither of the other two timeout
+    /// paths can reach it. `MatchingEngineActionStateResult::changed` skips
+    /// the `Queued` stage outright, and `should_timeout_operation` only
+    /// considers `Executing`. That leaves the matching pass as the only
+    /// thing that retires them, and it only does so for actions it happens
+    /// to visit.
+    ///
+    /// When it does not, they accumulate with no expiry and are handed to
+    /// the matcher again on every pass, ahead of live work because they are
+    /// the oldest. Enough of them starve dispatch entirely: workers sit
+    /// idle, nothing executes or completes, and clients eventually report a
+    /// remote execution failure.
+    ///
+    /// Returns how many were retired.
+    pub async fn sweep_abandoned_queued_actions(&self) -> Result<u64, Error> {
+        let now = (self.now_fn)().now();
+        let stream = self
+            .action_db
+            .get_range_of_actions(
+                SortedAwaitedActionState::Queued,
+                Bound::Unbounded,
+                Bound::Unbounded,
+                true,
+            )
+            .await
+            .err_tip(|| "In sweep_abandoned_queued_actions")?;
+        tokio::pin!(stream);
+
+        let mut retired = 0u64;
+        while let Some(subscriber) = stream.next().await {
+            let subscriber = subscriber.err_tip(|| "In sweep_abandoned_queued_actions")?;
+            let awaited_action = subscriber
+                .borrow()
+                .await
+                .err_tip(|| "In sweep_abandoned_queued_actions")?;
+
+            // Only queued actions belong to this sweep, and only once the
+            // client has been gone longer than it is allowed to be.
+            if !matches!(awaited_action.state().stage, ActionStage::Queued) {
+                continue;
+            }
+            if awaited_action.last_client_keepalive_timestamp() + self.client_action_timeout >= now
+            {
+                continue;
+            }
+
+            let mut state = awaited_action.state().as_ref().clone();
+            state.stage = ActionStage::Completed(ActionResult {
+                error: Some(make_err!(
+                    Code::DeadlineExceeded,
+                    "Operation timed out {} seconds of having no more clients listening",
+                    self.client_action_timeout.as_secs_f32(),
+                )),
+                ..ActionResult::default()
+            });
+            state.last_transition_timestamp = now;
+
+            let mut new_awaited_action = awaited_action;
+            new_awaited_action.worker_set_state(Arc::new(state), now);
+            // A conflict means something else is already changing this
+            // action, which is the outcome this sweep wants anyway. Leave it
+            // for the next pass rather than fighting for it.
+            match self
+                .action_db
+                .update_awaited_action(new_awaited_action)
+                .await
+            {
+                Ok(()) => retired += 1,
+                Err(err) if err.code == Code::Aborted => {}
+                Err(err) => {
+                    return Err(err).err_tip(|| "In sweep_abandoned_queued_actions");
+                }
+            }
+        }
+
+        if retired > 0 {
+            warn!(
+                retired,
+                timeout_secs = self.client_action_timeout.as_secs_f32(),
+                "Retired queued operations that had no clients listening"
+            );
+        }
+        Ok(retired)
+    }
+
     pub async fn should_timeout_operation(&self, awaited_action: &AwaitedAction) -> bool {
         if !matches!(awaited_action.state().stage, ActionStage::Executing) {
             return false;

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -71,6 +71,10 @@ pub struct OperationSubscriber<S: SchedulerStore, I: InstantWrapper, NowFn: Fn()
     // as well as listening for the publishing.
     maybe_last_stage: Option<Discriminant<ActionStage>>,
     retain_completed_for: Duration,
+    /// How long a written client keepalive stays meaningful. Past it, an
+    /// absent key and a stale one say the same thing, so the key may as
+    /// well be gone.
+    client_keepalive_ttl: Duration,
 }
 
 impl<S: SchedulerStore, I: InstantWrapper, NowFn: Fn() -> I + core::fmt::Debug> core::fmt::Debug
@@ -103,6 +107,7 @@ where
         weak_store: Weak<S>,
         now_fn: NowFn,
         retain_completed_for: Duration,
+        client_keepalive_ttl: Duration,
     ) -> Self {
         Self {
             maybe_client_operation_id,
@@ -113,6 +118,7 @@ where
             now_fn,
             maybe_last_stage: None,
             retain_completed_for,
+            client_keepalive_ttl,
         }
     }
 
@@ -258,7 +264,13 @@ where
                                 operation_id,
                                 timestamp: now_ts,
                             },
-                            None,
+                            // Written with no expiry these outlive every
+                            // action that produced them and accumulate
+                            // without bound. A keepalive older than the
+                            // client timeout cannot change any decision,
+                            // because the timeout has already come due and
+                            // the stored timestamp is consulted either way.
+                            Some(self.client_keepalive_ttl),
                         )
                         .await;
 
@@ -645,6 +657,7 @@ where
     operation_id_creator: F,
     _pull_task_change_subscriber_spawn: JoinHandleDropGuard<()>,
     retain_completed_for: Duration,
+    client_keepalive_ttl: Duration,
     worker_registry: Option<SharedWorkerRegistry>,
 }
 
@@ -661,6 +674,7 @@ where
         now_fn: NowFn,
         operation_id_creator: F,
         retain_completed_for_s: u32,
+        client_action_timeout_s: u64,
     ) -> Result<Self, Error> {
         let mut subscription = store
             .subscription_manager()
@@ -697,6 +711,7 @@ where
             operation_id_creator,
             _pull_task_change_subscriber_spawn: pull_task_change_subscriber,
             retain_completed_for: Duration::from_secs(retain_completed_for_s.into()),
+            client_keepalive_ttl: Duration::from_secs(client_action_timeout_s),
             worker_registry: None,
         })
     }
@@ -883,6 +898,7 @@ where
             Arc::downgrade(&self.store),
             self.now_fn.clone(),
             self.retain_completed_for,
+            self.client_keepalive_ttl,
         )))
     }
 }
@@ -914,6 +930,7 @@ where
             Arc::downgrade(&self.store),
             self.now_fn.clone(),
             self.retain_completed_for,
+            self.client_keepalive_ttl,
         ))))
     }
 
@@ -1007,6 +1024,7 @@ where
                 Arc::downgrade(&self.store),
                 self.now_fn.clone(),
                 self.retain_completed_for,
+                self.client_keepalive_ttl,
             ));
         }
     }
@@ -1054,6 +1072,7 @@ where
                     Arc::downgrade(&self.store),
                     self.now_fn.clone(),
                     self.retain_completed_for,
+                    self.client_keepalive_ttl,
                 )
             }))
     }
@@ -1073,6 +1092,7 @@ where
                     Arc::downgrade(&self.store),
                     self.now_fn.clone(),
                     self.retain_completed_for,
+                    self.client_keepalive_ttl,
                 )
             }))
     }

--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -231,7 +231,22 @@ where
             let mut maybe_changed_action = None;
 
             let last_known_keepalive_ts = self.last_known_keepalive_ts.load(Ordering::Acquire);
-            if I::from_secs(last_known_keepalive_ts).elapsed() > CLIENT_KEEPALIVE_DURATION {
+            // Only a subscriber that stands for a client may say a client is
+            // still there. The matching engine subscribes to every queued
+            // action it considers, and `get_range_of_actions` builds those
+            // subscribers with no client operation id precisely because there
+            // is no client behind them. Letting them write the keepalive
+            // makes the scheduler hold open the actions it is supposed to be
+            // retiring: the keepalive is refreshed, the client timeout in
+            // `apply_filter_predicate` never comes due, and the action is
+            // offered to the matcher again, which refreshes it again.
+            //
+            // The effect is that every queued action carries a keepalive
+            // only seconds old however long its client has been gone, and
+            // none of them are ever retired.
+            if self.maybe_client_operation_id.is_some()
+                && I::from_secs(last_known_keepalive_ts).elapsed() > CLIENT_KEEPALIVE_DURATION
+            {
                 let now = (self.now_fn)().now();
                 let now_ts = now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
 

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -153,6 +153,7 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         MockInstantWrapped::default,
         move || WORKER_OPERATION_ID.into(),
         60,
+        60,
     )
     .await
     .unwrap();
@@ -261,6 +262,7 @@ async fn test_multiple_clients_subscribe_to_same_action() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
+        60,
         60,
     )
     .await
@@ -419,6 +421,7 @@ async fn test_outdated_version() -> Result<(), Error> {
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
         60,
+        60,
     )
     .await
     .unwrap();
@@ -494,6 +497,7 @@ async fn test_orphaned_client_operation_id_returns_none() -> Result<(), Error> {
         MockInstantWrapped::default,
         move || worker_operation_id_clone.lock().clone().into(),
         60,
+        60,
     )
     .await
     .unwrap();
@@ -552,6 +556,7 @@ async fn add_action_attaches_ttl_to_cid_mapping() -> Result<(), Error> {
         notifier.clone(),
         MockInstantWrapped::default,
         move || WORKER_OPERATION_ID.into(),
+        60,
         60,
     )
     .await

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -588,3 +588,84 @@ async fn add_action_attaches_ttl_to_cid_mapping() -> Result<(), Error> {
 
     Ok(())
 }
+
+/// A caller holding a version for a record that has since gone must not
+/// bring it back as an empty shell.
+///
+/// The versioned update increments before it can compare, so the increment
+/// itself creates the key. On a mismatch the increment is undone, but the
+/// key stays: a hash with nothing in it but a zeroed version, no data and
+/// no expiry. It still matches the index prefix, so it sits in the index
+/// as an empty document and crowds every search that reads it. Records
+/// expire on completion, so any straggler holding a version hits exactly
+/// this path.
+///
+/// This pins the contract at this layer. It does not exercise the Lua,
+/// which the fake backend emulates rather than runs, and which already
+/// declined to insert here - the behaviour being fixed is only observable
+/// against a real redis.
+#[nativelink_test]
+async fn an_update_against_a_vanished_record_leaves_nothing_behind() -> Result<(), Error> {
+    const OPERATION_ID: &str = "vanished_operation_id";
+
+    let worker_operation_id = Arc::new(Mutex::new(OPERATION_ID));
+    let worker_operation_id_clone = worker_operation_id.clone();
+
+    let fake_redis_backend: FakeRedisBackend<RedisSubscriptionManager> = FakeRedisBackend::new();
+    let fake_redis_port = fake_redis_backend.clone().run().await;
+    let spec = RedisSpec {
+        addresses: vec![format!("redis://127.0.0.1:{fake_redis_port}")],
+        experimental_pub_sub_channel: Some("sub_channel".into()),
+        ..Default::default()
+    };
+    let store = RedisStore::new_standard(spec).await.expect("Working spec");
+    let notifier = Arc::new(Notify::new());
+    let awaited_action_db = StoreAwaitedActionDb::new(
+        store.clone(),
+        notifier.clone(),
+        MockInstantWrapped::default,
+        move || worker_operation_id_clone.lock().clone().into(),
+        60,
+        60,
+    )
+    .await
+    .unwrap();
+
+    // Land it once so the stored version moves off zero, then read it back
+    // so the handle carries that version.
+    let mut awaited_action = make_awaited_action(OPERATION_ID);
+    awaited_action_db
+        .update_awaited_action(awaited_action.clone())
+        .await
+        .unwrap();
+    awaited_action = awaited_action_db
+        .get_by_operation_id(&OPERATION_ID.into())
+        .await
+        .unwrap()
+        .expect("just written")
+        .borrow()
+        .await
+        .unwrap();
+    // The record completes and its retention expires.
+    let key = format!("aa_{OPERATION_ID}");
+    fake_redis_backend.table.lock().unwrap().remove(&key);
+
+    // A straggler updates with the version it was holding.
+    let update_res = awaited_action_db
+        .update_awaited_action(awaited_action)
+        .await;
+    // Refusal is also what proves the handle carried a non-zero version: a
+    // zero-version update against a missing key is a create, and succeeds.
+    assert!(
+        update_res.is_err(),
+        "the update must still be refused: {update_res:?}"
+    );
+
+    assert!(
+        !fake_redis_backend.table.lock().unwrap().contains_key(&key),
+        "a refused update recreated {key} as an empty shell; it has no data and \
+         no expiry, and the index will carry it forever"
+    );
+
+    Ok(())
+}

--- a/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
+++ b/nativelink-scheduler/tests/simple_scheduler_state_manager_test.rs
@@ -394,3 +394,61 @@ async fn is_executing_on_worker_follows_the_assignment() -> Result<(), Error> {
     );
     Ok(())
 }
+
+/// Counts what the matching engine would be handed.
+async fn queued_count(
+    state_mgr: &SimpleSchedulerStateManager<
+        impl nativelink_scheduler::awaited_action_db::AwaitedActionDb,
+        MockInstantWrapped,
+        fn() -> MockInstantWrapped,
+    >,
+) -> Result<usize, Error> {
+    Ok(MatchingEngineStateManager::filter_operations(
+        state_mgr,
+        OperationFilter {
+            stages: OperationStageFlags::Queued,
+            ..Default::default()
+        },
+    )
+    .await?
+    .collect::<Vec<_>>()
+    .await
+    .len())
+}
+
+/// A queued action has no worker, so neither the worker-liveness timeout nor
+/// the executing-stage ceiling can retire it. The only thing that does is a
+/// filter pass reaching it, which is the matching engine's job and is exactly
+/// what stops happening when these accumulate. The sweep retires them without
+/// needing the matching engine to get there first.
+#[nativelink_test]
+async fn the_sweep_retires_queued_actions_no_client_is_waiting_on() -> Result<(), Error> {
+    MockClock::set_time(Duration::from_secs(NOW_TIME));
+    let state_mgr = state_manager(Arc::new(WorkerRegistry::new()));
+
+    let client_listener = state_mgr
+        .add_action(
+            OperationId::default(),
+            Arc::new(action_info(make_system_time(0))),
+        )
+        .await?;
+
+    // Nothing is retired while the client is still listening.
+    assert_eq!(state_mgr.sweep_abandoned_queued_actions().await?, 0);
+    assert_eq!(queued_count(state_mgr.as_ref()).await?, 1);
+
+    // The client goes away and stops keeping the action alive.
+    drop(client_listener);
+    MockClock::advance(Duration::from_mins(6));
+
+    // Retired without any matching pass having run.
+    assert_eq!(state_mgr.sweep_abandoned_queued_actions().await?, 1);
+    assert_eq!(
+        queued_count(state_mgr.as_ref()).await?,
+        0,
+        "a retired action must stop being offered to the matching engine"
+    );
+    // And stays retired rather than being retired again on every pass.
+    assert_eq!(state_mgr.sweep_abandoned_queued_actions().await?, 0);
+    Ok(())
+}

--- a/nativelink-scheduler/tests/store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/store_awaited_action_db_test.rs
@@ -296,7 +296,7 @@ async fn build_db(
     }
     let now_fn: fn() -> MockInstantWrapped = MockInstantWrapped::default;
     let op_id_fn: fn() -> OperationId = new_op_id;
-    StoreAwaitedActionDb::new(store, Arc::new(Notify::new()), now_fn, op_id_fn, 60)
+    StoreAwaitedActionDb::new(store, Arc::new(Notify::new()), now_fn, op_id_fn, 60, 60)
         .await
         .expect("construct test db")
 }

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1591,7 +1591,17 @@ local i
 local indexes = {{}}
 
 if new_version-1 ~= expected_version then
-    redis.call('HINCRBY', key, '{VERSION_FIELD_NAME}', -1)
+    local reverted = redis.call('HINCRBY', key, '{VERSION_FIELD_NAME}', -1)
+    -- HINCRBY creates the key before the version can be checked, so a
+    -- caller holding a stale version for a key that has since gone leaves
+    -- behind a hash with nothing in it but a zeroed version. It has no
+    -- data, no expiry and never gains either, yet it still matches the
+    -- index prefix, so it sits in the index as an empty document and
+    -- crowds every search that reads it. Only ever removes a key this
+    -- call brought into existence: a real record always carries data.
+    if reverted == 0 and redis.call('HEXISTS', key, '{DATA_FIELD_NAME}') == 0 then
+        redis.call('DEL', key)
+    end
     return {{ 0, new_version-1 }}
 end
 -- Skip first 3 argvs, as they are known inputs.

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -71,7 +71,7 @@ async fn make_mock_store(
     make_mock_store_with_prefix(commands, String::new()).await
 }
 
-const FAKE_SCRIPT_SHA: &str = "5148c724ce419ea27d1971dcb61c111dbbc6b63e";
+const FAKE_SCRIPT_SHA: &str = "d89e3573a1f9689c22115e8a41bd332d0c7c2643";
 
 fn add_lua_version_script(mut responses: HashMap<String, String>) -> HashMap<String, String> {
     add_lua_script(&mut responses, LUA_VERSION_SET_SCRIPT, FAKE_SCRIPT_SHA);


### PR DESCRIPTION
## What and why

Abandoned queued actions were never retired, and enough of them starve dispatch: they are handed to the matcher ahead of live work because they are the oldest, so workers sit idle while nothing executes or completes.

The cause is that the matching engine's subscriber wrote the client keepalive, so the client timeout never came due for an action no client was waiting on. Also expires that keepalive key, which was written with no expiry and accumulated without bound, and stops a refused versioned update leaving an empty indexed record behind.

## How was this verified?

`cargo test -p nativelink-scheduler -p nativelink-store` (95 + 326). New tests cover the sweep retiring an action only once its client is gone and not churning on later passes, and a refused update against a vanished record leaving nothing behind.

## Risk

The keepalive change is the one to look at: a subscriber with no client operation id no longer refreshes it, so an action whose client really has gone now times out as intended. Erring short is safe, since a missing key falls back to the stored timestamp, which is older.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2726)
<!-- Reviewable:end -->
