### PR TITLE
Bound the wait for a GCS connection permit

### DIFF
--- a/nativelink-config/src/stores.rs
+++ b/nativelink-config/src/stores.rs
@@ -1281,6 +1281,14 @@ pub struct ExperimentalGcsSpec {
     /// Default: 3000
     #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
     pub read_timeout_s: u64,
+
+    /// Maximum time in seconds a request waits for one of the
+    /// `multipart_max_concurrent_uploads` connection permits before it fails
+    /// with `FailedPrecondition`. A value of `0` waits until a permit is free.
+    ///
+    /// Default: 0 (unbounded)
+    #[serde(default, deserialize_with = "convert_duration_with_shellexpand")]
+    pub permit_wait_timeout_s: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/nativelink-store/src/gcs_client/client.rs
+++ b/nativelink-store/src/gcs_client/client.rs
@@ -14,6 +14,7 @@
 
 use core::fmt::{Debug, Formatter};
 use core::future::Future;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -33,7 +34,7 @@ use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_util::buf_channel::DropCloserReadHalf;
 use rand::Rng;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 use crate::common_s3_utils::install_default_rustls_crypto_provider;
 use crate::gcs_client::types::{
@@ -106,6 +107,9 @@ pub struct GcsClient {
     client: Client,
     resumable_chunk_size: usize,
     semaphore: Arc<Semaphore>,
+    max_connections: usize,
+    permit_wait_timeout: Option<Duration>,
+    permit_waiters: AtomicUsize,
 }
 
 impl GcsClient {
@@ -172,11 +176,12 @@ impl GcsClient {
             .multipart_max_concurrent_uploads
             .unwrap_or(DEFAULT_CONCURRENT_UPLOADS);
 
-        Ok(Self {
+        Ok(Self::with_client(
             client,
             resumable_chunk_size,
-            semaphore: Arc::new(Semaphore::new(max_connections)),
-        })
+            max_connections,
+            spec,
+        ))
     }
 
     /// Create a mock GCS client for testing
@@ -191,11 +196,61 @@ impl GcsClient {
             .multipart_max_concurrent_uploads
             .unwrap_or(DEFAULT_CONCURRENT_UPLOADS);
 
-        Ok(Self {
+        Ok(Self::with_client(
+            client,
+            resumable_chunk_size,
+            max_connections,
+            spec,
+        ))
+    }
+
+    fn with_client(
+        client: Client,
+        resumable_chunk_size: usize,
+        max_connections: usize,
+        spec: &ExperimentalGcsSpec,
+    ) -> Self {
+        Self {
             client,
             resumable_chunk_size,
             semaphore: Arc::new(Semaphore::new(max_connections)),
-        })
+            max_connections,
+            permit_wait_timeout: (spec.permit_wait_timeout_s > 0)
+                .then(|| Duration::from_secs(spec.permit_wait_timeout_s)),
+            permit_waiters: AtomicUsize::new(0),
+        }
+    }
+
+    /// Acquire a connection permit, giving up after `permit_wait_timeout` when
+    /// one is configured. Expiry is `FailedPrecondition` so that neither the
+    /// store `Retrier` nor `upload_from_reader` re-queues the request behind
+    /// the same saturated semaphore.
+    async fn acquire_permit(&self) -> Result<OwnedSemaphorePermit, Error> {
+        let acquire = self.semaphore.clone().acquire_owned();
+        let Some(wait_timeout) = self.permit_wait_timeout else {
+            return acquire.await.map_err(|e| {
+                Error::from_std_err(Code::Internal, &e)
+                    .append("Failed to acquire connection permit")
+            });
+        };
+
+        self.permit_waiters.fetch_add(1, Ordering::Relaxed);
+        let result = timeout(wait_timeout, acquire).await;
+        // The previous value still counts this request, which is what an
+        // operator reading the error wants to know: how deep the queue was.
+        let waiters = self.permit_waiters.fetch_sub(1, Ordering::Relaxed);
+        match result {
+            Ok(Ok(permit)) => Ok(permit),
+            Ok(Err(e)) => Err(Error::from_std_err(Code::Internal, &e)
+                .append("Failed to acquire connection permit")),
+            Err(_) => Err(make_err!(
+                Code::FailedPrecondition,
+                "Waited {}s for a GCS connection permit ({} permits, {} waiters queued)",
+                wait_timeout.as_secs(),
+                self.max_connections,
+                waiters,
+            )),
+        }
     }
 
     /// Generic method to execute operations with connection limiting
@@ -204,9 +259,7 @@ impl GcsClient {
         F: FnOnce() -> Fut + Send,
         Fut: Future<Output = Result<T, Error>> + Send,
     {
-        let permit = self.semaphore.acquire().await.map_err(|e| {
-            Error::from_std_err(Code::Internal, &e).append("Failed to acquire connection permit")
-        })?;
+        let permit = self.acquire_permit().await?;
 
         let result = operation().await;
         drop(permit);
@@ -384,7 +437,9 @@ impl Debug for GcsClient {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("GcsClient")
             .field("resumable_chunk_size", &self.resumable_chunk_size)
-            .field("max_connections", &self.semaphore.available_permits())
+            .field("max_connections", &self.max_connections)
+            .field("available_permits", &self.semaphore.available_permits())
+            .field("permit_wait_timeout", &self.permit_wait_timeout)
             .finish_non_exhaustive()
     }
 }
@@ -456,9 +511,7 @@ impl GcsOperations for GcsClient {
             }
         }
 
-        let permit = self.semaphore.clone().acquire_owned().await.map_err(|e| {
-            Error::from_std_err(Code::Internal, &e).append("Failed to acquire connection permit")
-        })?;
+        let permit = self.acquire_permit().await?;
         let request = GetObjectRequest {
             bucket: object_path.bucket.clone(),
             object: object_path.path.clone(),

--- a/nativelink-store/tests/gcs_client_test.rs
+++ b/nativelink-store/tests/gcs_client_test.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{StreamExt, join};
-use nativelink_error::{Code, Error, ResultExt};
+use nativelink_error::{Code, Error, ResultExt, make_err};
 use nativelink_macro::nativelink_test;
 use nativelink_store::gcs_client::client::GcsOperations;
 use nativelink_store::gcs_client::mocks::MockGcsOperations;
@@ -624,5 +624,166 @@ async fn test_gcs_client_error_mapping() -> Result<(), Error> {
     let err = client.read_object_metadata(&object_path).await.unwrap_err();
     assert_eq!(err.code, Code::Unknown);
 
+    Ok(())
+}
+
+/// A `GcsClient` with a single connection permit that is already held by a
+/// request the fake server never answers, so every further request queues on
+/// the semaphore. Later connections get a plain `404` so a request that does
+/// obtain a permit fails with `NotFound` rather than the permit expiry.
+struct HeldPermitFixture {
+    client: Arc<nativelink_store::gcs_client::GcsClient>,
+    hung_request: nativelink_util::task::JoinHandleDropGuard<
+        Result<Option<nativelink_store::gcs_client::GcsObject>, Error>,
+    >,
+}
+
+async fn held_permit_fixture(permit_wait_timeout_s: u64) -> HeldPermitFixture {
+    use nativelink_config::stores::ExperimentalGcsSpec;
+    use nativelink_store::gcs_client::GcsClient;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (first_accepted_tx, first_accepted_rx) = tokio::sync::oneshot::channel();
+    nativelink_util::background_spawn!("held_permit_gcs_server", async move {
+        // Never answered and never dropped, so its request keeps the permit.
+        let (_held_socket, _) = listener.accept().await.unwrap();
+        first_accepted_tx.send(()).unwrap();
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            // Read the request first: closing a socket with unread bytes resets
+            // the connection on Windows instead of delivering the response.
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") && socket.read(&mut byte).await.unwrap_or(0) == 1
+            {
+                request.push(byte[0]);
+            }
+            drop(
+                socket
+                    .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                    .await,
+            );
+            drop(socket.shutdown().await);
+        }
+    });
+
+    let mut spec = ExperimentalGcsSpec {
+        read_timeout_s: 60,
+        permit_wait_timeout_s,
+        ..Default::default()
+    };
+    spec.common.multipart_max_concurrent_uploads = Some(1);
+    let client = Arc::new(GcsClient::new_mock(&spec, format!("http://127.0.0.1:{port}")).unwrap());
+
+    let hung_client = client.clone();
+    let hung_request = nativelink_util::spawn!("held_permit_gcs_request", async move {
+        let object_path = ObjectPath::new(BUCKET_NAME.to_string(), "held-object");
+        hung_client.read_object_metadata(&object_path).await
+    });
+    // The server only accepts once the hung request holds the permit.
+    first_accepted_rx.await.unwrap();
+
+    HeldPermitFixture {
+        client,
+        hung_request,
+    }
+}
+
+#[nativelink_test]
+async fn permit_wait_timeout_fails_fast_with_failed_precondition() -> Result<(), Error> {
+    const WAIT_S: u64 = 1;
+    let fixture = held_permit_fixture(WAIT_S).await;
+    let object_path = ObjectPath::new(BUCKET_NAME.to_string(), OBJECT_PATH);
+
+    let start = tokio::time::Instant::now();
+    let err = fixture
+        .client
+        .read_object_metadata(&object_path)
+        .await
+        .unwrap_err();
+    let elapsed = start.elapsed();
+
+    assert_eq!(err.code, Code::FailedPrecondition, "got {err:?}");
+    assert_eq!(
+        err.messages,
+        vec!["Waited 1s for a GCS connection permit (1 permits, 1 waiters queued)".to_string()],
+        "error should name the bound, the permit count and the queue depth"
+    );
+    assert!(
+        elapsed >= core::time::Duration::from_secs(WAIT_S),
+        "returned before the wait bound: {elapsed:?}"
+    );
+    assert!(
+        elapsed < core::time::Duration::from_secs(5),
+        "took far longer than the wait bound: {elapsed:?}"
+    );
+
+    drop(fixture.hung_request);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn permit_wait_timeout_bounds_streaming_reads() -> Result<(), Error> {
+    let fixture = held_permit_fixture(1).await;
+    let object_path = ObjectPath::new(BUCKET_NAME.to_string(), OBJECT_PATH);
+
+    let err = fixture
+        .client
+        .read_object_content(&object_path, 0, None)
+        .await
+        .err()
+        .expect("expected the permit wait to expire");
+    assert_eq!(err.code, Code::FailedPrecondition, "got {err:?}");
+
+    drop(fixture.hung_request);
+    Ok(())
+}
+
+#[nativelink_test]
+async fn permit_wait_timeout_succeeds_when_permit_frees_in_time() -> Result<(), Error> {
+    let fixture = held_permit_fixture(5).await;
+    let object_path = ObjectPath::new(BUCKET_NAME.to_string(), OBJECT_PATH);
+
+    let waiting_client = fixture.client.clone();
+    let waiting = nativelink_util::spawn!("waiting_gcs_request", async move {
+        waiting_client.read_object_metadata(&object_path).await
+    });
+    // Release the permit well inside the bound by aborting the hung request.
+    tokio::time::sleep(core::time::Duration::from_millis(200)).await;
+    drop(fixture.hung_request);
+
+    // The fake server answers every later connection with a bare 404, so a
+    // request that got its permit inside the bound surfaces the server's
+    // answer, not the permit expiry.
+    let err = waiting
+        .await
+        .map_err(|e| make_err!(Code::Internal, "{e}"))?
+        .unwrap_err();
+    assert_eq!(err.code, Code::NotFound, "got {err:?}");
+    Ok(())
+}
+
+#[nativelink_test]
+async fn permit_wait_unbounded_by_default() -> Result<(), Error> {
+    let fixture = held_permit_fixture(0).await;
+    let object_path = ObjectPath::new(BUCKET_NAME.to_string(), OBJECT_PATH);
+
+    // With the default of 0 the request queues behind the held permit for as
+    // long as it takes, so it must still be pending well after a bounded
+    // client would have failed.
+    let waited = tokio::time::timeout(
+        core::time::Duration::from_millis(1500),
+        fixture.client.read_object_metadata(&object_path),
+    )
+    .await;
+    assert!(
+        waited.is_err(),
+        "expected request to still be waiting, got {waited:?}"
+    );
+
+    drop(fixture.hung_request);
     Ok(())
 }


### PR DESCRIPTION
## What and why

`GcsClient` serializes every request behind a `tokio::sync::Semaphore`
sized by `multipart_max_concurrent_uploads` (default 10). The permit is
acquired FIFO with no bound, so under a lookup storm the queue on one
pod grows past `cas_server`'s 30 s per-blob deadline and the caller sees
a bare `DeadlineExceeded` that says nothing about the cause. Measured on
a v1.6.3 deployment with a 256-permit client: 69 `GetActionResult` and
4 `BatchReadBlobs` at >= 29 s per storm minute, p99 30.0 s. Raising the
permit count to 10000 did not help; it turned the FIFO wait into
reqwest 3 s read timeouts and h2 `too_many_internal_resets` connection
kills. The queue needs a bound, not more depth.

This adds `permit_wait_timeout_s` to `ExperimentalGcsSpec`. The default
`0` keeps the current unbounded wait, so existing configs behave exactly
as before. When set, the acquire is wrapped in `tokio::time::timeout`
and expiry returns `FailedPrecondition` with a message naming the bound,
the permit count and the queue depth. Both `with_connection` (metadata,
uploads, delete) and the streaming `read_object_content` path go through
the same bounded acquire. The `Debug` output of `GcsClient`, which
printed the free permit count under the label `max_connections`, now
shows the limit, the free count and the configured bound.

`FailedPrecondition` is deliberate: `Retrier::should_retry` and the
retry loop in `upload_from_reader` both retry `ResourceExhausted` and
`Unavailable`, and retrying a permit expiry only re-queues the request
at the tail of the same saturated semaphore. `FailedPrecondition` is in
the retrier's never-retry set, so the caller gets a classified error on
the first expiry. Operators who want retries can still list it in
`retry.retry_on_errors`.

## How was this verified?

Four tests in `nativelink-store/tests/gcs_client_test.rs` use a real
`GcsClient` with one permit held by a request a local TCP server never
answers: the bounded wait fails within the bound with
`FailedPrecondition` and the documented message; the streaming read
path is bounded the same way; a permit freed inside the bound lets the
waiting request reach the server; `0` still queues indefinitely.
Without the client change the first test fails after 60 s with
`NotFound` (the waiter only proceeded once the hung request's read
timeout released the permit). Deployed with a 5 s bound alongside two
related changes, the same storm produced 0 requests at >= 29 s and a
`GetActionResult` p99 of 0.85 s.

## Risk

Default off, no request behavior changes unless `permit_wait_timeout_s`
is set. When set too low for a healthy but busy client, requests fail
with `FailedPrecondition` instead of waiting; the error message names
the permit count and queue depth so the misconfiguration is visible. The
extra `AtomicUsize` is two relaxed operations per bounded acquire.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2730)
<!-- Reviewable:end -->
