### PR TITLE
fix: stop linking released macOS binaries to /nix/store libiconv

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,12 +63,18 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
             attr: nativelink-x86_64-linux
+            # The runner shares this target's architecture, so the packaged
+            # binary can be executed to prove it actually starts.
+            smoke_test: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04
             attr: nativelink-aarch64-linux
+            # Cross-built from x86_64, so the runner cannot execute it.
+            smoke_test: false
           - target: aarch64-apple-darwin
             os: macos-26
             attr: nativelink-aarch64-darwin
+            smoke_test: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
@@ -124,6 +130,38 @@ jobs:
 
           sha256 "${ASSET}.tar.gz" | tee "${ASSET}.tar.gz.sha256"
           echo "asset=${ASSET}" >> "${GITHUB_OUTPUT}"
+
+      # The v1.6.6 macOS tarball shipped with an absolute /nix/store install
+      # name for libiconv and could not launch on any machine but the builder
+      # (#2727). The Nix build now fails on a leftover store reference, and
+      # this re-checks the packaged tarball so a regression cannot reach a
+      # published release unnoticed.
+      - name: Smoke test packaged binary
+        if: matrix.smoke_test
+        run: |
+          set -euo pipefail
+          ASSET="${{ steps.package.outputs.asset }}"
+          CHECK="$(mktemp -d)"
+          tar -C "${CHECK}" -xzf "${ASSET}.tar.gz"
+
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            otool -L "${CHECK}/nativelink"
+            if otool -L "${CHECK}/nativelink" | tail -n +2 | grep '/nix/store'; then
+              echo "::error::Packaged macOS binary links against /nix/store paths that do not exist on user machines."
+              exit 1
+            fi
+            codesign --verify --verbose "${CHECK}/nativelink"
+          fi
+
+          # nativelink exits non-zero with a usage message when handed no
+          # config file. Reaching that message proves dyld loaded the binary
+          # and it ran, which is all this check needs to establish.
+          output="$("${CHECK}/nativelink" 2>&1 || true)"
+          echo "${output}"
+          if ! echo "${output}" | grep -q 'Usage: nativelink'; then
+            echo "::error::Packaged binary for ${{ matrix.target }} did not start."
+            exit 1
+          fi
 
       - name: Generate SBOM
         uses: >- # v0.24.0

--- a/flake.nix
+++ b/flake.nix
@@ -171,6 +171,60 @@
         cargoArtifactsFor = p: (craneLibFor p).buildDepsOnly (commonArgsFor p);
         nightlyCargoArtifactsFor = p: (nightlyCraneLibFor p).buildDepsOnly (commonArgsFor p);
 
+        # Darwin binaries link against Nix's `libiconv`, which records an
+        # absolute `/nix/store/...` install name. That path only exists on the
+        # machine that built the binary, so the published macOS tarball failed
+        # to launch anywhere else with a dyld "Library not loaded" error.
+        #
+        # Nix's darwin `libiconv` is Apple's own libiconv and exports the same
+        # symbols as the copy macOS keeps in the dyld shared cache, so pointing
+        # the install name at `/usr/lib` is ABI-safe and leaves the binary with
+        # no Nix store references at all.
+        #
+        # See https://github.com/TraceMachina/nativelink/issues/2727.
+        darwinSystemDylibArgs = p: {
+          # `install_name_tool` invalidates the ad-hoc signature that arm64
+          # macOS requires. This hook re-signs during fixup, i.e. after the
+          # `preFixup` rewrite below.
+          nativeBuildInputs =
+            (commonArgsFor p).nativeBuildInputs
+            ++ [p.darwin.autoSignDarwinBinariesHook];
+
+          preFixup = ''
+            for binary in "$out"/bin/*; do
+              [ -f "$binary" ] || continue
+
+              # Skip anything that isn't a Mach-O image, such as wrapper scripts.
+              linkage="$(otool -L "$binary" 2>/dev/null)" || continue
+
+              printf '%s\n' "$linkage" | tail -n +2 | awk '{print $1}' \
+              | while read -r dylib; do
+                case "$dylib" in
+                  /nix/store/*/lib/libiconv*.dylib | /nix/store/*/lib/libcharset*.dylib)
+                    echo "relocating $dylib -> /usr/lib/''${dylib##*/} in $binary"
+                    install_name_tool \
+                      -change "$dylib" "/usr/lib/''${dylib##*/}" "$binary"
+                    ;;
+                esac
+              done
+
+              remaining="$(
+                otool -L "$binary" | tail -n +2 | awk '{print $1}' \
+                | grep '^/nix/store' || true
+              )"
+              if [ -n "$remaining" ]; then
+                echo "error: $binary still links against Nix store libraries:" >&2
+                echo "$remaining" >&2
+                echo "Those paths do not exist on machines without Nix, so the" >&2
+                echo "released binary would fail to launch. Either relocate the" >&2
+                echo "library to its /usr/lib equivalent above, or link it" >&2
+                echo "statically." >&2
+                exit 1
+              fi
+            done
+          '';
+        };
+
         nativelinkFor = p:
           (craneLibFor p).buildPackage ((commonArgsFor p)
             // {
@@ -178,7 +232,8 @@
               # If you're testing Nativelink locally, doing a dev profile will
               # massively speedup build times. Just don't commit/push anything build with dev!
               # CARGO_PROFILE = "dev";
-            });
+            }
+            // pkgs.lib.optionalAttrs p.stdenv.targetPlatform.isDarwin (darwinSystemDylibArgs p));
 
         nativeTargetPkgs =
           if pkgs.stdenv.hostPlatform.system == "x86_64-linux"


