### PR TITLE
Fail a read that delivers fewer bytes than the store holds

### DIFF
--- a/nativelink-store/src/gcs_client/mocks.rs
+++ b/nativelink-store/src/gcs_client/mocks.rs
@@ -39,6 +39,9 @@ pub struct MockGcsOperations {
     call_counts: CallCounts,
     // For capturing requests to verify correct parameter passing
     requests: RwLock<Vec<MockRequest>>,
+    // When non-zero, every content read returns at most this many bytes,
+    // simulating an HTTP body that ends before the requested range.
+    truncate_reads_to: AtomicUsize,
 }
 
 #[derive(Debug, Clone)]
@@ -130,7 +133,14 @@ impl MockGcsOperations {
             failure_mode: RwLock::new(FailureMode::None),
             call_counts: CallCounts::default(),
             requests: RwLock::new(Vec::new()),
+            truncate_reads_to: AtomicUsize::new(0),
         }
+    }
+
+    /// Cap every content read at `max_bytes` (0 disables), so a read body ends
+    /// before the requested range like a truncated HTTP response would.
+    pub fn set_truncate_reads_to(&self, max_bytes: usize) {
+        self.truncate_reads_to.store(max_bytes, Ordering::Relaxed);
     }
 
     /// Set whether operations should fail or not
@@ -357,6 +367,12 @@ impl GcsOperations for MockGcsOperations {
                 core::cmp::min(usize::try_from(e).unwrap_or(usize::MAX), content.len())
             } else {
                 content.len()
+            };
+            let truncate = self.truncate_reads_to.load(Ordering::Relaxed);
+            let end_idx = if truncate > 0 {
+                core::cmp::min(end_idx, start_idx.saturating_add(truncate))
+            } else {
+                end_idx
             };
 
             Ok(Box::new(OnceStream {

--- a/nativelink-store/src/gcs_store.rs
+++ b/nativelink-store/src/gcs_store.rs
@@ -420,10 +420,42 @@ where
         let client = &self.client;
 
         let object_path_ref = &object_path;
+        let key_ref = &key;
         self.retrier
             .retry(unfold(
-                (offset, writer),
-                |(mut offset, writer)| async move {
+                (offset, None::<u64>, writer),
+                |(mut offset, mut expected_end, writer)| async move {
+                    // The body's end is only trustworthy against a known size; resolve
+                    // it inside the retry loop so NotFound keeps its retry_on_errors path.
+                    let want_end = if let Some(end) = expected_end {
+                        end
+                    } else {
+                        let size = match client.read_object_metadata(object_path_ref).await {
+                            Ok(Some(metadata)) => u64::try_from(metadata.size).unwrap_or(0),
+                            Ok(None) => {
+                                return Some((
+                                    RetryResult::Retry(make_err!(
+                                        Code::NotFound,
+                                        "Object {} not found in GCS store",
+                                        key_ref.as_str()
+                                    )),
+                                    (offset, expected_end, writer),
+                                ));
+                            }
+                            Err(e) => return Some((RetryResult::Retry(e), (offset, expected_end, writer))),
+                        };
+                        let end = end_offset.map_or(size, |end| end.min(size)).max(offset);
+                        expected_end = Some(end);
+                        end
+                    };
+
+                    if offset >= want_end {
+                        if let Err(err) = writer.send_eof() {
+                            return Some((RetryResult::Err(err), (offset, expected_end, writer)));
+                        }
+                        return Some((RetryResult::Ok(()), (offset, expected_end, writer)));
+                    }
+
                     let mut stream = match client
                         .read_object_content(object_path_ref, offset, end_offset)
                         .await
@@ -434,7 +466,7 @@ where
                         // emitting `Retry` lets `retry.retry_on_errors` opt
                         // reads into retrying read-after-write races where
                         // an object is still finalizing or being repopulated.
-                        Err(e) => return Some((RetryResult::Retry(e), (offset, writer))),
+                        Err(e) => return Some((RetryResult::Retry(e), (offset, expected_end, writer))),
                     };
 
                     while let Some(next_chunk) = stream.next().await {
@@ -449,18 +481,34 @@ where
                                 }
                                 offset += bytes.len() as u64;
                                 if let Err(err) = writer.send(bytes).await {
-                                    return Some((RetryResult::Err(err), (offset, writer)));
+                                    return Some((RetryResult::Err(err), (offset, expected_end, writer)));
                                 }
                             }
-                            Err(err) => return Some((RetryResult::Retry(err), (offset, writer))),
+                            Err(err) => return Some((RetryResult::Retry(err), (offset, expected_end, writer))),
                         }
                     }
 
-                    if let Err(err) = writer.send_eof() {
-                        return Some((RetryResult::Err(err), (offset, writer)));
+                    // Retry resumes from `offset`, so a transient truncation heals and a
+                    // short object surfaces as this error once the retries are spent.
+                    if offset < want_end {
+                        return Some((
+                            RetryResult::Retry(make_err!(
+                                Code::Internal,
+                                "Short read from GCS store for {}: expected {} bytes, body ended after {} bytes (resuming at offset {})",
+                                key_ref.as_str(),
+                                want_end,
+                                offset,
+                                offset,
+                            )),
+                            (offset, expected_end, writer),
+                        ));
                     }
 
-                    Some((RetryResult::Ok(()), (offset, writer)))
+                    if let Err(err) = writer.send_eof() {
+                        return Some((RetryResult::Err(err), (offset, expected_end, writer)));
+                    }
+
+                    Some((RetryResult::Ok(()), (offset, expected_end, writer)))
                 },
             ))
             .await

--- a/nativelink-store/src/redis_store.rs
+++ b/nativelink-store/src/redis_store.rs
@@ -1031,7 +1031,7 @@ where
         self: Pin<&Self>,
         key: StoreKey<'_>,
         mut reader: DropCloserReadHalf,
-        _upload_size: UploadSizeInfo,
+        upload_size: UploadSizeInfo,
     ) -> Result<u64, Error> {
         let final_key = self.encode_key(&key);
 
@@ -1141,6 +1141,20 @@ where
             if last_pos > total_len {
                 total_len = last_pos;
             }
+        }
+
+        // A stream that ends before the announced size must not be renamed in
+        // as a shorter value: every later read would serve it as complete.
+        if let UploadSizeInfo::ExactSize(exact_size) = upload_size
+            && u64::from(total_len) != exact_size
+        {
+            return Err(make_input_err!(
+                "Data length mismatch in RedisStore::update for {}({}) - expected {} bytes, stream ended after {} bytes",
+                key.borrow().as_str(),
+                temp_key,
+                exact_size,
+                total_len,
+            ));
         }
 
         let expected_len = usize::try_from(total_len).unwrap_or(usize::MAX);
