### PR TITLE
Remove the byline from the RE API Fellow post

### DIFF
--- a/web/apps/web/content/posts/RE_API_Fellowship.mdx
+++ b/web/apps/web/content/posts/RE_API_Fellowship.mdx
@@ -6,8 +6,6 @@ pubDate: 2026-09-08
 readTime: 8 minutes
 ---
 
-*By Marcus Eagan and Sumon Sadhu*
-
 When people first see the open source [NativeLink repository](https://github.com/TraceMachina/nativelink) on GitHub, they think about CI: continuous integration, the practice of building and testing software every time someone pushes a change. It's a fair assumption. Most people associate us with [Bazel](https://bazel.build), and most Bazel users think CI when they think about what Bazel is for.
 
 The association was incomplete. When we started, before we had incorporated our scientific computing parent, Trace Machina, we only supported pure software teams, usually building browsers or applications. Shortly thereafter we started working with robotics, biology, and semiconductor teams, and they shared three characteristics that set them apart from our software customers:


### PR DESCRIPTION
## What and why

Removes the author byline from the top of the RE API Fellow announcement so the post opens directly with its first paragraph. Requested after the post went live in #2749; the post should carry no byline.

## How was this verified?

Ran vale on the post with zero errors. Loaded the post through the site's post loader and confirmed it still parses as the newest post with an unchanged excerpt, since the excerpt never included the byline. Not rendered in a full site build.

## Risk

Low. A two-line deletion in one blog post. If wrong, the post reads oddly on the public blog, which the authors would notice first. No config, code, or API changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/2754)
<!-- Reviewable:end -->