### PR DESCRIPTION
## What and why

Fixes #2727.

The `aarch64-apple-darwin` release binary recorded an absolute
`/nix/store/...-libiconv-113/lib/libiconv.2.dylib` install name, so dyld refused
to launch it on any machine but the one that built it — including machines that
do have Nix, since that particular store path isn't there.

Nix's darwin `libiconv` is Apple's own libiconv, not GNU libiconv. I dumped both
symbol tables and they match: the nixpkgs build (115.100.1) and the copy macOS
keeps in the dyld shared cache each export `_iconv_open` / `_iconv` /
`_iconv_close` / `_iconvctl` / `_iconvlist` / `_libiconv_set_relocation_prefix`,
and neither exports the GNU-style `_libiconv_*` entry points. Repointing the
install name at `/usr/lib/libiconv.2.dylib` is therefore an ABI-safe swap rather
than just a path rewrite that happens to load.

So `flake.nix` now rewrites the install name in `preFixup` for darwin targets and
then **fails the build** if any `/nix/store` reference survives in `$out/bin`.
`install_name_tool` invalidates the ad-hoc signature arm64 macOS requires, which
is why the rewrite runs in `preFixup` — `autoSignDarwinBinariesHook` re-signs
during fixup, after it.

I also considered dropping `p.libiconv` from `buildInputs` and letting the linker
pick up an SDK stub, which would have recorded `/usr/lib/libiconv.2.dylib`
naturally. `apple-sdk_14` ships no `libiconv.tbd`, so that isn't available.

`release.yaml` grows a smoke test that unpacks the finished tarball and runs it,
because the only reason this reached users is that nothing ever executed the
artifact we published. It's skipped for `aarch64-unknown-linux-musl`, which is
cross-built on an x86_64 runner and can't be executed there.

## How was this verified?

Built `.#nativelink-aarch64-darwin` on an M-series Mac running macOS 26.6 and
checked the actual release binary, not a proxy:

- `otool -L` on the built `nativelink` now reads `/usr/lib/libiconv.2.dylib`,
  matching the good state described in the issue. All three binaries in
  `$out/bin` (`nativelink`, `redis_store_tester`, `cas_speed_check`) come out
  with zero `/nix/store` references.
- `codesign --verify --verbose` reports "valid on disk" and "satisfies its
  Designated Requirement", so the re-signing after `install_name_tool` works.
- Reproduced the release packaging exactly — `install -m 0755` into a staging
  dir, `tar -czf`, extract into a fresh directory outside the store — and ran
  the extracted binary. It prints `Usage: nativelink` instead of dying in dyld,
  which is the failure mode from the issue.

Before landing on this shape I confirmed the mechanics in a standalone
derivation: that `preFixup` really does run before `autoSignDarwinBinariesHook`,
that `otool` and `install_name_tool` are on `PATH` in the darwin stdenv while
`codesign` is not (hence the hook rather than a direct call), and that a C
program relinked this way resolves `iconv_open` against the system library at
runtime.

I could not exercise the `release.yaml` change itself, since that workflow only
runs on a published release. It's shell I read carefully rather than shell I
watched pass, and the `grep 'Usage: nativelink'` assertion is matched against
the real binary output quoted above.

## Risk

Low, and contained to macOS builds — the added attributes are behind
`p.stdenv.targetPlatform.isDarwin`, so both Linux musl targets are byte-for-byte
unaffected.

The rewrite is deliberately narrow: it only touches `libiconv*`/`libcharset*`
under `/nix/store`, and anything else from the store trips the guard and fails
the build. That's the intended failure direction — a future dependency that
drags in another store dylib breaks the build loudly instead of shipping another
binary that won't start. Whoever hits it has to decide between relocating it or
linking statically, which is the right call to make deliberately.

The one real assumption is that `/usr/lib/libiconv.2.dylib` stays present in the
dyld shared cache and ABI-compatible. It's been there since the shared cache
existed, and the release smoke test would catch it if that ever changed, at
release time rather than in a user's hands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmmEKcy5V7MJvqQz2Gu1dD

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2742)
<!-- Reviewable:end -->