@@ -1290,13 +1304,58 @@ where
         let encoded_key = self.encode_key(&key);
         let encoded_key = encoded_key.as_ref();
 
+        let mut client = self.get_client().await?;
+
+        // GETRANGE on a missing key returns "", indistinguishable from end of
+        // data, so learn the stored length first and read exactly that window.
+        let (blob_len, exists): (u64, bool) = {
+            let mut attempt: u32 = 0;
+            loop {
+                attempt += 1;
+                match pipe()
+                    .strlen(encoded_key)
+                    .exists(encoded_key)
+                    .query_async::<(u64, bool)>(&mut client.connection_manager)
+                    .await
+                {
+                    Ok(v) => break v,
+                    Err(err)
+                        if attempt < MAX_REDIS_RETRY_ATTEMPTS && is_retryable_redis_error(&err) =>
+                    {
+                        client.reconnect(&self.connection_manager).await?;
+                        sleep(Duration::from_secs_f32(DEFAULT_RETRY_DELAY)).await;
+                    }
+                    Err(err) => {
+                        return Err(Error::from(err).append("In RedisStore::get_part::strlen"));
+                    }
+                }
+            }
+        };
+        if !exists {
+            return Err(make_err!(
+                Code::NotFound,
+                "Data not found in Redis store for digest: {key:?}"
+            ));
+        }
+
+        let available = blob_len.saturating_sub(u64::try_from(offset).unwrap_or(u64::MAX));
+        let expected_len = length.map_or(available, |l| {
+            cmp::min(u64::try_from(l).unwrap_or(u64::MAX), available)
+        });
+        if expected_len == 0 {
+            return writer
+                .send_eof()
+                .err_tip(|| "Failed to write EOF in redis store get_part");
+        }
+        let expected_len_isize = isize::try_from(expected_len).unwrap_or(isize::MAX);
+
         // N.B. the `-1`'s you see here are because redis GETRANGE is inclusive at both the start and end, so when we
         // do math with indices we change them to be exclusive at the end.
 
