### PR TITLE
Return an error when TlsClient cannot load CA root certificates

### DIFF
--- a/nativelink-store/BUILD.bazel
+++ b/nativelink-store/BUILD.bazel
@@ -150,6 +150,7 @@ rust_test_suite(
         "tests/shard_store_test.rs",
         "tests/size_partitioning_store_test.rs",
         "tests/store_manager_test.rs",
+        "tests/tls_client_no_roots_test.rs",
         "tests/verify_store_test.rs",
     ],
     compile_data = [

--- a/nativelink-store/src/common_s3_utils.rs
+++ b/nativelink-store/src/common_s3_utils.rs
@@ -41,7 +41,7 @@ use nativelink_config::stores::CommonObjectSpec;
 // when in a retryable wrapper. Always prefer Code::Aborted or another
 // retryable code over Code::InvalidArgument or make_input_err!().
 // ie: Don't import make_input_err!() to help prevent this.
-use nativelink_error::{Code, make_err};
+use nativelink_error::{Code, Error, make_err};
 use nativelink_util::buf_channel::DropCloserReadHalf;
 use nativelink_util::fs;
 use nativelink_util::retry::{Retrier, RetryResult};
@@ -58,8 +58,7 @@ pub struct TlsClient {
 }
 
 impl TlsClient {
-    #[must_use]
-    pub fn new(common: &CommonObjectSpec) -> Self {
+    pub fn new(common: &CommonObjectSpec) -> Result<Self, Error> {
         Self::new_with_http_support(common, common.insecure_allow_http)
     }
 
@@ -67,15 +66,23 @@ impl TlsClient {
     ///
     /// The default credential chain uses plain HTTP for link-local metadata
     /// services, including the EKS Pod Identity, ECS, and EC2 providers.
-    #[must_use]
-    pub fn new_for_credentials(common: &CommonObjectSpec) -> Self {
+    pub fn new_for_credentials(common: &CommonObjectSpec) -> Result<Self, Error> {
         Self::new_with_http_support(common, true)
     }
 
-    fn new_with_http_support(common: &CommonObjectSpec, allow_http: bool) -> Self {
+    fn new_with_http_support(common: &CommonObjectSpec, allow_http: bool) -> Result<Self, Error> {
         install_default_rustls_crypto_provider();
 
-        let connector_with_roots = HttpsConnectorBuilder::new().with_platform_verifier();
+        let connector_with_roots = HttpsConnectorBuilder::new()
+            .try_with_platform_verifier()
+            .map_err(|e| {
+                make_err!(
+                    Code::InvalidArgument,
+                    "Failed to load CA root certificates for the TLS client: {e}. \
+                     Mount a CA bundle into the container and point SSL_CERT_FILE \
+                     or SSL_CERT_DIR at it."
+                )
+            })?;
 
         let connector_with_schemes = if allow_http {
             connector_with_roots.https_or_http()
@@ -89,7 +96,7 @@ impl TlsClient {
             connector_with_schemes.enable_http1().enable_http2().build()
         };
 
-        Self::with_https_connector(common, connector)
+        Ok(Self::with_https_connector(common, connector))
     }
 
     pub fn with_https_connector(

--- a/nativelink-store/src/oci_store.rs
+++ b/nativelink-store/src/oci_store.rs
@@ -55,7 +55,7 @@ impl OciStore {
         I: InstantWrapper,
         NowFn: Fn() -> I + Send + Sync + Unpin + 'static,
     {
-        Self::new_with_http_client(spec, TlsClient::new(&spec.common.clone()), now_fn).await
+        Self::new_with_http_client(spec, TlsClient::new(&spec.common.clone())?, now_fn).await
     }
 
     /// Builds the store with a caller-supplied HTTP client. Production uses

--- a/nativelink-store/src/ontap_s3_existence_cache_store.rs
+++ b/nativelink-store/src/ontap_s3_existence_cache_store.rs
@@ -415,7 +415,7 @@ where
 }
 
 async fn create_s3_client(spec: &ExperimentalOntapS3Spec) -> Result<Client, Error> {
-    let http_client = TlsClient::new(&spec.common);
+    let http_client = TlsClient::new(&spec.common)?;
     let credentials_provider = DefaultCredentialsChain::builder()
         .configure(
             ProviderConfig::without_region()

--- a/nativelink-store/src/r2_store.rs
+++ b/nativelink-store/src/r2_store.rs
@@ -46,7 +46,7 @@ impl R2Store {
         let aws_spec = Self::build_aws_spec(spec);
         let jitter_fn = spec.common.retry.make_jitter_fn();
 
-        let http_client = TlsClient::new(&spec.common.clone());
+        let http_client = TlsClient::new(&spec.common.clone())?;
         let endpoint = Self::derive_endpoint(spec);
 
         let mut config_loader = aws_config::defaults(BehaviorVersion::latest())

--- a/nativelink-store/src/s3_store.rs
+++ b/nativelink-store/src/s3_store.rs
@@ -109,8 +109,8 @@ where
     pub async fn new(spec: &ExperimentalAwsSpec, now_fn: NowFn) -> Result<Arc<Self>, Error> {
         let jitter_fn = spec.common.retry.make_jitter_fn();
         let s3_client = {
-            let http_client = TlsClient::new(&spec.common.clone());
-            let credential_http_client = TlsClient::new_for_credentials(&spec.common);
+            let http_client = TlsClient::new(&spec.common.clone())?;
+            let credential_http_client = TlsClient::new_for_credentials(&spec.common)?;
 
             let credential_provider = credentials::DefaultCredentialsChain::builder()
                 .configure(

--- a/nativelink-store/tests/common_s3_utils_test.rs
+++ b/nativelink-store/tests/common_s3_utils_test.rs
@@ -47,6 +47,7 @@ async fn credential_client_allows_http() {
 
     let (credential_url, credential_server) = start_http_server().await;
     let credential_result = TlsClient::new_for_credentials(&common)
+        .unwrap()
         .call(HttpRequest::get(credential_url).unwrap())
         .await;
     assert!(
@@ -63,6 +64,7 @@ async fn s3_client_rejects_http_by_default() {
 
     let (s3_url, s3_server) = start_http_server().await;
     let s3_result = TlsClient::new(&common)
+        .unwrap()
         .call(HttpRequest::get(s3_url).unwrap())
         .await;
     drop(s3_server);

--- a/nativelink-store/tests/tls_client_no_roots_test.rs
+++ b/nativelink-store/tests/tls_client_no_roots_test.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The NativeLink Authors. All rights reserved.
+//
+// Licensed under the Functional Source License, Version 1.1, Apache 2.0 Future License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    See LICENSE file for details
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verifies that `TlsClient` reports a configuration error instead of
+//! panicking when no CA root certificates can be loaded.
+//!
+//! Only Linux reads `SSL_CERT_FILE`/`SSL_CERT_DIR` for the platform
+//! verifier, and this binary is kept separate from the other `TlsClient`
+//! tests because those environment variables are process-wide.
+
+#![cfg(target_os = "linux")]
+
+use nativelink_config::stores::CommonObjectSpec;
+use nativelink_error::Code;
+use nativelink_macro::nativelink_test;
+use nativelink_store::common_s3_utils::TlsClient;
+
+#[nativelink_test]
+async fn tls_client_without_ca_roots_returns_error() {
+    let empty_dir = tempfile::tempdir().unwrap();
+    let empty_file = empty_dir.path().join("empty.pem");
+    std::fs::write(&empty_file, b"").unwrap();
+    // SAFETY: this test binary has no other tests reading the environment.
+    unsafe {
+        std::env::set_var("SSL_CERT_FILE", &empty_file);
+        std::env::set_var("SSL_CERT_DIR", empty_dir.path());
+    }
+
+    let common = CommonObjectSpec::default();
+    for result in [
+        TlsClient::new(&common),
+        TlsClient::new_for_credentials(&common),
+    ] {
+        let err = result.expect_err("TlsClient must not build without CA roots");
+        assert_eq!(err.code, Code::InvalidArgument, "{err:?}");
+        assert!(
+            err.to_string().contains("SSL_CERT_FILE"),
+            "error should tell the operator how to supply roots: {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What and why

**Problem**

With the published `ghcr.io/tracemachina/nativelink` image (which carries no CA store) any `experimental_cloud_object_store` with `provider: "aws"` or `"r2"`, as well as the OCI store and the ONTAP S3 existence cache, aborts the whole process during store construction instead of reporting a configuration error:

```
thread '...' panicked at .../hyper-rustls-0.27.7/src/connector/builder.rs:78:14:
failure to initialize platform verifier: General("No CA certificates were loaded from the system")
```

Fixes #2747

**Root cause**

`nativelink-store/src/common_s3_utils.rs:78` built the connector with `HttpsConnectorBuilder::new().with_platform_verifier()`. In hyper-rustls 0.27.7 that method is `try_with_platform_verifier().expect("failure to initialize platform verifier")`, and `rustls-platform-verifier` returns `Err` on Linux when the root store it loads via `rustls-native-certs` ends up empty. `TlsClient::new`, `new_for_credentials` and `new_with_http_support` returned `Self`, so there was no way to surface that error even though every caller (`s3_store.rs:112-113`, `r2_store.rs:49`, `oci_store.rs:58`, `ontap_s3_existence_cache_store.rs:418`) already sits inside a `Result`-returning constructor. The ONTAP store itself already handles this correctly through `with_native_roots()?`.

**Fix**

- `TlsClient::new`, `TlsClient::new_for_credentials` and `TlsClient::new_with_http_support` now return `Result<Self, Error>` and use `try_with_platform_verifier()`, mapping the failure to `Code::InvalidArgument` with a message that names the remedy (mount a CA bundle and point `SSL_CERT_FILE` or `SSL_CERT_DIR` at it).
- The four production call sites propagate the error with `?`; the two existing `TlsClient` tests `unwrap()` the constructor.
- New test binary `nativelink-store/tests/tls_client_no_roots_test.rs` (registered in `BUILD.bazel`), gated to Linux because only the Linux platform verifier reads `SSL_CERT_FILE`/`SSL_CERT_DIR`. It lives in its own binary because it sets process-wide environment variables that the other `TlsClient` tests would otherwise observe.

Scope note: the GCS store builds its HTTP client through `reqwest` rather than `TlsClient`, so it is not on this panic path and is unchanged here. Adding a `root_certificates` option to `CommonObjectSpec` and documenting the CA requirement (items 2 and 3 in the issue) are left for follow-ups so this stays a small behavioural fix.

## How was this verified?

**How tested**

Before the fix, the new test body (with the assertion reduced to just constructing the client, since the old return type was not a `Result`) reproduces the report:

```
$ cargo test -p nativelink-store --test tls_client_no_roots_test
test tls_client_without_ca_roots_does_not_panic ... FAILED

thread 'tls_client_without_ca_roots_does_not_panic' panicked at .../hyper-rustls-0.27.7/src/connector/builder.rs:78:14:
failure to initialize platform verifier: General("No CA certificates were loaded from the system")
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

After the fix, on the same machine (Linux x86_64, Rust 1.97.1, `SSL_CERT_FILE` pointed at an empty file and `SSL_CERT_DIR` at an empty directory inside the test):

```
$ cargo test -p nativelink-store --test tls_client_no_roots_test
test tls_client_without_ca_roots_returns_error ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p nativelink-store --test common_s3_utils_test
test credential_client_allows_http ... ok
test s3_client_rejects_http_by_default ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt --all -- --check` and `cargo clippy -p nativelink-store --tests` (workspace lints: `all`/`pedantic`/`nursery` denied) are clean. The Bazel target was added to the `integration` `rust_test_suite` but I did not run the Bazel build locally; CI will cover it.

## Risk

Low. The only behavioural change is on the failure path: a configuration that used to abort with a panic now fails store construction with an `InvalidArgument` error carrying an actionable message. Deployments that already have a CA store see no difference. The public signatures of `TlsClient::new` and `TlsClient::new_for_credentials` change from `Self` to `Result<Self, Error>`; all in-tree callers are updated.

## Links

- Issue: https://github.com/TraceMachina/nativelink/issues/2747
- Related: https://github.com/TraceMachina/nativelink/issues/441 (test-time/runtime dependency on system CAs), https://github.com/TraceMachina/nativelink/pull/1785 (switch to the platform verifier)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2748)
<!-- Reviewable:end -->
