### PR TITLE
Release NativeLink v1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.7](https://github.com/TraceMachina/nativelink/compare/v1.6.6..v1.6.7) - 2026-09-07
+
+### ⛰️  Features
+
+- Introduce Rules Omniverse ([#2720](https://github.com/TraceMachina/nativelink/issues/2720)) - ([1b735ca](https://github.com/TraceMachina/nativelink/commit/1b735caee0410c9177ce603ec278c9c4e4c0b39c))
+
+### 🐛 Bug Fixes
+
+- point Media kit Download at the shared Drive folder ([#2722](https://github.com/TraceMachina/nativelink/issues/2722)) - ([4c5fa6f](https://github.com/TraceMachina/nativelink/commit/4c5fa6fed171d340739361cd48f155edaf17b749))
+
+### 📚 Documentation
+
+- *(config-reference)* regenerate for NativeLink ([#2711](https://github.com/TraceMachina/nativelink/issues/2711)) - ([9d0731e](https://github.com/TraceMachina/nativelink/commit/9d0731e8c8629524e3115a071f22bb788417c094))
+- Update mermaid to 11.17.2 [SECURITY] ([#2738](https://github.com/TraceMachina/nativelink/issues/2738)) - ([e6d3796](https://github.com/TraceMachina/nativelink/commit/e6d37967f1aeccb438e1c7cdeaf3bd3d5c3a3716))
+- Update esbuild to 0.28.2 [SECURITY] ([#2736](https://github.com/TraceMachina/nativelink/issues/2736)) - ([df6d817](https://github.com/TraceMachina/nativelink/commit/df6d817192f4da0adadc1e06feef643599352b9a))
+- track Menlo case-study figures under public/assets ([#2723](https://github.com/TraceMachina/nativelink/issues/2723)) - ([4d8fc4b](https://github.com/TraceMachina/nativelink/commit/4d8fc4bf4bd58bf3082d1b6eab42e826854c2fef))
+- Cursor/menlo security case study 6c68 ([#2721](https://github.com/TraceMachina/nativelink/issues/2721)) - ([574986b](https://github.com/TraceMachina/nativelink/commit/574986bb99e236a22931e050d41a9ab7895d7d2e))
+
+### 🧪 Testing & CI
+
+- Upgrade to Rust 1.97.1 ([#2718](https://github.com/TraceMachina/nativelink/issues/2718)) - ([710ab3b](https://github.com/TraceMachina/nativelink/commit/710ab3b5786c976476dbc57a4240aff988d053b6))
+
+### ⚙️ Miscellaneous
+
+- stop linking released macOS binaries to /nix/store libiconv ([#2742](https://github.com/TraceMachina/nativelink/issues/2742)) - ([63c9fd7](https://github.com/TraceMachina/nativelink/commit/63c9fd7a82105e627fbbd5b96f6cb9c0011297ce))
+- Retire queued actions no client is waiting on ([#2726](https://github.com/TraceMachina/nativelink/issues/2726)) - ([090d972](https://github.com/TraceMachina/nativelink/commit/090d9722aaa4813631c14221edde77a43c9bd801))
+- Label execution resource samples with the action mnemonic ([#2712](https://github.com/TraceMachina/nativelink/issues/2712)) - ([53b528e](https://github.com/TraceMachina/nativelink/commit/53b528e36c2a2657ba132dd94e6616877f5270d9))
+
+### ⬆️ Bumps & Version Updates
+
+- Update postcss to 8.5.28 [SECURITY] ([#2740](https://github.com/TraceMachina/nativelink/issues/2740)) - ([908250c](https://github.com/TraceMachina/nativelink/commit/908250c782d6e4f4e48f78b15d5dbdfe25bd5660))
+- Update Next.js to 16.2.12 [SECURITY] ([#2733](https://github.com/TraceMachina/nativelink/issues/2733)) - ([f081c89](https://github.com/TraceMachina/nativelink/commit/f081c89c768cec6a964f09ab04df55e7dcf29f7a))
+- Update js-yaml to 4.3.2 [SECURITY] ([#2737](https://github.com/TraceMachina/nativelink/issues/2737)) - ([634214f](https://github.com/TraceMachina/nativelink/commit/634214f89827613d8990982a217ab3004a63d60f))
+- Update dompurify to 3.4.14 [SECURITY] ([#2735](https://github.com/TraceMachina/nativelink/issues/2735)) - ([64e6e04](https://github.com/TraceMachina/nativelink/commit/64e6e041c888e0d7e900276db33859502729869f))
+- Update nanoid to 3.3.18 [SECURITY] ([#2739](https://github.com/TraceMachina/nativelink/issues/2739)) - ([5d720d5](https://github.com/TraceMachina/nativelink/commit/5d720d527f96f9a3afc23935f19b50719b648ecc))
+- Update Rust crate h2 to 0.4.19 [SECURITY] ([#2732](https://github.com/TraceMachina/nativelink/issues/2732)) - ([b8a1163](https://github.com/TraceMachina/nativelink/commit/b8a1163b8d8aec7cc3303c1906687e6d56ae7e36))
+- Update Rust crate event-listener to 5.4.2 [SECURITY] ([#2731](https://github.com/TraceMachina/nativelink/issues/2731)) - ([5dae6a0](https://github.com/TraceMachina/nativelink/commit/5dae6a01496364a63f5f60f3a0165e2280dea22a))
+- Upgrade scorecard action to 2.4.4 ([#2725](https://github.com/TraceMachina/nativelink/issues/2725)) - ([5daa1a2](https://github.com/TraceMachina/nativelink/commit/5daa1a29f6ea3ebcc4cef4ad61551306b4a67ec1))
+- Upgrade rules_rs to 0.0.108 to fix zlib issues ([#2724](https://github.com/TraceMachina/nativelink/issues/2724)) - ([e42efc8](https://github.com/TraceMachina/nativelink/commit/e42efc8693271ae9445f0b5f9d44d0faa53535a4))
+- Upgrade curl to 8.5.0-2ubuntu10.13 ([#2717](https://github.com/TraceMachina/nativelink/issues/2717)) - ([1330267](https://github.com/TraceMachina/nativelink/commit/1330267e5a5ef8fedd8d0829f731f124e2f2fada))
+
 ## [1.6.6](https://github.com/TraceMachina/nativelink/compare/v1.6.5..v1.6.6) - 2026-08-21
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nativelink"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "axum",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "base64 0.22.1",
  "mongodb",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-macro"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "derive_more 2.1.0",
  "prost",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-redis-tester"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "either",
  "nativelink-util",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-scheduler"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-service"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-store"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-util"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-worker"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 edition = "2024"
 name = "nativelink"
 rust-version = "1.97.1"
-version = "1.6.6"
+version = "1.6.7"
 
 [profile.release]
 lto = true

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "nativelink",
-    version = "1.6.6",
+    version = "1.6.7",
     compatibility_level = 0,
 )
 

--- a/nativelink-config/Cargo.toml
+++ b/nativelink-config/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-config"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-error = { path = "../nativelink-error" }

--- a/nativelink-error/Cargo.toml
+++ b/nativelink-error/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 autotests = true
 edition = "2024"
 name = "nativelink-error"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-metric = { path = "../nativelink-metric" }

--- a/nativelink-macro/Cargo.toml
+++ b/nativelink-macro/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-macro"
-version = "1.6.6"
+version = "1.6.7"
 
 [lib]
 proc-macro = true

--- a/nativelink-metric/Cargo.toml
+++ b/nativelink-metric/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-metric"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-metric-macro-derive = { path = "nativelink-metric-macro-derive" }

--- a/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
+++ b/nativelink-metric/nativelink-metric-macro-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "nativelink-metric-macro-derive"
-version = "1.6.6"
+version = "1.6.7"
 
 [lib]
 proc-macro = true

--- a/nativelink-proto/Cargo.toml
+++ b/nativelink-proto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "nativelink-proto"
-version = "1.6.6"
+version = "1.6.7"
 
 [lib]
 doctest = false           # because some of the generated protos have things that look like doctests but break

--- a/nativelink-redis-tester/Cargo.toml
+++ b/nativelink-redis-tester/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-redis-tester"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-util = { path = "../nativelink-util" }

--- a/nativelink-scheduler/Cargo.toml
+++ b/nativelink-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-scheduler"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-service/Cargo.toml
+++ b/nativelink-service/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-service"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-store/Cargo.toml
+++ b/nativelink-store/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-store"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-test/fuzz/Cargo.lock
+++ b/nativelink-test/fuzz/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-config"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "byte-unit",
  "humantime",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-error"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "base64",
  "mongodb",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "async-lock",
  "nativelink-metric-macro-derive",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-metric-macro-derive"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "nativelink-proto"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "derive_more",
  "prost",

--- a/nativelink-util/Cargo.toml
+++ b/nativelink-util/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-util"
-version = "1.6.6"
+version = "1.6.7"
 
 [dependencies]
 nativelink-config = { path = "../nativelink-config" }

--- a/nativelink-worker/Cargo.toml
+++ b/nativelink-worker/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 [package]
 edition = "2024"
 name = "nativelink-worker"
-version = "1.6.6"
+version = "1.6.7"
 
 [features]
 nix = []


### PR DESCRIPTION
## What and why

Releases a new version of the Nativelink v1.6.7

## How was this verified?

Standard Unit tests and CI runs green. No additional tests needed.

## Risk

Low risk, since the PR is simply a Nativelink version update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2745)
<!-- Reviewable:end -->