-        // We want to read the data at the key from `offset` to `offset + length`.
+        // We want to read the data at the key from `offset` to `offset + expected_len`.
         let data_start = offset;
         let data_end = data_start
-            .saturating_add(length.map_or(isize::MAX, |l| isize::try_from(l).unwrap_or(isize::MAX)))
+            .saturating_add(expected_len_isize)
             .saturating_sub(1);
 
         // And we don't ever want to read more than `read_chunk_size` bytes at a time, so we'll need to iterate.
@@ -1306,7 +1365,7 @@ where
             data_end,
         );
 
-        let mut client = self.get_client().await?;
+        let mut delivered: u64 = 0;
         loop {
             // getrange is position-based and idempotent, so re-resolve the
             // master and retry on a transient failover without re-sending
@@ -1337,25 +1396,40 @@ where
                 }
             };
 
-            let didnt_receive_full_chunk = chunk.len() < self.read_chunk_size;
-            let reached_end_of_data = chunk_end == data_end;
-
-            if didnt_receive_full_chunk || reached_end_of_data {
-                if !chunk.is_empty() {
-                    writer
-                        .send(chunk)
-                        .await
-                        .err_tip(|| "Failed to write data in RedisStore::get_part")?;
-                }
-
-                break; // No more data to read.
+            // Inside the window every chunk has a known length; a shorter one
+            // means the value was evicted or replaced, never end of data.
+            let expected_chunk_len = u64::try_from(chunk_end - chunk_start + 1).unwrap_or(u64::MAX);
+            let chunk_len = u64::try_from(chunk.len()).unwrap_or(u64::MAX);
+            if chunk_len < expected_chunk_len {
+                // Nothing delivered yet is a plain miss so fast_slow can fall through.
+                let code = if chunk.is_empty() && delivered == 0 {
+                    Code::NotFound
+                } else {
+                    Code::Internal
+                };
+                return Err(make_err!(
+                    code,
+                    "Short read from Redis store for digest {key:?}: expected {} bytes from offset {}, key held {} bytes, got {} bytes (chunk at {}..={} returned {} of {})",
+                    expected_len,
+                    offset,
+                    blob_len,
+                    delivered + chunk_len,
+                    chunk_start,
+                    chunk_end,
+                    chunk_len,
+                    expected_chunk_len,
+                ));
             }
 
-            // We received a full chunk's worth of data, so write it...
+            delivered += chunk_len;
             writer
                 .send(chunk)
                 .await
                 .err_tip(|| "Failed to write data in RedisStore::get_part")?;
+
+            if chunk_end == data_end {
+                break; // Delivered the whole window.
+            }
 
             // ...and go grab the next chunk.
             chunk_start = chunk_end + 1;
@@ -1364,40 +1438,6 @@ where
                     - 1,
                 data_end,
             );
-        }
-
-        // If we didn't write any data, check if the key exists, if not return a NotFound error.
-        // This is required by spec.
-        if writer.get_bytes_written() == 0 {
-            // We're supposed to read 0 bytes, so just check if the key exists.
-            let exists: bool = {
-                let mut attempt: u32 = 0;
-                loop {
-                    attempt += 1;
-                    match client.connection_manager.exists(encoded_key).await {
-                        Ok(v) => break v,
-                        Err(err)
-                            if attempt < MAX_REDIS_RETRY_ATTEMPTS
-                                && is_retryable_redis_error(&err) =>
-                        {
-                            client.reconnect(&self.connection_manager).await?;
-                            sleep(Duration::from_secs_f32(DEFAULT_RETRY_DELAY)).await;
-                        }
-                        Err(err) => {
-                            return Err(
-                                Error::from(err).append("In RedisStore::get_part::zero_exists")
-                            );
-                        }
-                    }
-                }
-            };
-
-            if !exists {
-                return Err(make_err!(
-                    Code::NotFound,
-                    "Data not found in Redis store for digest: {key:?}"
-                ));
-            }
         }
 
         writer

--- a/nativelink-store/tests/gcs_store_test.rs
+++ b/nativelink-store/tests/gcs_store_test.rs
@@ -210,12 +210,18 @@ async fn get_part_not_found_not_retried_by_default() -> Result<(), Error> {
     assert_eq!(err.code, Code::NotFound, "Expected NotFound error");
 
     // Even with a retry budget configured, NotFound must not consume it
-    // unless explicitly opted in via `retry_on_errors`.
+    // unless explicitly opted in via `retry_on_errors`. The miss is seen on
+    // the size lookup that precedes the content read.
     let call_counts = mock_ops.get_call_counts();
     assert_eq!(
-        call_counts.read_calls.load(Ordering::Relaxed),
+        call_counts.metadata_calls.load(Ordering::Relaxed),
         1,
-        "read_object_content should not be retried on NotFound by default"
+        "read_object_metadata should not be retried on NotFound by default"
+    );
+    assert_eq!(
+        call_counts.read_calls.load(Ordering::Relaxed),
+        0,
+        "read_object_content should not be attempted for a missing object"
     );
 
     Ok(())
@@ -254,12 +260,13 @@ async fn get_part_retries_not_found_when_opted_in() -> Result<(), Error> {
     );
 
     // With NotFound in `retry_on_errors`, the read should be attempted
-    // once plus `max_retries` more times before giving up.
+    // once plus `max_retries` more times before giving up. The miss is seen
+    // on the size lookup that precedes the content read.
     let call_counts = mock_ops.get_call_counts();
     assert_eq!(
-        call_counts.read_calls.load(Ordering::Relaxed),
+        call_counts.metadata_calls.load(Ordering::Relaxed),
         3,
-        "read_object_content should be retried on NotFound when opted in"
+        "read_object_metadata should be retried on NotFound when opted in"
     );
 
     Ok(())
@@ -551,6 +558,127 @@ async fn get_part_with_range() -> Result<(), Error> {
         *read_requests[0].1,
         Some(11),
         "Expected end offset to be Some(11)"
+    );
+
+    Ok(())
+}
+
+// An HTTP body that ends before the object does used to be forwarded as a
+// clean EOF; the caller then took the truncated object as the whole blob.
+// With no retry budget the shortfall must surface as an error naming it.
+#[nativelink_test]
+async fn get_part_errors_on_short_body() -> Result<(), Error> {
+    let mock_ops = Arc::new(MockGcsOperations::new());
+    let store = create_test_store_with_retry(
+        mock_ops.clone(),
+        Retry {
+            max_retries: 0,
+            delay: 0.001,
+            jitter: 0.0,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 11)?;
+    let store_key: StoreKey = to_store_key(digest);
+    let object_path = create_object_path(&store_key);
+    mock_ops
+        .add_object(&object_path, b"hello world".to_vec())
+        .await;
+    // Every content read returns at most 5 bytes of the 11 requested.
+    mock_ops.set_truncate_reads_to(5);
+
+    let (mut tx, _rx) = make_buf_channel_pair();
+    let store_clone = store.clone();
+    let get_part_fut = nativelink_util::spawn!("get_part_task", async move {
+        store_clone.get_part(store_key, &mut tx, 0, None).await
+    });
+
+    let err = get_part_fut.await?.unwrap_err();
+    assert_eq!(err.code, Code::Internal, "{err:?}");
+    let message = err.to_string();
+    assert!(
+        message.contains("Short read from GCS store")
+            && message.contains("expected 11 bytes, body ended after 5 bytes"),
+        "Error must name the expected and the received length: {message}",
+    );
+
+    let call_counts = mock_ops.get_call_counts();
+    assert_eq!(
+        call_counts.metadata_calls.load(Ordering::Relaxed),
+        1,
+        "the object size is looked up once per get_part"
+    );
+    assert_eq!(
+        call_counts.read_calls.load(Ordering::Relaxed),
+        1,
+        "no retry budget: one content read"
+    );
+
+    Ok(())
+}
+
+// With a retry budget, a short body resumes from the bytes already delivered
+// until the whole object has been sent.
+#[nativelink_test]
+async fn get_part_resumes_after_short_body() -> Result<(), Error> {
+    let mock_ops = Arc::new(MockGcsOperations::new());
+    let store = create_test_store_with_retry(
+        mock_ops.clone(),
+        Retry {
+            max_retries: 3,
+            delay: 0.001,
+            jitter: 0.0,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let digest = DigestInfo::try_new(VALID_HASH1, 11)?;
+    let store_key: StoreKey = to_store_key(digest);
+    let object_path = create_object_path(&store_key);
+    mock_ops
+        .add_object(&object_path, b"hello world".to_vec())
+        .await;
+    mock_ops.set_truncate_reads_to(5);
+
+    let (mut tx, mut rx) = make_buf_channel_pair();
+    let store_clone = store.clone();
+    let store_key_clone = store_key.clone();
+    let handle = nativelink_util::spawn!("get_part_task", async move {
+        store_clone
+            .get_part(store_key_clone, &mut tx, 0, None)
+            .await
+    });
+
+    let received_data =
+        match tokio::time::timeout(Duration::from_secs(5), rx.consume(Some(100))).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(make_err!(
+                    Code::DeadlineExceeded,
+                    "Timeout waiting for data"
+                ));
+            }
+        };
+    handle.await??;
+
+    assert_eq!(
+        received_data.as_ref(),
+        b"hello world",
+        "Resumed reads must deliver the whole object exactly once"
+    );
+    let call_counts = mock_ops.get_call_counts();
+    assert_eq!(
+        call_counts.metadata_calls.load(Ordering::Relaxed),
+        1,
+        "the object size is looked up once per get_part"
+    );
+    assert_eq!(
+        call_counts.read_calls.load(Ordering::Relaxed),
+        3,
+        "5 + 5 + 1 bytes: three content reads"
     );
 
     Ok(())

--- a/nativelink-store/tests/redis_store_test.rs
+++ b/nativelink-store/tests/redis_store_test.rs
@@ -180,6 +180,18 @@ async fn upload_and_get_data() -> Result<(), Error> {
             Ok(vec![Value::Int(2), Value::Boolean(true)]),
         ),
         // Retrieve the data from the real key.
+        // get_part learns the stored length before streaming.
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(&real_key)
+                .cmd("EXISTS")
+                .arg(&real_key),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
         MockCmd::new(
             redis::cmd("GETRANGE").arg(real_key).arg(0).arg(1),
             Ok(Value::BulkString(b"14".to_vec())),
@@ -409,6 +421,18 @@ async fn upload_and_get_data_with_prefix() -> Result<(), Error> {
                 .arg(real_key.clone()),
             Ok(vec![Value::Int(2), Value::Boolean(true)]),
         ),
+        // get_part learns the stored length before streaming.
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(&real_key)
+                .cmd("EXISTS")
+                .arg(&real_key),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
         MockCmd::new(
             redis::cmd("GETRANGE").arg(real_key).arg(0).arg(1),
             Ok(Value::BulkString(b"14".to_vec())),
@@ -510,6 +534,18 @@ async fn test_large_downloads_are_chunked() -> Result<(), Error> {
                 Value::Int(1),
             ]),
         ),
+        // get_part learns the stored length before streaming.
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(real_key.clone())
+                .cmd("EXISTS")
+                .arg(real_key.clone()),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
         MockCmd::new(
             // We expect to be asked for data from `0..READ_CHUNK_SIZE`, but since GETRANGE is inclusive
             // the actual call should be from `0..=(READ_CHUNK_SIZE - 1)`.
@@ -600,6 +636,18 @@ async fn yield_between_sending_packets_in_update() -> Result<(), Error> {
                 .arg(real_key.clone()),
             Ok(vec![Value::Int(2), Value::Int(1)]),
         ),
+        // get_part learns the stored length before streaming.
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(real_key.clone())
+                .cmd("EXISTS")
+                .arg(real_key.clone()),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
         MockCmd::new(
             redis::cmd("GETRANGE")
                 .arg(real_key.clone())
@@ -676,15 +724,107 @@ async fn zero_len_items_exist_check() -> Result<(), Error> {
     let packed_hash_hex = format!("{digest}");
     let real_key = packed_hash_hex;
 
+    let commands = vec![MockCmd::with_values(
+        redis::pipe()
+            .cmd("STRLEN")
+            .arg(real_key.clone())
+            .cmd("EXISTS")
+            .arg(real_key),
+        Ok(vec![Value::Int(0), Value::Int(0)]),
+    )];
+
+    let store = make_mock_store(commands).await;
+
+    let result = store.get_part_unchunked(digest, 0, None).await;
+    assert_eq!(
+        result.as_ref().unwrap_err().code,
+        Code::NotFound,
+        "{result:?}"
+    );
+
+    Ok(())
+}
+
+// A key evicted between two GETRANGE chunks used to end the stream with a
+// clean EOF after the first chunk; the caller then took a truncated value as
+// the whole blob. The store must fail the read and name the shortfall.
+#[nativelink_test]
+async fn get_part_errors_when_key_vanishes_mid_read() -> Result<(), Error> {
+    let data = Bytes::from(vec![7u8; DEFAULT_READ_CHUNK_SIZE * 3]);
+    let digest = DigestInfo::try_new(VALID_HASH1, data.len() as u64)?;
+    let real_key = format!("{digest}");
+
     let commands = vec![
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(real_key.clone())
+                .cmd("EXISTS")
+                .arg(real_key.clone()),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
         MockCmd::new(
             redis::cmd("GETRANGE")
                 .arg(real_key.clone())
                 .arg(0)
-                .arg(DEFAULT_READ_CHUNK_SIZE.try_into().unwrap_or(i64::MAX) - 1),
+                .arg((DEFAULT_READ_CHUNK_SIZE - 1).try_into().unwrap_or(i64::MAX)),
+            Ok(Value::BulkString(
+                data.slice(..DEFAULT_READ_CHUNK_SIZE).to_vec(),
+            )),
+        ),
+        // The key is evicted here: GETRANGE on a missing key returns "".
+        MockCmd::new(
+            redis::cmd("GETRANGE")
+                .arg(real_key)
+                .arg(DEFAULT_READ_CHUNK_SIZE.try_into().unwrap_or(i64::MAX))
+                .arg(
+                    (DEFAULT_READ_CHUNK_SIZE * 2 - 1)
+                        .try_into()
+                        .unwrap_or(i64::MAX),
+                ),
             Ok(Value::BulkString(vec![])),
         ),
-        MockCmd::new(redis::cmd("EXISTS").arg(real_key), Ok(Value::Int(0))),
+    ];
+
+    let store = make_mock_store(commands).await;
+
+    let result = store.get_part_unchunked(digest, 0, None).await;
+    let err = result.as_ref().unwrap_err();
+    assert_eq!(err.code, Code::Internal, "{result:?}");
+    let message = err.to_string();
+    assert!(
+        message.contains("Short read from Redis store")
+            && message.contains(&format!("expected {} bytes", data.len()))
+            && message.contains(&format!("got {DEFAULT_READ_CHUNK_SIZE} bytes")),
+        "Error must name the digest, the expected and the received length: {message}",
+    );
+
+    Ok(())
+}
+
+// A key that vanishes before the first chunk is a plain miss, so a fast_slow
+// caller can fall through to its slow store.
+#[nativelink_test]
+async fn get_part_reports_not_found_when_key_vanishes_before_first_chunk() -> Result<(), Error> {
+    let digest = DigestInfo::try_new(VALID_HASH1, 2)?;
+    let real_key = format!("{digest}");
+
+    let commands = vec![
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(real_key.clone())
+                .cmd("EXISTS")
+                .arg(real_key.clone()),
+            Ok(vec![Value::Int(2), Value::Int(1)]),
+        ),
+        MockCmd::new(
+            redis::cmd("GETRANGE").arg(real_key).arg(0).arg(1),
+            Ok(Value::BulkString(vec![])),
+        ),
     ];
 
     let store = make_mock_store(commands).await;
@@ -694,6 +834,107 @@ async fn zero_len_items_exist_check() -> Result<(), Error> {
         result.as_ref().unwrap_err().code,
         Code::NotFound,
         "{result:?}"
+    );
+
+    Ok(())
+}
+
+// A GETRANGE chunk that comes back non-empty but shorter than the window
+// means the value was replaced by a shorter one after the length was read.
+#[nativelink_test]
+async fn get_part_errors_when_chunk_is_shorter_than_window() -> Result<(), Error> {
+    let data = Bytes::from(vec![9u8; DEFAULT_READ_CHUNK_SIZE * 2]);
+    let digest = DigestInfo::try_new(VALID_HASH1, data.len() as u64)?;
+    let real_key = format!("{digest}");
+
+    let commands = vec![
+        MockCmd::with_values(
+            redis::pipe()
+                .cmd("STRLEN")
+                .arg(real_key.clone())
+                .cmd("EXISTS")
+                .arg(real_key.clone()),
+            Ok(vec![
+                Value::Int(data.len().try_into().unwrap_or(i64::MAX)),
+                Value::Int(1),
+            ]),
+        ),
+        MockCmd::new(
+            redis::cmd("GETRANGE")
+                .arg(real_key.clone())
+                .arg(0)
+                .arg((DEFAULT_READ_CHUNK_SIZE - 1).try_into().unwrap_or(i64::MAX)),
+            Ok(Value::BulkString(
+                data.slice(..DEFAULT_READ_CHUNK_SIZE).to_vec(),
+            )),
+        ),
+        // The value now holds only 1.5 chunks: the second chunk is short.
+        MockCmd::new(
+            redis::cmd("GETRANGE")
+                .arg(real_key)
+                .arg(DEFAULT_READ_CHUNK_SIZE.try_into().unwrap_or(i64::MAX))
+                .arg(
+                    (DEFAULT_READ_CHUNK_SIZE * 2 - 1)
+                        .try_into()
+                        .unwrap_or(i64::MAX),
+                ),
+            Ok(Value::BulkString(
+                data.slice(..DEFAULT_READ_CHUNK_SIZE / 2).to_vec(),
+            )),
+        ),
+    ];
+
+    let store = make_mock_store(commands).await;
+
+    let result = store.get_part_unchunked(digest, 0, None).await;
+    let err = result.as_ref().unwrap_err();
+    assert_eq!(err.code, Code::Internal, "{result:?}");
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!("expected {} bytes", data.len()))
+            && message.contains(&format!("got {} bytes", DEFAULT_READ_CHUNK_SIZE * 3 / 2)),
+        "Error must name the expected and the received length: {message}",
+    );
+
+    Ok(())
+}
+
+// A populate stream that ends before the announced ExactSize must be rejected
+// before the temp key is renamed in: otherwise the short value is served as
+// the whole blob on every later read.
+#[nativelink_test]
+async fn update_rejects_stream_shorter_than_exact_size() -> Result<(), Error> {
+    let data = Bytes::from_static(b"14");
+    let digest = DigestInfo::try_new(VALID_HASH1, 4)?;
+    let packed_hash_hex = format!("{digest}");
+    let temp_key = make_temp_key(&packed_hash_hex);
+
+    // Only the chunk append is expected: no STRLEN, no RENAME.
+    let commands = vec![MockCmd::new(
+        redis::cmd("SETRANGE")
+            .arg(&temp_key)
+            .arg(0)
+            .arg(data.to_vec()),
+        Ok(Value::Int(0)),
+    )];
+
+    let store = make_mock_store(commands).await;
+
+    let (mut tx, rx) = make_buf_channel_pair();
+    let (result, send_result) = tokio::join!(
+        store.update(digest, rx, UploadSizeInfo::ExactSize(4)),
+        async {
+            tx.send(data.clone()).await?;
+            tx.send_eof()
+        },
+    );
+    send_result?;
+    let err = result.as_ref().unwrap_err();
+    assert_eq!(err.code, Code::InvalidArgument, "{result:?}");
+    let message = err.to_string();
+    assert!(
+        message.contains("expected 4 bytes, stream ended after 2 bytes"),
+        "Error must name the expected and the received length: {message}",
     );
 
     Ok(())


### PR DESCRIPTION
## What and why

`RedisStore::get_part` reads a value in `read_chunk_size` GETRANGE calls
and treats any chunk shorter than the chunk size as the end of the data.
GETRANGE on a missing key returns an empty string, so a key that is
evicted or replaced between two chunks ends the stream with a clean EOF
after the bytes already sent. `GcsStore::get_part` forwards the HTTP
body and sends EOF when the body ends, with no check against the object
size. `RedisStore::update` ignores `UploadSizeInfo::ExactSize`, so a
populate stream that ends early is renamed in as a shorter value under
the real key and every later read serves it as complete. Under a `verify
-> lz4 -> fast_slow{redis, gcs}` chain a `VerifyStore` cannot catch any
of this on the read side, and the caller sees `Got EOF earlier than
expected` from the compression reader with no store error in the chain.
Measured on a v1.6.3 deployment: 11 such truncated `ByteStream.Read`
calls in 24 h on blobs from 454 KB to 50.8 MB, each one a build-fatal
`materialize_inputs_failed` for Buck2, which does not retry them.

The stores now know how many bytes a read owes before they stream it.
`RedisStore::get_part` reads STRLEN and EXISTS first (the same pipeline
`has_with_results` uses), clips the requested window to the stored
length, and requires every GETRANGE chunk inside that window to come
back whole; a short chunk returns `Internal` naming the key, the
expected and the delivered length, or `NotFound` when nothing has been
sent yet so a `fast_slow` caller can fall through to its slow store.
`GcsStore::get_part` resolves the object size once per call inside the
retry loop, counts the bytes delivered across retries, and treats a body
that ends early as a retryable error that resumes from the last offset;
a genuinely short object surfaces as that error once the retries are
spent. `RedisStore::update` rejects a stream whose length differs from
`ExactSize` before the STRLEN check and the RENAME, with
`InvalidArgument` naming both lengths. The digest size cannot serve as
the expected length here: under a compression store the stored value is
the compressed frame, so the length has to come from the store itself.

## How was this verified?

New tests, one per invariant, in the existing test files.

In `redis_store_test`:

- `get_part_errors_when_key_vanishes_mid_read`: STRLEN says three
  chunks, the second GETRANGE returns "" -> `Internal` naming 3072
  expected and 1024 delivered.
- `get_part_errors_when_chunk_is_shorter_than_window`: a non-empty short
  chunk -> `Internal` naming 2048 expected and 1536 delivered.
- `get_part_reports_not_found_when_key_vanishes_before_first_chunk`:
  first GETRANGE returns "" -> `NotFound`.
- `update_rejects_stream_shorter_than_exact_size`: two bytes against
  `ExactSize(4)` -> `InvalidArgument`, no STRLEN, no RENAME.

In `gcs_store_test`:

- `get_part_errors_on_short_body`: the mock caps every body at 5 of 11
  bytes, no retry budget -> `Internal` naming both.
- `get_part_resumes_after_short_body`: with retries the read completes
  in three bodies (5 + 5 + 1) and one metadata call.

Without the store changes the five failure tests pass the truncated data
through as a clean EOF and fail on their assertions; the resume test
fails because the store sends EOF after 5 bytes. The existing tests were
updated for the up-front STRLEN/EXISTS call and for the size lookup that
now precedes a GCS content read; all of them pass.

Deployed on a development ring with the Redis fast tier capped at 256 MB
so it evicted continuously, with a fault injector that deleted the Redis
key or shrank it to a 4 KiB prefix partway through a chunked read. On
the unpatched image the injected mid-read eviction produced the clean-
EOF signature in 1163 of 1163 landed injections over three runs. On the
patched image the same fault produced the explicit short-read error 31
of 31 times and a clean EOF never. Under natural eviction alone on the
patched image (256 MB tier, 2.4 GB write flood, 2595 evictions) 1404
reads completed with 0 short. On a production deployment of the patched
build, 12 hours of live traffic (about 4 million CAS requests) produced
0 clean-EOF truncations and 1 explicit short-read error, on a 555 KB
blob whose Redis key was lost between chunks; the affected build failed
with the named digest instead of a truncated file, and GetActionResult
p99 stayed at 235 ms with no request at the 30 s deadline.

## Risk

Default on; there is no knob because a read that returns fewer bytes
than the store holds is never correct. Behavior changes for every
deployment: a Redis read costs one extra STRLEN/EXISTS round trip and a
GCS read one metadata request per `get_part` call, both before the first
byte; a `fast_slow` populate already made the same two calls through
`has`, so on that path the count doubles from one to two each. Readers
of a key that shrinks or disappears mid-read now get an error where they
got a truncated success; readers of a genuinely short GCS object get an
error after the retry budget instead of the short body. A Redis populate
whose stream ends before `ExactSize` now fails instead of storing the
prefix. Callers that request a window past the end of a value still get
the clipped window, as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2743)
<!-- Reviewable:end -->
